### PR TITLE
feat: auto-rsync mount before job submission

### DIFF
--- a/src/srunx/web/frontend/src/components/FileExplorer.tsx
+++ b/src/srunx/web/frontend/src/components/FileExplorer.tsx
@@ -189,7 +189,7 @@ function SubmitDialog({
       setSubmitting(true);
       setError(null);
       const { content } = await files.read(mountName, filePath);
-      const res = await jobs.submit(content, jobName);
+      const res = await jobs.submit(content, jobName, mountName);
       setResult(res);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Submission failed");

--- a/src/srunx/web/frontend/src/lib/api.ts
+++ b/src/srunx/web/frontend/src/lib/api.ts
@@ -63,6 +63,7 @@ export const jobs = {
   submit: async (
     scriptContent: string,
     jobName: string,
+    mountName?: string,
   ): Promise<{ name: string; job_id: number | null; status: string }> => {
     const res = await fetch("/api/jobs", {
       method: "POST",
@@ -71,6 +72,7 @@ export const jobs = {
         name: jobName,
         script_content: scriptContent,
         job_name: jobName,
+        mount_name: mountName,
       }),
     });
     if (!res.ok) {

--- a/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
@@ -602,14 +602,19 @@ export function SSHProfilesTab() {
                       }}
                     />
                     <button
-                      className="btn btn-ghost"
+                      className="btn btn-primary"
                       onClick={() => handleAddMount(name)}
                       disabled={
                         !newMount.name || !newMount.local || !newMount.remote
                       }
-                      style={{ padding: "var(--sp-2)" }}
+                      style={{
+                        padding: "var(--sp-2) var(--sp-3)",
+                        fontSize: "0.75rem",
+                        gap: 4,
+                      }}
                     >
                       <Plus size={14} />
+                      Add
                     </button>
                   </div>
                 </div>

--- a/src/srunx/web/routers/files.py
+++ b/src/srunx/web/routers/files.py
@@ -51,23 +51,10 @@ class BrowseResponse(BaseModel):
 
 
 def _get_current_profile():
-    """Get the current SSH profile from web config or ConfigManager.
+    """Get the current SSH profile from web config or ConfigManager."""
+    from ..sync_utils import get_current_profile
 
-    Returns the ServerProfile, or None if no profile is configured.
-    """
-    from srunx.ssh.core.config import ConfigManager
-
-    config = get_web_config()
-    cm = ConfigManager()
-
-    profile_name = config.ssh_profile
-    if not profile_name:
-        profile_name = cm.get_current_profile_name()
-
-    if not profile_name:
-        return None
-
-    return cm.get_profile(profile_name)
+    return get_current_profile()
 
 
 def _find_mount(profile, mount_name: str):

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import anyio
@@ -12,12 +13,14 @@ from ..deps import get_adapter
 from ..ssh_adapter import SlurmSSHAdapter
 
 router = APIRouter(prefix="/api/jobs", tags=["jobs"])
+_logger = logging.getLogger(__name__)
 
 
 class JobSubmitRequest(BaseModel):
     name: str
     script_content: str
     job_name: str | None = None
+    mount_name: str | None = None
 
 
 @router.post("", status_code=201)
@@ -25,7 +28,36 @@ async def submit_job(
     req: JobSubmitRequest,
     adapter: SlurmSSHAdapter = Depends(get_adapter),
 ) -> dict[str, Any]:
-    """Submit a new job to SLURM via SSH."""
+    """Submit a new job to SLURM via SSH.
+
+    If *mount_name* is provided, the corresponding mount is synced
+    via rsync before submission.
+    """
+    # Sync mount before submission if requested
+    if req.mount_name:
+        from ..sync_utils import get_current_profile, sync_mount_by_name
+
+        mount_name = req.mount_name
+        profile = await anyio.to_thread.run_sync(get_current_profile)
+        if profile is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No SSH profile configured; cannot sync mount",
+            )
+        try:
+            _logger.info("Syncing mount '%s' before job submission", mount_name)
+            await anyio.to_thread.run_sync(
+                lambda: sync_mount_by_name(profile, mount_name)
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=404, detail=f"Mount '{mount_name}' not found"
+            ) from exc
+        except RuntimeError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Mount sync failed: {exc}"
+            ) from exc
+
     try:
         return await anyio.to_thread.run_sync(
             lambda: adapter.submit_job(

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -445,7 +445,11 @@ async def run_workflow(
 
     from srunx.models import render_job_script
 
-    from ..sync_utils import resolve_mounts_for_workflow, sync_mount_by_name
+    from ..sync_utils import (
+        get_current_profile,
+        resolve_mounts_for_workflow,
+        sync_mount_by_name,
+    )
 
     if not _SAFE_NAME.match(name):
         raise HTTPException(status_code=422, detail="Invalid workflow name")
@@ -462,19 +466,8 @@ async def run_workflow(
     run_registry.update_status(run_id, "syncing")
 
     # ── Sync mounts ─────────────────────────────────────────────────
-    def _get_current_profile():
-        from srunx.ssh.core.config import ConfigManager
 
-        config = get_web_config()
-        cm = ConfigManager()
-        profile_name = config.ssh_profile
-        if not profile_name:
-            profile_name = cm.get_current_profile_name()
-        if not profile_name:
-            return None
-        return cm.get_profile(profile_name)
-
-    profile = await anyio.to_thread.run_sync(_get_current_profile)
+    profile = await anyio.to_thread.run_sync(get_current_profile)
 
     if profile is not None:
         # Build raw jobs data from the loaded workflow for mount resolution

--- a/src/srunx/web/sync_utils.py
+++ b/src/srunx/web/sync_utils.py
@@ -11,6 +11,31 @@ if TYPE_CHECKING:
 from srunx.sync.rsync import RsyncClient
 
 
+def get_current_profile() -> ServerProfile | None:
+    """Get the current SSH profile from web config or ConfigManager.
+
+    Checks ``SRUNX_SSH_PROFILE`` (via :func:`get_web_config`) first,
+    then falls back to :meth:`ConfigManager.get_current_profile_name`.
+
+    Returns ``None`` if no profile is configured.
+    """
+    from srunx.ssh.core.config import ConfigManager
+
+    from .config import get_web_config
+
+    config = get_web_config()
+    cm = ConfigManager()
+
+    profile_name = config.ssh_profile
+    if not profile_name:
+        profile_name = cm.get_current_profile_name()
+
+    if not profile_name:
+        return None
+
+    return cm.get_profile(profile_name)
+
+
 def build_rsync_client(profile: ServerProfile) -> RsyncClient:
     """Create RsyncClient from SSH profile, handling ssh_host vs hostname.
 


### PR DESCRIPTION
## Summary
- ジョブsubmit時に `mount_name` が指定されていれば自動でrsync実行してからsubmitする
- `get_current_profile()` を `sync_utils.py` に共通化し、`files.py` / `workflows.py` / `jobs.py` の重複を解消
- SSH Profilesのマウント追加ボタンをアイコンのみ → 「Add」ラベル付きに改善

## Test plan
- [x] `ruff check` / `mypy` / `tsc --noEmit` 全パス
- [x] `pytest` 173テストパス (1件既存の無関係な失敗)
- [x] API: `mount_name` なしsubmit → 従来通り正常動作
- [x] API: 存在しないマウント名 → 404エラー
- [x] API: 有効なマウント名 → rsync実行後にsubmit成功 (ログで確認)
- [x] Workflow実行のrsyncも引き続き正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)