### PR TITLE
feat: add rsync exclude patterns to mount config, CLI, and Web UI

### DIFF
--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -565,6 +565,10 @@ def sync_mount(
         str | None,
         typer.Argument(help="Mount name (auto-detected from cwd if omitted)"),
     ] = None,
+    exclude: Annotated[
+        list[str] | None,
+        typer.Option("--exclude", "-e", help="Exclude pattern (repeatable)"),
+    ] = None,
     dry_run: Annotated[
         bool, typer.Option("--dry-run", "-n", help="Preview without syncing")
     ] = False,
@@ -658,6 +662,13 @@ def sync_mount(
             console.print("  [yellow]Dry run — no files will be transferred[/yellow]")
         console.print()
 
+        # Merge mount-level and CLI-level exclude patterns
+        mount_excludes = mount.exclude_patterns or []
+        cli_excludes = exclude or []
+        all_excludes = mount_excludes + [
+            p for p in cli_excludes if p not in mount_excludes
+        ]
+
         # When ssh_host is set, delegate to ~/.ssh/config for all
         # connection params (user, key, proxy, port).
         if profile.ssh_host:
@@ -665,6 +676,7 @@ def sync_mount(
                 hostname=profile.ssh_host,
                 username="",
                 ssh_config_path=str(Path.home() / ".ssh" / "config"),
+                exclude_patterns=all_excludes or None,
             )
         else:
             rsync = RsyncClient(
@@ -673,6 +685,7 @@ def sync_mount(
                 key_filename=profile.key_filename,
                 port=profile.port,
                 proxy_jump=profile.proxy_jump,
+                exclude_patterns=all_excludes or None,
             )
 
         result = rsync.push(mount.local, mount.remote, dry_run=dry_run)
@@ -944,6 +957,10 @@ def mount_add(
     remote: Annotated[
         str, typer.Option("--remote", help="Remote directory path (absolute)")
     ],
+    exclude: Annotated[
+        list[str] | None,
+        typer.Option("--exclude", "-e", help="Exclude pattern (repeatable)"),
+    ] = None,
     config: Annotated[
         str | None,
         typer.Option(
@@ -954,7 +971,7 @@ def mount_add(
     """Add a path mount to a profile."""
     from .profile_impl import add_mount_impl
 
-    add_mount_impl(profile_name, name, local, remote, config)
+    add_mount_impl(profile_name, name, local, remote, config, exclude_patterns=exclude)
 
 
 @profile_mount_app.command("list")

--- a/src/srunx/ssh/cli/profile_impl.py
+++ b/src/srunx/ssh/cli/profile_impl.py
@@ -513,6 +513,7 @@ def add_mount_impl(
     local: str,
     remote: str,
     config: str | None = None,
+    exclude_patterns: list[str] | None = None,
 ) -> None:
     """Implementation for adding a mount to a profile."""
     from ..core.config import MountConfig
@@ -535,7 +536,12 @@ def add_mount_impl(
                 raise typer.Exit(1)
 
         # Create MountConfig (triggers path validation)
-        mount = MountConfig(name=name, local=local, remote=remote)
+        mount = MountConfig(
+            name=name,
+            local=local,
+            remote=remote,
+            exclude_patterns=exclude_patterns or [],
+        )
 
         # Add mount to profile
         success = config_manager.add_profile_mount(profile_name, mount)
@@ -546,6 +552,10 @@ def add_mount_impl(
             )
             console.print(f"[dim]  Local:  {mount.local}[/dim]")
             console.print(f"[dim]  Remote: {mount.remote}[/dim]")
+            if mount.exclude_patterns:
+                console.print(
+                    f"[dim]  Exclude: {', '.join(mount.exclude_patterns)}[/dim]"
+                )
         else:
             console.print(
                 f"[red]Failed to add mount '{name}' to profile '{profile_name}'[/red]"
@@ -580,9 +590,13 @@ def list_mounts_impl(profile_name: str, config: str | None = None) -> None:
         table.add_column("Name", style="cyan", no_wrap=True)
         table.add_column("Local", style="green")
         table.add_column("Remote", style="magenta")
+        table.add_column("Excludes", style="dim")
 
         for mount in profile.mounts:
-            table.add_row(mount.name, mount.local, mount.remote)
+            excludes_str = (
+                ", ".join(mount.exclude_patterns) if mount.exclude_patterns else ""
+            )
+            table.add_row(mount.name, mount.local, mount.remote, excludes_str)
 
         console.print(table)
 

--- a/src/srunx/ssh/core/config.py
+++ b/src/srunx/ssh/core/config.py
@@ -12,6 +12,9 @@ class MountConfig(BaseModel):
     name: str
     local: str  # local path, e.g. "~/projects/ml-project"
     remote: str  # remote path, e.g. "/home/user/projects/ml-project"
+    exclude_patterns: list[str] = Field(
+        default=[], description="Additional rsync exclude patterns for this mount"
+    )
 
     @model_validator(mode="after")
     def expand_and_validate_paths(self) -> "MountConfig":

--- a/src/srunx/web/frontend/src/components/MountSettings.tsx
+++ b/src/srunx/web/frontend/src/components/MountSettings.tsx
@@ -94,6 +94,7 @@ export function MountSettings({ onClose }: MountSettingsProps) {
   const [newName, setNewName] = useState("");
   const [newLocal, setNewLocal] = useState("");
   const [newRemote, setNewRemote] = useState("");
+  const [newExcludes, setNewExcludes] = useState("");
 
   /* Load mounts */
   useEffect(() => {
@@ -145,6 +146,11 @@ export function MountSettings({ onClose }: MountSettingsProps) {
       return;
     }
 
+    const excludePatterns = newExcludes
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
     try {
       setAdding(true);
       setError(null);
@@ -152,17 +158,20 @@ export function MountSettings({ onClose }: MountSettingsProps) {
         name: trimmedName,
         local: trimmedLocal,
         remote: trimmedRemote,
+        exclude_patterns:
+          excludePatterns.length > 0 ? excludePatterns : undefined,
       });
       setMounts((prev) => [...prev, created]);
       setNewName("");
       setNewLocal("");
       setNewRemote("");
+      setNewExcludes("");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to add mount");
     } finally {
       setAdding(false);
     }
-  }, [newName, newLocal, newRemote]);
+  }, [newName, newLocal, newRemote, newExcludes]);
 
   /* Close on backdrop click */
   function handleBackdropClick(e: React.MouseEvent) {
@@ -381,6 +390,20 @@ export function MountSettings({ onClose }: MountSettingsProps) {
                             <Trash2 size={14} />
                           )}
                         </button>
+                        {mount.exclude_patterns &&
+                          mount.exclude_patterns.length > 0 && (
+                            <div
+                              style={{
+                                gridColumn: "1 / -1",
+                                fontFamily: "var(--font-mono)",
+                                fontSize: "0.7rem",
+                                color: "var(--text-muted)",
+                                paddingTop: 2,
+                              }}
+                            >
+                              exclude: {mount.exclude_patterns.join(", ")}
+                            </div>
+                          )}
                       </div>
                     ))}
                   </div>
@@ -458,6 +481,21 @@ export function MountSettings({ onClose }: MountSettingsProps) {
                         }}
                       />
                     </div>
+                  </div>
+
+                  <div style={{ display: "flex", flexDirection: "column" }}>
+                    <label style={labelStyle}>Exclude Patterns</label>
+                    <input
+                      className="input"
+                      type="text"
+                      value={newExcludes}
+                      onChange={(e) => setNewExcludes(e.target.value)}
+                      placeholder="data/,logs/,*.bin (comma-separated)"
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                      }}
+                    />
                   </div>
 
                   <div style={{ display: "flex", justifyContent: "flex-end" }}>

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -176,6 +176,7 @@ export type MountConfig = {
   name: string;
   local: string;
   remote: string;
+  exclude_patterns?: string[];
 };
 
 /* ── Config types ────────────────────────────── */
