### PR TITLE
feat: add MCP server for Claude Code integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "srunx": {
+      "command": "uv",
+      "args": ["run", "--extra", "mcp", "srunx-mcp"]
+    }
+  }
+}

--- a/docs/explanation/mcp-architecture.rst
+++ b/docs/explanation/mcp-architecture.rst
@@ -1,0 +1,202 @@
+MCP Integration Architecture
+============================
+
+This document explains the design decisions behind the srunx MCP server and
+how it fits into the broader srunx architecture.
+
+Why MCP
+-------
+
+srunx already has a CLI, a Python API, and a Web UI. The MCP integration adds
+a fourth interface optimized for LLM-driven interaction. The key advantages
+over wrapping the CLI with shell commands:
+
+**Structured data in, structured data out.**
+  Every tool accepts typed parameters and returns JSON. The LLM never needs
+  to parse ``squeue`` table output or construct ``sbatch`` flags from free
+  text.
+
+**Tool selection by the model.**
+  MCP provides a tool catalog with descriptions and parameter schemas. The
+  model picks the right tool based on intent rather than pattern-matching
+  against CLI help text.
+
+**No subprocess parsing.**
+  The MCP server calls the srunx Python API directly. There is no shell
+  invocation, no stdout capture, and no regex extraction of job IDs from
+  human-readable output.
+
+**Composability.**
+  The model can chain multiple tool calls in a single turn (check resources,
+  sync files, submit job) without writing a shell script.
+
+Architecture
+------------
+
+The MCP server is a thin wrapper around existing srunx modules. It does not
+add business logic -- it translates between MCP tool calls and the Python API.
+
+.. mermaid::
+
+   flowchart LR
+     subgraph client["Claude Code"]
+       LLM["LLM"]
+     end
+     subgraph mcp_layer["MCP Server (stdio)"]
+       FastMCP["FastMCP\n(srunx-mcp)"]
+     end
+     subgraph srunx_api["srunx Python API"]
+       Client["Slurm Client"]
+       Runner["WorkflowRunner"]
+       Monitor["ResourceMonitor"]
+       Config["ConfigManager"]
+       Sync["RsyncClient"]
+       SSH["SSHSlurmClient"]
+     end
+     subgraph cluster["SLURM Cluster"]
+       sbatch["sbatch"]
+       squeue["squeue"]
+       sinfo["sinfo"]
+       sacct["sacct"]
+     end
+
+     LLM -- "MCP Protocol\n(JSON over stdio)" --> FastMCP
+     FastMCP --> Client
+     FastMCP --> Runner
+     FastMCP --> Monitor
+     FastMCP --> Config
+     FastMCP --> Sync
+     FastMCP --> SSH
+     Client -- subprocess --> sbatch
+     Client -- subprocess --> squeue
+     Monitor -- subprocess --> sinfo
+     SSH -- "Paramiko SSH" --> sbatch
+     SSH -- "Paramiko SSH" --> squeue
+     Sync -- "rsync subprocess" --> cluster
+
+The server process is started by Claude Code using the command configured in
+``.mcp.json``:
+
+.. code-block:: json
+
+   {
+     "mcpServers": {
+       "srunx": {
+         "command": "uv",
+         "args": ["run", "--extra", "mcp", "srunx-mcp"]
+       }
+     }
+   }
+
+Communication uses stdio (stdin/stdout JSON messages). The server runs for
+the duration of the Claude Code session and handles tool calls sequentially.
+
+Thin Wrapper Pattern
+--------------------
+
+Each MCP tool function follows the same pattern:
+
+1. Validate inputs (job IDs, partition names).
+2. Import and call the relevant srunx module.
+3. Convert the result to a JSON-serializable dict.
+4. Return ``{"success": true, ...}`` or ``{"success": false, "error": ...}``.
+
+The server file (``src/srunx/mcp/server.py``) contains no SLURM logic.
+All SLURM interaction happens through existing modules:
+
+- **Job management** (``submit_job``, ``list_jobs``, etc.) uses ``srunx.client.Slurm``
+  for local execution and ``srunx.ssh.core.client.SSHSlurmClient`` for remote.
+- **Workflows** (``create_workflow``, ``run_workflow``, etc.) uses ``srunx.runner.WorkflowRunner``
+  and ``srunx.models.Workflow``.
+- **Resources** (``get_resources``) uses ``srunx.monitor.resource_monitor.ResourceMonitor``.
+- **File sync** (``sync_files``) uses ``srunx.sync.RsyncClient`` via the SSH profile.
+- **Configuration** (``get_config``, ``list_ssh_profiles``) uses ``srunx.config``
+  and ``srunx.ssh.core.config.ConfigManager``.
+
+Local vs SSH Execution
+----------------------
+
+Most tools accept a ``use_ssh`` boolean parameter. The execution path diverges
+early in each tool:
+
+**Local path** (``use_ssh=false``):
+  Imports ``srunx.client.Slurm`` and calls SLURM commands via ``subprocess``.
+  Requires the MCP server to run on a machine with SLURM access (login node
+  or compute node).
+
+**SSH path** (``use_ssh=true``):
+  Reads the active SSH profile from ``ConfigManager``, creates an
+  ``SSHSlurmClient``, and routes commands through Paramiko SSH. The MCP
+  server runs on the developer's local machine while SLURM runs on a
+  remote cluster.
+
+.. mermaid::
+
+   flowchart TD
+     Tool["MCP Tool Call"]
+     Check{"use_ssh?"}
+     Local["Slurm Client\n(subprocess)"]
+     Remote["SSHSlurmClient\n(Paramiko)"]
+     SLURM["SLURM Cluster"]
+
+     Tool --> Check
+     Check -- "false" --> Local --> SLURM
+     Check -- "true" --> Remote --> SLURM
+
+For SSH mode, the ``work_dir`` parameter is required on ``submit_job`` because
+the local working directory has no meaning on the remote cluster.
+
+Security
+--------
+
+**Input validation.**
+  Job IDs are validated against ``^\d+(_\d+)?$`` (numeric with optional
+  array index). Partition names are validated against ``^[a-zA-Z0-9_\-]+$``.
+  These checks prevent command injection when values are interpolated into
+  SLURM commands executed over SSH.
+
+**No shell interpolation.**
+  Local SLURM commands use ``subprocess`` with argument lists, not shell
+  strings. SSH commands go through Paramiko's ``exec_command``, which does
+  not invoke a login shell.
+
+**Scope limitation.**
+  The MCP server exposes only read and submit operations. It cannot modify
+  SLURM configuration, access other users' jobs, or execute arbitrary
+  commands on the cluster. File sync is constrained to configured mount
+  points or explicit paths.
+
+Relationship to Other Interfaces
+---------------------------------
+
+srunx provides four interfaces to the same underlying functionality:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 20 20 42
+
+   * - Interface
+     - Entry point
+     - Transport
+     - Best for
+   * - CLI
+     - ``srunx``
+     - Terminal
+     - Manual job management, scripting
+   * - Python API
+     - ``from srunx import ...``
+     - In-process
+     - Programmatic integration, notebooks
+   * - Web UI
+     - ``srunx-web``
+     - HTTP (browser)
+     - Visual workflow building, monitoring dashboards
+   * - MCP
+     - ``srunx-mcp``
+     - stdio (JSON)
+     - LLM-driven operations via Claude Code
+
+All four share the same core modules (``client.py``, ``models.py``,
+``runner.py``, ``ssh/``, ``sync/``, ``monitor/``). The MCP server adds
+no new capabilities -- it is a translation layer that makes existing
+functionality accessible to the model.

