### PR TITLE
refactor: store workflows per-mount in .srunx/workflows/

### DIFF
--- a/docs/reference/webui-api.rst
+++ b/docs/reference/webui-api.rst
@@ -1085,6 +1085,6 @@ The Web UI is configured via environment variables:
    * - ``SRUNX_SSH_PORT``
      - 22
      - SSH port
-   * - ``SRUNX_WORKFLOW_DIR``
-     - ``workflows/``
-     - Directory for workflow YAML files
+   * -
+     -
+     - Workflows are stored per-mount in ``<mount>/.srunx/workflows/``

--- a/src/srunx/web/config.py
+++ b/src/srunx/web/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 from pydantic import BaseModel, Field
 
@@ -11,9 +10,6 @@ class WebConfig(BaseModel):
 
     host: str = Field(default="127.0.0.1")
     port: int = Field(default=8000)
-    workflow_dir: Path = Field(
-        default_factory=lambda: Path(os.getenv("SRUNX_WORKFLOW_DIR", "workflows"))
-    )
     cors_origins: list[str] = Field(default_factory=lambda: ["http://localhost:3000"])
 
     # SSH connection — either profile_name or (hostname + username)

--- a/src/srunx/web/frontend/e2e/fixtures/mock-routes.ts
+++ b/src/srunx/web/frontend/e2e/fixtures/mock-routes.ts
@@ -54,6 +54,24 @@ export async function setupMockRoutes(page: Page) {
     return route.continue();
   });
 
+  /* ── Mounts (needed by workflows page) ─────── */
+  await page.route("**/api/files/mounts/config*", (route) => {
+    return route.fulfill({
+      json: [
+        {
+          name: "ml-project",
+          local: "/home/user/ml-project",
+          remote: "/home/user/ml-project",
+        },
+      ],
+    });
+  });
+  await page.route("**/api/files/mounts*", (route) => {
+    return route.fulfill({
+      json: [{ name: "ml-project", remote: "/home/user/ml-project" }],
+    });
+  });
+
   /* ── Workflows ─────────────────────────────── */
   await page.route("**/api/workflows/runs/*/cancel", (route) => {
     if (route.request().method() === "POST") {
@@ -114,13 +132,17 @@ export async function setupMockRoutes(page: Page) {
     });
   });
 