@@ -229,6 +230,7 @@ export type SSHMountConfig = {
   name: string;
   local: string;
   remote: string;
+  exclude_patterns?: string[];
 };
 
 export type SSHProfile = {

--- a/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
@@ -100,6 +100,7 @@ export function SSHProfilesTab() {
     local: "",
     remote: "",
   });
+  const [newMountExcludes, setNewMountExcludes] = useState("");
   const [newEnvKey, setNewEnvKey] = useState("");
   const [newEnvValue, setNewEnvValue] = useState("");
 
@@ -208,9 +209,18 @@ export function SSHProfilesTab() {
 
   const handleAddMount = async (profileName: string) => {
     if (!newMount.name || !newMount.local || !newMount.remote) return;
+    const excludePatterns = newMountExcludes
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
     try {
-      await configApi.addSSHMount(profileName, newMount);
+      await configApi.addSSHMount(profileName, {
+        ...newMount,
+        exclude_patterns:
+          excludePatterns.length > 0 ? excludePatterns : undefined,
+      });
       setNewMount({ name: "", local: "", remote: "" });
+      setNewMountExcludes("");
       await load();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to add mount");
@@ -510,9 +520,6 @@ export function SSHProfilesTab() {
                     <div
                       key={m.name}
                       style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "var(--sp-2)",
                         padding: "var(--sp-2) var(--sp-3)",
                         background: "var(--bg-base)",
                         borderRadius: "var(--radius-md)",
@@ -520,102 +527,141 @@ export function SSHProfilesTab() {
                         marginBottom: "var(--sp-2)",
                       }}
                     >
-                      <span
+                      <div
                         style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "0.8rem",
-                          color: "var(--accent)",
-                          minWidth: 80,
-                        }}
-                      >
-                        {m.name}
-                      </span>
-                      <span
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "0.75rem",
-                          color: "var(--text-secondary)",
-                          flex: 1,
-                        }}
-                      >
-                        {m.local} &rarr; {m.remote}
-                      </span>
-                      <button
-                        onClick={() => handleRemoveMount(name, m.name)}
-                        style={{
-                          background: "transparent",
-                          border: "none",
-                          color: "var(--text-muted)",
-                          cursor: "pointer",
-                          padding: 4,
                           display: "flex",
+                          alignItems: "center",
+                          gap: "var(--sp-2)",
                         }}
                       >