--- a/docs/how-to/mcp-usage.rst
+++ b/docs/how-to/mcp-usage.rst
@@ -1,0 +1,187 @@
+Using srunx MCP Tools
+=====================
+
+This guide shows how to accomplish specific tasks through Claude Code using the
+srunx MCP tools. Each section is a self-contained recipe.
+
+For setup instructions, see :doc:`/tutorials/mcp-setup`.
+For the full tool reference, see :doc:`/reference/mcp-tools`.
+
+Submit a Job
+------------
+
+Ask Claude Code to submit a job with the resources you need:
+
+.. code-block:: text
+
+   > Submit a job named "training" that runs "python train.py --epochs 50"
+   > with 4 GPUs, 64GB memory, on the gpu partition, using conda env pytorch
+
+Claude Code calls ``submit_job`` and returns the job ID. You can then
+reference that ID in follow-up prompts:
+
+.. code-block:: text
+
+   > What's the status of that job?
+
+Create a Workflow from Natural Language
+---------------------------------------
+
+Describe your pipeline and let Claude Code generate the workflow YAML:
+
+.. code-block:: text
+
+   > Create a workflow called "ml_pipeline" with three jobs:
+   > 1. "preprocess" runs "python preprocess.py" on 1 node
+   > 2. "train" runs "python train.py" with 2 GPUs, depends on preprocess,
+   >    uses conda env ml_env, time limit 8 hours
+   > 3. "evaluate" runs "python evaluate.py", depends on train
+   > Save it to workflows/ml_pipeline.yaml
+
+Claude Code calls ``create_workflow`` with the job definitions and writes
+the YAML file. You can then validate and run it:
+
+.. code-block:: text
+
+   > Validate the workflow at workflows/ml_pipeline.yaml
+   > Run it
+
+Monitor Resources and Make Decisions
+-------------------------------------
+
+Use resource checks to decide when and where to submit jobs:
+
+.. code-block:: text
+
+   > Check GPU availability on all partitions. If there are at least 4 GPUs
+   > free on any partition, submit my training job there.
+
+Claude Code calls ``get_resources``, inspects the result, and conditionally
+calls ``submit_job`` with the partition that has capacity.
+
+Check Job Logs
+--------------
+
+Retrieve stdout and stderr from completed or running jobs:
+
+.. code-block:: text
+
+   > Show me the logs for job 12345
+
+Claude Code calls ``get_job_logs`` and displays the output. For SSH jobs,
+it fetches logs from the remote cluster.
+
+Sync Files Before Job Submission
+---------------------------------
+
+Ensure your latest code is on the remote cluster before submitting:
+
+.. code-block:: text
+
+   > Sync the ml-project mount and then submit "python train.py" with
+   > 2 GPUs via SSH
+
+Claude Code calls ``sync_files`` with the mount name, then calls
+``submit_job`` with ``use_ssh=True``. The sync uses your configured mount
+points from the SSH profile.
+
+For explicit paths instead of named mounts:
+
+.. code-block:: text
+
+   > Sync ./src to ~/workspace/src on the remote cluster (dry run first)
+
+Claude Code calls ``sync_files`` with ``local_path`` and ``remote_path``,
+first with ``dry_run=True`` to preview, then again to execute.
+
+Use SSH Mode for Remote Clusters
+---------------------------------
+
+Most tools accept a ``use_ssh`` flag. You can tell Claude Code to operate
+remotely:
+
+.. code-block:: text
+
+   > List jobs on the remote cluster
+
+.. code-block:: text
+
+   > Cancel job 12345 on the remote cluster
+
+.. code-block:: text
+
+   > Check resources on the gpu partition via SSH
+
+Claude Code routes these through the active SSH profile. To see which
+profiles are configured:
+
+.. code-block:: text
+
+   > List my SSH profiles
+
+Run Partial Workflows
+---------------------
+
+Execute specific portions of a workflow:
+
+.. code-block:: text
+
+   > Run only the "train" job from workflows/ml_pipeline.yaml
+
+.. code-block:: text
+
+   > Run the workflow from "train" to "evaluate", skipping preprocess
+
+.. code-block:: text
+
+   > Do a dry run of workflows/ml_pipeline.yaml to see what would execute
+
+Claude Code uses the ``single_job``, ``from_job``, ``to_job``, and
+``dry_run`` parameters of ``run_workflow``.
+
+Combine Multiple Operations
+----------------------------
+
+Claude Code can chain tools in a single conversation turn:
+
+.. code-block:: text
+
+   > Check if there are at least 2 GPUs available. If yes, sync my
+   > ml-project mount and submit "python train.py --lr 0.001" with
+   > 2 GPUs via SSH. Show me the job ID when done.
+
+This triggers a sequence: ``get_resources`` -> ``sync_files`` -> ``submit_job``.
+
+Another multi-step example:
+
+.. code-block:: text
+
+   > Find all workflows in this project, validate each one, and tell me
+   > which ones have issues.
+
+This calls ``list_workflows`` then ``validate_workflow`` for each file found.
+
+Inspect Configuration
+---------------------
+
+Review your srunx setup:
+
+.. code-block:: text
+
+   > Show my srunx configuration
+
+.. code-block:: text
+
+   > What SSH profiles do I have configured? Show their mount points.
+
+These call ``get_config`` and ``list_ssh_profiles`` respectively.
+
+Tips
+----
+
+- Claude Code picks the right tool based on your intent. You do not need
+  to name tools explicitly.
+- Include "via SSH" or "on the remote cluster" to trigger SSH mode.
+- Use "dry run" to preview any destructive operation before executing.
+- Reference job IDs from earlier in the conversation -- Claude Code tracks
+  context across turns.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ Define a workflow:
    tutorials/installation
    tutorials/quickstart
    tutorials/webui
+   tutorials/mcp-setup
 
 .. toctree::
    :maxdepth: 2
@@ -70,6 +71,7 @@ Define a workflow:
    how-to/webui
    how-to/settings
    how-to/explorer
+   how-to/mcp-usage
 
 .. toctree::
    :maxdepth: 2
@@ -77,12 +79,14 @@ Define a workflow:
 
    reference/api
    reference/webui-api
+   reference/mcp-tools
 
 .. toctree::
    :maxdepth: 2
    :caption: Explanation
 
    explanation/architecture
+   explanation/mcp-architecture
 
 Indices and tables
 ==================