+  await page.route("**/api/workflows?*", (route) => {
+    return route.fulfill({ json: MOCK_WORKFLOWS });
+  });
   await page.route("**/api/workflows", (route) => {
     return route.fulfill({ json: MOCK_WORKFLOWS });
   });
 
   await page.route("**/api/workflows/*", (route) => {
     const url = route.request().url();
-    const segment = decodeURIComponent(url.split("/api/workflows/")[1]);
+    const rawSegment = url.split("/api/workflows/")[1];
+    const segment = decodeURIComponent(rawSegment.split("?")[0]);
 
     /* Let create endpoint through to its own mock */
     if (segment === "create" && route.request().method() === "POST") {

--- a/src/srunx/web/frontend/e2e/workflow-builder.spec.ts
+++ b/src/srunx/web/frontend/e2e/workflow-builder.spec.ts
@@ -15,11 +15,11 @@ test.describe("Workflow Builder", () => {
     await expect(newBtn).toBeVisible();
     await newBtn.click();
 
-    await expect(page).toHaveURL(/\/workflows\/new$/);
+    await expect(page).toHaveURL(/\/workflows\/new/);
   });
 
   test("displays empty builder canvas with toolbar", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     /* Toolbar elements */
     await expect(page.getByPlaceholder("workflow-name")).toBeVisible();
@@ -33,7 +33,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("Add Job creates a new node on the canvas", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     const addBtn = page.getByRole("button", { name: "Add Job" });
     await addBtn.click();
@@ -45,7 +45,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("adding multiple jobs creates multiple nodes", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     const addBtn = page.getByRole("button", { name: "Add Job" });
     await addBtn.click();
@@ -58,7 +58,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("clicking a node opens the property panel", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     /* Add a job */
     await page.getByRole("button", { name: "Add Job" }).click();
@@ -75,7 +75,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("editing job name in panel updates the node", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     await page.getByRole("button", { name: "Add Job" }).click();
     await expect(page.getByText("job_1")).toBeVisible();
@@ -98,7 +98,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("save shows error when workflow name is empty", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     await page.getByRole("button", { name: "Add Job" }).click();
 
@@ -110,7 +110,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("save shows validation errors for empty command", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     /* Add a job (default has empty command) */
     await page.getByRole("button", { name: "Add Job" }).click();
@@ -126,7 +126,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("successful save redirects to workflow detail", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     /* Set workflow name */
     await page.getByPlaceholder("workflow-name").fill("my-pipeline");
@@ -152,13 +152,13 @@ test.describe("Workflow Builder", () => {
     await page.getByRole("button", { name: /Save Workflow/ }).click();
 
     /* Should redirect to the workflow detail page */
-    await expect(page).toHaveURL(/\/workflows\/my-pipeline$/, {
+    await expect(page).toHaveURL(/\/workflows\/my-pipeline/, {
       timeout: 5000,
     });
   });
 
   test("save with invalid name shows error", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     /* Set invalid workflow name with spaces */
     await page.getByPlaceholder("workflow-name").fill("my pipeline");
@@ -186,7 +186,7 @@ test.describe("Workflow Builder", () => {
   });
 
   test("close button on property panel hides it", async ({ page }) => {
-    await page.goto("/workflows/new");
+    await page.goto("/workflows/new?mount=ml-project");
 
     await page.getByRole("button", { name: "Add Job" }).click();
     await expect(page.getByText("job_1")).toBeVisible();

--- a/src/srunx/web/frontend/e2e/workflow-detail.spec.ts
+++ b/src/srunx/web/frontend/e2e/workflow-detail.spec.ts
@@ -7,14 +7,14 @@ test.beforeEach(async ({ page }) => {
 
 test.describe("Workflow Detail", () => {
   test("DAG view renders with React Flow canvas", async ({ page }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     const reactFlow = page.locator(".react-flow");
     await expect(reactFlow).toBeVisible({ timeout: 10000 });
   });
 
   test("shows workflow name and job count in header", async ({ page }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     await expect(
       page.getByRole("heading", { name: "ml-pipeline" }),
@@ -23,7 +23,7 @@ test.describe("Workflow Detail", () => {
   });
 
   test("DAG/list view toggle works", async ({ page }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     /* Default is DAG view */
     await expect(page.locator(".react-flow")).toBeVisible({ timeout: 10000 });
@@ -42,7 +42,7 @@ test.describe("Workflow Detail", () => {
   });
 
   test("clicking a job in list view opens detail sidebar", async ({ page }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     /* Switch to list view */
     await page.getByRole("button", { name: /list/i }).click();
@@ -60,7 +60,7 @@ test.describe("Workflow Detail", () => {
   });
 
   test("shows error state for non-existent workflow", async ({ page }) => {
-    await page.goto("/workflows/nonexistent");
+    await page.goto("/workflows/nonexistent?mount=ml-project");
 
     await expect(page.getByText("Failed to load workflow")).toBeVisible({
       timeout: 10000,

--- a/src/srunx/web/frontend/e2e/workflow-run.spec.ts
+++ b/src/srunx/web/frontend/e2e/workflow-run.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe("Workflow Run & Lifecycle", () => {
   test("Run Workflow button is visible on detail page", async ({ page }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     await expect(
       page.getByRole("button", { name: /Run Workflow/ }),
@@ -16,7 +16,7 @@ test.describe("Workflow Run & Lifecycle", () => {
 
   test("clicking Run Workflow triggers execution", async ({ page }) => {
     let runCalled = false;
-    await page.route("**/api/workflows/ml-pipeline/run", (route) => {
+    await page.route("**/api/workflows/ml-pipeline/run*", (route) => {
       runCalled = true;
       return route.fulfill({
         status: 202,
@@ -41,7 +41,7 @@ test.describe("Workflow Run & Lifecycle", () => {
       });
     });
 
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
     await page.getByRole("button", { name: /Run Workflow/ }).click();
 
     await expect(() => expect(runCalled).toBe(true)).toPass({ timeout: 3000 });
@@ -50,7 +50,7 @@ test.describe("Workflow Run & Lifecycle", () => {
   test("Run Workflow button becomes disabled after clicking", async ({
     page,
   }) => {
-    await page.route("**/api/workflows/ml-pipeline/run", (route) => {
+    await page.route("**/api/workflows/ml-pipeline/run*", (route) => {
       return route.fulfill({
         status: 202,
         json: {
@@ -66,7 +66,7 @@ test.describe("Workflow Run & Lifecycle", () => {
       });
     });
 
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
     const runBtn = page.getByRole("button", { name: /Run Workflow/ });
     await runBtn.click();
 
@@ -75,7 +75,7 @@ test.describe("Workflow Run & Lifecycle", () => {
   });
 
   test("cancel button appears during active run", async ({ page }) => {
-    await page.route("**/api/workflows/ml-pipeline/run", (route) => {
+    await page.route("**/api/workflows/ml-pipeline/run*", (route) => {
       return route.fulfill({
         status: 202,
         json: {
@@ -91,7 +91,7 @@ test.describe("Workflow Run & Lifecycle", () => {
       });
     });
 
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     /* Cancel button should not be visible before a run starts */
     await expect(
@@ -107,7 +107,7 @@ test.describe("Workflow Run & Lifecycle", () => {
   });
 
   test("clicking Cancel sets run to cancelled", async ({ page }) => {
-    await page.route("**/api/workflows/ml-pipeline/run", (route) => {
+    await page.route("**/api/workflows/ml-pipeline/run*", (route) => {
       return route.fulfill({
         status: 202,
         json: {
@@ -123,7 +123,7 @@ test.describe("Workflow Run & Lifecycle", () => {
       });
     });
 
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
     await page.getByRole("button", { name: /Run Workflow/ }).click();
 
     /* Wait for Cancel button to appear */
@@ -137,7 +137,7 @@ test.describe("Workflow Run & Lifecycle", () => {
   });
 
   test("delete workflow navigates back to list", async ({ page }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     /* Override confirm dialog to accept */
     page.on("dialog", (dialog) => dialog.accept());
@@ -146,13 +146,13 @@ test.describe("Workflow Run & Lifecycle", () => {
     await expect(deleteBtn).toBeVisible();
     await deleteBtn.click();
 
-    await expect(page).toHaveURL(/\/workflows$/, { timeout: 3000 });
+    await expect(page).toHaveURL(/\/workflows/, { timeout: 3000 });
   });
 
   test("delete workflow is cancelled when dialog is dismissed", async ({
     page,
   }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     /* Override confirm dialog to dismiss */
     page.on("dialog", (dialog) => dialog.dismiss());
@@ -160,26 +160,26 @@ test.describe("Workflow Run & Lifecycle", () => {
     await page.getByTitle("Delete workflow").click();
 
     /* Should remain on the detail page */
-    await expect(page).toHaveURL(/\/workflows\/ml-pipeline$/);
+    await expect(page).toHaveURL(/\/workflows\/ml-pipeline/);
     await expect(
       page.getByRole("heading", { name: "ml-pipeline" }),
     ).toBeVisible();
   });
 
   test("Edit link navigates to edit page", async ({ page }) => {
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
 
     const editLink = page.getByRole("link", { name: /Edit/i });
     await expect(editLink).toBeVisible();
     await editLink.click();
 
-    await expect(page).toHaveURL(/\/workflows\/ml-pipeline\/edit$/);
+    await expect(page).toHaveURL(/\/workflows\/ml-pipeline\/edit/);
   });
 
   test("Run Workflow button is disabled during active run", async ({
     page,
   }) => {
-    await page.route("**/api/workflows/ml-pipeline/run", (route) => {
+    await page.route("**/api/workflows/ml-pipeline/run*", (route) => {
       return route.fulfill({
         status: 202,
         json: {
@@ -195,7 +195,7 @@ test.describe("Workflow Run & Lifecycle", () => {
       });
     });
 
-    await page.goto("/workflows/ml-pipeline");
+    await page.goto("/workflows/ml-pipeline?mount=ml-project");
     await page.getByRole("button", { name: /Run Workflow/ }).click();
 
     /* Button should be disabled while a run is active */

--- a/src/srunx/web/frontend/e2e/workflows.spec.ts
+++ b/src/srunx/web/frontend/e2e/workflows.spec.ts
@@ -34,7 +34,7 @@ test.describe("Workflows", () => {
     const viewBtn = page.getByRole("link", { name: "View DAG" }).first();
     await viewBtn.click();
 
-    await expect(page).toHaveURL(/\/workflows\/ml-pipeline$/);
+    await expect(page).toHaveURL(/\/workflows\/ml-pipeline/);
   });
 
   test("Upload YAML button opens file dialog", async ({ page }) => {

--- a/src/srunx/web/frontend/src/lib/api.ts
+++ b/src/srunx/web/frontend/src/lib/api.ts
@@ -103,23 +103,31 @@ export const jobs = {
 /* ── Workflows ────────────────────────────────── */
 
 export const workflows = {
-  list: async (): Promise<Workflow[]> => {
-    const res = await fetch("/api/workflows");
+  list: async (mount: string): Promise<Workflow[]> => {
+    const params = new URLSearchParams({ mount });
+    const res = await fetch(`/api/workflows?${params}`);
     if (!res.ok) throw new Error("Failed to fetch workflows");
     return res.json();
   },
 
-  get: async (name: string): Promise<Workflow> => {
-    const res = await fetch(`/api/workflows/${encodeURIComponent(name)}`);
+  get: async (name: string, mount: string): Promise<Workflow> => {
+    const params = new URLSearchParams({ mount });
+    const res = await fetch(
+      `/api/workflows/${encodeURIComponent(name)}?${params}`,
+    );
     if (!res.ok) throw new Error(`Failed to fetch workflow "${name}"`);
     return res.json();
   },
 
-  upload: async (yamlContent: string, filename: string): Promise<Workflow> => {
+  upload: async (
+    yamlContent: string,
+    filename: string,
+    mount: string,
+  ): Promise<Workflow> => {
     const res = await fetch("/api/workflows/upload", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ yaml: yamlContent, filename }),
+      body: JSON.stringify({ yaml: yamlContent, filename, mount }),
     });
     if (!res.ok) {
       const err = await res.json();
@@ -141,10 +149,12 @@ export const workflows = {
     return res.json();
   },
 
-  run: async (name: string): Promise<WorkflowRun> => {
-    const res = await fetch(`/api/workflows/${encodeURIComponent(name)}/run`, {
-      method: "POST",
-    });
+  run: async (name: string, mount: string): Promise<WorkflowRun> => {
+    const params = new URLSearchParams({ mount });
+    const res = await fetch(
+      `/api/workflows/${encodeURIComponent(name)}/run?${params}`,
+      { method: "POST" },
+    );
     if (!res.ok) {
       const err = await res.json();
       throw new Error(extractDetail(err, "Failed to run workflow"));
@@ -161,10 +171,12 @@ export const workflows = {
     return res.json();
   },
 
-  delete: async (name: string): Promise<void> => {
-    const res = await fetch(`/api/workflows/${encodeURIComponent(name)}`, {
-      method: "DELETE",
-    });
+  delete: async (name: string, mount: string): Promise<void> => {
+    const params = new URLSearchParams({ mount });
+    const res = await fetch(
+      `/api/workflows/${encodeURIComponent(name)}?${params}`,
+      { method: "DELETE" },
+    );
     if (!res.ok) {
       const err = await res.json();
       throw new Error(extractDetail(err, "Failed to delete workflow"));

--- a/src/srunx/web/frontend/src/pages/WorkflowBuilder.tsx
+++ b/src/srunx/web/frontend/src/pages/WorkflowBuilder.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import {
   ReactFlow,
   Background,
@@ -313,6 +318,8 @@ const WORKFLOW_NAME_RE = /^[\w-]+$/;
 
 export function WorkflowBuilder() {
   const { name: editName } = useParams<{ name?: string }>();
+  const [searchParams] = useSearchParams();
+  const mountFromUrl = searchParams.get("mount");
   const isEditMode = editName !== undefined;
   const navigate = useNavigate();
 
@@ -335,7 +342,9 @@ export function WorkflowBuilder() {
 
   const [workflowName, setWorkflowName] = useState("");
   const [originalName, setOriginalName] = useState<string | null>(null);
-  const [defaultProject, setDefaultProject] = useState<string | null>(null);
+  const [defaultProject, setDefaultProject] = useState<string | null>(
+    mountFromUrl,
+  );
   const [mounts, setMounts] = useState<Mount[]>([]);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<SelectedEdge | null>(null);
@@ -364,7 +373,12 @@ export function WorkflowBuilder() {
 
     async function fetchWorkflow() {
       try {
-        const workflow = await workflowsApi.get(nameToLoad);
+        if (!mountFromUrl) {
+          setSaveError("No mount specified in URL");
+          setLoadingWorkflow(false);
+          return;
+        }
+        const workflow = await workflowsApi.get(nameToLoad, mountFromUrl);
         if (cancelled) return;
         setWorkflowName(workflow.name);
         setOriginalName(workflow.name);
@@ -489,27 +503,32 @@ export function WorkflowBuilder() {
     try {
       const request = serialize(trimmedName, defaultProject);
 
+      if (!defaultProject) {
+        setSaveError("A project (mount) must be selected to save a workflow");
+        setSaving(false);
+        return;
+      }
+
       if (isEditMode && originalName) {
-        // Edit mode: delete the old workflow first, then create the new one.
-        // If the name changed, we create first (to fail early on conflict),
-        // then delete the old one.
+        const editMount = mountFromUrl ?? defaultProject;
         if (trimmedName !== originalName) {
           await workflowsApi.create(request);
           try {
-            await workflowsApi.delete(originalName);
+            await workflowsApi.delete(originalName, editMount);
           } catch {
             // Old workflow deletion failed, but new one was created -- acceptable
           }
         } else {
-          // Same name: delete old, then create new
-          await workflowsApi.delete(originalName);
+          await workflowsApi.delete(originalName, editMount);
           await workflowsApi.create(request);
         }
       } else {
         await workflowsApi.create(request);
       }
 
-      navigate(`/workflows/${encodeURIComponent(trimmedName)}`);
+      navigate(
+        `/workflows/${encodeURIComponent(trimmedName)}?mount=${encodeURIComponent(defaultProject)}`,
+      );
     } catch (err) {
       if (err instanceof Error) {
         setSaveError(err.message);

--- a/src/srunx/web/frontend/src/pages/WorkflowDetail.tsx
+++ b/src/srunx/web/frontend/src/pages/WorkflowDetail.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import {
+  useParams,
+  Link,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
 import { motion } from "framer-motion";
 import {
   ArrowLeft,
@@ -47,6 +52,8 @@ const RUN_STATUS_LABELS: Record<WorkflowRunStatus, string> = {
 
 export function WorkflowDetail() {
   const { name } = useParams<{ name: string }>();
+  const [searchParams] = useSearchParams();
+  const mount = searchParams.get("mount");
   const navigate = useNavigate();
   const [selectedJob, setSelectedJob] = useState<string | null>(null);
   const [view, setView] = useState<"dag" | "list">("dag");
@@ -57,12 +64,12 @@ export function WorkflowDetail() {
   const [runError, setRunError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  if (!name) {
+  if (!name || !mount) {
     return (
       <div
         style={{ padding: 48, textAlign: "center", color: "var(--text-muted)" }}
       >
-        Invalid workflow name
+        {!name ? "Invalid workflow name" : "No mount specified"}
       </div>
     );
   }
@@ -71,7 +78,9 @@ export function WorkflowDetail() {
     data: workflow,
     loading,
     error,
-  } = useApi(() => workflowsApi.get(name), [name], { pollInterval: 10000 });
+  } = useApi(() => workflowsApi.get(name, mount), [name, mount], {
+    pollInterval: 10000,
+  });
 
   /* ── Stop polling on unmount ──────────────── */
   useEffect(() => {
@@ -122,7 +131,7 @@ export function WorkflowDetail() {
     setRunError(null);
     setRunning(true);
     try {
-      const run = await workflowsApi.run(name);
+      const run = await workflowsApi.run(name, mount);
       setRunData(run);
     } catch (err) {
       setRunError(
@@ -131,7 +140,7 @@ export function WorkflowDetail() {
     } finally {
       setRunning(false);
     }
-  }, [name, running]);
+  }, [name, mount, running]);
 
   /* ── Delete handler ────────────────────────── */
   const handleDelete = useCallback(async () => {
@@ -139,14 +148,14 @@ export function WorkflowDetail() {
     if (!window.confirm(`Delete workflow "${name}"? This cannot be undone.`))
       return;
     try {
-      await workflowsApi.delete(name);
+      await workflowsApi.delete(name, mount);
       navigate("/workflows");
     } catch (err) {
       setRunError(
         err instanceof Error ? err.message : "Failed to delete workflow",
       );
     }
-  }, [name, navigate]);
+  }, [name, mount, navigate]);
 
   /* ── Cancel handler ────────────────────────── */
   const handleCancel = useCallback(async () => {
@@ -307,7 +316,7 @@ export function WorkflowDetail() {
           </div>
 
           <Link
-            to={`/workflows/${encodeURIComponent(name)}/edit`}
+            to={`/workflows/${encodeURIComponent(name)}/edit?mount=${encodeURIComponent(mount)}`}
             className="btn btn-ghost"
             title="Edit workflow"
           >

--- a/src/srunx/web/frontend/src/pages/Workflows.tsx
+++ b/src/srunx/web/frontend/src/pages/Workflows.tsx
@@ -1,25 +1,53 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
-import { GitFork, Pencil, Play, Eye, Upload, Plus, X } from "lucide-react";
+import {
+  GitFork,
+  Pencil,
+  Play,
+  Eye,
+  Upload,
+  Plus,
+  X,
+  FolderOpen,
+} from "lucide-react";
 import { useApi } from "../hooks/use-api.ts";
-import { workflows as workflowsApi } from "../lib/api.ts";
-import type { Workflow } from "../lib/types.ts";
+import { workflows as workflowsApi, files as filesApi } from "../lib/api.ts";
+import type { Mount, Workflow } from "../lib/types.ts";
 
 export function Workflows() {
+  const [mounts, setMounts] = useState<Mount[]>([]);
+  const [selectedMount, setSelectedMount] = useState<string | null>(null);
+
+  // Load available mounts
+  useEffect(() => {
+    filesApi
+      .mounts()
+      .then((m) => {
+        setMounts(m);
+        if (m.length > 0) setSelectedMount(m[0].name);
+      })
+      .catch(() => {});
+  }, []);
+
   const {
     data: workflowList,
     error,
     refetch,
-  } = useApi(() => workflowsApi.list(), []);
+  } = useApi(
+    () =>
+      selectedMount ? workflowsApi.list(selectedMount) : Promise.resolve([]),
+    [selectedMount],
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   const handleUpload = async (file: File) => {
+    if (!selectedMount) return;
     try {
       setUploadError(null);
       const text = await file.text();
-      await workflowsApi.upload(text, file.name);
+      await workflowsApi.upload(text, file.name, selectedMount);
       refetch();
     } catch (err) {
       setUploadError(err instanceof Error ? err.message : "Upload failed");
@@ -42,9 +70,40 @@ export function Workflows() {
       >
         <div>
           <h1 style={{ marginBottom: 4 }}>Workflows</h1>
-          <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
-            YAML-defined pipelines with dependency graphs
-          </p>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              color: "var(--text-muted)",
+              fontSize: "0.85rem",
+            }}
+          >
+            {mounts.length > 0 ? (
+              <>
+                <FolderOpen size={14} />
+                <select
+                  className="input"
+                  value={selectedMount ?? ""}
+                  onChange={(e) => setSelectedMount(e.target.value || null)}
+                  style={{
+                    width: 180,
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.8rem",
+                    padding: "2px 8px",
+                  }}
+                >
+                  {mounts.map((m) => (
+                    <option key={m.name} value={m.name}>
+                      {m.name}
+                    </option>
+                  ))}
+                </select>
+              </>
+            ) : (
+              <span>No mounts configured. Add one in Settings.</span>
+            )}
+          </div>
         </div>
         <input
           ref={fileInputRef}
@@ -58,7 +117,14 @@ export function Workflows() {
           }}
         />
         <div style={{ display: "flex", gap: 8 }}>
-          <Link to="/workflows/new" className="btn btn-primary">
+          <Link
+            to={
+              selectedMount
+                ? `/workflows/new?mount=${encodeURIComponent(selectedMount)}`
+                : "/workflows/new"
+            }
+            className="btn btn-primary"
+          >
             <Plus size={14} />
             New Workflow
           </Link>
@@ -101,10 +167,12 @@ export function Workflows() {
             <WorkflowCard
               key={wf.name}
               workflow={wf}
+              mount={selectedMount!}
               index={i}
               onDelete={async () => {
+                if (!selectedMount) return;
                 try {
-                  await workflowsApi.delete(wf.name);
+                  await workflowsApi.delete(wf.name, selectedMount);
                   refetch();
                 } catch (err) {
                   setUploadError(
@@ -144,11 +212,12 @@ export function Workflows() {
 
 type WorkflowCardProps = {
   workflow: Workflow;
+  mount: string;
   index: number;
   onDelete: () => void;
 };
 
-function WorkflowCard({ workflow, index, onDelete }: WorkflowCardProps) {
+function WorkflowCard({ workflow, mount, index, onDelete }: WorkflowCardProps) {
   const jobCount = workflow.jobs.length;
   const depCount = workflow.jobs.reduce(
     (sum, j) => sum + (j.depends_on?.length ?? 0),
@@ -318,7 +387,7 @@ function WorkflowCard({ workflow, index, onDelete }: WorkflowCardProps) {
         {/* Actions */}
         <div style={{ display: "flex", gap: 8 }}>
           <Link
-            to={`/workflows/${workflow.name}`}
+            to={`/workflows/${encodeURIComponent(workflow.name)}?mount=${encodeURIComponent(mount)}`}
             className="btn btn-ghost"
             style={{ flex: 1, justifyContent: "center" }}
           >
@@ -326,7 +395,7 @@ function WorkflowCard({ workflow, index, onDelete }: WorkflowCardProps) {
             View DAG
           </Link>
           <Link
-            to={`/workflows/${encodeURIComponent(workflow.name)}/edit`}
+            to={`/workflows/${encodeURIComponent(workflow.name)}/edit?mount=${encodeURIComponent(mount)}`}
             className="btn btn-ghost"
             style={{ flex: 1, justifyContent: "center" }}
             onClick={(e) => e.stopPropagation()}

--- a/src/srunx/web/routers/config.py
+++ b/src/srunx/web/routers/config.py
@@ -237,7 +237,6 @@ _ENV_VAR_DESCRIPTIONS: dict[str, str] = {
     "SRUNX_SSH_USERNAME": "SSH username for web server",
     "SRUNX_SSH_KEY": "SSH key path for web server",
     "SRUNX_SSH_PORT": "SSH port for web server",
-    "SRUNX_WORKFLOW_DIR": "Workflow directory for web server",
     "SRUNX_TEMP_DIR": "Temporary directory for SSH operations",
     "SLACK_WEBHOOK_URL": "Slack webhook URL for notifications",
 }

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -23,7 +23,6 @@ from srunx.models import (
 )
 from srunx.runner import WorkflowRunner
 
-from ..config import get_web_config
 from ..deps import get_adapter
 from ..ssh_adapter import SlurmSSHAdapter
 from ..state import run_registry
@@ -152,12 +151,45 @@ def _workflow_to_yaml(
     return yaml.dump(doc, default_flow_style=False, sort_keys=False)
 
 
-def _workflow_dir() -> Path:
-    return get_web_config().workflow_dir
+def _get_current_profile():
+    """Get the current SSH profile from web config or ConfigManager."""
+    from ..sync_utils import get_current_profile
+
+    return get_current_profile()
 
 
-def _find_yaml(name: str) -> Path:
-    d = _workflow_dir()
+def _find_mount(profile, mount_name: str):
+    """Find a mount by name within a profile's mounts."""
+    for m in profile.mounts:
+        if m.name == mount_name:
+            return m
+    raise HTTPException(status_code=404, detail=f"Mount '{mount_name}' not found")
+
+
+def _workflow_dir(mount_name: str) -> Path:
+    """Resolve workflow directory for a given mount.
+
+    Returns ``<mount.local>/.srunx/workflows/``.
+    """
+    profile = _get_current_profile()
+    if profile is None:
+        raise HTTPException(status_code=503, detail="No SSH profile configured")
+    mount = _find_mount(profile, mount_name)
+    return Path(mount.local) / ".srunx" / "workflows"
+
+
+def _ensure_workflow_dir(mount_name: str) -> Path:
+    """Like ``_workflow_dir`` but creates the directory (and ``.srunx/.gitignore``) if needed."""
+    d = _workflow_dir(mount_name)
+    d.mkdir(parents=True, exist_ok=True)
+    gitignore = d.parent / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n!workflows/\n!workflows/**\n!.gitignore\n")
+    return d
+
+
+def _find_yaml(name: str, mount_name: str) -> Path:
+    d = _workflow_dir(mount_name)
     for ext in (".yaml", ".yml"):
         p = d / f"{name}{ext}"
         if p.exists():
@@ -207,8 +239,8 @@ def _serialize_workflow(runner: WorkflowRunner) -> dict[str, Any]:
 
 
 @router.get("")
-async def list_workflows() -> list[dict[str, Any]]:
-    d = _workflow_dir()
+async def list_workflows(mount: str) -> list[dict[str, Any]]:
+    d = _workflow_dir(mount)
     if not d.exists():
         return []
 
@@ -297,10 +329,11 @@ async def validate_workflow(body: dict[str, str]) -> dict[str, Any]:
 async def upload_workflow(body: dict[str, str]) -> dict[str, Any]:
     yaml_content = body.get("yaml", "")
     filename = body.get("filename", "")
+    mount_name = body.get("mount", "")
 
-    if not yaml_content or not filename:
+    if not yaml_content or not filename or not mount_name:
         raise HTTPException(
-            status_code=422, detail="Both 'yaml' and 'filename' required"
+            status_code=422, detail="'yaml', 'filename', and 'mount' are required"
         )
 
     _reject_python_args(yaml_content)
@@ -316,8 +349,7 @@ async def upload_workflow(body: dict[str, str]) -> dict[str, Any]:
             detail="Filename must be alphanumeric with hyphens/underscores only",
         )
 
-    d = _workflow_dir()
-    d.mkdir(parents=True, exist_ok=True)
+    d = _ensure_workflow_dir(mount_name)
     dest = d / safe_filename
     dest.write_text(yaml_content)
 
@@ -338,6 +370,12 @@ async def create_workflow(body: WorkflowCreateRequest) -> dict[str, Any]:
     dependency cycles, serializes to YAML, and persists to disk.
     """
     name = body.name
+    mount_name = body.default_project
+    if not mount_name:
+        raise HTTPException(
+            status_code=422,
+            detail="A mount (default_project) is required to save a workflow",
+        )
 
     # Reserved name guard
     if name in _RESERVED_NAMES:
@@ -347,8 +385,7 @@ async def create_workflow(body: WorkflowCreateRequest) -> dict[str, Any]:
         )
 
     # Check for existing workflow with the same name
-    d = _workflow_dir()
-    d.mkdir(parents=True, exist_ok=True)
+    d = _ensure_workflow_dir(mount_name)
     for ext in (".yaml", ".yml"):
         if (d / f"{name}{ext}").exists():
             raise HTTPException(
@@ -438,6 +475,7 @@ async def _monitor_run(
 async def run_workflow(
     name: str,
     request: Request,
+    mount: str | None = None,
     adapter: SlurmSSHAdapter = Depends(get_adapter),
 ) -> dict[str, Any]:
     """Run a workflow: sync mounts, submit jobs with SLURM dependencies."""
@@ -453,8 +491,10 @@ async def run_workflow(
 
     if not _SAFE_NAME.match(name):
         raise HTTPException(status_code=422, detail="Invalid workflow name")
+    if not mount:
+        raise HTTPException(status_code=422, detail="mount query parameter is required")
 
-    yaml_path = _find_yaml(name)
+    yaml_path = _find_yaml(name, mount)
 
     # Load workflow
     runner = await anyio.to_thread.run_sync(lambda: WorkflowRunner.from_yaml(yaml_path))
@@ -520,7 +560,7 @@ async def run_workflow(
                     # ShellJob: read the script directly
                     # Validate script_path is within allowed boundaries
                     script_path = Path(job.script_path).resolve()  # type: ignore[union-attr]
-                    allowed_roots = [_workflow_dir().resolve()]
+                    allowed_roots = [_workflow_dir(mount).resolve()]
                     if profile:
                         allowed_roots.extend(
                             Path(m.local).resolve() for m in profile.mounts
@@ -613,21 +653,21 @@ async def run_workflow(
 
 
 @router.delete("/{name}")
-async def delete_workflow(name: str) -> dict[str, str]:
+async def delete_workflow(name: str, mount: str) -> dict[str, str]:
     """Delete a workflow YAML file."""
     if not _SAFE_NAME.match(name):
         raise HTTPException(status_code=422, detail="Invalid workflow name")
-    yaml_path = _find_yaml(name)  # raises 404 if not found
+    yaml_path = _find_yaml(name, mount)  # raises 404 if not found
     await anyio.to_thread.run_sync(lambda: yaml_path.unlink())
     return {"status": "deleted", "name": name}
 
 
 @router.get("/{name}")
-async def get_workflow(name: str) -> dict[str, Any]:
+async def get_workflow(name: str, mount: str) -> dict[str, Any]:
     if not _SAFE_NAME.match(name):
         raise HTTPException(status_code=422, detail="Invalid workflow name")
 
-    yaml_path = _find_yaml(name)
+    yaml_path = _find_yaml(name, mount)
     try:
         runner = await anyio.to_thread.run_sync(
             lambda: WorkflowRunner.from_yaml(yaml_path)

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -66,15 +66,32 @@ def mock_adapter() -> MagicMock:
 def client(  # type: ignore[misc]
     mock_adapter: MagicMock, tmp_path: Path
 ) -> TestClient:
-    # Use tmp_path for workflow_dir to avoid leftover files
     import srunx.web.config as config_mod
     from srunx.web.config import get_web_config
 
     original = config_mod._config
     config_mod._config = None
     cfg = get_web_config()
-    cfg.workflow_dir = tmp_path / "workflows"
     config_mod._config = cfg
+
+    # Create a fake mount directory so per-mount workflow storage works
+    mount_local = tmp_path / "project"
+    mount_local.mkdir()
+
+    # Patch get_current_profile in sync_utils to return a profile with a mount
+    from unittest.mock import patch
+
+    from srunx.ssh.core.config import MountConfig, ServerProfile
+
+    fake_mount = MountConfig(
+        name="test-project", local=str(mount_local), remote="/home/user/project"
+    )
+    fake_profile = ServerProfile(
+        hostname="test.example.com",
+        username="tester",
+        key_filename="~/.ssh/id_rsa",
+        mounts=[fake_mount],
+    )
 
     # Clear run registry to avoid cross-test state leakage
     from srunx.web.state import run_registry
@@ -83,10 +100,18 @@ def client(  # type: ignore[misc]
 
     app = create_app()
     app.dependency_overrides[get_adapter] = lambda: mock_adapter
-    yield TestClient(app, raise_server_exceptions=False)
+
+    with patch(
+        "srunx.web.routers.workflows._get_current_profile", return_value=fake_profile
+    ):
+        yield TestClient(app, raise_server_exceptions=False)
 
     config_mod._config = original
     run_registry._runs.clear()
+
+
+# Mount name used in all workflow tests
+MOUNT = "test-project"
 
 
 # ── Jobs Router ───────────────────────────────────
@@ -215,7 +240,7 @@ class TestHistoryRouter:
 
 class TestWorkflowsRouter:
     def test_list_empty(self, client: TestClient) -> None:
-        resp = client.get("/api/workflows")
+        resp = client.get("/api/workflows", params={"mount": MOUNT})
         assert resp.status_code == 200
         assert resp.json() == []
 
@@ -234,16 +259,26 @@ class TestWorkflowsRouter:
     def test_upload_rejects_path_traversal(self, client: TestClient) -> None:
         resp = client.post(
             "/api/workflows/upload",
-            json={"yaml": "name: test\njobs: []", "filename": "../../evil.yaml"},
+            json={
+                "yaml": "name: test\njobs: []",
+                "filename": "../../evil.yaml",
+                "mount": MOUNT,
+            },
         )
         # Should use safe basename, so stem "evil" passes but path is safe
-        # The actual behavior depends on the workflow_dir existing
         assert resp.status_code in (200, 422)
 
     def test_upload_rejects_bad_filename(self, client: TestClient) -> None:
         resp = client.post(
             "/api/workflows/upload",
-            json={"yaml": "name: test", "filename": "bad name!.yaml"},
+            json={"yaml": "name: test", "filename": "bad name!.yaml", "mount": MOUNT},
+        )
+        assert resp.status_code == 422
+
+    def test_upload_requires_mount(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/workflows/upload",
+            json={"yaml": "name: test\njobs: []", "filename": "test.yaml"},
         )
         assert resp.status_code == 422
 
@@ -254,9 +289,18 @@ class TestWorkflowsRouter:
 
     # ── POST /api/workflows/create ───────────────────
 
+    def test_create_workflow_requires_mount(self, client: TestClient) -> None:
+        payload = {
+            "name": "no-mount",
+            "jobs": [{"name": "a", "command": ["echo", "hi"]}],
+        }
+        resp = client.post("/api/workflows/create", json=payload)
+        assert resp.status_code == 422
+
     def test_create_workflow_success(self, client: TestClient) -> None:
         payload = {
             "name": "my-pipeline",
+            "default_project": MOUNT,
             "jobs": [
                 {
                     "name": "preprocess",
@@ -283,6 +327,7 @@ class TestWorkflowsRouter:
     def test_create_workflow_conflict(self, client: TestClient) -> None:
         payload = {
             "name": "dup-wf",
+            "default_project": MOUNT,
             "jobs": [{"name": "a", "command": ["echo", "hi"]}],
         }
         resp1 = client.post("/api/workflows/create", json=payload)
@@ -294,6 +339,7 @@ class TestWorkflowsRouter:
     def test_create_workflow_reserved_name(self, client: TestClient) -> None:
         payload = {
             "name": "new",
+            "default_project": MOUNT,
             "jobs": [{"name": "a", "command": ["echo", "hi"]}],
         }
         resp = client.post("/api/workflows/create", json=payload)
@@ -303,6 +349,7 @@ class TestWorkflowsRouter:
     def test_create_workflow_bad_name(self, client: TestClient) -> None:
         payload = {
             "name": "bad name!",
+            "default_project": MOUNT,
             "jobs": [{"name": "a", "command": ["echo", "hi"]}],
         }
         resp = client.post("/api/workflows/create", json=payload)
@@ -311,6 +358,7 @@ class TestWorkflowsRouter:
     def test_create_workflow_cycle_detected(self, client: TestClient) -> None:
         payload = {
             "name": "cyclic",
+            "default_project": MOUNT,
             "jobs": [
                 {"name": "a", "command": ["echo", "a"], "depends_on": ["b"]},
                 {"name": "b", "command": ["echo", "b"], "depends_on": ["a"]},
@@ -324,6 +372,7 @@ class TestWorkflowsRouter:
     def test_create_workflow_unknown_dependency(self, client: TestClient) -> None:
         payload = {
             "name": "bad-dep",
+            "default_project": MOUNT,
             "jobs": [
                 {
                     "name": "a",
@@ -339,25 +388,27 @@ class TestWorkflowsRouter:
         """Verify the YAML file is written and can be re-loaded."""
         payload = {
             "name": "persist-test",
+            "default_project": MOUNT,
             "jobs": [{"name": "step1", "command": ["bash", "-c", "echo ok"]}],
         }
         resp = client.post("/api/workflows/create", json=payload)
         assert resp.status_code == 200
 
         # The workflow should now appear in the list
-        list_resp = client.get("/api/workflows")
+        list_resp = client.get("/api/workflows", params={"mount": MOUNT})
         names = [w["name"] for w in list_resp.json()]
         assert "persist-test" in names
 
     def test_create_workflow_retrievable_by_name(self, client: TestClient) -> None:
         payload = {
             "name": "fetch-me",
+            "default_project": MOUNT,
             "jobs": [{"name": "only", "command": ["true"]}],
         }
         resp = client.post("/api/workflows/create", json=payload)
         assert resp.status_code == 200
 
-        get_resp = client.get("/api/workflows/fetch-me")
+        get_resp = client.get("/api/workflows/fetch-me", params={"mount": MOUNT})
         assert get_resp.status_code == 200
         assert get_resp.json()["name"] == "fetch-me"
 
@@ -387,6 +438,7 @@ class TestWorkflowsRouter:
         # Create the workflow first
         create_payload = {
             "name": "run-test",
+            "default_project": MOUNT,
             "jobs": [
                 {"name": "step1", "command": ["echo", "a"]},
                 {
@@ -417,7 +469,7 @@ class TestWorkflowsRouter:
         mock_adapter.submit_job.side_effect = mock_submit
 
         # Run the workflow
-        resp = client.post("/api/workflows/run-test/run")
+        resp = client.post("/api/workflows/run-test/run", params={"mount": MOUNT})
         assert resp.status_code == 202
         data = resp.json()
         assert data["workflow_name"] == "run-test"
@@ -439,11 +491,15 @@ class TestWorkflowsRouter:
         assert "afterok:10001" in dep
 
     def test_run_workflow_not_found(self, client: TestClient) -> None:
-        resp = client.post("/api/workflows/nonexistent-wf/run")
+        resp = client.post("/api/workflows/nonexistent-wf/run", params={"mount": MOUNT})
         assert resp.status_code == 404
 
     def test_run_workflow_invalid_name(self, client: TestClient) -> None:
-        resp = client.post("/api/workflows/bad name!/run")
+        resp = client.post("/api/workflows/bad name!/run", params={"mount": MOUNT})
+        assert resp.status_code == 422
+
+    def test_run_workflow_requires_mount(self, client: TestClient) -> None:
+        resp = client.post("/api/workflows/some-wf/run")
         assert resp.status_code == 422
 
     def test_run_workflow_submit_failure(
@@ -452,6 +508,7 @@ class TestWorkflowsRouter:
         """If sbatch fails, the run should be marked as failed."""
         create_payload = {
             "name": "fail-run",
+            "default_project": MOUNT,
             "jobs": [{"name": "boom", "command": ["echo", "fail"]}],
         }
         resp = client.post("/api/workflows/create", json=create_payload)
@@ -459,7 +516,7 @@ class TestWorkflowsRouter:
 
         mock_adapter.submit_job.side_effect = RuntimeError("sbatch error")
 
-        resp = client.post("/api/workflows/fail-run/run")
+        resp = client.post("/api/workflows/fail-run/run", params={"mount": MOUNT})
         assert resp.status_code == 502
         assert "sbatch" in resp.json()["detail"]
 
@@ -469,27 +526,28 @@ class TestWorkflowsRouter:
         """Create a workflow then delete it."""
         payload = {
             "name": "to-delete",
+            "default_project": MOUNT,
             "jobs": [{"name": "a", "command": ["echo", "hi"]}],
         }
         resp = client.post("/api/workflows/create", json=payload)
         assert resp.status_code == 200
 
-        resp = client.delete("/api/workflows/to-delete")
+        resp = client.delete("/api/workflows/to-delete", params={"mount": MOUNT})
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "deleted"
         assert data["name"] == "to-delete"
 
         # Confirm it's gone
-        resp = client.get("/api/workflows/to-delete")
+        resp = client.get("/api/workflows/to-delete", params={"mount": MOUNT})
         assert resp.status_code == 404
 
     def test_delete_workflow_not_found(self, client: TestClient) -> None:
-        resp = client.delete("/api/workflows/nonexistent")
+        resp = client.delete("/api/workflows/nonexistent", params={"mount": MOUNT})
         assert resp.status_code == 404
 
     def test_delete_workflow_invalid_name(self, client: TestClient) -> None:
-        resp = client.delete("/api/workflows/bad name!")
+        resp = client.delete("/api/workflows/bad name!", params={"mount": MOUNT})
         assert resp.status_code == 422
 
     # ── POST /api/workflows/runs/{run_id}/cancel ───


### PR DESCRIPTION
## Summary

- Workflow YAML files are now stored per-mount in `<mount.local>/.srunx/workflows/` instead of a global CWD-relative `workflows/` directory
- All workflow API endpoints require a `mount` query parameter
- Web UI shows a mount selector on the Workflows page; mount context is preserved across navigation
- Removed `SRUNX_WORKFLOW_DIR` env var and `workflow_dir` config field

## Motivation

Workflows reference scripts (`python train.py`) that live in a project directory. Storing them globally meant:
- CWD-dependent (fragile, lost on server restart from different dir)
- No association with the project they belong to
- Couldn't be git-tracked alongside project code

Now workflows live with their project, are synced via `srunx ssh sync`, and are git-trackable.

## Storage layout

```
~/ml-experiment/           ← mount local path
├── train.py
├── .srunx.json            ← project config (existing)
└── .srunx/
    ├── .gitignore          ← auto-created, tracks only workflows/
    └── workflows/
        └── train_pipeline.yaml
```

## Test plan

- [x] Unit tests: 45 pass (mock mount fixture, new require-mount guard tests)
- [x] E2E tests: 53 pass (all workflow tests updated with mount param)
- [x] TypeScript compilation: clean
- [x] Frontend build: clean
- [x] mypy: clean (15 files)
- [x] ruff: clean
- [x] Manual API verification: mount-less requests return 422, nonexistent mount returns 404
- [x] CLI `srunx flow run` unaffected (uses absolute paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)