-                        <X size={14} />
-                      </button>
+                        <span
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.8rem",
+                            color: "var(--accent)",
+                            minWidth: 80,
+                          }}
+                        >
+                          {m.name}
+                        </span>
+                        <span
+                          style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.75rem",
+                            color: "var(--text-secondary)",
+                            flex: 1,
+                          }}
+                        >
+                          {m.local} &rarr; {m.remote}
+                        </span>
+                        <button
+                          onClick={() => handleRemoveMount(name, m.name)}
+                          style={{
+                            background: "transparent",
+                            border: "none",
+                            color: "var(--text-muted)",
+                            cursor: "pointer",
+                            padding: 4,
+                            display: "flex",
+                          }}
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                      {m.exclude_patterns && m.exclude_patterns.length > 0 && (
+                        <div
+                          style={{
+                            marginTop: "var(--sp-1)",
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "0.7rem",
+                            color: "var(--text-muted)",
+                            paddingLeft: 80,
+                          }}
+                        >
+                          exclude: {m.exclude_patterns.join(", ")}
+                        </div>
+                      )}
                     </div>
                   ))}
                   <div
                     style={{
                       display: "flex",
+                      flexDirection: "column",
                       gap: "var(--sp-2)",
-                      alignItems: "center",
                     }}
                   >
-                    <input
-                      className="input"
-                      placeholder="name"
-                      value={newMount.name}
-                      onChange={(e) =>
-                        setNewMount({ ...newMount, name: e.target.value })
-                      }
+                    <div
                       style={{
-                        width: 100,
-                        fontFamily: "var(--font-mono)",
-                        fontSize: "0.8rem",
-                      }}
-                    />
-                    <input
-                      className="input"
-                      placeholder="local path"
-                      value={newMount.local}
-                      onChange={(e) =>
-                        setNewMount({ ...newMount, local: e.target.value })
-                      }
-                      style={{
-                        flex: 1,
-                        fontFamily: "var(--font-mono)",
-                        fontSize: "0.8rem",
-                      }}
-                    />
-                    <input
-                      className="input"
-                      placeholder="remote path"
-                      value={newMount.remote}
-                      onChange={(e) =>
-                        setNewMount({ ...newMount, remote: e.target.value })
-                      }
-                      style={{
-                        flex: 1,
-                        fontFamily: "var(--font-mono)",
-                        fontSize: "0.8rem",
-                      }}
-                    />
-                    <button
-                      className="btn btn-primary"
-                      onClick={() => handleAddMount(name)}
-                      disabled={
-                        !newMount.name || !newMount.local || !newMount.remote
-                      }
-                      style={{
-                        padding: "var(--sp-2) var(--sp-3)",
-                        fontSize: "0.75rem",
-                        gap: 4,
+                        display: "flex",
+                        gap: "var(--sp-2)",
+                        alignItems: "center",
                       }}
                     >