--- a/docs/reference/mcp-tools.rst
+++ b/docs/reference/mcp-tools.rst
@@ -1,0 +1,821 @@
+MCP Tool Reference
+==================
+
+Complete reference for all 14 tools exposed by the srunx MCP server.
+
+The server is started with ``uv run --extra mcp srunx-mcp`` and communicates
+over stdio using the Model Context Protocol.
+
+All tools return a JSON object with a ``success`` boolean. On success,
+additional fields carry the result data. On failure, an ``error`` string
+describes what went wrong.
+
+.. contents::
+   :local:
+   :depth: 2
+
+Job Management
+--------------
+
+submit_job
+~~~~~~~~~~
+
+Submit a SLURM job.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``command``
+     - str
+     - Yes
+     -
+     - Shell command to execute (e.g. ``"python train.py --epochs 100"``)
+   * - ``name``
+     - str
+     - No
+     - ``"job"``
+     - Job name for identification in the SLURM queue
+   * - ``nodes``
+     - int
+     - No
+     - ``1``
+     - Number of compute nodes to allocate
+   * - ``gpus_per_node``
+     - int
+     - No
+     - ``0``
+     - Number of GPUs per node (0 for CPU-only)
+   * - ``ntasks_per_node``
+     - int
+     - No
+     - ``1``
+     - Number of tasks per node
+   * - ``cpus_per_task``
+     - int
+     - No
+     - ``1``
+     - Number of CPUs per task
+   * - ``memory_per_node``
+     - str | null
+     - No
+     - ``null``
+     - Memory per node (e.g. ``"32GB"``, ``"64G"``)
+   * - ``time_limit``
+     - str | null
+     - No
+     - ``null``
+     - Wall time limit (e.g. ``"4:00:00"``, ``"1-00:00:00"``)
+   * - ``partition``
+     - str | null
+     - No
+     - ``null``
+     - SLURM partition name (e.g. ``"gpu"``, ``"cpu"``)
+   * - ``nodelist``
+     - str | null
+     - No
+     - ``null``
+     - Specific nodes to use (e.g. ``"node001,node002"``)
+   * - ``conda``
+     - str | null
+     - No
+     - ``null``
+     - Conda environment name to activate before running
+   * - ``venv``
+     - str | null
+     - No
+     - ``null``
+     - Path to Python virtual environment to activate
+   * - ``env_vars``
+     - dict | null
+     - No
+     - ``null``
+     - Additional environment variables as key-value pairs
+   * - ``log_dir``
+     - str
+     - No
+     - ``"logs"``
+     - Directory for stdout/stderr log files
+   * - ``work_dir``
+     - str | null
+     - No
+     - ``null``
+     - Working directory for the job (defaults to cwd; required when ``use_ssh=true``)
+   * - ``use_ssh``
+     - bool
+     - No
+     - ``false``
+     - Submit via SSH to remote SLURM cluster
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "job_id": "12345",
+     "name": "training",
+     "status": "PENDING"
+   }
+
+**Example:**
+
+.. code-block:: text
+
+   > Submit "python train.py" with 2 GPUs, conda env ml_env, 8 hour time limit
+
+list_jobs
+~~~~~~~~~
+
+List current user's SLURM jobs in the queue.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``use_ssh``
+     - bool
+     - No
+     - ``false``
+     - Query jobs via SSH on remote cluster
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "jobs": [
+       {
+         "name": "training",
+         "job_id": "12345",
+         "status": "RUNNING",
+         "partition": "gpu",
+         "nodes": "1"
+       }
+     ],
+     "count": 1
+   }
+
+get_job_status
+~~~~~~~~~~~~~~
+
+Get the status of a specific SLURM job.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``job_id``
+     - str
+     - Yes
+     -
+     - SLURM job ID to check (numeric, e.g. ``"12345"`` or ``"12345_1"``)
+   * - ``use_ssh``
+     - bool
+     - No
+     - ``false``
+     - Query via SSH on remote cluster
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "job_id": "12345",
+     "name": "training",
+     "status": "RUNNING",
+     "partition": "gpu",
+     "nodes": "1"
+   }
+
+cancel_job
+~~~~~~~~~~
+
+Cancel a running or pending SLURM job.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``job_id``
+     - str
+     - Yes
+     -
+     - SLURM job ID to cancel
+   * - ``use_ssh``
+     - bool
+     - No
+     - ``false``
+     - Cancel via SSH on remote cluster
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "job_id": "12345",
+     "message": "Job cancelled"
+   }
+
+get_job_logs
+~~~~~~~~~~~~
+
+Get stdout/stderr logs for a SLURM job.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``job_id``
+     - str
+     - Yes
+     -
+     - SLURM job ID
+   * - ``job_name``
+     - str | null
+     - No
+     - ``null``
+     - Job name to help locate log files
+   * - ``use_ssh``
+     - bool
+     - No
+     - ``false``
+     - Fetch logs via SSH from remote cluster
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "job_id": "12345",
+     "stdout": "Epoch 1/10: loss=0.45 ...",
+     "stderr": "",
+     "log_files": ["logs/training-12345.out"]
+   }
+
+.. note::
+
+   The ``log_files`` field is only present for local (non-SSH) queries.
+
+Resources
+---------
+
+get_resources
+~~~~~~~~~~~~~
+
+Get current GPU and node resource availability on the SLURM cluster.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``partition``
+     - str | null
+     - No
+     - ``null``
+     - Specific partition to check (null for all partitions)
+   * - ``use_ssh``
+     - bool
+     - No
+     - ``false``
+     - Query resources via SSH on remote cluster
+
+**Return value (local):**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "partition": "gpu",
+     "total_gpus": 32,
+     "gpus_in_use": 24,
+     "gpus_available": 8,
+     "gpu_utilization": 0.75,
+     "jobs_running": 12,
+     "nodes_total": 8,
+     "nodes_idle": 2,
+     "nodes_down": 0
+   }
+
+**Return value (SSH):**
+
+When using SSH mode, the return includes a ``raw_output`` field with the
+``sinfo`` output instead of parsed metrics:
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "partition": "gpu",
+     "raw_output": "node001 gpu:4 idle gpu*\nnode002 gpu:4 mixed gpu*"
+   }
+
+Workflows
+---------
+
+create_workflow
+~~~~~~~~~~~~~~~
+
+Create a SLURM workflow YAML file. Generates a workflow definition that can
+be executed with ``run_workflow``.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``name``
+     - str
+     - Yes
+     -
+     - Workflow name for identification
+   * - ``jobs``
+     - list[dict]
+     - Yes
+     -
+     - List of job definitions (see schema below)
+   * - ``output_path``
+     - str
+     - Yes
+     -
+     - File path to write the YAML (e.g. ``"workflow.yaml"``)
+   * - ``args``
+     - dict | null
+     - No
+     - ``null``
+     - Template variables for Jinja2 templating in job definitions
+   * - ``default_project``
+     - str | null
+     - No
+     - ``null``
+     - Default SSH mount name for file syncing
+
+**Job definition schema:**
+
+Each entry in the ``jobs`` list is a dict with these fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 60
+
+   * - Field
+     - Type
+     - Required
+     - Description
+   * - ``name``
+     - str
+     - Yes
+     - Job identifier (must be unique within the workflow)
+   * - ``command``
+     - str | list[str]
+     - Yes*
+     - Command to execute (*required for regular jobs)
+   * - ``script_path``
+     - str
+     - Yes*
+     - Path to shell script (*required for shell jobs, mutually exclusive with ``command``)
+   * - ``depends_on``
+     - list[str]
+     - No
+     - Job names this job depends on. Supports dependency types: ``"afterok:preprocess"``, ``"after:job_a"``, ``"afterany:job_a"``, ``"afternotok:job_a"``
+   * - ``retry``
+     - int
+     - No
+     - Number of retry attempts on failure (default 0)
+   * - ``retry_delay``
+     - int
+     - No
+     - Seconds between retries (default 60)
+   * - ``resources``
+     - dict
+     - No
+     - Resource allocation: ``nodes``, ``gpus_per_node``, ``ntasks_per_node``, ``cpus_per_task``, ``memory_per_node``, ``time_limit``, ``partition``, ``nodelist``
+   * - ``environment``
+     - dict
+     - No
+     - Environment setup: ``conda``, ``venv``, ``env_vars``, ``container``
+   * - ``log_dir``
+     - str
+     - No
+     - Log directory path
+   * - ``work_dir``
+     - str
+     - No
+     - Working directory path
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "path": "/absolute/path/to/workflow.yaml",
+     "name": "ml_pipeline",
+     "job_count": 3,
+     "job_names": ["preprocess", "train", "evaluate"],
+     "message": "Workflow 'ml_pipeline' created at workflow.yaml"
+   }
+
+validate_workflow
+~~~~~~~~~~~~~~~~~
+
+Validate a workflow YAML file for correctness. Checks YAML syntax, job
+structure, dependency resolution, and circular dependency detection.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``yaml_path``
+     - str
+     - Yes
+     -
+     - Path to the YAML workflow file to validate
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "name": "ml_pipeline",
+     "valid": true,
+     "job_count": 3,
+     "jobs": [
+       {"name": "preprocess", "depends_on": [], "command": "python preprocess.py"},
+       {"name": "train", "depends_on": ["preprocess"], "command": "python train.py"},
+       {"name": "evaluate", "depends_on": ["train"], "command": "python evaluate.py"}
+     ]
+   }
+
+run_workflow
+~~~~~~~~~~~~
+
+Execute a SLURM workflow from a YAML file. Jobs are executed in dependency
+order -- independent jobs run in parallel, dependent jobs wait for their
+prerequisites to complete.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``yaml_path``
+     - str
+     - Yes
+     -
+     - Path to the YAML workflow file
+   * - ``from_job``
+     - str | null
+     - No
+     - ``null``
+     - Start execution from this job (skip earlier jobs)
+   * - ``to_job``
+     - str | null
+     - No
+     - ``null``
+     - Stop execution at this job (skip later jobs)
+   * - ``single_job``
+     - str | null
+     - No
+     - ``null``
+     - Execute only this specific job, ignoring dependencies
+   * - ``dry_run``
+     - bool
+     - No
+     - ``false``
+     - Show what would be executed without running
+
+**Return value (execution):**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "workflow": "ml_pipeline",
+     "results": {
+       "preprocess": {"job_id": "12345", "status": "COMPLETED"},
+       "train": {"job_id": "12346", "status": "COMPLETED"},
+       "evaluate": {"job_id": "12347", "status": "COMPLETED"}
+     },
+     "all_completed": true
+   }
+
+**Return value (dry run):**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "dry_run": true,
+     "workflow": "ml_pipeline",
+     "jobs_to_execute": [
+       {"name": "preprocess", "depends_on": [], "command": "python preprocess.py"},
+       {"name": "train", "depends_on": ["preprocess"], "command": "python train.py"}
+     ],
+     "count": 2
+   }
+
+list_workflows
+~~~~~~~~~~~~~~
+
+List workflow YAML files in a directory. Scans for YAML files that contain a
+valid srunx workflow structure (must have ``name`` and ``jobs`` keys). Skips
+hidden directories, ``node_modules``, ``.venv``, and ``__pycache__``.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``directory``
+     - str
+     - No
+     - ``"."``
+     - Directory to search for workflow files
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "workflows": [
+       {
+         "path": "/home/user/project/workflows/ml_pipeline.yaml",
+         "name": "ml_pipeline",
+         "job_count": 3,
+         "job_names": ["preprocess", "train", "evaluate"]
+       }
+     ],
+     "count": 1
+   }
+
+get_workflow
+~~~~~~~~~~~~
+
+Read and parse a workflow YAML file, returning its full structure including
+resource and environment configuration for each job.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``yaml_path``
+     - str
+     - Yes
+     -
+     - Path to the YAML workflow file
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "name": "ml_pipeline",
+     "args": null,
+     "default_project": null,
+     "jobs": [
+       {
+         "name": "train",
+         "depends_on": ["preprocess"],
+         "retry": 0,
+         "retry_delay": 60,
+         "command": "python train.py",
+         "resources": {
+           "nodes": 1,
+           "gpus_per_node": 2,
+           "ntasks_per_node": 1,
+           "cpus_per_task": 1,
+           "memory_per_node": "32GB",
+           "time_limit": "8:00:00",
+           "partition": null,
+           "nodelist": null
+         },
+         "environment": {
+           "conda": "ml_env",
+           "venv": null,
+           "env_vars": {}
+         }
+       }
+     ],
+     "raw_yaml": "name: ml_pipeline\njobs:\n  ..."
+   }
+
+File Sync
+---------
+
+sync_files
+~~~~~~~~~~
+
+Sync files between local machine and remote SLURM cluster using rsync.
+Supports two modes: mount-based (using a named mount from the SSH profile)
+or path-based (using explicit local and remote paths).
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 12 8 12 48
+
+   * - Name
+     - Type
+     - Required
+     - Default
+     - Description
+   * - ``profile_name``
+     - str | null
+     - No
+     - ``null``
+     - SSH profile name (uses current profile if not specified)
+   * - ``mount_name``
+     - str | null
+     - No
+     - ``null``
+     - Mount point name from the SSH profile to sync
+   * - ``local_path``
+     - str | null
+     - No
+     - ``null``
+     - Local directory path (alternative to ``mount_name``)
+   * - ``remote_path``
+     - str | null
+     - No
+     - ``null``
+     - Remote directory path (alternative to ``mount_name``)
+   * - ``dry_run``
+     - bool
+     - No
+     - ``false``
+     - Show what would be transferred without actually syncing
+
+.. note::
+
+   You must provide either ``mount_name`` or ``local_path``. When using
+   ``mount_name``, the local and remote paths are read from the SSH profile
+   configuration. When using ``local_path`` without ``remote_path``, a
+   default remote path is derived.
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "profile": "myserver",
+     "mount": "ml-project",
+     "local": "/home/user/projects/ml-project",
+     "remote": "/home/researcher/projects/ml-project",
+     "dry_run": false,
+     "output": "sending incremental file list\nsrc/train.py\n..."
+   }
+
+Configuration
+-------------
+
+get_config
+~~~~~~~~~~
+
+Get the current srunx configuration including resource defaults and
+environment settings.
+
+**Parameters:** None.
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "resources": {
+       "nodes": 1,
+       "gpus_per_node": 0,
+       "ntasks_per_node": 1,
+       "cpus_per_task": 1,
+       "memory_per_node": null,
+       "time_limit": null,
+       "partition": null,
+       "nodelist": null
+     },
+     "environment": {
+       "conda": null,
+       "venv": null,
+       "env_vars": {}
+     },
+     "log_dir": "logs",
+     "work_dir": null
+   }
+
+list_ssh_profiles
+~~~~~~~~~~~~~~~~~
+
+List all configured SSH connection profiles for remote SLURM clusters.
+Shows profile names, hostnames, and configured mount points.
+
+**Parameters:** None.
+
+**Return value:**
+
+.. code-block:: json
+
+   {
+     "success": true,
+     "profiles": [
+       {
+         "name": "dgx",
+         "hostname": "dgx.example.com",
+         "username": "researcher",
+         "port": 22,
+         "description": "Main DGX cluster",
+         "is_current": true,
+         "mounts": [
+           {
+             "name": "ml-project",
+             "local": "/home/user/projects/ml-project",
+             "remote": "/home/researcher/projects/ml-project"
+           }
+         ]
+       }
+     ],
+     "current": "dgx",
+     "count": 1
+   }

