### PR TITLE
fix: Explorer file viewer race condition, lazy-load, and edge cases

### DIFF
--- a/src/srunx/web/frontend/src/components/FileExplorer.tsx
+++ b/src/srunx/web/frontend/src/components/FileExplorer.tsx
@@ -46,7 +46,11 @@ hljs.registerLanguage("ini", ini);
 hljs.registerLanguage("dockerfile", dockerfile);
 
 function detectLanguage(filename: string): string | undefined {
-  const ext = filename.split(".").pop()?.toLowerCase();
+  const lower = filename.toLowerCase();
+  if (lower === "dockerfile" || lower.startsWith("dockerfile."))
+    return "dockerfile";
+  if (lower === "makefile") return "bash";
+  const ext = lower.split(".").pop();
   if (!ext) return undefined;
   const map: Record<string, string> = {
     py: "python",
@@ -1259,6 +1263,7 @@ export function FileExplorer() {
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [fileLoading, setFileLoading] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
+  const fileRequestRef = useRef(0);
 
   // Context menu
   const [contextMenu, setContextMenu] = useState<{
@@ -1378,28 +1383,35 @@ export function FileExplorer() {
   /* File select handler */
   const handleFileSelect = useCallback(
     async (mountName: string, filePath: string, fileName: string) => {
+      // Allow re-click to retry on error
       if (
         selectedFile?.mount === mountName &&
-        selectedFile?.path === filePath
+        selectedFile?.path === filePath &&
+        !fileError
       ) {
         return;
       }
+      const requestId = ++fileRequestRef.current;
       setSelectedFile({ mount: mountName, path: filePath, name: fileName });
       setFileContent(null);
       setFileLoading(true);
       setFileError(null);
       try {
         const result = await files.read(mountName, filePath);
+        if (fileRequestRef.current !== requestId) return;
         setFileContent(result.content);
       } catch (err) {
+        if (fileRequestRef.current !== requestId) return;
         setFileError(
           err instanceof Error ? err.message : "Failed to read file",
         );
       } finally {
-        setFileLoading(false);
+        if (fileRequestRef.current === requestId) {
+          setFileLoading(false);
+        }
       }
     },
-    [selectedFile],
+    [selectedFile, fileError],
   );
 
   /* Context menu handler */

--- a/src/srunx/web/frontend/src/components/Layout.tsx
+++ b/src/srunx/web/frontend/src/components/Layout.tsx
@@ -1,7 +1,10 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar.tsx";
-import { FileExplorer } from "./FileExplorer.tsx";
+
+const FileExplorer = lazy(() =>
+  import("./FileExplorer.tsx").then((m) => ({ default: m.FileExplorer })),
+);
 
 export function Layout() {
   const [explorerOpen, setExplorerOpen] = useState(false);
@@ -14,7 +17,24 @@ export function Layout() {
         onNavigate={() => setExplorerOpen(false)}
       />
       {explorerOpen ? (
-        <FileExplorer />
+        <Suspense
+          fallback={
+            <div
+              style={{
+                flex: 1,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "var(--text-muted)",
+                fontSize: "0.8rem",
+              }}
+            >
+              Loading Explorer...
+            </div>
+          }
+        >
+          <FileExplorer />
+        </Suspense>
       ) : (
         <main
           className="grid-bg"


### PR DESCRIPTION
## Summary
Follow-up to #29. Addresses review findings from automated code review.

- **Race condition fix**: Guard async file reads with request ID ref to prevent stale responses from overwriting newer file selections
- **Lazy-load**: Use `React.lazy()` for FileExplorer so highlight.js is not included in the initial bundle (main bundle 334KB → 314KB gzip, Explorer split to 21KB separate chunk)
- **Error retry**: Allow re-clicking a file to retry after read errors
- **Dockerfile detection**: Detect `Dockerfile` and `Makefile` by filename, not just extension

## Test plan
- [ ] Rapidly click multiple files in Explorer → viewer always shows the last-clicked file's content
- [ ] First page load (Dashboard) does not fetch FileExplorer chunk (check Network tab)
- [ ] Open Explorer → FileExplorer chunk is loaded on demand
- [ ] Disconnect network, click a file → error shown → reconnect, click same file → content loads
- [ ] Dockerfile without extension → syntax highlighted as dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)