-                      <Plus size={14} />
-                      Add
-                    </button>
+                      <input
+                        className="input"
+                        placeholder="name"
+                        value={newMount.name}
+                        onChange={(e) =>
+                          setNewMount({ ...newMount, name: e.target.value })
+                        }
+                        style={{
+                          width: 100,
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                        }}
+                      />
+                      <input
+                        className="input"
+                        placeholder="local path"
+                        value={newMount.local}
+                        onChange={(e) =>
+                          setNewMount({ ...newMount, local: e.target.value })
+                        }
+                        style={{
+                          flex: 1,
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                        }}
+                      />
+                      <input
+                        className="input"
+                        placeholder="remote path"
+                        value={newMount.remote}
+                        onChange={(e) =>
+                          setNewMount({ ...newMount, remote: e.target.value })
+                        }
+                        style={{
+                          flex: 1,
+                          fontFamily: "var(--font-mono)",
+                          fontSize: "0.8rem",
+                        }}
+                      />
+                      <button
+                        className="btn btn-primary"
+                        onClick={() => handleAddMount(name)}
+                        disabled={
+                          !newMount.name || !newMount.local || !newMount.remote
+                        }
+                        style={{
+                          padding: "var(--sp-2) var(--sp-3)",
+                          fontSize: "0.75rem",
+                          gap: 4,
+                        }}
+                      >
+                        <Plus size={14} />
+                        Add
+                      </button>
+                    </div>
+                    <input
+                      className="input"
+                      placeholder="exclude patterns (comma-separated, e.g. data/,logs/,*.bin)"
+                      value={newMountExcludes}
+                      onChange={(e) => setNewMountExcludes(e.target.value)}
+                      style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "0.8rem",
+                      }}
+                    />
                   </div>
                 </div>
 

--- a/src/srunx/web/routers/config.py
+++ b/src/srunx/web/routers/config.py
@@ -108,6 +108,7 @@ class MountCreateRequest(BaseModel):
     name: str
     local: str
     remote: str
+    exclude_patterns: list[str] = []
 
 
 @router.get("/ssh/profiles")