--- a/docs/tutorials/mcp-setup.rst
+++ b/docs/tutorials/mcp-setup.rst
@@ -1,0 +1,153 @@
+Getting Started with MCP
+========================
+
+MCP (Model Context Protocol) lets Claude Code call srunx tools directly,
+so you can manage SLURM jobs through natural language instead of memorizing
+CLI flags.
+
+This tutorial walks through installation, configuration, and your first
+interaction.
+
+Prerequisites
+-------------
+
+- srunx installed (see :doc:`installation`)
+- `Claude Code <https://docs.anthropic.com/en/docs/claude-code>`_ installed
+- A working SLURM cluster (local or via SSH profile)
+
+Install the MCP Extra
+---------------------
+
+The MCP server is an optional dependency. Install it with:
+
+.. code-block:: bash
+
+   uv sync --extra mcp
+
+Or if you are adding srunx to another project:
+
+.. code-block:: bash
+
+   uv add "srunx[mcp]"
+
+This pulls in the ``mcp[cli]`` package required to run the server.
+
+Configure the MCP Server
+-------------------------
+
+There are two ways to register the server with Claude Code: a project config
+file or the ``claude mcp add`` CLI command.
+
+Option A: Project config file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create a ``.mcp.json`` file in your project root:
+
+.. code-block:: json
+
+   {
+     "mcpServers": {
+       "srunx": {
+         "command": "uv",
+         "args": ["run", "--extra", "mcp", "srunx-mcp"]
+       }
+     }
+   }
+
+Claude Code reads this file automatically when you open the project.
+
+Option B: ``claude mcp add`` command
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``claude mcp add`` CLI supports three scopes:
+
+**Local** (current project only, written to ``.mcp.json``):
+
+.. code-block:: bash
+
+   claude mcp add srunx -- uv run --extra mcp srunx-mcp
+
+**Project** (shared with collaborators via ``.mcp.json`` in version control):
+
+.. code-block:: bash
+
+   claude mcp add --scope project srunx -- uv run --extra mcp srunx-mcp
+
+**User** (available in all your projects):
+
+.. code-block:: bash
+
+   claude mcp add --scope user srunx -- uv run --extra mcp srunx-mcp
+
+.. tip::
+
+   Use **project** scope if your team shares the same SLURM cluster setup.
+   Use **user** scope if you want srunx available everywhere without
+   per-project config.
+
+Verify the Connection
+---------------------
+
+Check that Claude Code sees the srunx server:
+
+.. code-block:: bash
+
+   claude mcp list
+
+You should see ``srunx`` listed with its tools. If the server does not
+appear, ensure the ``uv`` command is on your ``PATH`` and that
+``uv sync --extra mcp`` completed without errors.
+
+First Interaction
+-----------------
+
+Open Claude Code in your project and try these prompts:
+
+**List your SLURM jobs:**
+
+.. code-block:: text
+
+   > List my current SLURM jobs
+
+Claude Code calls the ``list_jobs`` tool and returns a formatted table
+of your queued and running jobs.
+
+**Check GPU resources:**
+
+.. code-block:: text
+
+   > How many GPUs are available on the gpu partition?
+
+Claude Code calls ``get_resources`` with ``partition="gpu"`` and reports
+total, in-use, and available GPU counts.
+
+**Submit a simple job:**
+
+.. code-block:: text
+
+   > Submit a job to run "python train.py" with 2 GPUs, using the ml_env
+   > conda environment
+
+Claude Code calls ``submit_job`` with the appropriate parameters and
+returns the SLURM job ID.
+
+Using SSH Mode
+~~~~~~~~~~~~~~
+
+If your SLURM cluster is remote, ensure you have an SSH profile configured
+(see :doc:`/how-to/sync` for mount setup). Then include "via SSH" in your
+prompt:
+
+.. code-block:: text
+
+   > List my jobs on the remote cluster
+
+Claude Code detects the SSH context and passes ``use_ssh=True`` to the
+underlying tools, routing commands through your active SSH profile.
+
+Next Steps
+----------
+
+- :doc:`/how-to/mcp-usage` -- task-oriented recipes for common operations
+- :doc:`/reference/mcp-tools` -- complete reference for all 14 MCP tools
+- :doc:`/explanation/mcp-architecture` -- how the MCP integration works under the hood

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,14 @@ web = [
     "uvicorn[standard]>=0.34.0",
     "anyio>=4.0.0",
 ]
