### PR TITLE
feat: Settings Web UI for config management

### DIFF
--- a/specs/settings-webui/plan.md
+++ b/specs/settings-webui/plan.md
@@ -1,0 +1,111 @@
+# Plan: Settings Web UI — Full Configuration Management
+
+## Spec Reference
+See `specs/settings-webui/spec.md` — REQ-1 through REQ-9.
+
+## Approach
+Extend existing config router and Settings page. Add tab-based navigation to organize config areas. Backend uses existing ConfigManager for SSH profiles and existing config.py for SLURM/notification settings.
+
+### Trade-offs Considered
+| Option | Pros | Cons |
+|--------|------|------|
+| **Extend existing config router** (chosen) | Single router, consistent patterns, fewer files | Router file grows larger |
+| Separate routers per section | Better separation | More files, more app.py wiring, fragmented API |
+| **Tab navigation in single page** (chosen) | Familiar UX, shared state (save/reset), URL reflects tab | Page component grows |
+| Separate pages per section | Smaller components | Inconsistent save UX, more routing |
+
+## Architecture
+
+### Components
+
+| Component | File Path | Responsibility |
+|-----------|-----------|----------------|
+| Config Router | `src/srunx/web/routers/config.py` | All /api/config/* endpoints |
+| NotificationConfig | `src/srunx/config.py` | Notification settings model |
+| Settings Page | `src/srunx/web/frontend/src/pages/Settings.tsx` | Tab container + General tab |
+| SSHProfilesTab | `src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx` | SSH profile CRUD + mounts |
+| NotificationsTab | `src/srunx/web/frontend/src/pages/settings/NotificationsTab.tsx` | Slack webhook config |
+| EnvironmentTab | `src/srunx/web/frontend/src/pages/settings/EnvironmentTab.tsx` | SRUNX_* env var display |
+| ProjectTab | `src/srunx/web/frontend/src/pages/settings/ProjectTab.tsx` | Project config management |
+| API Client | `src/srunx/web/frontend/src/lib/api.ts` | config.* API methods |
+| Types | `src/srunx/web/frontend/src/lib/types.ts` | SSH profile, notification types |
+
+### API Endpoints
+
+```
+GET    /api/config                          → SrunxConfig (existing)
+PUT    /api/config                          → SrunxConfig (existing)
+POST   /api/config/reset                    → SrunxConfig (existing)
+GET    /api/config/paths                    → ConfigPathInfo[] (existing)
+
+GET    /api/config/ssh/profiles             → { current: str|null, profiles: {name: ServerProfile}[] }
+POST   /api/config/ssh/profiles             → ServerProfile (body: { name, ...fields })
+PUT    /api/config/ssh/profiles/{name}      → ServerProfile
+DELETE /api/config/ssh/profiles/{name}      → { ok: true }
+POST   /api/config/ssh/profiles/{name}/activate → { ok: true }
+POST   /api/config/ssh/profiles/{name}/mounts   → MountConfig
+DELETE /api/config/ssh/profiles/{name}/mounts/{mount_name} → { ok: true }
+
+GET    /api/config/env                      → { name: str, value: str, description: str }[]
+
+GET    /api/config/project                  → { exists: bool, path: str, config: SrunxConfig|null }
+PUT    /api/config/project                  → SrunxConfig
+POST   /api/config/project/init             → { path: str, config: SrunxConfig }
+```
+
+### Data Flow
+```
+Frontend Tab Component
+    ↓ fetch on mount
+API Client (lib/api.ts)
+    ↓ HTTP request
+FastAPI Router (config.py)
+    ↓ calls
+ConfigManager / load_config / save_user_config
+    ↓ reads/writes
+~/.config/srunx/config.json or .srunx.json
+```
+
+### Frontend Tab Structure
+```
+Settings Page
+├── Tab Bar: [General] [SSH Profiles] [Notifications] [Environment] [Project]
+├── General Tab (existing content: resources, environment, general, config paths)
+├── SSH Profiles Tab
+│   ├── Profile List (cards with activate/edit/delete)
+│   ├── Add Profile Form (expandable)
+│   └── Per-profile: Mounts list + Env vars list
+├── Notifications Tab
+│   └── Slack Webhook URL field + save
+├── Environment Tab
+│   └── Read-only SRUNX_* variable list with descriptions
+└── Project Tab
+    ├── Status (exists/not exists, path)
+    ├── Initialize button
+    └── Project config form (resource/env overrides)
+```
+
+## Integration Points
+- `ConfigManager` (ssh/core/config.py): SSH profile CRUD, mount management
+- `SrunxConfig` (config.py): SLURM defaults, notifications — save_user_config/load_config
+- `load_config_from_file` / `get_config_paths`: Project config detection
+
+## Dependencies
+### Internal
+- `srunx.config` — SrunxConfig, save_user_config, load_config, get_config_paths, load_config_from_file
+- `srunx.ssh.core.config` — ConfigManager, ServerProfile, MountConfig
+
+### External
+- No new dependencies
+
+## Risks & Mitigations
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| ConfigManager and SrunxConfig share the same config.json file | Med | Both operate on different top-level keys (profiles vs resources/environment) |
+| Project config cwd-relative may differ from server cwd | Med | Show absolute path in UI, let user know which directory |
+| Large Settings.tsx file | Low | Split into tab sub-components |
+
+## Testing Strategy
+- Manual: Playwright MCP browser verification for each tab
+- Lint: ruff check for backend, tsc --noEmit for frontend
+- API: curl verification of each endpoint

--- a/specs/settings-webui/spec.md
+++ b/specs/settings-webui/spec.md
@@ -1,0 +1,52 @@
+# Spec: Settings Web UI — Full Configuration Management
+
+## Overview
+Expand the Settings page to manage all srunx configuration: SSH profiles (with mounts), SLURM defaults, notifications, environment variable overrides, and project-scoped config.
+
+## Background
+The web UI currently only manages SLURM resource/environment defaults. All other configuration (SSH profiles, mounts, notifications) requires CLI or manual file editing. Users need a single place to manage all configuration through the browser.
+
+## Requirements
+
+### Must Have
+- REQ-1: SSH Profile management — list, add, edit, delete profiles with all ServerProfile fields (hostname, username, key_filename, port, description, ssh_host, proxy_jump)
+- REQ-2: SSH Profile activation — set current/active profile, visually indicate which profile is active
+- REQ-3: Per-profile mount management — add/remove MountConfig (name, local, remote) per profile
+- REQ-4: Per-profile environment variables — add/remove env vars per profile
+- REQ-5: Notification settings — configure Slack webhook URL with format validation, persist in user config
+- REQ-6: Environment variable overview — read-only display of all active SRUNX_* env vars and their values
+- REQ-7: Project config management — detect if .srunx.json exists, initialize, edit project-scoped config
+- REQ-8: SLURM resource/environment defaults — already implemented, must be preserved
+- REQ-9: Tab navigation — organize settings into logical tabs (General, SSH Profiles, Notifications, Environment, Project)
+
+### Nice to Have
+- REQ-N1: SSH connection test button per profile
+- REQ-N2: Webhook test (send test notification)
+
+## Acceptance Criteria
+- AC-1: Given the Settings page, when user navigates between tabs, then each section loads and displays correct data
+- AC-2: Given SSH Profiles tab, when user adds a profile with valid fields, then it persists and appears in the list
+- AC-3: Given SSH Profiles tab, when user activates a profile, then it becomes the current profile (highlighted)
+- AC-4: Given SSH Profiles tab, when user adds/removes a mount, then changes persist and the mount list updates
+- AC-5: Given Notifications tab, when user enters a valid Slack webhook URL and saves, then it persists in user config
+- AC-6: Given Notifications tab, when user enters an invalid URL, then validation error is shown
+- AC-7: Given Environment tab, when page loads, then all SRUNX_* env vars are displayed read-only
+- AC-8: Given Project tab, when no .srunx.json exists, then "Initialize" button is shown
+- AC-9: Given Project tab, when user initializes project config, then .srunx.json is created with example values
+- AC-10: All existing Settings functionality (resource defaults, save, reset, config paths) continues to work
+
+## Out of Scope
+- Web server config (host/port/CORS) — requires restart, not useful via UI
+- Monitor config (poll_interval/timeout) — runtime-only, per-operation
+- SSH key generation or ~/.ssh/config editing
+- Container resource defaults (complex nested config, low priority for v1)
+
+## Constraints
+- TypeScript strict mode, no `any` types
+- Use existing CSS design system (panel, btn, input classes, CSS variables)
+- ConfigManager from ssh/core/config.py must be instantiated per-request (reads from file)
+- Slack webhook URL validation must match existing pattern in callbacks.py
+- Project config writes to cwd-relative .srunx.json
+
+## Open Questions
+- None — requirements confirmed by user

--- a/specs/settings-webui/tasks.md
+++ b/specs/settings-webui/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Settings Web UI
+
+## Phase 1: Backend — Data Model & API Endpoints
+
+- [ ] 1.1 Add `NotificationConfig` to `SrunxConfig` in `src/srunx/config.py`
+- [ ] 1.2 Add SSH profile endpoints to `src/srunx/web/routers/config.py` (list, add, update, delete, activate, mounts)
+- [ ] 1.3 Add notification endpoints to config router (GET/PUT using SrunxConfig)
+- [ ] 1.4 Add environment variable endpoint to config router (GET /api/config/env)
+- [ ] 1.5 Add project config endpoints to config router (GET, PUT, POST init)
+- [ ] 1.6 Verify backend: ruff check + import test
+
+## Phase 2: Frontend — Types, API Client, Tab Infrastructure
+
+- [ ] 2.1 Add SSH profile, notification, env var, project config types to `types.ts`
+- [ ] 2.2 Add all new API methods to `api.ts` (config.sshProfiles.*, config.notifications.*, config.env, config.project.*)
+- [ ] 2.3 Refactor Settings.tsx into tab-based layout, extract existing content to GeneralTab
+
+## Phase 3: Frontend — Tab Components
+
+- [ ] 3.1 Create `SSHProfilesTab.tsx` — profile list, add/edit/delete forms, mount management, env vars, activate
+- [ ] 3.2 Create `NotificationsTab.tsx` — Slack webhook URL input with validation
+- [ ] 3.3 Create `EnvironmentTab.tsx` — read-only SRUNX_* env var display
+- [ ] 3.4 Create `ProjectTab.tsx` — project config status, init, edit form
+
+## Phase 4: Verification
+
+- [ ] 4.1 TypeScript type check (tsc --noEmit)
+- [ ] 4.2 Python lint (ruff check)
+- [ ] 4.3 Playwright MCP browser verification of each tab

--- a/src/srunx/config.py
+++ b/src/srunx/config.py
@@ -49,11 +49,20 @@ class EnvironmentDefaults(BaseModel):
     )
 
 
+class NotificationConfig(BaseModel):
+    """Notification configuration."""
+
+    slack_webhook_url: str | None = Field(
+        default=None, description="Slack webhook URL for notifications"
+    )
+
+
 class SrunxConfig(BaseModel):
     """Main srunx configuration."""
 
     resources: ResourceDefaults = Field(default_factory=ResourceDefaults)
     environment: EnvironmentDefaults = Field(default_factory=EnvironmentDefaults)
+    notifications: NotificationConfig = Field(default_factory=NotificationConfig)
     log_dir: str = Field(default="logs", description="Default log directory")
     work_dir: str | None = Field(default=None, description="Default working directory")
 
@@ -226,6 +235,7 @@ def save_user_config(config: SrunxConfig) -> None:
         logger.info(f"Configuration saved to {user_config_path}")
     except OSError as e:
         logger.error(f"Failed to save config to {user_config_path}: {e}")
+        raise
 
 
 def create_example_config() -> str:

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -105,6 +105,9 @@ def create_app() -> FastAPI:
     )
 
     # REST routers
+    from .routers import config as config_router
+
+    app.include_router(config_router.router)
     app.include_router(jobs.router)
     app.include_router(workflows.router)
     app.include_router(resources.router)

--- a/src/srunx/web/frontend/src/App.tsx
+++ b/src/srunx/web/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Workflows } from "./pages/Workflows.tsx";
 import { WorkflowDetail } from "./pages/WorkflowDetail.tsx";
 import { WorkflowBuilder } from "./pages/WorkflowBuilder.tsx";
 import { Resources } from "./pages/Resources.tsx";
+import { Settings } from "./pages/Settings.tsx";
 import { LogViewer } from "./pages/LogViewer.tsx";
 
 export function App() {
@@ -22,6 +23,7 @@ export function App() {
           <Route path="workflows/:name/edit" element={<WorkflowBuilder />} />
           <Route path="workflows/:name" element={<WorkflowDetail />} />
           <Route path="resources" element={<Resources />} />
+          <Route path="settings" element={<Settings />} />
         </Route>
       </Routes>
     </ErrorBoundary>

--- a/src/srunx/web/frontend/src/components/Sidebar.tsx
+++ b/src/srunx/web/frontend/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Layers,
   GitFork,
   Cpu,
+  Settings,
   Terminal,
   ChevronLeft,
   ChevronRight,
@@ -22,6 +23,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/jobs", icon: <Layers size={18} />, label: "Jobs" },
   { to: "/workflows", icon: <GitFork size={18} />, label: "Workflows" },
   { to: "/resources", icon: <Cpu size={18} />, label: "Resources" },
+  { to: "/settings", icon: <Settings size={18} />, label: "Settings" },
 ];
 
 export function Sidebar() {

--- a/src/srunx/web/frontend/src/lib/api.ts
+++ b/src/srunx/web/frontend/src/lib/api.ts
@@ -1,11 +1,19 @@
 import type {
   BrowseResult,
   CommandJob,
+  ConfigPathInfo,
+  EnvVarInfo,
   HistoryStats,
   LogData,
   Mount,
   MountConfig,
+  ProjectConfigResponse,
+  ProjectInfo,
   ResourceSnapshot,
+  SSHMountConfig,
+  SSHProfile,
+  SSHProfilesResponse,
+  SrunxConfig,
   SyncResult,
   Workflow,
   WorkflowCreateRequest,
@@ -110,10 +118,9 @@ export const workflows = {
   },
 
   run: async (name: string): Promise<WorkflowRun> => {
-    const res = await fetch(
-      `/api/workflows/${encodeURIComponent(name)}/run`,
-      { method: "POST" },
-    );
+    const res = await fetch(`/api/workflows/${encodeURIComponent(name)}/run`, {
+      method: "POST",
+    });
     if (!res.ok) {
       const err = await res.json();
       throw new Error(extractDetail(err, "Failed to run workflow"));
@@ -122,9 +129,7 @@ export const workflows = {
   },
 
   getRun: async (runId: string): Promise<WorkflowRun> => {
-    const res = await fetch(
-      `/api/workflows/runs/${encodeURIComponent(runId)}`,
-    );
+    const res = await fetch(`/api/workflows/runs/${encodeURIComponent(runId)}`);
     if (!res.ok) {
       const err = await res.json();
       throw new Error(extractDetail(err, "Failed to fetch run"));
@@ -133,10 +138,9 @@ export const workflows = {
   },
 
   delete: async (name: string): Promise<void> => {
-    const res = await fetch(
-      `/api/workflows/${encodeURIComponent(name)}`,
-      { method: "DELETE" },
-    );
+    const res = await fetch(`/api/workflows/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    });
     if (!res.ok) {
       const err = await res.json();
       throw new Error(extractDetail(err, "Failed to delete workflow"));
@@ -235,5 +239,204 @@ export const files = {
       const err = await res.json();
       throw new Error(extractDetail(err, "Failed to remove mount"));
     }
+  },
+};
+
+/* ── Config ──────────────────────────────────── */
+
+export const config = {
+  get: async (): Promise<SrunxConfig> => {
+    const res = await fetch("/api/config");
+    if (!res.ok) throw new Error("Failed to fetch config");
+    return res.json();
+  },
+
+  update: async (body: SrunxConfig): Promise<SrunxConfig> => {
+    const res = await fetch("/api/config", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to update config"));
+    }
+    return res.json();
+  },
+
+  paths: async (): Promise<ConfigPathInfo[]> => {
+    const res = await fetch("/api/config/paths");
+    if (!res.ok) throw new Error("Failed to fetch config paths");
+    return res.json();
+  },
+
+  reset: async (): Promise<SrunxConfig> => {
+    const res = await fetch("/api/config/reset", { method: "POST" });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to reset config"));
+    }
+    return res.json();
+  },
+
+  /* SSH Profiles */
+
+  sshProfiles: async (): Promise<SSHProfilesResponse> => {
+    const res = await fetch("/api/config/ssh/profiles");
+    if (!res.ok) throw new Error("Failed to fetch SSH profiles");
+    return res.json();
+  },
+
+  addSSHProfile: async (body: {
+    name: string;
+    hostname: string;
+    username: string;
+    key_filename: string;
+    port?: number;
+    description?: string;
+    ssh_host?: string;
+    proxy_jump?: string;
+  }): Promise<SSHProfile> => {
+    const res = await fetch("/api/config/ssh/profiles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to add SSH profile"));
+    }
+    return res.json();
+  },
+
+  updateSSHProfile: async (
+    name: string,
+    body: Partial<SSHProfile>,
+  ): Promise<SSHProfile> => {
+    const res = await fetch(
+      `/api/config/ssh/profiles/${encodeURIComponent(name)}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to update SSH profile"));
+    }
+    return res.json();
+  },
+
+  deleteSSHProfile: async (name: string): Promise<void> => {
+    const res = await fetch(
+      `/api/config/ssh/profiles/${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to delete SSH profile"));
+    }
+  },
+
+  activateSSHProfile: async (name: string): Promise<void> => {
+    const res = await fetch(
+      `/api/config/ssh/profiles/${encodeURIComponent(name)}/activate`,
+      { method: "POST" },
+    );
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to activate SSH profile"));
+    }
+  },
+
+  addSSHMount: async (
+    profileName: string,
+    mount: SSHMountConfig,
+  ): Promise<SSHMountConfig> => {
+    const res = await fetch(
+      `/api/config/ssh/profiles/${encodeURIComponent(profileName)}/mounts`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(mount),
+      },
+    );
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to add mount"));
+    }
+    return res.json();
+  },
+
+  removeSSHMount: async (
+    profileName: string,
+    mountName: string,
+  ): Promise<void> => {
+    const res = await fetch(
+      `/api/config/ssh/profiles/${encodeURIComponent(profileName)}/mounts/${encodeURIComponent(mountName)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to remove mount"));
+    }
+  },
+
+  /* Environment Variables */
+
+  envVars: async (): Promise<EnvVarInfo[]> => {
+    const res = await fetch("/api/config/env");
+    if (!res.ok) throw new Error("Failed to fetch environment variables");
+    return res.json();
+  },
+
+  /* Projects (mount-based) */
+
+  listProjects: async (): Promise<ProjectInfo[]> => {
+    const res = await fetch("/api/config/projects");
+    if (!res.ok) throw new Error("Failed to fetch projects");
+    return res.json();
+  },
+
+  getProject: async (mountName: string): Promise<ProjectConfigResponse> => {
+    const res = await fetch(
+      `/api/config/projects/${encodeURIComponent(mountName)}`,
+    );
+    if (!res.ok) throw new Error("Failed to fetch project config");
+    return res.json();
+  },
+
+  updateProject: async (
+    mountName: string,
+    body: SrunxConfig,
+  ): Promise<ProjectConfigResponse> => {
+    const res = await fetch(
+      `/api/config/projects/${encodeURIComponent(mountName)}`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to update project config"));
+    }
+    return res.json();
+  },
+
+  initProject: async (mountName: string): Promise<ProjectConfigResponse> => {
+    const res = await fetch(
+      `/api/config/projects/${encodeURIComponent(mountName)}/init`,
+      { method: "POST" },
+    );
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(
+        extractDetail(err, "Failed to initialize project config"),
+      );
+    }
+    return res.json();
   },
 };

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -178,6 +178,104 @@ export type MountConfig = {
   remote: string;
 };
 
+/* ── Config types ────────────────────────────── */
+
+export type ContainerConfig = {
+  image: string;
+  runtime?: string;
+  mounts?: string[];
+  workdir?: string;
+};
+
+export type ResourceDefaultsConfig = {
+  nodes: number;
+  gpus_per_node: number;
+  ntasks_per_node: number;
+  cpus_per_task: number;
+  memory_per_node: string | null;
+  time_limit: string | null;
+  nodelist: string | null;
+  partition: string | null;
+};
+
+export type EnvironmentDefaultsConfig = {
+  conda: string | null;
+  venv: string | null;
+  container: ContainerConfig | null;
+  env_vars: Record<string, string>;
+};
+
+export type SrunxConfig = {
+  resources: ResourceDefaultsConfig;
+  environment: EnvironmentDefaultsConfig;
+  notifications: NotificationConfig;
+  log_dir: string;
+  work_dir: string | null;
+};
+
+export type NotificationConfig = {
+  slack_webhook_url: string | null;
+};
+
+export type ConfigPathInfo = {
+  path: string;
+  exists: boolean;
+  source: string;
+};
+
+/* ── SSH Profile types ──────────────────────── */
+
+export type SSHMountConfig = {
+  name: string;
+  local: string;
+  remote: string;
+};
+
+export type SSHProfile = {
+  hostname: string;
+  username: string;
+  key_filename: string;
+  port: number;
+  description: string | null;
+  ssh_host: string | null;
+  proxy_jump: string | null;
+  env_vars: Record<string, string> | null;
+  mounts: SSHMountConfig[];
+};
+
+export type SSHProfilesResponse = {
+  current: string | null;
+  profiles: Record<string, SSHProfile>;
+};
+
+/* ── Environment variable info ──────────────── */
+
+export type EnvVarInfo = {
+  name: string;
+  value: string;
+  description: string;
+};
+
+/* ── Project config (mount-based) ────────────── */
+
+export type ProjectInfo = {
+  mount_name: string;
+  local_path: string;
+  remote_path: string;
+  config_exists: boolean;
+  config_path: string;
+};
+
+export type ProjectConfigResponse = {
+  mount_name: string;
+  local_path: string;
+  config_path: string;
+  exists: boolean;
+  config: SrunxConfig | null;
+};
+
+/* ── Workflow create request ─────────────────── */
+
 export type WorkflowCreateRequest = {
   name: string;
   default_project?: string | null;

--- a/src/srunx/web/frontend/src/pages/Settings.tsx
+++ b/src/srunx/web/frontend/src/pages/Settings.tsx
@@ -1,0 +1,775 @@
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import {
+  Save,
+  RotateCcw,
+  FolderOpen,
+  Check,
+  AlertTriangle,
+  Plus,
+  X,
+  Server,
+  Bell,
+  Variable,
+  Sliders,
+} from "lucide-react";
+import { config as configApi } from "../lib/api.ts";
+import type {
+  SrunxConfig,
+  ConfigPathInfo,
+  ResourceDefaultsConfig,
+  EnvironmentDefaultsConfig,
+} from "../lib/types.ts";
+import { SSHProfilesTab } from "./settings/SSHProfilesTab.tsx";
+import { NotificationsTab } from "./settings/NotificationsTab.tsx";
+import { EnvironmentTab } from "./settings/EnvironmentTab.tsx";
+import { ProjectTab } from "./settings/ProjectTab.tsx";
+
+const EASE = [0.16, 1, 0.3, 1] as [number, number, number, number];
+
+const stagger = (i: number) => ({
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0 },
+  transition: { delay: i * 0.06, duration: 0.4, ease: EASE },
+});
+
+type FieldRowProps = {
+  label: string;
+  description?: string;
+  children: React.ReactNode;
+};
+
+function FieldRow({ label, description, children }: FieldRowProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "space-between",
+        gap: "var(--sp-6)",
+        padding: "var(--sp-3) 0",
+        borderBottom: "1px solid var(--border-ghost)",
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: "0.85rem",
+            fontWeight: 500,
+            color: "var(--text-primary)",
+          }}
+        >
+          {label}
+        </div>
+        {description && (
+          <div
+            style={{
+              fontSize: "0.75rem",
+              color: "var(--text-muted)",
+              marginTop: 2,
+            }}
+          >
+            {description}
+          </div>
+        )}
+      </div>
+      <div style={{ flexShrink: 0, minWidth: 200 }}>{children}</div>
+    </div>
+  );
+}
+
+function NumberInput({
+  value,
+  onChange,
+  min,
+  placeholder,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  placeholder?: string;
+}) {
+  return (
+    <input
+      className="input"
+      type="number"
+      value={value}
+      min={min}
+      placeholder={placeholder}
+      onChange={(e) => {
+        const n = Number(e.target.value);
+        if (!Number.isNaN(n)) onChange(n);
+      }}
+      style={{ width: "100%" }}
+    />
+  );
+}
+
+function TextInput({
+  value,
+  onChange,
+  placeholder,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <input
+      className="input"
+      type="text"
+      value={value}
+      placeholder={placeholder}
+      onChange={(e) => onChange(e.target.value)}
+      style={{ width: "100%" }}
+    />
+  );
+}
+
+/* ── Tab definitions ─────────────────────────── */
+
+type TabId = "general" | "ssh" | "notifications" | "environment" | "project";
+
+type TabDef = {
+  id: TabId;
+  label: string;
+  icon: React.ReactNode;
+};
+
+const TABS: TabDef[] = [
+  { id: "general", label: "General", icon: <Sliders size={14} /> },
+  { id: "ssh", label: "SSH Profiles", icon: <Server size={14} /> },
+  { id: "notifications", label: "Notifications", icon: <Bell size={14} /> },
+  { id: "environment", label: "Environment", icon: <Variable size={14} /> },
+  { id: "project", label: "Project", icon: <FolderOpen size={14} /> },
+];
+
+/* ── Main Settings component ─────────────────── */
+
+export function Settings() {
+  const [activeTab, setActiveTab] = useState<TabId>("general");
+  const [config, setConfig] = useState<SrunxConfig | null>(null);
+  const [paths, setPaths] = useState<ConfigPathInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // env_vars editor state
+  const [newEnvKey, setNewEnvKey] = useState("");
+  const [newEnvValue, setNewEnvValue] = useState("");
+
+  const loadConfig = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [cfg, p] = await Promise.all([configApi.get(), configApi.paths()]);
+      setConfig(cfg);
+      setPaths(p);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load config");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  useEffect(() => {
+    if (success) {
+      const timer = setTimeout(() => setSuccess(null), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [success]);
+
+  const handleSave = async () => {
+    if (!config) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const updated = await configApi.update(config);
+      setConfig(updated);
+      setSuccess("Configuration saved successfully");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save config");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (
+      !window.confirm("Reset all settings to defaults? This cannot be undone.")
+    )
+      return;
+    try {
+      setSaving(true);
+      setError(null);
+      const updated = await configApi.reset();
+      setConfig(updated);
+      setSuccess("Configuration reset to defaults");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to reset config");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const updateResources = (patch: Partial<ResourceDefaultsConfig>) => {
+    if (!config) return;
+    setConfig({
+      ...config,
+      resources: { ...config.resources, ...patch },
+    });
+  };
+
+  const updateEnvironment = (patch: Partial<EnvironmentDefaultsConfig>) => {
+    if (!config) return;
+    setConfig({
+      ...config,
+      environment: { ...config.environment, ...patch },
+    });
+  };
+
+  const addEnvVar = () => {
+    if (!config || !newEnvKey.trim()) return;
+    updateEnvironment({
+      env_vars: { ...config.environment.env_vars, [newEnvKey]: newEnvValue },
+    });
+    setNewEnvKey("");
+    setNewEnvValue("");
+  };
+
+  const removeEnvVar = (key: string) => {
+    if (!config) return;
+    const next = { ...config.environment.env_vars };
+    delete next[key];
+    updateEnvironment({ env_vars: next });
+  };
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: "var(--sp-6)" }}
+    >
+      {/* Header */}
+      <motion.div {...stagger(0)}>
+        <h1 style={{ marginBottom: 4 }}>Settings</h1>
+        <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
+          Manage srunx configuration, SSH profiles, and notifications
+        </p>
+      </motion.div>
+
+      {/* Tab bar */}
+      <motion.div
+        {...stagger(1)}
+        style={{
+          display: "flex",
+          gap: 2,
+          borderBottom: "1px solid var(--border-subtle)",
+          paddingBottom: 0,
+        }}
+      >
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--sp-2)",
+              padding: "var(--sp-3) var(--sp-4)",
+              background: "transparent",
+              border: "none",
+              borderBottom:
+                activeTab === tab.id
+                  ? "2px solid var(--accent)"
+                  : "2px solid transparent",
+              color:
+                activeTab === tab.id
+                  ? "var(--text-primary)"
+                  : "var(--text-muted)",
+              fontFamily: "var(--font-display)",
+              fontSize: "0.8rem",
+              fontWeight: 500,
+              letterSpacing: "0.04em",
+              cursor: "pointer",
+              transition: "all 150ms var(--ease-out)",
+            }}
+          >
+            {tab.icon}
+            {tab.label}
+          </button>
+        ))}
+      </motion.div>
+
+      {/* Tab content */}
+      {activeTab === "general" && (
+        <>
+          {/* General tab header actions */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "flex-end",
+              gap: "var(--sp-2)",
+            }}
+          >
+            <button
+              className="btn btn-ghost"
+              onClick={handleReset}
+              disabled={saving}
+            >
+              <RotateCcw size={14} />
+              Reset
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              <Save size={14} />
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+
+          {/* Status messages */}
+          {error && (
+            <div
+              style={{
+                padding: "var(--sp-3) var(--sp-4)",
+                background: "var(--st-failed-dim)",
+                border: "1px solid rgba(244,63,94,0.3)",
+                borderRadius: "var(--radius-md)",
+                color: "var(--st-failed)",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.8rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--sp-2)",
+              }}
+            >
+              <AlertTriangle size={14} />
+              {error}
+            </div>
+          )}
+          {success && (
+            <motion.div
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              style={{
+                padding: "var(--sp-3) var(--sp-4)",
+                background: "var(--st-completed-dim)",
+                border: "1px solid rgba(52,211,153,0.3)",
+                borderRadius: "var(--radius-md)",
+                color: "var(--st-completed)",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.8rem",
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--sp-2)",
+              }}
+            >
+              <Check size={14} />
+              {success}
+            </motion.div>
+          )}
+
+          {loading ? (
+            <div className="panel skeleton" style={{ height: 400 }} />
+          ) : config ? (
+            <>
+              {/* Resource Defaults */}
+              <motion.div {...stagger(2)} className="panel">
+                <div className="panel-header">
+                  <h3>Resource Defaults</h3>
+                </div>
+                <div className="panel-body">
+                  <FieldRow
+                    label="Nodes"
+                    description="Default number of compute nodes"
+                  >
+                    <NumberInput
+                      value={config.resources.nodes}
+                      onChange={(v) => updateResources({ nodes: v })}
+                      min={1}
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="GPUs per Node"
+                    description="Default GPU allocation per node"
+                  >
+                    <NumberInput
+                      value={config.resources.gpus_per_node}
+                      onChange={(v) => updateResources({ gpus_per_node: v })}
+                      min={0}
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Tasks per Node"
+                    description="Default number of tasks per node"
+                  >
+                    <NumberInput
+                      value={config.resources.ntasks_per_node}
+                      onChange={(v) => updateResources({ ntasks_per_node: v })}
+                      min={1}
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="CPUs per Task"
+                    description="Default CPU cores per task"
+                  >
+                    <NumberInput
+                      value={config.resources.cpus_per_task}
+                      onChange={(v) => updateResources({ cpus_per_task: v })}
+                      min={1}
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Memory per Node"
+                    description="e.g. 32GB, 128GB"
+                  >
+                    <TextInput
+                      value={config.resources.memory_per_node ?? ""}
+                      onChange={(v) =>
+                        updateResources({ memory_per_node: v || null })
+                      }
+                      placeholder="e.g. 32GB"
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Time Limit"
+                    description="e.g. 2:00:00, 1-00:00:00"
+                  >
+                    <TextInput
+                      value={config.resources.time_limit ?? ""}
+                      onChange={(v) =>
+                        updateResources({ time_limit: v || null })
+                      }
+                      placeholder="e.g. 2:00:00"
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Partition"
+                    description="Default SLURM partition"
+                  >
+                    <TextInput
+                      value={config.resources.partition ?? ""}
+                      onChange={(v) =>
+                        updateResources({ partition: v || null })
+                      }
+                      placeholder="e.g. gpu"
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Nodelist"
+                    description="Specific nodes to target"
+                  >
+                    <TextInput
+                      value={config.resources.nodelist ?? ""}
+                      onChange={(v) => updateResources({ nodelist: v || null })}
+                      placeholder="e.g. node[01-04]"
+                    />
+                  </FieldRow>
+                </div>
+              </motion.div>
+
+              {/* Environment Defaults */}
+              <motion.div {...stagger(3)} className="panel">
+                <div className="panel-header">
+                  <h3>Environment Defaults</h3>
+                </div>
+                <div className="panel-body">
+                  <FieldRow
+                    label="Conda Environment"
+                    description="Default conda env to activate"
+                  >
+                    <TextInput
+                      value={config.environment.conda ?? ""}
+                      onChange={(v) => updateEnvironment({ conda: v || null })}
+                      placeholder="e.g. ml_env"
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Virtual Environment"
+                    description="Path to venv to activate"
+                  >
+                    <TextInput
+                      value={config.environment.venv ?? ""}
+                      onChange={(v) => updateEnvironment({ venv: v || null })}
+                      placeholder="e.g. /path/to/venv"
+                    />
+                  </FieldRow>
+
+                  {/* Environment Variables */}
+                  <div style={{ paddingTop: "var(--sp-4)" }}>
+                    <div
+                      style={{
+                        fontSize: "0.85rem",
+                        fontWeight: 500,
+                        color: "var(--text-primary)",
+                        marginBottom: "var(--sp-3)",
+                      }}
+                    >
+                      Environment Variables
+                    </div>
+
+                    {Object.entries(config.environment.env_vars).length > 0 && (
+                      <div
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "var(--sp-2)",
+                          marginBottom: "var(--sp-3)",
+                        }}
+                      >
+                        {Object.entries(config.environment.env_vars).map(
+                          ([key, value]) => (
+                            <div
+                              key={key}
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "var(--sp-2)",
+                                padding: "var(--sp-2) var(--sp-3)",
+                                background: "var(--bg-base)",
+                                borderRadius: "var(--radius-md)",
+                                border: "1px solid var(--border-ghost)",
+                              }}
+                            >
+                              <span
+                                style={{
+                                  fontFamily: "var(--font-mono)",
+                                  fontSize: "0.8rem",
+                                  color: "var(--accent)",
+                                  minWidth: 120,
+                                }}
+                              >
+                                {key}
+                              </span>
+                              <span
+                                style={{
+                                  color: "var(--text-muted)",
+                                  fontSize: "0.8rem",
+                                }}
+                              >
+                                =
+                              </span>
+                              <span
+                                style={{
+                                  fontFamily: "var(--font-mono)",
+                                  fontSize: "0.8rem",
+                                  color: "var(--text-secondary)",
+                                  flex: 1,
+                                }}
+                              >
+                                {value}
+                              </span>
+                              <button
+                                onClick={() => removeEnvVar(key)}
+                                style={{
+                                  background: "transparent",
+                                  border: "none",
+                                  color: "var(--text-muted)",
+                                  cursor: "pointer",
+                                  padding: 4,
+                                  display: "flex",
+                                }}
+                              >
+                                <X size={14} />
+                              </button>
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    )}
+
+                    <div
+                      style={{
+                        display: "flex",
+                        gap: "var(--sp-2)",
+                        alignItems: "center",
+                      }}
+                    >
+                      <input
+                        className="input"
+                        type="text"
+                        value={newEnvKey}
+                        onChange={(e) => setNewEnvKey(e.target.value)}
+                        placeholder="KEY"
+                        style={{
+                          width: 140,
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                        }}
+                        onKeyDown={(e) => e.key === "Enter" && addEnvVar()}
+                      />
+                      <span
+                        style={{
+                          color: "var(--text-muted)",
+                          fontSize: "0.8rem",
+                        }}
+                      >
+                        =
+                      </span>
+                      <input
+                        className="input"
+                        type="text"
+                        value={newEnvValue}
+                        onChange={(e) => setNewEnvValue(e.target.value)}
+                        placeholder="value"
+                        style={{
+                          flex: 1,
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                        }}
+                        onKeyDown={(e) => e.key === "Enter" && addEnvVar()}
+                      />
+                      <button
+                        className="btn btn-ghost"
+                        onClick={addEnvVar}
+                        disabled={!newEnvKey.trim()}
+                        style={{ padding: "var(--sp-2)" }}
+                      >
+                        <Plus size={14} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </motion.div>
+
+              {/* General */}
+              <motion.div {...stagger(4)} className="panel">
+                <div className="panel-header">
+                  <h3>General</h3>
+                </div>
+                <div className="panel-body">
+                  <FieldRow
+                    label="Log Directory"
+                    description="Default directory for SLURM log output"
+                  >
+                    <TextInput
+                      value={config.log_dir}
+                      onChange={(v) =>
+                        setConfig({ ...config, log_dir: v || "logs" })
+                      }
+                      placeholder="logs"
+                    />
+                  </FieldRow>
+                  <FieldRow
+                    label="Working Directory"
+                    description="Default working directory for jobs"
+                  >
+                    <TextInput
+                      value={config.work_dir ?? ""}
+                      onChange={(v) =>
+                        setConfig({ ...config, work_dir: v || null })
+                      }
+                      placeholder="e.g. /scratch/username"
+                    />
+                  </FieldRow>
+                </div>
+              </motion.div>
+
+              {/* Config File Paths */}
+              <motion.div {...stagger(5)} className="panel">
+                <div className="panel-header">
+                  <h3>
+                    <FolderOpen
+                      size={14}
+                      style={{ marginRight: 8, verticalAlign: -2 }}
+                    />
+                    Config File Paths
+                  </h3>
+                </div>
+                <div className="panel-body">
+                  <div
+                    style={{
+                      fontSize: "0.75rem",
+                      color: "var(--text-muted)",
+                      marginBottom: "var(--sp-3)",
+                    }}
+                  >
+                    Files are loaded in order of precedence (lowest to highest).
+                    Environment variables override all files.
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: "var(--sp-2)",
+                    }}
+                  >
+                    {paths.map((p, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "var(--sp-3)",
+                          padding: "var(--sp-2) var(--sp-3)",
+                          background: "var(--bg-base)",
+                          borderRadius: "var(--radius-md)",
+                          border: "1px solid var(--border-ghost)",
+                        }}
+                      >
+                        <span
+                          style={{
+                            fontSize: "0.7rem",
+                            fontFamily: "var(--font-display)",
+                            textTransform: "uppercase",
+                            letterSpacing: "0.08em",
+                            color: "var(--text-muted)",
+                            minWidth: 100,
+                          }}
+                        >
+                          {p.source}
+                        </span>
+                        <span
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.8rem",
+                            color: "var(--text-secondary)",
+                            flex: 1,
+                          }}
+                        >
+                          {p.path}
+                        </span>
+                        <span
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.7rem",
+                            color: p.exists
+                              ? "var(--st-completed)"
+                              : "var(--text-muted)",
+                          }}
+                        >
+                          {p.exists ? "FOUND" : "NOT FOUND"}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </motion.div>
+            </>
+          ) : (
+            <div
+              style={{
+                padding: "var(--sp-4)",
+                color: "var(--st-failed)",
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              {error ?? "Unable to load configuration"}
+            </div>
+          )}
+        </>
+      )}
+
+      {activeTab === "ssh" && <SSHProfilesTab />}
+      {activeTab === "notifications" && <NotificationsTab />}
+      {activeTab === "environment" && <EnvironmentTab />}
+      {activeTab === "project" && <ProjectTab />}
+    </div>
+  );
+}

--- a/src/srunx/web/frontend/src/pages/settings/EnvironmentTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/EnvironmentTab.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState, useCallback } from "react";
+import { Variable } from "lucide-react";
+import { config as configApi } from "../../lib/api.ts";
+import type { EnvVarInfo } from "../../lib/types.ts";
+
+export function EnvironmentTab() {
+  const [vars, setVars] = useState<EnvVarInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await configApi.envVars();
+      setVars(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load env vars");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return <div className="panel skeleton" style={{ height: 200 }} />;
+  }
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}
+    >
+      {error && (
+        <div
+          style={{
+            padding: "var(--sp-3) var(--sp-4)",
+            background: "var(--st-failed-dim)",
+            border: "1px solid rgba(244,63,94,0.3)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--st-failed)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      <div className="panel">
+        <div className="panel-header">
+          <h3>
+            <Variable size={14} style={{ marginRight: 8, verticalAlign: -2 }} />
+            Active Environment Variables
+          </h3>
+        </div>
+        <div className="panel-body">
+          <p
+            style={{
+              fontSize: "0.75rem",
+              color: "var(--text-muted)",
+              marginBottom: "var(--sp-4)",
+            }}
+          >
+            Environment variables override config file values. These are
+            currently set in the server process.
+          </p>
+
+          {vars.length === 0 ? (
+            <div
+              style={{
+                textAlign: "center",
+                padding: "var(--sp-6)",
+                color: "var(--text-muted)",
+                fontSize: "0.85rem",
+              }}
+            >
+              No SRUNX_* environment variables are currently set
+            </div>
+          ) : (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--sp-2)",
+              }}
+            >
+              {vars.map((v) => (
+                <div
+                  key={v.name}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "var(--sp-3)",
+                    padding: "var(--sp-3) var(--sp-4)",
+                    background: "var(--bg-base)",
+                    borderRadius: "var(--radius-md)",
+                    border: "1px solid var(--border-ghost)",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.8rem",
+                      color: "var(--accent)",
+                      minWidth: 240,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {v.name}
+                  </span>
+                  <span
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.8rem",
+                      color: "var(--text-primary)",
+                      flex: 1,
+                    }}
+                  >
+                    {v.value}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: "0.7rem",
+                      color: "var(--text-muted)",
+                      flexShrink: 0,
+                      maxWidth: 200,
+                    }}
+                  >
+                    {v.description}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/srunx/web/frontend/src/pages/settings/NotificationsTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/NotificationsTab.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Bell, Save, Check, AlertTriangle } from "lucide-react";
+import { config as configApi } from "../../lib/api.ts";
+import type { SrunxConfig } from "../../lib/types.ts";
+
+const SLACK_WEBHOOK_PATTERN =
+  /^https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+$/;
+
+export function NotificationsTab() {
+  const [cfg, setCfg] = useState<SrunxConfig | null>(null);
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const c = await configApi.get();
+      setCfg(c);
+      setWebhookUrl(c.notifications?.slack_webhook_url ?? "");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load config");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (success) {
+      const t = setTimeout(() => setSuccess(null), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [success]);
+
+  const isValid = !webhookUrl || SLACK_WEBHOOK_PATTERN.test(webhookUrl);
+
+  const handleSave = async () => {
+    if (!cfg || !isValid) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const updated = await configApi.update({
+        ...cfg,
+        notifications: {
+          slack_webhook_url: webhookUrl || null,
+        },
+      });
+      setCfg(updated);
+      setSuccess("Notification settings saved");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <div className="panel skeleton" style={{ height: 200 }} />;
+  }
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}
+    >
+      {error && (
+        <div
+          style={{
+            padding: "var(--sp-3) var(--sp-4)",
+            background: "var(--st-failed-dim)",
+            border: "1px solid rgba(244,63,94,0.3)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--st-failed)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+          }}
+        >
+          {error}
+        </div>
+      )}
+      {success && (
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          style={{
+            padding: "var(--sp-3) var(--sp-4)",
+            background: "var(--st-completed-dim)",
+            border: "1px solid rgba(52,211,153,0.3)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--st-completed)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+          }}
+        >
+          <Check size={14} style={{ verticalAlign: -2, marginRight: 6 }} />
+          {success}
+        </motion.div>
+      )}
+
+      <div className="panel">
+        <div className="panel-header">
+          <h3>
+            <Bell size={14} style={{ marginRight: 8, verticalAlign: -2 }} />
+            Slack
+          </h3>
+        </div>
+        <div className="panel-body">
+          <div style={{ marginBottom: "var(--sp-3)" }}>
+            <label
+              style={{
+                fontSize: "0.85rem",
+                fontWeight: 500,
+                color: "var(--text-primary)",
+                display: "block",
+                marginBottom: 4,
+              }}
+            >
+              Webhook URL
+            </label>
+            <p
+              style={{
+                fontSize: "0.75rem",
+                color: "var(--text-muted)",
+                marginBottom: "var(--sp-3)",
+              }}
+            >
+              Used for job completion/failure notifications and scheduled
+              reports.
+            </p>
+            <input
+              className="input"
+              type="url"
+              value={webhookUrl}
+              onChange={(e) => setWebhookUrl(e.target.value)}
+              placeholder="https://hooks.slack.com/services/..."
+              style={{
+                width: "100%",
+                fontFamily: "var(--font-mono)",
+                fontSize: "0.8rem",
+                borderColor:
+                  webhookUrl && !isValid ? "var(--st-failed)" : undefined,
+              }}
+            />
+            {webhookUrl && !isValid && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--sp-1)",
+                  marginTop: "var(--sp-2)",
+                  color: "var(--st-failed)",
+                  fontSize: "0.75rem",
+                }}
+              >
+                <AlertTriangle size={12} />
+                Must be a valid Slack webhook URL
+                (https://hooks.slack.com/services/...)
+              </div>
+            )}
+          </div>
+
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <button
+              className="btn btn-primary"
+              onClick={handleSave}
+              disabled={saving || !isValid}
+            >
+              <Save size={14} />
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/srunx/web/frontend/src/pages/settings/ProjectTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/ProjectTab.tsx
@@ -1,0 +1,486 @@
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import {
+  FolderOpen,
+  Plus,
+  Save,
+  Check,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { config as configApi } from "../../lib/api.ts";
+import type {
+  ProjectInfo,
+  SrunxConfig,
+  ResourceDefaultsConfig,
+  EnvironmentDefaultsConfig,
+} from "../../lib/types.ts";
+
+type FieldRowProps = {
+  label: string;
+  children: React.ReactNode;
+};
+
+function FieldRow({ label, children }: FieldRowProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "var(--sp-6)",
+        padding: "var(--sp-2) 0",
+        borderBottom: "1px solid var(--border-ghost)",
+      }}
+    >
+      <div
+        style={{
+          fontSize: "0.85rem",
+          fontWeight: 500,
+          color: "var(--text-primary)",
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ flexShrink: 0, minWidth: 200 }}>{children}</div>
+    </div>
+  );
+}
+
+export function ProjectTab() {
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [expandedMount, setExpandedMount] = useState<string | null>(null);
+  const [editConfig, setEditConfig] = useState<SrunxConfig | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const p = await configApi.listProjects();
+      setProjects(p);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load projects");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (success) {
+      const t = setTimeout(() => setSuccess(null), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [success]);
+
+  const handleExpand = async (mountName: string) => {
+    if (expandedMount === mountName) {
+      setExpandedMount(null);
+      setEditConfig(null);
+      return;
+    }
+    setExpandedMount(mountName);
+    try {
+      const resp = await configApi.getProject(mountName);
+      setEditConfig(resp.config);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Failed to load project config",
+      );
+    }
+  };
+
+  const handleInit = async (mountName: string) => {
+    try {
+      setSaving(true);
+      const resp = await configApi.initProject(mountName);
+      setEditConfig(resp.config);
+      setSuccess(`Initialized .srunx.json for "${mountName}"`);
+      await load();
+      setExpandedMount(mountName);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to initialize");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!expandedMount || !editConfig) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const resp = await configApi.updateProject(expandedMount, editConfig);
+      setEditConfig(resp.config);
+      setSuccess(`Project config saved for "${expandedMount}"`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const updateResources = (patch: Partial<ResourceDefaultsConfig>) => {
+    if (!editConfig) return;
+    setEditConfig({
+      ...editConfig,
+      resources: { ...editConfig.resources, ...patch },
+    });
+  };
+
+  const updateEnvironment = (patch: Partial<EnvironmentDefaultsConfig>) => {
+    if (!editConfig) return;
+    setEditConfig({
+      ...editConfig,
+      environment: { ...editConfig.environment, ...patch },
+    });
+  };
+
+  if (loading) {
+    return <div className="panel skeleton" style={{ height: 200 }} />;
+  }
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}
+    >
+      {error && (
+        <div
+          style={{
+            padding: "var(--sp-3) var(--sp-4)",
+            background: "var(--st-failed-dim)",
+            border: "1px solid rgba(244,63,94,0.3)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--st-failed)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+          }}
+        >
+          {error}
+        </div>
+      )}
+      {success && (
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          style={{
+            padding: "var(--sp-3) var(--sp-4)",
+            background: "var(--st-completed-dim)",
+            border: "1px solid rgba(52,211,153,0.3)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--st-completed)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+          }}
+        >
+          <Check size={14} style={{ verticalAlign: -2, marginRight: 6 }} />
+          {success}
+        </motion.div>
+      )}
+
+      {projects.length === 0 && (
+        <div className="panel">
+          <div
+            className="panel-body"
+            style={{ textAlign: "center", padding: "var(--sp-8)" }}
+          >
+            <p
+              style={{
+                color: "var(--text-muted)",
+                fontSize: "0.85rem",
+                marginBottom: "var(--sp-2)",
+              }}
+            >
+              No projects found
+            </p>
+            <p style={{ color: "var(--text-muted)", fontSize: "0.75rem" }}>
+              Projects are derived from mounts in the active SSH profile. Add
+              mounts in the SSH Profiles tab first.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {projects.map((proj) => {
+        const isExpanded = expandedMount === proj.mount_name;
+
+        return (
+          <div key={proj.mount_name} className="panel">
+            <div
+              className="panel-header"
+              style={{ cursor: "pointer" }}
+              onClick={() => handleExpand(proj.mount_name)}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--sp-3)",
+                }}
+              >
+                <FolderOpen size={14} />
+                <h3 style={{ textTransform: "none", letterSpacing: 0 }}>
+                  {proj.mount_name}
+                </h3>
+                <span
+                  className={
+                    proj.config_exists
+                      ? "badge badge-completed"
+                      : "badge badge-cancelled"
+                  }
+                  style={{ fontSize: "0.6rem" }}
+                >
+                  {proj.config_exists ? ".srunx.json" : "NO CONFIG"}
+                </span>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--sp-3)",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.7rem",
+                    color: "var(--text-muted)",
+                  }}
+                >
+                  {proj.local_path}
+                </span>
+                {isExpanded ? (
+                  <ChevronUp size={14} />
+                ) : (
+                  <ChevronDown size={14} />
+                )}
+              </div>
+            </div>
+
+            {isExpanded && (
+              <div className="panel-body">
+                {/* Path info */}
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 1fr",
+                    gap: "var(--sp-3)",
+                    marginBottom: "var(--sp-4)",
+                  }}
+                >
+                  <div>
+                    <span
+                      style={{
+                        fontSize: "0.7rem",
+                        color: "var(--text-muted)",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.08em",
+                      }}
+                    >
+                      Local
+                    </span>
+                    <div
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                        color: "var(--text-secondary)",
+                        marginTop: 2,
+                      }}
+                    >
+                      {proj.local_path}
+                    </div>
+                  </div>
+                  <div>
+                    <span
+                      style={{
+                        fontSize: "0.7rem",
+                        color: "var(--text-muted)",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.08em",
+                      }}
+                    >
+                      Remote
+                    </span>
+                    <div
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                        color: "var(--text-secondary)",
+                        marginTop: 2,
+                      }}
+                    >
+                      {proj.remote_path}
+                    </div>
+                  </div>
+                </div>
+
+                {!proj.config_exists && !editConfig ? (
+                  <button
+                    className="btn btn-primary"
+                    onClick={() => handleInit(proj.mount_name)}
+                    disabled={saving}
+                  >
+                    <Plus size={14} />
+                    Initialize .srunx.json
+                  </button>
+                ) : editConfig ? (
+                  <div>
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: "var(--sp-3)",
+                        borderBottom: "1px solid var(--border-ghost)",
+                        paddingBottom: "var(--sp-3)",
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontSize: "0.75rem",
+                          fontWeight: 500,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.08em",
+                          color: "var(--text-muted)",
+                        }}
+                      >
+                        Project Config
+                      </span>
+                      <button
+                        className="btn btn-primary"
+                        onClick={handleSave}
+                        disabled={saving}
+                        style={{ fontSize: "0.7rem", padding: "4px 10px" }}
+                      >
+                        <Save size={12} />
+                        {saving ? "Saving..." : "Save"}
+                      </button>
+                    </div>
+
+                    <FieldRow label="Nodes">
+                      <input
+                        className="input"
+                        type="number"
+                        value={editConfig.resources.nodes}
+                        min={1}
+                        onChange={(e) => {
+                          const n = Number(e.target.value);
+                          if (!Number.isNaN(n)) updateResources({ nodes: n });
+                        }}
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                    <FieldRow label="GPUs per Node">
+                      <input
+                        className="input"
+                        type="number"
+                        value={editConfig.resources.gpus_per_node}
+                        min={0}
+                        onChange={(e) => {
+                          const n = Number(e.target.value);
+                          if (!Number.isNaN(n))
+                            updateResources({ gpus_per_node: n });
+                        }}
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Partition">
+                      <input
+                        className="input"
+                        type="text"
+                        value={editConfig.resources.partition ?? ""}
+                        onChange={(e) =>
+                          updateResources({ partition: e.target.value || null })
+                        }
+                        placeholder="e.g. gpu"
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Time Limit">
+                      <input
+                        className="input"
+                        type="text"
+                        value={editConfig.resources.time_limit ?? ""}
+                        onChange={(e) =>
+                          updateResources({
+                            time_limit: e.target.value || null,
+                          })
+                        }
+                        placeholder="e.g. 2:00:00"
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Memory per Node">
+                      <input
+                        className="input"
+                        type="text"
+                        value={editConfig.resources.memory_per_node ?? ""}
+                        onChange={(e) =>
+                          updateResources({
+                            memory_per_node: e.target.value || null,
+                          })
+                        }
+                        placeholder="e.g. 32GB"
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Conda">
+                      <input
+                        className="input"
+                        type="text"
+                        value={editConfig.environment.conda ?? ""}
+                        onChange={(e) =>
+                          updateEnvironment({ conda: e.target.value || null })
+                        }
+                        placeholder="e.g. ml_env"
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Log Directory">
+                      <input
+                        className="input"
+                        type="text"
+                        value={editConfig.log_dir}
+                        onChange={(e) =>
+                          setEditConfig({
+                            ...editConfig,
+                            log_dir: e.target.value || "logs",
+                          })
+                        }
+                        placeholder="logs"
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                    <FieldRow label="Working Directory">
+                      <input
+                        className="input"
+                        type="text"
+                        value={editConfig.work_dir ?? ""}
+                        onChange={(e) =>
+                          setEditConfig({
+                            ...editConfig,
+                            work_dir: e.target.value || null,
+                          })
+                        }
+                        placeholder="e.g. /scratch/username"
+                        style={{ width: "100%" }}
+                      />
+                    </FieldRow>
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
@@ -1,0 +1,867 @@
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import {
+  Server,
+  Plus,
+  Trash2,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  FolderSync,
+  X,
+  Edit3,
+} from "lucide-react";
+import { config as configApi } from "../../lib/api.ts";
+import type {
+  SSHProfile,
+  SSHProfilesResponse,
+  SSHMountConfig,
+} from "../../lib/types.ts";
+
+type ProfileFormData = {
+  name: string;
+  hostname: string;
+  username: string;
+  key_filename: string;
+  port: number;
+  description: string;
+  ssh_host: string;
+  proxy_jump: string;
+};
+
+const EMPTY_FORM: ProfileFormData = {
+  name: "",
+  hostname: "",
+  username: "",
+  key_filename: "",
+  port: 22,
+  description: "",
+  ssh_host: "",
+  proxy_jump: "",
+};
+
+type TabStatusProps = {
+  error: string | null;
+  success: string | null;
+};
+
+function TabStatus({ error, success }: TabStatusProps) {
+  return (
+    <>
+      {error && (
+        <div
+          style={{
+            padding: "var(--sp-3) var(--sp-4)",
+            background: "var(--st-failed-dim)",
+            border: "1px solid rgba(244,63,94,0.3)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--st-failed)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+          }}
+        >
+          {error}
+        </div>
+      )}
+      {success && (
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          style={{
+            padding: "var(--sp-3) var(--sp-4)",
+            background: "var(--st-completed-dim)",
+            border: "1px solid rgba(52,211,153,0.3)",
+            borderRadius: "var(--radius-md)",
+            color: "var(--st-completed)",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+          }}
+        >
+          <Check size={14} style={{ verticalAlign: -2, marginRight: 6 }} />
+          {success}
+        </motion.div>
+      )}
+    </>
+  );
+}
+
+export function SSHProfilesTab() {
+  const [data, setData] = useState<SSHProfilesResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [form, setForm] = useState<ProfileFormData>(EMPTY_FORM);
+  const [expandedProfile, setExpandedProfile] = useState<string | null>(null);
+  const [editingProfile, setEditingProfile] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<ProfileFormData>(EMPTY_FORM);
+  const [newMount, setNewMount] = useState<SSHMountConfig>({
+    name: "",
+    local: "",
+    remote: "",
+  });
+  const [newEnvKey, setNewEnvKey] = useState("");
+  const [newEnvValue, setNewEnvValue] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await configApi.sshProfiles();
+      setData(res);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load profiles");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    if (success) {
+      const t = setTimeout(() => setSuccess(null), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [success]);
+
+  const handleAdd = async () => {
+    if (!form.name || !form.hostname || !form.username || !form.key_filename)
+      return;
+    try {
+      await configApi.addSSHProfile({
+        name: form.name,
+        hostname: form.hostname,
+        username: form.username,
+        key_filename: form.key_filename,
+        port: form.port,
+        description: form.description || undefined,
+        ssh_host: form.ssh_host || undefined,
+        proxy_jump: form.proxy_jump || undefined,
+      });
+      setForm(EMPTY_FORM);
+      setShowAddForm(false);
+      setSuccess(`Profile "${form.name}" added`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add profile");
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    if (!window.confirm(`Delete profile "${name}"?`)) return;
+    try {
+      await configApi.deleteSSHProfile(name);
+      setSuccess(`Profile "${name}" deleted`);
+      if (expandedProfile === name) setExpandedProfile(null);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete profile");
+    }
+  };
+
+  const handleActivate = async (name: string) => {
+    try {
+      await configApi.activateSSHProfile(name);
+      setSuccess(`Profile "${name}" activated`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to activate profile");
+    }
+  };
+
+  const startEdit = (name: string, profile: SSHProfile) => {
+    setEditingProfile(name);
+    setEditForm({
+      name,
+      hostname: profile.hostname,
+      username: profile.username,
+      key_filename: profile.key_filename,
+      port: profile.port,
+      description: profile.description ?? "",
+      ssh_host: profile.ssh_host ?? "",
+      proxy_jump: profile.proxy_jump ?? "",
+    });
+  };
+
+  const handleUpdate = async () => {
+    if (!editingProfile) return;
+    try {
+      await configApi.updateSSHProfile(editingProfile, {
+        hostname: editForm.hostname,
+        username: editForm.username,
+        key_filename: editForm.key_filename,
+        port: editForm.port,
+        description: editForm.description || null,
+        ssh_host: editForm.ssh_host || null,
+        proxy_jump: editForm.proxy_jump || null,
+      });
+      setEditingProfile(null);
+      setSuccess(`Profile "${editingProfile}" updated`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update profile");
+    }
+  };
+
+  const handleAddMount = async (profileName: string) => {
+    if (!newMount.name || !newMount.local || !newMount.remote) return;
+    try {
+      await configApi.addSSHMount(profileName, newMount);
+      setNewMount({ name: "", local: "", remote: "" });
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add mount");
+    }
+  };
+
+  const handleRemoveMount = async (profileName: string, mountName: string) => {
+    try {
+      await configApi.removeSSHMount(profileName, mountName);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to remove mount");
+    }
+  };
+
+  const handleAddEnvVar = async (profileName: string) => {
+    if (!newEnvKey.trim()) return;
+    try {
+      const profile = data?.profiles[profileName];
+      if (!profile) return;
+      const envVars = { ...(profile.env_vars ?? {}), [newEnvKey]: newEnvValue };
+      await configApi.updateSSHProfile(profileName, { env_vars: envVars });
+      setNewEnvKey("");
+      setNewEnvValue("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add env var");
+    }
+  };
+
+  const handleRemoveEnvVar = async (profileName: string, key: string) => {
+    try {
+      const profile = data?.profiles[profileName];
+      if (!profile) return;
+      const envVars = { ...(profile.env_vars ?? {}) };
+      delete envVars[key];
+      await configApi.updateSSHProfile(profileName, { env_vars: envVars });
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to remove env var");
+    }
+  };
+
+  if (loading) {
+    return <div className="panel skeleton" style={{ height: 200 }} />;
+  }
+
+  const profiles = data ? Object.entries(data.profiles) : [];
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: "var(--sp-4)" }}
+    >
+      <TabStatus error={error} success={success} />
+
+      {/* Profile list */}
+      {profiles.map(([name, profile]) => {
+        const isActive = data?.current === name;
+        const isExpanded = expandedProfile === name;
+        const isEditing = editingProfile === name;
+
+        return (
+          <div key={name} className="panel">
+            {/* Header */}
+            <div
+              className="panel-header"
+              style={{ cursor: "pointer" }}
+              onClick={() => setExpandedProfile(isExpanded ? null : name)}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--sp-3)",
+                }}
+              >
+                <Server size={14} />
+                <h3 style={{ textTransform: "none", letterSpacing: 0 }}>
+                  {name}
+                </h3>
+                {isActive && (
+                  <span
+                    className="badge badge-completed"
+                    style={{ fontSize: "0.65rem" }}
+                  >
+                    ACTIVE
+                  </span>
+                )}
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.75rem",
+                    color: "var(--text-muted)",
+                  }}
+                >
+                  {profile.username}@{profile.hostname}:{profile.port}
+                </span>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--sp-2)",
+                }}
+              >
+                {!isActive && (
+                  <button
+                    className="btn btn-ghost"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleActivate(name);
+                    }}
+                    style={{ padding: "4px 8px", fontSize: "0.7rem" }}
+                  >
+                    Activate
+                  </button>
+                )}
+                <button
+                  className="btn btn-ghost"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isEditing) {
+                      setEditingProfile(null);
+                    } else {
+                      startEdit(name, profile);
+                      setExpandedProfile(name);
+                    }
+                  }}
+                  style={{ padding: "4px 8px" }}
+                >
+                  <Edit3 size={12} />
+                </button>
+                <button
+                  className="btn btn-danger"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(name);
+                  }}
+                  style={{ padding: "4px 8px" }}
+                >
+                  <Trash2 size={12} />
+                </button>
+                {isExpanded ? (
+                  <ChevronUp size={14} />
+                ) : (
+                  <ChevronDown size={14} />
+                )}
+              </div>
+            </div>
+
+            {/* Expanded content */}
+            {isExpanded && (
+              <div className="panel-body">
+                {/* Edit form */}
+                {isEditing ? (
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr 1fr",
+                      gap: "var(--sp-3)",
+                      marginBottom: "var(--sp-4)",
+                    }}
+                  >
+                    {(
+                      [
+                        ["hostname", "Hostname"],
+                        ["username", "Username"],
+                        ["key_filename", "Key File"],
+                        ["port", "Port"],
+                        ["description", "Description"],
+                        ["ssh_host", "SSH Host"],
+                        ["proxy_jump", "ProxyJump"],
+                      ] as const
+                    ).map(([field, label]) => (
+                      <div key={field}>
+                        <label
+                          style={{
+                            fontSize: "0.7rem",
+                            color: "var(--text-muted)",
+                            textTransform: "uppercase",
+                            letterSpacing: "0.08em",
+                          }}
+                        >
+                          {label}
+                        </label>
+                        <input
+                          className="input"
+                          type={field === "port" ? "number" : "text"}
+                          value={editForm[field]}
+                          onChange={(e) =>
+                            setEditForm({
+                              ...editForm,
+                              [field]:
+                                field === "port"
+                                  ? Number(e.target.value)
+                                  : e.target.value,
+                            })
+                          }
+                          style={{ width: "100%", marginTop: 4 }}
+                        />
+                      </div>
+                    ))}
+                    <div
+                      style={{
+                        gridColumn: "1 / -1",
+                        display: "flex",
+                        gap: "var(--sp-2)",
+                        justifyContent: "flex-end",
+                      }}
+                    >
+                      <button
+                        className="btn btn-ghost"
+                        onClick={() => setEditingProfile(null)}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        className="btn btn-primary"
+                        onClick={handleUpdate}
+                      >
+                        Save Changes
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr 1fr",
+                      gap: "var(--sp-2)",
+                      marginBottom: "var(--sp-4)",
+                    }}
+                  >
+                    {[
+                      ["Key File", profile.key_filename],
+                      ["Description", profile.description],
+                      ["SSH Host", profile.ssh_host],
+                      ["ProxyJump", profile.proxy_jump],
+                    ]
+                      .filter(([, v]) => v)
+                      .map(([label, value]) => (
+                        <div key={label}>
+                          <span
+                            style={{
+                              fontSize: "0.7rem",
+                              color: "var(--text-muted)",
+                              textTransform: "uppercase",
+                              letterSpacing: "0.08em",
+                            }}
+                          >
+                            {label}
+                          </span>
+                          <div
+                            style={{
+                              fontFamily: "var(--font-mono)",
+                              fontSize: "0.8rem",
+                              color: "var(--text-secondary)",
+                              marginTop: 2,
+                            }}
+                          >
+                            {value}
+                          </div>
+                        </div>
+                      ))}
+                  </div>
+                )}
+
+                {/* Mounts */}
+                <div
+                  style={{
+                    borderTop: "1px solid var(--border-ghost)",
+                    paddingTop: "var(--sp-4)",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "var(--sp-2)",
+                      marginBottom: "var(--sp-3)",
+                    }}
+                  >
+                    <FolderSync size={14} color="var(--text-muted)" />
+                    <span
+                      style={{
+                        fontSize: "0.75rem",
+                        fontWeight: 500,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.08em",
+                        color: "var(--text-muted)",
+                      }}
+                    >
+                      Mounts
+                    </span>
+                  </div>
+                  {profile.mounts.map((m) => (
+                    <div
+                      key={m.name}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "var(--sp-2)",
+                        padding: "var(--sp-2) var(--sp-3)",
+                        background: "var(--bg-base)",
+                        borderRadius: "var(--radius-md)",
+                        border: "1px solid var(--border-ghost)",
+                        marginBottom: "var(--sp-2)",
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                          color: "var(--accent)",
+                          minWidth: 80,
+                        }}
+                      >
+                        {m.name}
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.75rem",
+                          color: "var(--text-secondary)",
+                          flex: 1,
+                        }}
+                      >
+                        {m.local} &rarr; {m.remote}
+                      </span>
+                      <button
+                        onClick={() => handleRemoveMount(name, m.name)}
+                        style={{
+                          background: "transparent",
+                          border: "none",
+                          color: "var(--text-muted)",
+                          cursor: "pointer",
+                          padding: 4,
+                          display: "flex",
+                        }}
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                  ))}
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "var(--sp-2)",
+                      alignItems: "center",
+                    }}
+                  >
+                    <input
+                      className="input"
+                      placeholder="name"
+                      value={newMount.name}
+                      onChange={(e) =>
+                        setNewMount({ ...newMount, name: e.target.value })
+                      }
+                      style={{
+                        width: 100,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                      }}
+                    />
+                    <input
+                      className="input"
+                      placeholder="local path"
+                      value={newMount.local}
+                      onChange={(e) =>
+                        setNewMount({ ...newMount, local: e.target.value })
+                      }
+                      style={{
+                        flex: 1,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                      }}
+                    />
+                    <input
+                      className="input"
+                      placeholder="remote path"
+                      value={newMount.remote}
+                      onChange={(e) =>
+                        setNewMount({ ...newMount, remote: e.target.value })
+                      }
+                      style={{
+                        flex: 1,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                      }}
+                    />
+                    <button
+                      className="btn btn-ghost"
+                      onClick={() => handleAddMount(name)}
+                      disabled={
+                        !newMount.name || !newMount.local || !newMount.remote
+                      }
+                      style={{ padding: "var(--sp-2)" }}
+                    >
+                      <Plus size={14} />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Profile Env Vars */}
+                <div
+                  style={{
+                    borderTop: "1px solid var(--border-ghost)",
+                    paddingTop: "var(--sp-4)",
+                    marginTop: "var(--sp-4)",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "0.75rem",
+                      fontWeight: 500,
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      color: "var(--text-muted)",
+                      marginBottom: "var(--sp-3)",
+                      display: "block",
+                    }}
+                  >
+                    Environment Variables
+                  </span>
+                  {Object.entries(profile.env_vars ?? {}).map(([k, v]) => (
+                    <div
+                      key={k}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "var(--sp-2)",
+                        padding: "var(--sp-2) var(--sp-3)",
+                        background: "var(--bg-base)",
+                        borderRadius: "var(--radius-md)",
+                        border: "1px solid var(--border-ghost)",
+                        marginBottom: "var(--sp-2)",
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                          color: "var(--accent)",
+                          minWidth: 100,
+                        }}
+                      >
+                        {k}
+                      </span>
+                      <span
+                        style={{
+                          color: "var(--text-muted)",
+                          fontSize: "0.8rem",
+                        }}
+                      >
+                        =
+                      </span>
+                      <span
+                        style={{
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                          color: "var(--text-secondary)",
+                          flex: 1,
+                        }}
+                      >
+                        {v}
+                      </span>
+                      <button
+                        onClick={() => handleRemoveEnvVar(name, k)}
+                        style={{
+                          background: "transparent",
+                          border: "none",
+                          color: "var(--text-muted)",
+                          cursor: "pointer",
+                          padding: 4,
+                          display: "flex",
+                        }}
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                  ))}
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "var(--sp-2)",
+                      alignItems: "center",
+                    }}
+                  >
+                    <input
+                      className="input"
+                      placeholder="KEY"
+                      value={newEnvKey}
+                      onChange={(e) => setNewEnvKey(e.target.value)}
+                      style={{
+                        width: 120,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                      }}
+                      onKeyDown={(e) =>
+                        e.key === "Enter" && handleAddEnvVar(name)
+                      }
+                    />
+                    <span
+                      style={{ color: "var(--text-muted)", fontSize: "0.8rem" }}
+                    >
+                      =
+                    </span>
+                    <input
+                      className="input"
+                      placeholder="value"
+                      value={newEnvValue}
+                      onChange={(e) => setNewEnvValue(e.target.value)}
+                      style={{
+                        flex: 1,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                      }}
+                      onKeyDown={(e) =>
+                        e.key === "Enter" && handleAddEnvVar(name)
+                      }
+                    />
+                    <button
+                      className="btn btn-ghost"
+                      onClick={() => handleAddEnvVar(name)}
+                      disabled={!newEnvKey.trim()}
+                      style={{ padding: "var(--sp-2)" }}
+                    >
+                      <Plus size={14} />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {profiles.length === 0 && !showAddForm && (
+        <div
+          style={{
+            textAlign: "center",
+            padding: "var(--sp-8)",
+            color: "var(--text-muted)",
+            fontSize: "0.85rem",
+          }}
+        >
+          No SSH profiles configured
+        </div>
+      )}
+
+      {/* Add profile form */}
+      {showAddForm ? (
+        <div className="panel">
+          <div className="panel-header">
+            <h3>New SSH Profile</h3>
+          </div>
+          <div className="panel-body">
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: "var(--sp-3)",
+              }}
+            >
+              {(
+                [
+                  ["name", "Profile Name", "text", true],
+                  ["hostname", "Hostname", "text", true],
+                  ["username", "Username", "text", true],
+                  ["key_filename", "Key File", "text", true],
+                  ["port", "Port", "number", false],
+                  ["description", "Description", "text", false],
+                  ["ssh_host", "SSH Host", "text", false],
+                  ["proxy_jump", "ProxyJump", "text", false],
+                ] as const
+              ).map(([field, label, type, required]) => (
+                <div key={field}>
+                  <label
+                    style={{
+                      fontSize: "0.7rem",
+                      color: "var(--text-muted)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                    }}
+                  >
+                    {label}
+                    {required && (
+                      <span style={{ color: "var(--st-failed)" }}> *</span>
+                    )}
+                  </label>
+                  <input
+                    className="input"
+                    type={type}
+                    value={form[field]}
+                    onChange={(e) =>
+                      setForm({
+                        ...form,
+                        [field]:
+                          type === "number"
+                            ? Number(e.target.value)
+                            : e.target.value,
+                      })
+                    }
+                    style={{ width: "100%", marginTop: 4 }}
+                  />
+                </div>
+              ))}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                gap: "var(--sp-2)",
+                justifyContent: "flex-end",
+                marginTop: "var(--sp-4)",
+              }}
+            >
+              <button
+                className="btn btn-ghost"
+                onClick={() => {
+                  setShowAddForm(false);
+                  setForm(EMPTY_FORM);
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn btn-primary"
+                onClick={handleAdd}
+                disabled={
+                  !form.name ||
+                  !form.hostname ||
+                  !form.username ||
+                  !form.key_filename
+                }
+              >
+                <Plus size={14} />
+                Add Profile
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <button
+          className="btn btn-ghost"
+          onClick={() => setShowAddForm(true)}
+          style={{ alignSelf: "flex-start" }}
+        >
+          <Plus size={14} />
+          Add Profile
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/srunx/web/routers/config.py
+++ b/src/srunx/web/routers/config.py
@@ -1,0 +1,421 @@
+"""Configuration management endpoints: /api/config"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ValidationError
+
+from srunx.config import (
+    SrunxConfig,
+    create_example_config,
+    get_config,
+    get_config_paths,
+    load_config_from_file,
+    save_user_config,
+)
+
+router = APIRouter(prefix="/api/config", tags=["config"])
+
+# ── Shared models ────────────────────────────────────────────────────────────
+
+
+class ConfigPathInfo(BaseModel):
+    path: str
+    exists: bool
+    source: str
+
+
+# ── General config endpoints (existing) ─────────────────────────────────────
+
+
+@router.get("")
+async def get_current_config() -> dict[str, Any]:
+    """Return the current merged configuration."""
+    config = get_config(reload=True)
+    return config.model_dump()
+
+
+@router.put("")
+async def update_config(body: dict[str, Any]) -> dict[str, Any]:
+    """Validate and save configuration to the user config file."""
+    try:
+        config = SrunxConfig.model_validate(body)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from e
+
+    try:
+        save_user_config(config)
+    except OSError as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to write config file: {e}"
+        ) from e
+
+    updated = get_config(reload=True)
+    return updated.model_dump()
+
+
+@router.get("/paths")
+async def get_paths() -> list[ConfigPathInfo]:
+    """Return all config file paths with their existence status."""
+    sources = ["system", "user", "project (.srunx.json)", "project (srunx.json)"]
+    paths = get_config_paths()
+    return [
+        ConfigPathInfo(
+            path=str(p),
+            exists=p.exists(),
+            source=sources[i] if i < len(sources) else f"config-{i}",
+        )
+        for i, p in enumerate(paths)
+    ]
+
+
+@router.post("/reset")
+async def reset_config() -> dict[str, Any]:
+    """Reset user config to defaults by saving a fresh SrunxConfig."""
+    default_config = SrunxConfig()
+    save_user_config(default_config)
+    updated = get_config(reload=True)
+    return updated.model_dump()
+
+
+# ── SSH Profile endpoints ────────────────────────────────────────────────────
+
+
+def _get_config_manager():
+    """Instantiate ConfigManager per-request to read fresh state from disk."""
+    from srunx.ssh.core.config import ConfigManager
+
+    return ConfigManager()
+
+
+class SSHProfileCreateRequest(BaseModel):
+    name: str
+    hostname: str
+    username: str
+    key_filename: str
+    port: int = 22
+    description: str | None = None
+    ssh_host: str | None = None
+    proxy_jump: str | None = None
+
+
+class MountCreateRequest(BaseModel):
+    name: str
+    local: str
+    remote: str
+
+
+@router.get("/ssh/profiles")
+async def list_ssh_profiles() -> dict[str, Any]:
+    """List all SSH profiles and the current active profile."""
+    cm = _get_config_manager()
+    profiles = cm.list_profiles()
+    return {
+        "current": cm.get_current_profile_name(),
+        "profiles": {name: p.model_dump() for name, p in profiles.items()},
+    }
+
+
+@router.post("/ssh/profiles")
+async def add_ssh_profile(body: SSHProfileCreateRequest) -> dict[str, Any]:
+    """Add a new SSH profile."""
+    from srunx.ssh.core.config import ServerProfile
+
+    cm = _get_config_manager()
+    if cm.get_profile(body.name):
+        raise HTTPException(
+            status_code=409, detail=f"Profile '{body.name}' already exists"
+        )
+
+    profile = ServerProfile(
+        hostname=body.hostname,
+        username=body.username,
+        key_filename=body.key_filename,
+        port=body.port,
+        description=body.description,
+        ssh_host=body.ssh_host,
+        proxy_jump=body.proxy_jump,
+    )
+    cm.add_profile(body.name, profile)
+    return profile.model_dump()
+
+
+@router.put("/ssh/profiles/{name}")
+async def update_ssh_profile(name: str, body: dict[str, Any]) -> dict[str, Any]:
+    """Update an existing SSH profile."""
+    cm = _get_config_manager()
+    if not cm.get_profile(name):
+        raise HTTPException(status_code=404, detail=f"Profile '{name}' not found")
+
+    # Filter to only valid ServerProfile fields
+    valid_fields = {
+        "hostname",
+        "username",
+        "key_filename",
+        "port",
+        "description",
+        "ssh_host",
+        "proxy_jump",
+        "env_vars",
+    }
+    update_data = {k: v for k, v in body.items() if k in valid_fields}
+    cm.update_profile(name, **update_data)
+
+    updated = cm.get_profile(name)
+    return updated.model_dump() if updated else {}
+
+
+@router.delete("/ssh/profiles/{name}")
+async def delete_ssh_profile(name: str) -> dict[str, bool]:
+    """Delete an SSH profile."""
+    cm = _get_config_manager()
+    if not cm.remove_profile(name):
+        raise HTTPException(status_code=404, detail=f"Profile '{name}' not found")
+    return {"ok": True}
+
+
+@router.post("/ssh/profiles/{name}/activate")
+async def activate_ssh_profile(name: str) -> dict[str, bool]:
+    """Set an SSH profile as the current active profile."""
+    cm = _get_config_manager()
+    if not cm.set_current_profile(name):
+        raise HTTPException(status_code=404, detail=f"Profile '{name}' not found")
+    return {"ok": True}
+
+
+@router.post("/ssh/profiles/{name}/mounts")
+async def add_profile_mount(name: str, body: MountCreateRequest) -> dict[str, Any]:
+    """Add a mount to an SSH profile."""
+    from srunx.ssh.core.config import MountConfig
+
+    cm = _get_config_manager()
+    if not cm.get_profile(name):
+        raise HTTPException(status_code=404, detail=f"Profile '{name}' not found")
+
+    try:
+        mount = MountConfig(name=body.name, local=body.local, remote=body.remote)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+
+    cm.add_profile_mount(name, mount)
+    return mount.model_dump()
+
+
+@router.delete("/ssh/profiles/{name}/mounts/{mount_name}")
+async def remove_profile_mount(name: str, mount_name: str) -> dict[str, bool]:
+    """Remove a mount from an SSH profile."""
+    cm = _get_config_manager()
+    if not cm.remove_profile_mount(name, mount_name):
+        raise HTTPException(status_code=404, detail="Mount not found")
+    return {"ok": True}
+
+
+# ── Environment variables endpoint ──────────────────────────────────────────
+
+_ENV_VAR_DESCRIPTIONS: dict[str, str] = {
+    "SRUNX_DEFAULT_NODES": "Default number of compute nodes",
+    "SRUNX_DEFAULT_GPUS_PER_NODE": "Default GPUs per node",
+    "SRUNX_DEFAULT_NTASKS_PER_NODE": "Default tasks per node",
+    "SRUNX_DEFAULT_CPUS_PER_TASK": "Default CPUs per task",
+    "SRUNX_DEFAULT_MEMORY_PER_NODE": "Default memory per node (e.g. 32GB)",
+    "SRUNX_DEFAULT_TIME_LIMIT": "Default time limit (e.g. 2:00:00)",
+    "SRUNX_DEFAULT_NODELIST": "Default nodelist",
+    "SRUNX_DEFAULT_PARTITION": "Default SLURM partition",
+    "SRUNX_DEFAULT_CONDA": "Default conda environment",
+    "SRUNX_DEFAULT_VENV": "Default virtual environment path",
+    "SRUNX_DEFAULT_CONTAINER": "Default container image",
+    "SRUNX_DEFAULT_CONTAINER_RUNTIME": "Default container runtime",
+    "SRUNX_DEFAULT_LOG_DIR": "Default log directory",
+    "SRUNX_DEFAULT_WORK_DIR": "Default working directory",
+    "SRUNX_SSH_PROFILE": "SSH profile for web server",
+    "SRUNX_SSH_HOSTNAME": "SSH hostname for web server",
+    "SRUNX_SSH_USERNAME": "SSH username for web server",
+    "SRUNX_SSH_KEY": "SSH key path for web server",
+    "SRUNX_SSH_PORT": "SSH port for web server",
+    "SRUNX_WORKFLOW_DIR": "Workflow directory for web server",
+    "SRUNX_TEMP_DIR": "Temporary directory for SSH operations",
+    "SLACK_WEBHOOK_URL": "Slack webhook URL for notifications",
+}
+
+
+class EnvVarInfo(BaseModel):
+    name: str
+    value: str
+    description: str
+
+
+@router.get("/env")
+async def get_env_vars() -> list[EnvVarInfo]:
+    """Return all SRUNX_* and SLACK_WEBHOOK_URL environment variables currently set."""
+    result: list[EnvVarInfo] = []
+    for name, description in sorted(_ENV_VAR_DESCRIPTIONS.items()):
+        value = os.environ.get(name)
+        if value is not None:
+            result.append(EnvVarInfo(name=name, value=value, description=description))
+    return result
+
+
+# ── Project config endpoints (mount-based) ──────────────────────────────────
+
+
+class ProjectInfo(BaseModel):
+    mount_name: str
+    local_path: str
+    remote_path: str
+    config_exists: bool
+    config_path: str
+
+
+class ProjectConfigResponse(BaseModel):
+    mount_name: str
+    local_path: str
+    config_path: str
+    exists: bool
+    config: dict[str, Any] | None
+
+
+def _resolve_project_path(local_dir: str) -> Path:
+    """Find .srunx.json or srunx.json in a local directory."""
+    local = Path(local_dir).expanduser().resolve()
+    for filename in [".srunx.json", "srunx.json"]:
+        candidate = local / filename
+        if candidate.exists():
+            return candidate
+    return local / ".srunx.json"
+
+
+def _get_mount_from_profile(mount_name: str) -> tuple[str, str]:
+    """Get (local, remote) paths for a mount from the current SSH profile."""
+    cm = _get_config_manager()
+    current_name = cm.get_current_profile_name()
+    if not current_name:
+        raise HTTPException(
+            status_code=400, detail="No active SSH profile. Activate a profile first."
+        )
+    profile = cm.get_profile(current_name)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Active profile not found")
+
+    for m in profile.mounts:
+        if m.name == mount_name:
+            return m.local, m.remote
+
+    raise HTTPException(
+        status_code=404,
+        detail=f"Mount '{mount_name}' not found in profile '{current_name}'",
+    )
+
+
+@router.get("/projects")
+async def list_projects() -> list[ProjectInfo]:
+    """List projects from the current SSH profile's mounts."""
+    cm = _get_config_manager()
+    current_name = cm.get_current_profile_name()
+    if not current_name:
+        return []
+
+    profile = cm.get_profile(current_name)
+    if not profile:
+        return []
+
+    result: list[ProjectInfo] = []
+    for m in profile.mounts:
+        config_path = _resolve_project_path(m.local)
+        result.append(
+            ProjectInfo(
+                mount_name=m.name,
+                local_path=m.local,
+                remote_path=m.remote,
+                config_exists=config_path.exists(),
+                config_path=str(config_path),
+            )
+        )
+    return result
+
+
+@router.get("/projects/{mount_name}")
+async def get_project_config(mount_name: str) -> ProjectConfigResponse:
+    """Read .srunx.json from a mount's local directory."""
+    local, _ = _get_mount_from_profile(mount_name)
+    config_path = _resolve_project_path(local)
+
+    if config_path.exists():
+        data = load_config_from_file(config_path)
+        return ProjectConfigResponse(
+            mount_name=mount_name,
+            local_path=local,
+            config_path=str(config_path),
+            exists=True,
+            config=data,
+        )
+
+    return ProjectConfigResponse(
+        mount_name=mount_name,
+        local_path=local,
+        config_path=str(config_path),
+        exists=False,
+        config=None,
+    )
+
+
+@router.put("/projects/{mount_name}")
+async def update_project_config(
+    mount_name: str, body: dict[str, Any]
+) -> ProjectConfigResponse:
+    """Save .srunx.json to a mount's local directory."""
+    local, _ = _get_mount_from_profile(mount_name)
+
+    try:
+        config = SrunxConfig.model_validate(body)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from e
+
+    config_path = Path(local).expanduser().resolve() / ".srunx.json"
+    try:
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump(config.model_dump(exclude_unset=True), f, indent=2)
+    except OSError as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to write project config: {e}"
+        ) from e
+
+    return ProjectConfigResponse(
+        mount_name=mount_name,
+        local_path=local,
+        config_path=str(config_path),
+        exists=True,
+        config=config.model_dump(),
+    )
+
+
+@router.post("/projects/{mount_name}/init")
+async def init_project_config(mount_name: str) -> ProjectConfigResponse:
+    """Initialize .srunx.json in a mount's local directory."""
+    local, _ = _get_mount_from_profile(mount_name)
+    config_path = Path(local).expanduser().resolve() / ".srunx.json"
+
+    if config_path.exists():
+        raise HTTPException(status_code=409, detail=f"{config_path} already exists")
+
+    example = create_example_config()
+    try:
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write(example)
+    except OSError as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to create project config: {e}"
+        ) from e
+
+    data = json.loads(example)
+    return ProjectConfigResponse(
+        mount_name=mount_name,
+        local_path=local,
+        config_path=str(config_path),
+        exists=True,
+        config=data,
+    )

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -84,12 +84,35 @@ class SlurmSSHAdapter:
                     env_vars=dict(profile.env_vars) if profile.env_vars else None,
                 )
             else:
+                # Resolve hostname via ~/.ssh/config if it's an alias
+                resolved_hostname = profile.hostname
+                resolved_key = profile.key_filename
+                resolved_port = profile.port
+                resolved_proxy = profile.proxy_jump
+
+                parser = SSHConfigParser()
+                ssh_host = parser.get_host(profile.hostname)
+                if ssh_host and ssh_host.hostname:
+                    resolved_hostname = ssh_host.hostname
+                    if ssh_host.identity_file and not resolved_key:
+                        resolved_key = ssh_host.identity_file
+                    if ssh_host.port:
+                        resolved_port = ssh_host.port
+                    if ssh_host.proxy_jump and not resolved_proxy:
+                        resolved_proxy = ssh_host.proxy_jump
+
+                # Expand ~ in key_filename
+                if resolved_key:
+                    from pathlib import Path
+
+                    resolved_key = str(Path(resolved_key).expanduser())
+
                 self._client = SSHSlurmClient(
-                    hostname=profile.hostname,
+                    hostname=resolved_hostname,
                     username=profile.username,
-                    key_filename=profile.key_filename,
-                    port=profile.port,
-                    proxy_jump=profile.proxy_jump,
+                    key_filename=resolved_key,
+                    port=resolved_port,
+                    proxy_jump=resolved_proxy,
                     env_vars=dict(profile.env_vars) if profile.env_vars else None,
                 )
         elif hostname and username:


### PR DESCRIPTION
## Summary
- Add tabbed Settings page (General, SSH Profiles, Notifications, Environment, Project)
- Backend: `/api/config` endpoints for SLURM defaults, SSH profile CRUD + mounts, Slack webhook, env var overview, mount-based project config
- Fix SSH adapter to resolve `~/.ssh/config` aliases and expand `~` in key paths
- Projects derived from SSH profile mounts (no `cwd` dependency)

## Changes
### Backend
- `config.py`: Add `NotificationConfig` to `SrunxConfig`
- `web/routers/config.py`: New — 15 API endpoints for all config areas
- `web/ssh_adapter.py`: Auto-resolve SSH config aliases + tilde expansion
- `web/app.py`: Register config router

### Frontend
- `pages/Settings.tsx`: Tabbed layout (General / SSH Profiles / Notifications / Environment / Project)
- `pages/settings/SSHProfilesTab.tsx`: Profile CRUD, mount management, per-profile env vars
- `pages/settings/NotificationsTab.tsx`: Slack webhook URL with validation
- `pages/settings/EnvironmentTab.tsx`: Read-only SRUNX_* env var display
- `pages/settings/ProjectTab.tsx`: Mount-based project config init/edit
- `lib/types.ts` + `lib/api.ts`: All new types and API client methods

## Test plan
- [x] TypeScript type check (tsc --noEmit)
- [x] Python lint (ruff check) + mypy
- [x] pytest (web)
- [x] Playwright MCP browser verification (all 5 tabs)
- [ ] E2E: SSH profile add/activate + mount add + project init with live server

🤖 Generated with [Claude Code](https://claude.com/claude-code)