@@ -198,7 +199,12 @@ async def add_profile_mount(name: str, body: MountCreateRequest) -> dict[str, An
         raise HTTPException(status_code=404, detail=f"Profile '{name}' not found")
 
     try:
-        mount = MountConfig(name=body.name, local=body.local, remote=body.remote)
+        mount = MountConfig(
+            name=body.name,
+            local=body.local,
+            remote=body.remote,
+            exclude_patterns=body.exclude_patterns,
+        )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 

--- a/src/srunx/web/routers/files.py
+++ b/src/srunx/web/routers/files.py
@@ -130,13 +130,19 @@ def _list_entries(target: Path, mount_root: Path) -> list[FileEntry]:
 
 
 @router.get("/mounts/config")
-async def list_mounts_config() -> list[dict[str, str]]:
+async def list_mounts_config() -> list[dict]:
     """List all mounts with full details (name, local, remote) for management."""
     profile = await anyio.to_thread.run_sync(_get_current_profile)
     if profile is None or not profile.mounts:
         return []
     return [
-        {"name": m.name, "local": m.local, "remote": m.remote} for m in profile.mounts
+        {
+            "name": m.name,
+            "local": m.local,
+            "remote": m.remote,
+            "exclude_patterns": m.exclude_patterns,
+        }
+        for m in profile.mounts
     ]
 
 
@@ -153,11 +159,12 @@ async def list_mounts() -> list[MountInfo]:
 
 
 @router.post("/mounts")
-async def add_mount(body: dict[str, str]) -> dict[str, str]:
+async def add_mount(body: dict) -> dict:
     """Add a new mount to the current SSH profile."""
     name = body.get("name", "")
     local = body.get("local", "")
     remote = body.get("remote", "")
+    exclude_patterns: list[str] = body.get("exclude_patterns", [])
 
     if not name or not local or not remote:
         raise HTTPException(422, "name, local, and remote are required")
@@ -173,7 +180,12 @@ async def add_mount(body: dict[str, str]) -> dict[str, str]:
         raise HTTPException(409, f"Mount '{name}' already exists")
 
     try:
-        mount = MountConfig(name=name, local=local, remote=remote)
+        mount = MountConfig(
+            name=name,
+            local=local,
+            remote=remote,
+            exclude_patterns=exclude_patterns,
+        )
     except Exception as e:
         raise HTTPException(422, str(e)) from e
 
@@ -184,7 +196,12 @@ async def add_mount(body: dict[str, str]) -> dict[str, str]:
     pname = profile_name  # bind for lambda
     await anyio.to_thread.run_sync(lambda: cm.add_profile_mount(pname, mount))
 
-    return {"name": mount.name, "local": mount.local, "remote": mount.remote}
+    return {
+        "name": mount.name,
+        "local": mount.local,
+        "remote": mount.remote,
+        "exclude_patterns": mount.exclude_patterns,
+    }
 
 
 @router.delete("/mounts/{mount_name}")

--- a/src/srunx/web/sync_utils.py
+++ b/src/srunx/web/sync_utils.py
@@ -68,7 +68,9 @@ def sync_mount_by_name(profile: ServerProfile, mount_name: str) -> None:
     if mount is None:
         raise ValueError(f"Mount '{mount_name}' not found in profile")
     rsync = build_rsync_client(profile)
-    result = rsync.push(mount.local, mount.remote)
+    result = rsync.push(
+        mount.local, mount.remote, exclude_patterns=mount.exclude_patterns or None
+    )
     if result.returncode != 0:
         raise RuntimeError(
             f"rsync sync failed for mount '{mount_name}': {result.stderr}"

--- a/tests/test_rsync.py
+++ b/tests/test_rsync.py
@@ -440,6 +440,43 @@ class TestPushWithExcludePatterns:
         assert "artifacts/" in exclude_values
         assert ".git/" in exclude_values
 
+    def test_constructor_excludes_merged_with_defaults(self):
+        """Exclude patterns passed at construction are merged with DEFAULT_EXCLUDES."""
+        client = _make_rsync_client(
+            hostname="h", username="u", exclude_patterns=["data/", "*.bin"]
+        )
+        assert "data/" in client.exclude_patterns
+        assert "*.bin" in client.exclude_patterns
+        # Defaults still present
+        assert ".git/" in client.exclude_patterns
+        assert "__pycache__/" in client.exclude_patterns
+
+    def test_constructor_excludes_no_duplicates(self):
+        """Passing a pattern already in DEFAULT_EXCLUDES doesn't create duplicates."""
+        client = _make_rsync_client(
+            hostname="h", username="u", exclude_patterns=[".git/", "data/"]
+        )
+        assert client.exclude_patterns.count(".git/") == 1
+        assert "data/" in client.exclude_patterns
+
+    def test_constructor_and_per_call_excludes_combined(self, tmp_path: Path):
+        """Constructor-level and per-call excludes are both present in the command."""
+        client = _make_rsync_client(
+            hostname="h", username="u", exclude_patterns=["weights/"]
+        )
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/", exclude_patterns=["logs/"])
+
+        call_args = mock_run.call_args[0][0]
+        exclude_values = [
+            call_args[i + 1] for i, v in enumerate(call_args) if v == "--exclude"
+        ]
+        assert "weights/" in exclude_values  # from constructor
+        assert "logs/" in exclude_values  # from per-call
+        assert ".git/" in exclude_values  # from defaults
+
 
 class TestMkpath:
     def test_mkpath_in_rsync_cmd_when_supported(self):

--- a/tests/test_ssh_profiles_config.py
+++ b/tests/test_ssh_profiles_config.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from srunx.ssh.core.config import ConfigManager, ServerProfile
+from srunx.ssh.core.config import ConfigManager, MountConfig, ServerProfile
 
 
 @pytest.fixture
@@ -168,3 +168,87 @@ class TestConfigManager:
         config_manager = ConfigManager(temp_config_file)
         result = config_manager.set_current_profile("nonexistent")
         assert result is False
+
+
+class TestMountConfigExcludePatterns:
+    """Tests for MountConfig.exclude_patterns field."""
+
+    def test_default_exclude_patterns_is_empty(self, tmp_path):
+        mount = MountConfig(name="proj", local=str(tmp_path), remote="/remote/proj")
+        assert mount.exclude_patterns == []
+
+    def test_exclude_patterns_set_on_creation(self, tmp_path):
+        patterns = ["data/", "*.bin", "logs/"]
+        mount = MountConfig(
+            name="proj",
+            local=str(tmp_path),
+            remote="/remote/proj",
+            exclude_patterns=patterns,
+        )
+        assert mount.exclude_patterns == patterns
+
+    def test_exclude_patterns_serialized_in_model_dump(self, tmp_path):
+        patterns = ["data/", "*.log"]
+        mount = MountConfig(
+            name="proj",
+            local=str(tmp_path),
+            remote="/remote/proj",
+            exclude_patterns=patterns,
+        )
+        dumped = mount.model_dump()
+        assert dumped["exclude_patterns"] == patterns
+
+    def test_exclude_patterns_deserialized_from_dict(self, tmp_path):
+        data = {
+            "name": "proj",
+            "local": str(tmp_path),
+            "remote": "/remote/proj",
+            "exclude_patterns": ["weights/", "*.ckpt"],
+        }
+        mount = MountConfig.model_validate(data)
+        assert mount.exclude_patterns == ["weights/", "*.ckpt"]
+
+    def test_backward_compat_missing_exclude_patterns(self, tmp_path):
+        """Old config without exclude_patterns should deserialize with default []."""
+        data = {
+            "name": "proj",
+            "local": str(tmp_path),
+            "remote": "/remote/proj",
+        }
+        mount = MountConfig.model_validate(data)
+        assert mount.exclude_patterns == []
+
+    def test_mount_with_excludes_persisted_via_config_manager(self, temp_config_file):
+        cm = ConfigManager(temp_config_file)
+        profile = ServerProfile(hostname="h", username="u", key_filename="/k")
+        cm.add_profile("p", profile)
+
+        mount = MountConfig(
+            name="proj",
+            local="/tmp/local",
+            remote="/remote/proj",
+            exclude_patterns=["data/", "*.bin"],
+        )
+        cm.add_profile_mount("p", mount)
+
+        # Reload from disk
+        cm2 = ConfigManager(temp_config_file)
+        loaded_profile = cm2.get_profile("p")
+        assert loaded_profile is not None
+        assert len(loaded_profile.mounts) == 1
+        assert loaded_profile.mounts[0].exclude_patterns == ["data/", "*.bin"]
+
+    def test_mount_without_excludes_persisted_via_config_manager(
+        self, temp_config_file
+    ):
+        cm = ConfigManager(temp_config_file)
+        profile = ServerProfile(hostname="h", username="u", key_filename="/k")
+        cm.add_profile("p", profile)
+
+        mount = MountConfig(name="proj", local="/tmp/local", remote="/remote/proj")
+        cm.add_profile_mount("p", mount)
+
+        cm2 = ConfigManager(temp_config_file)
+        loaded_profile = cm2.get_profile("p")
+        assert loaded_profile is not None
+        assert loaded_profile.mounts[0].exclude_patterns == []


### PR DESCRIPTION
## Summary
- マウントごとにrsyncの除外パターン（`exclude_patterns`）を設定可能に
- CLI・Web UI・Web APIの全レイヤーで対応
- 既存設定との後方互換性あり（デフォルト `[]`）

## Changes
- `MountConfig` に `exclude_patterns: list[str]` フィールド追加
- CLI `srunx ssh sync --exclude` で一時的な除外パターン指定（リピート可）
- CLI `srunx ssh profile mount add --exclude` で永続的な除外パターン設定
- CLI `srunx ssh profile mount list` に Excludes 列追加
- Web API: config / files ルーターで `exclude_patterns` の送受信対応
- Web UI: SSHProfilesTab / MountSettings で除外パターンの表示・入力対応
- テスト10件追加（モデル、永続化、rsyncコマンド統合）

## Test plan
- [x] `srunx ssh sync --help` / `mount add --help` で `--exclude` オプション表示確認
- [x] `mount add --exclude` → config JSON に `exclude_patterns` 保存確認
- [x] `mount list` テーブルに Excludes 列表示確認
- [x] mount + CLI excludes が rsync コマンドに正しくマージされることを確認
- [x] Web API `POST /mounts` (exclude付き/無し) レスポンス確認
- [x] Web API `GET /mounts/config` に `exclude_patterns` 含む確認
- [x] ディスク永続化 → 再読み込みで復元確認
- [x] TypeScript 型チェック (`tsc -b`) パス
- [x] Vite プロダクションビルド パス
- [x] 新規ユニットテスト 10件 パス
- [x] 既存テスト リグレッションなし (504 passed)
- [x] pre-commit hooks 全パス (ruff, mypy, pytest, tsc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)