+mcp = [
+    "mcp[cli]>=1.0.0",
+]
 
 [project.scripts]
 srunx = "srunx.cli.main:main"
 srunx-web = "srunx.web.app:main"
+srunx-mcp = "srunx.mcp.server:main"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/src/srunx/mcp/__init__.py
+++ b/src/srunx/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server for srunx - expose SLURM operations as Claude Code tools."""

--- a/src/srunx/mcp/server.py
+++ b/src/srunx/mcp/server.py
@@ -1,0 +1,883 @@
+"""MCP server exposing srunx SLURM operations as tools for Claude Code."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP(
+    "srunx",
+    instructions=(
+        "SLURM job management tools. Use these to submit jobs, monitor status, "
+        "manage workflows, check GPU resources, and sync files to remote clusters. "
+        "Most operations require either local SLURM access or a configured SSH profile."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ok(data: Any = None, **kwargs: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {"success": True}
+    if data is not None:
+        result["data"] = data
+    result.update(kwargs)
+    return result
+
+
+def _err(message: str) -> dict[str, Any]:
+    return {"success": False, "error": message}
+
+
+_SAFE_JOB_ID = re.compile(r"^\d+(_\d+)?$")
+_SAFE_PARTITION = re.compile(r"^[a-zA-Z0-9_\-]+$")
+
+
+def _validate_job_id(job_id: str) -> str:
+    """Validate that job_id is a numeric SLURM job ID (e.g. '12345' or '12345_1')."""
+    if not _SAFE_JOB_ID.match(job_id):
+        raise ValueError(f"Invalid job ID: {job_id!r}. Must be numeric (e.g. '12345').")
+    return job_id
+
+
+def _validate_partition(partition: str) -> str:
+    """Validate that partition name contains only safe characters."""
+    if not _SAFE_PARTITION.match(partition):
+        raise ValueError(
+            f"Invalid partition name: {partition!r}. "
+            "Must contain only alphanumeric, underscore, or hyphen."
+        )
+    return partition
+
+
+def _job_to_dict(job: Any) -> dict[str, Any]:
+    """Convert a BaseJob / Job / ShellJob to a JSON-serializable dict."""
+    d: dict[str, Any] = {
+        "name": job.name,
+        "job_id": job.job_id,
+        "status": job._status.value if hasattr(job, "_status") else "UNKNOWN",
+    }
+    for field in (
+        "partition",
+        "user",
+        "elapsed_time",
+        "nodes",
+        "nodelist",
+        "cpus",
+        "gpus",
+    ):
+        val = getattr(job, field, None)
+        if val is not None:
+            d[field] = val
+    if hasattr(job, "command"):
+        cmd = job.command
+        d["command"] = cmd if isinstance(cmd, str) else " ".join(cmd or [])
+    if hasattr(job, "script_path"):
+        d["script_path"] = job.script_path
+    return d
+
+
+def _get_ssh_client() -> Any:
+    """Get an SSHSlurmClient from the current SSH profile."""
+    from srunx.ssh.core.config import ConfigManager
+
+    cm = ConfigManager()
+    profile_name = cm.get_current_profile_name()
+    if not profile_name:
+        raise RuntimeError(
+            "No active SSH profile. Set one with: srunx ssh profile use <name>"
+        )
+    profile = cm.get_profile(profile_name)
+    if not profile:
+        raise RuntimeError(f"SSH profile '{profile_name}' not found")
+
+    from srunx.ssh.core.client import SSHSlurmClient
+
+    client = SSHSlurmClient(
+        hostname=profile.hostname,
+        username=profile.username,
+        key_filename=profile.key_filename,
+        port=profile.port,
+        proxy_jump=profile.proxy_jump,
+        ssh_config_path=None,
+        env_vars=profile.env_vars,
+    )
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Job Management Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def submit_job(
+    command: str,
+    name: str = "job",
+    nodes: int = 1,
+    gpus_per_node: int = 0,
+    ntasks_per_node: int = 1,
+    cpus_per_task: int = 1,
+    memory_per_node: str | None = None,
+    time_limit: str | None = None,
+    partition: str | None = None,
+    nodelist: str | None = None,
+    conda: str | None = None,
+    venv: str | None = None,
+    env_vars: dict[str, str] | None = None,
+    log_dir: str = "logs",
+    work_dir: str | None = None,
+    use_ssh: bool = False,
+) -> dict[str, Any]:
+    """Submit a SLURM job.
+
+    Args:
+        command: Shell command to execute (e.g. "python train.py --epochs 100")
+        name: Job name for identification in SLURM queue
+        nodes: Number of compute nodes to allocate
+        gpus_per_node: Number of GPUs per node (0 for CPU-only)
+        ntasks_per_node: Number of tasks per node
+        cpus_per_task: Number of CPUs per task
+        memory_per_node: Memory per node (e.g. "32GB", "64G")
+        time_limit: Wall time limit (e.g. "4:00:00", "1-00:00:00")
+        partition: SLURM partition name (e.g. "gpu", "cpu")
+        nodelist: Specific nodes to use (e.g. "node001,node002")
+        conda: Conda environment name to activate before running
+        venv: Path to Python virtual environment to activate
+        env_vars: Additional environment variables as key-value pairs
+        log_dir: Directory for stdout/stderr log files
+        work_dir: Working directory for the job (defaults to cwd)
+        use_ssh: If true, submit via SSH to remote SLURM cluster
+    """
+    try:
+        from srunx.models import Job, JobEnvironment, JobResource
+
+        resource = JobResource(
+            nodes=nodes,
+            gpus_per_node=gpus_per_node,
+            ntasks_per_node=ntasks_per_node,
+            cpus_per_task=cpus_per_task,
+            memory_per_node=memory_per_node,
+            time_limit=time_limit,
+            partition=partition,
+            nodelist=nodelist,
+        )
+        environment = JobEnvironment(
+            conda=conda,
+            venv=venv,
+            env_vars=env_vars or {},
+        )
+        if use_ssh and not work_dir:
+            return _err(
+                "work_dir is required for SSH job submission "
+                "(local cwd does not exist on remote cluster)"
+            )
+
+        job = Job(
+            name=name,
+            command=command,
+            resources=resource,
+            environment=environment,
+            log_dir=log_dir,
+            work_dir=work_dir or str(Path.cwd()),
+        )
+
+        if use_ssh:
+            from srunx.models import _build_environment_setup
+
+            template_path = (
+                Path(__file__).parent.parent / "templates" / "advanced.slurm.jinja"
+            )
+
+            import jinja2
+
+            with open(template_path) as f:
+                tmpl = jinja2.Template(f.read(), undefined=jinja2.StrictUndefined)
+
+            env_setup, srun_args, launch_prefix = _build_environment_setup(environment)
+            cmd_str = command if isinstance(command, str) else " ".join(command)
+            script_content = tmpl.render(
+                job_name=name,
+                command=cmd_str,
+                log_dir=log_dir,
+                work_dir=work_dir,
+                environment_setup=env_setup,
+                srun_args=srun_args,
+                launch_prefix=launch_prefix,
+                container=environment.container,
+                **resource.model_dump(),
+            )
+            ssh_client = _get_ssh_client()
+            with ssh_client:
+                slurm_job = ssh_client.submit_sbatch_job(script_content, job_name=name)
+                if slurm_job is None:
+                    return _err("SSH job submission failed")
+                return _ok(
+                    job_id=slurm_job.job_id, name=slurm_job.name, status="PENDING"
+                )
+        else:
+            from srunx.client import Slurm
+
+            slurm = Slurm()
+            result = slurm.submit(job)
+            return _ok(
+                job_id=result.job_id, name=result.name, status=result._status.value
+            )
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def list_jobs(use_ssh: bool = False) -> dict[str, Any]:
+    """List current user's SLURM jobs in the queue.
+
+    Args:
+        use_ssh: If true, query jobs via SSH on remote cluster
+    """
+    try:
+        if use_ssh:
+            ssh_client = _get_ssh_client()
+            with ssh_client:
+                stdout, stderr, rc = ssh_client._execute_slurm_command(
+                    'squeue --me --format "%.18i %.9P %.30j %.12u %.8T %.10M %.9l %.6D %R %b" --noheader'
+                )
+                if rc != 0:
+                    return _err(f"squeue failed: {stderr}")
+                jobs = []
+                for line in stdout.strip().splitlines():
+                    parts = line.split()
+                    if len(parts) >= 5:
+                        jobs.append(
+                            {
+                                "job_id": parts[0],
+                                "partition": parts[1],
+                                "name": parts[2],
+                                "user": parts[3],
+                                "status": parts[4],
+                                "time": parts[5] if len(parts) > 5 else None,
+                                "nodes": parts[7] if len(parts) > 7 else None,
+                            }
+                        )
+                return _ok(jobs=jobs, count=len(jobs))
+        else:
+            from srunx.client import Slurm
+
+            slurm = Slurm()
+            queued = slurm.queue()
+            return _ok(
+                jobs=[_job_to_dict(j) for j in queued],
+                count=len(queued),
+            )
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def get_job_status(job_id: str, use_ssh: bool = False) -> dict[str, Any]:
+    """Get the status of a specific SLURM job.
+
+    Args:
+        job_id: SLURM job ID to check
+        use_ssh: If true, query via SSH on remote cluster
+    """
+    try:
+        _validate_job_id(job_id)
+        if use_ssh:
+            ssh_client = _get_ssh_client()
+            with ssh_client:
+                status = ssh_client.get_job_status(str(job_id))
+                if status in ("ERROR", "NOT_FOUND"):
+                    return _err(f"Job {job_id}: {status}")
+                return _ok(job_id=job_id, status=status)
+        else:
+            from srunx.client import Slurm
+
+            job = Slurm.retrieve(int(job_id))
+            return _ok(job_id=job_id, **_job_to_dict(job))
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def cancel_job(job_id: str, use_ssh: bool = False) -> dict[str, Any]:
+    """Cancel a running or pending SLURM job.
+
+    Args:
+        job_id: SLURM job ID to cancel
+        use_ssh: If true, cancel via SSH on remote cluster
+    """
+    try:
+        _validate_job_id(job_id)
+        if use_ssh:
+            ssh_client = _get_ssh_client()
+            with ssh_client:
+                stdout, stderr, rc = ssh_client._execute_slurm_command(
+                    f"scancel {job_id}"
+                )
+                if rc != 0:
+                    return _err(f"scancel failed: {stderr}")
+                return _ok(job_id=job_id, message="Job cancelled")
+        else:
+            from srunx.client import Slurm
+
+            slurm = Slurm()
+            slurm.cancel(int(job_id))
+            return _ok(job_id=job_id, message="Job cancelled")
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def get_job_logs(
+    job_id: str,
+    job_name: str | None = None,
+    use_ssh: bool = False,
+) -> dict[str, Any]:
+    """Get stdout/stderr logs for a SLURM job.
+
+    Args:
+        job_id: SLURM job ID
+        job_name: Optional job name to help locate log files
+        use_ssh: If true, fetch logs via SSH from remote cluster
+    """
+    try:
+        _validate_job_id(job_id)
+        if use_ssh:
+            ssh_client = _get_ssh_client()
+            with ssh_client:
+                stdout, stderr, _, _ = ssh_client.get_job_output(str(job_id), job_name)
+                if not stdout and not stderr:
+                    return _err(f"No logs found for job {job_id}")
+                return _ok(job_id=job_id, stdout=stdout, stderr=stderr)
+        else:
+            from srunx.client import Slurm
+
+            slurm = Slurm()
+            details = slurm.get_job_output_detailed(job_id, job_name)
+            return _ok(
+                job_id=job_id,
+                stdout=details.get("output", ""),
+                stderr=details.get("error", ""),
+                log_files=details.get("found_files", []),
+            )
+    except Exception as e:
+        return _err(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Resource Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def get_resources(
+    partition: str | None = None, use_ssh: bool = False
+) -> dict[str, Any]:
+    """Get current GPU and node resource availability on the SLURM cluster.
+
+    Args:
+        partition: Specific partition to check (None for all partitions)
+        use_ssh: If true, query resources via SSH on remote cluster
+    """
+    try:
+        if partition:
+            _validate_partition(partition)
+        if use_ssh:
+            ssh_client = _get_ssh_client()
+            with ssh_client:
+                partition_flag = f"-p {partition}" if partition else ""
+                stdout, stderr, rc = ssh_client._execute_slurm_command(
+                    f'sinfo {partition_flag} -o "%n %G %T %P" --noheader'
+                )
+                if rc != 0:
+                    return _err(f"sinfo failed: {stderr}")
+                return _ok(partition=partition, raw_output=stdout.strip())
+        else:
+            from srunx.monitor.resource_monitor import ResourceMonitor
+
+            monitor = ResourceMonitor(min_gpus=0, partition=partition)
+            snapshot = monitor.get_partition_resources()
+            return _ok(
+                partition=snapshot.partition,
+                total_gpus=snapshot.total_gpus,
+                gpus_in_use=snapshot.gpus_in_use,
+                gpus_available=snapshot.gpus_available,
+                gpu_utilization=round(snapshot.gpu_utilization, 3),
+                jobs_running=snapshot.jobs_running,
+                nodes_total=snapshot.nodes_total,
+                nodes_idle=snapshot.nodes_idle,
+                nodes_down=snapshot.nodes_down,
+            )
+    except Exception as e:
+        return _err(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Workflow Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def create_workflow(
+    name: str,
+    jobs: list[dict[str, Any]],
+    output_path: str,
+    args: dict[str, Any] | None = None,
+    default_project: str | None = None,
+) -> dict[str, Any]:
+    """Create a SLURM workflow YAML file.
+
+    Generates a YAML workflow definition that can be executed with run_workflow.
+    Each job in the workflow can depend on other jobs, forming a DAG.
+
+    Args:
+        name: Workflow name for identification
+        jobs: List of job definitions. Each job dict should contain:
+            - name (required): Job identifier
+            - command (required for regular jobs): Command as string or list of strings
+            - script_path (required for shell jobs): Path to shell script
+            - depends_on: List of job names this job depends on (e.g. ["preprocess"])
+              Supports dependency types: "afterok:job_a", "after:job_a", "afterany:job_a"
+            - retry: Number of retry attempts on failure (default 0)
+            - retry_delay: Seconds between retries (default 60)
+            - resources: Dict with nodes, gpus_per_node, ntasks_per_node,
+              cpus_per_task, memory_per_node, time_limit, partition, nodelist
+            - environment: Dict with conda, venv, env_vars, container
+            - log_dir: Log directory path
+            - work_dir: Working directory path
+        output_path: File path to write the YAML workflow (e.g. "workflow.yaml")
+        args: Optional template variables for Jinja2 templating in job definitions
+        default_project: Default SSH project/mount name for file syncing
+    """
+    try:
+        from srunx.models import Workflow
+        from srunx.runner import WorkflowRunner
+
+        # Validate the workflow structure before writing.
+        # Skip job parsing validation when args are present (Jinja templates
+        # in job fields would fail parse before rendering).
+        if not args:
+            parsed_jobs = []
+            for job_data in jobs:
+                parsed_jobs.append(WorkflowRunner.parse_job(job_data))
+            workflow = Workflow(name=name, jobs=parsed_jobs)
+            workflow.validate()
+        else:
+            # Basic structural validation only
+            for job_data in jobs:
+                if "name" not in job_data:
+                    return _err("Each job must have a 'name' field")
+                if "command" not in job_data and "script_path" not in job_data:
+                    return _err(
+                        f"Job '{job_data.get('name', '?')}' must have "
+                        "'command' or 'script_path'"
+                    )
+
+        # Build the YAML structure
+        workflow_dict: dict[str, Any] = {"name": name}
+        if args:
+            workflow_dict["args"] = args
+        if default_project:
+            workflow_dict["default_project"] = default_project
+        workflow_dict["jobs"] = jobs
+
+        output_file = Path(output_path)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_file, "w") as f:
+            yaml.dump(workflow_dict, f, default_flow_style=False, sort_keys=False)
+
+        return _ok(
+            path=str(output_file.resolve()),
+            name=name,
+            job_count=len(jobs),
+            job_names=[j["name"] for j in jobs],
+            message=f"Workflow '{name}' created at {output_path}",
+        )
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def validate_workflow(yaml_path: str) -> dict[str, Any]:
+    """Validate a workflow YAML file for correctness.
+
+    Checks for valid YAML syntax, correct job structure, dependency resolution,
+    and circular dependency detection.
+
+    Args:
+        yaml_path: Path to the YAML workflow file to validate
+    """
+    try:
+        from srunx.runner import WorkflowRunner
+
+        runner = WorkflowRunner.from_yaml(yaml_path)
+        runner.workflow.validate()
+
+        jobs_info = []
+        for job in runner.workflow.jobs:
+            info: dict[str, Any] = {"name": job.name, "depends_on": job.depends_on}
+            if hasattr(job, "command"):
+                cmd = job.command
+                info["command"] = cmd if isinstance(cmd, str) else " ".join(cmd or [])
+            if hasattr(job, "script_path"):
+                info["script_path"] = job.script_path
+            jobs_info.append(info)
+
+        return _ok(
+            name=runner.workflow.name,
+            valid=True,
+            job_count=len(runner.workflow.jobs),
+            jobs=jobs_info,
+        )
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def run_workflow(
+    yaml_path: str,
+    from_job: str | None = None,
+    to_job: str | None = None,
+    single_job: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Execute a SLURM workflow from a YAML file.
+
+    Jobs are executed in dependency order - independent jobs run in parallel,
+    dependent jobs wait for their prerequisites to complete.
+
+    Args:
+        yaml_path: Path to the YAML workflow file
+        from_job: Start execution from this job (skip earlier jobs)
+        to_job: Stop execution at this job (skip later jobs)
+        single_job: Execute only this specific job, ignoring dependencies
+        dry_run: If true, show what would be executed without actually running
+    """
+    try:
+        from srunx.runner import WorkflowRunner
+
+        runner = WorkflowRunner.from_yaml(yaml_path)
+
+        if dry_run:
+            jobs_to_execute = runner._get_jobs_to_execute(from_job, to_job, single_job)
+            jobs_info = []
+            for job in jobs_to_execute:
+                info: dict[str, Any] = {"name": job.name, "depends_on": job.depends_on}
+                if hasattr(job, "command"):
+                    cmd = job.command
+                    info["command"] = (
+                        cmd if isinstance(cmd, str) else " ".join(cmd or [])
+                    )
+                if hasattr(job, "script_path"):
+                    info["script_path"] = job.script_path
+                jobs_info.append(info)
+            return _ok(
+                dry_run=True,
+                workflow=runner.workflow.name,
+                jobs_to_execute=jobs_info,
+                count=len(jobs_info),
+            )
+
+        results = runner.run(from_job=from_job, to_job=to_job, single_job=single_job)
+        completed = {}
+        for job_name, job in results.items():
+            completed[job_name] = {
+                "job_id": job.job_id,
+                "status": job._status.value,
+            }
+        return _ok(
+            workflow=runner.workflow.name,
+            results=completed,
+            all_completed=all(v["status"] == "COMPLETED" for v in completed.values()),
+        )
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def list_workflows(directory: str = ".") -> dict[str, Any]:
+    """List workflow YAML files in a directory.
+
+    Scans the directory for YAML files that contain a valid srunx workflow
+    structure (must have 'name' and 'jobs' keys).
+
+    Args:
+        directory: Directory to search for workflow files (default: current directory)
+    """
+    try:
+        search_dir = Path(directory).resolve()
+        yaml_files = list(search_dir.glob("**/*.yaml")) + list(
+            search_dir.glob("**/*.yml")
+        )
+
+        # Filter to only files that look like srunx workflows
+        workflows = []
+        for yf in yaml_files:
+            # Skip files in hidden dirs, node_modules, .venv
+            parts = yf.relative_to(search_dir).parts
+            if any(
+                p.startswith(".") or p in ("node_modules", ".venv", "__pycache__")
+                for p in parts
+            ):
+                continue
+            try:
+                with open(yf) as f:
+                    data = yaml.safe_load(f)
+                if isinstance(data, dict) and "jobs" in data:
+                    workflows.append(
+                        {
+                            "path": str(yf),
+                            "name": data.get("name", "unnamed"),
+                            "job_count": len(data["jobs"]),
+                            "job_names": [j.get("name", "?") for j in data["jobs"]],
+                        }
+                    )
+            except Exception:
+                continue
+
+        return _ok(workflows=workflows, count=len(workflows))
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def get_workflow(yaml_path: str) -> dict[str, Any]:
+    """Read and parse a workflow YAML file, returning its full structure.
+
+    Args:
+        yaml_path: Path to the YAML workflow file
+    """
+    try:
+        path = Path(yaml_path)
+        if not path.exists():
+            return _err(f"File not found: {yaml_path}")
+
+        with open(path) as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict) or "jobs" not in data:
+            return _err("File is not a valid srunx workflow (missing 'jobs' key)")
+
+        # Also validate it can be parsed
+        from srunx.runner import WorkflowRunner
+
+        runner = WorkflowRunner.from_yaml(yaml_path)
+
+        jobs_detail = []
+        for job in runner.workflow.jobs:
+            info: dict[str, Any] = {
+                "name": job.name,
+                "depends_on": job.depends_on,
+                "retry": job.retry,
+                "retry_delay": job.retry_delay,
+            }
+            from srunx.models import Job, ShellJob
+
+            if isinstance(job, Job):
+                cmd = job.command
+                info["command"] = cmd if isinstance(cmd, str) else " ".join(cmd or [])
+                info["resources"] = job.resources.model_dump()
+                info["environment"] = {
+                    "conda": job.environment.conda,
+                    "venv": job.environment.venv,
+                    "env_vars": job.environment.env_vars,
+                }
+            elif isinstance(job, ShellJob):
+                info["script_path"] = job.script_path
+                info["script_vars"] = job.script_vars
+            jobs_detail.append(info)
+
+        return _ok(
+            name=runner.workflow.name,
+            args=data.get("args"),
+            default_project=data.get("default_project"),
+            jobs=jobs_detail,
+            raw_yaml=path.read_text(),
+        )
+    except Exception as e:
+        return _err(str(e))
+
+
+# ---------------------------------------------------------------------------
+# File Sync Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def sync_files(
+    profile_name: str | None = None,
+    mount_name: str | None = None,
+    local_path: str | None = None,
+    remote_path: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Sync files between local machine and remote SLURM cluster using rsync.
+
+    Can sync using a configured mount point (profile_name + mount_name),
+    or using explicit paths (local_path + remote_path).
+
+    Args:
+        profile_name: SSH profile name (uses current profile if not specified)
+        mount_name: Mount point name from the SSH profile to sync
+        local_path: Local directory path (alternative to mount_name)
+        remote_path: Remote directory path (alternative to mount_name)
+        dry_run: If true, show what would be transferred without actually syncing
+    """
+    try:
+        from srunx.ssh.core.config import ConfigManager
+
+        cm = ConfigManager()
+
+        if mount_name:
+            # Use mount-based sync
+            pname = profile_name or cm.get_current_profile_name()
+            if not pname:
+                return _err("No SSH profile specified and no current profile set")
+            profile = cm.get_profile(pname)
+            if not profile:
+                return _err(f"SSH profile '{pname}' not found")
+
+            mount = next((m for m in profile.mounts if m.name == mount_name), None)
+            if not mount:
+                available = [m.name for m in profile.mounts]
+                return _err(
+                    f"Mount '{mount_name}' not found in profile '{pname}'. "
+                    f"Available: {available}"
+                )
+
+            from srunx.web.sync_utils import build_rsync_client
+
+            rsync = build_rsync_client(profile)
+            result = rsync.push(
+                mount.local,
+                mount.remote,
+                dry_run=dry_run,
+                exclude_patterns=mount.exclude_patterns,
+            )
+            if not result.success:
+                return _err(
+                    f"rsync failed (exit {result.returncode}): "
+                    f"{result.stderr[:500] if result.stderr else 'unknown error'}"
+                )
+            return _ok(
+                profile=pname,
+                mount=mount_name,
+                local=mount.local,
+                remote=mount.remote,
+                dry_run=dry_run,
+                output=result.stdout[:2000] if result.stdout else "",
+            )
+
+        elif local_path:
+            # Use explicit path sync
+            pname = profile_name or cm.get_current_profile_name()
+            if not pname:
+                return _err("No SSH profile specified and no current profile set")
+            profile = cm.get_profile(pname)
+            if not profile:
+                return _err(f"SSH profile '{pname}' not found")
+
+            from srunx.web.sync_utils import build_rsync_client
+
+            rsync = build_rsync_client(profile)
+            result = rsync.push(local_path, remote_path, dry_run=dry_run)
+            if not result.success:
+                return _err(
+                    f"rsync failed (exit {result.returncode}): "
+                    f"{result.stderr[:500] if result.stderr else 'unknown error'}"
+                )
+            return _ok(
+                profile=pname,
+                local=local_path,
+                remote=remote_path or rsync.get_default_remote_path(local_path),
+                dry_run=dry_run,
+                output=result.stdout[:2000] if result.stdout else "",
+            )
+        else:
+            return _err("Specify either mount_name or local_path for sync")
+
+    except Exception as e:
+        return _err(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Configuration Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def get_config() -> dict[str, Any]:
+    """Get the current srunx configuration including resource defaults and environment settings."""
+    try:
+        from srunx.config import get_config as _get_config
+
+        config = _get_config()
+        return _ok(
+            resources=config.resources.model_dump(),
+            environment={
+                "conda": config.environment.conda,
+                "venv": config.environment.venv,
+                "env_vars": config.environment.env_vars,
+            },
+            log_dir=config.log_dir,
+            work_dir=config.work_dir,
+        )
+    except Exception as e:
+        return _err(str(e))
+
+
+@mcp.tool()
+def list_ssh_profiles() -> dict[str, Any]:
+    """List all configured SSH connection profiles for remote SLURM clusters.
+
+    Shows profile names, hostnames, and configured mount points.
+    """
+    try:
+        from srunx.ssh.core.config import ConfigManager
+
+        cm = ConfigManager()
+        profiles = cm.list_profiles()
+        current = cm.get_current_profile_name()
+
+        result = []
+        for name, profile in profiles.items():
+            mounts = [
+                {"name": m.name, "local": m.local, "remote": m.remote}
+                for m in profile.mounts
+            ]
+            result.append(
+                {
+                    "name": name,
+                    "hostname": profile.hostname,
+                    "username": profile.username,
+                    "port": profile.port,
+                    "description": profile.description,
+                    "is_current": name == current,
+                    "mounts": mounts,
+                }
+            )
+
+        return _ok(profiles=result, current=current, count=len(result))
+    except Exception as e:
+        return _err(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Run the srunx MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -723,6 +723,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.15"
 source = { registry = "https://pypi.org/simple" }
@@ -1182,6 +1191,37 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1544,6 +1584,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pydata-sphinx-theme"
 version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1569,6 +1623,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1678,6 +1746,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642, upload-time = "2025-03-07T07:08:27.301Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163, upload-time = "2025-03-07T07:08:25.627Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]
@@ -2241,6 +2318,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+mcp = [
+    { name = "mcp", extra = ["cli"] },
+]
 web = [
     { name = "anyio" },
     { name = "fastapi" },
@@ -2272,6 +2352,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "paramiko", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -2280,7 +2361,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.17.3" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.34.0" },
 ]
-provides-extras = ["web"]
+provides-extras = ["mcp", "web"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2302,6 +2383,19 @@ dev = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2317,15 +2411,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- srunx の SLURM 操作を **14個の MCP ツール** として公開し、Claude Code から自然言語で直接呼び出せるようにする
- ジョブ管理、ワークフロー作成・実行、GPU リソース監視、rsync同期、設定確認に対応
- Diataxis 構成のドキュメント（tutorial / how-to / reference / explanation）を追加

## Changes
- `src/srunx/mcp/` — FastMCP サーバー実装（14ツール）
- `pyproject.toml` — `mcp` optional dependency + `srunx-mcp` エントリポイント
- `.mcp.json` — Claude Code 自動認識設定
- `docs/` — MCP 関連ドキュメント4ファイル + index.rst 更新

## MCP Tools

| Category | Tools |
|----------|-------|
| Job Management | `submit_job`, `list_jobs`, `get_job_status`, `cancel_job`, `get_job_logs` |
| Resources | `get_resources` |
| Workflows | `create_workflow`, `validate_workflow`, `run_workflow`, `list_workflows`, `get_workflow` |
| File Sync | `sync_files` |
| Configuration | `get_config`, `list_ssh_profiles` |

## Security
- コマンドインジェクション対策: `job_id`, `partition` パラメータのバリデーション
- SSH 経由のコマンドは `_execute_slurm_command()` で環境設定済みパスを使用
- エラー時は `{"success": false, "error": "..."}` で統一的にシグナリング

## Test plan
- [x] `uv run ruff check src/srunx/mcp/` — pass
- [x] `uv run mypy src/srunx/mcp/` — pass
- [x] MCP サーバーのインポート・ツール登録確認（14ツール）
- [x] pre-commit hooks 全通過
- [x] Sphinx ドキュメントビルド成功
- [ ] 実クラスタでの E2E テスト（ジョブ投入・ワークフロー実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)