### PR TITLE
refactor: unify project config to srunx.json

### DIFF
--- a/docs/explanation/architecture.rst
+++ b/docs/explanation/architecture.rst
@@ -283,7 +283,7 @@ Stateless per-request reads
 Mount-based project model
    Projects are not derived from the current working directory (which is
    meaningless for a web server). Instead, each SSH profile mount defines a
-   project: the mount's ``local`` directory is scanned for ``.srunx.json``.
+   project: the mount's ``local`` directory is scanned for ``srunx.json``.
    This makes project configuration remote-friendly — the same mount mapping
    used for file browsing and rsync sync also drives per-project settings.
 
@@ -339,5 +339,5 @@ Configuration is loaded in order of precedence (lowest to highest):
 
 1. System-wide: ``/etc/srunx/config.json``
 2. User-wide: ``~/.config/srunx/config.json``
-3. Project-wide: ``.srunx.json`` or ``srunx.json`` in the working directory
+3. Project-wide: ``srunx.json`` in the working directory
 4. Environment variables: ``SRUNX_DEFAULT_*``

--- a/docs/how-to/settings.rst
+++ b/docs/how-to/settings.rst
@@ -130,16 +130,16 @@ Initialize a project
 
 1. Open the **Project** tab
 2. Find a mount that shows "No config"
-3. Click **Initialize** to create a ``.srunx.json`` with example values in the mount's local directory
+3. Click **Initialize** to create a ``srunx.json`` with example values in the mount's local directory
 
 Edit project config
 ~~~~~~~~~~~~~~~~~~~~
 
-1. Click **Edit** on a project that has an existing ``.srunx.json``
+1. Click **Edit** on a project that has an existing ``srunx.json``
 2. Modify per-project resource defaults, environment settings, or notification overrides
 3. Click **Save**
 
-Project-level settings in ``.srunx.json`` override the global user config for workflows that execute within that mount's directory.
+Project-level settings in ``srunx.json`` override the global user config for workflows that execute within that mount's directory.
 
 Equivalent CLI Commands
 ------------------------

--- a/docs/reference/webui-api.rst
+++ b/docs/reference/webui-api.rst
@@ -691,7 +691,7 @@ Config
      - List projects from current profile's mounts
    * - GET
      - ``/api/config/projects/{mount_name}``
-     - Read project config (.srunx.json)
+     - Read project config (srunx.json)
    * - PUT
      - ``/api/config/projects/{mount_name}``
      - Update project config
@@ -758,8 +758,7 @@ Returns all config file paths with their existence status and source label.
    [
      {"path": "/etc/srunx/config.json", "exists": false, "source": "system"},
      {"path": "/home/user/.config/srunx/config.json", "exists": true, "source": "user"},
-     {"path": ".srunx.json", "exists": false, "source": "project (.srunx.json)"},
-     {"path": "srunx.json", "exists": false, "source": "project (srunx.json)"}
+     {"path": "srunx.json", "exists": false, "source": "project"}
    ]
 
 POST /api/config/reset
@@ -940,7 +939,7 @@ List projects derived from the current SSH profile's mounts.
        "local_path": "/home/user/projects/ml-project",
        "remote_path": "/home/researcher/ml-project",
        "config_exists": true,
-       "config_path": "/home/user/projects/ml-project/.srunx.json"
+       "config_path": "/home/user/projects/ml-project/srunx.json"
      }
    ]
 
@@ -949,7 +948,7 @@ Returns an empty list if no SSH profile is active.
 GET /api/config/projects/{mount_name}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Read ``.srunx.json`` from a mount's local directory.
+Read ``srunx.json`` from a mount's local directory.
 
 **Response:**
 
@@ -958,7 +957,7 @@ Read ``.srunx.json`` from a mount's local directory.
    {
      "mount_name": "ml-project",
      "local_path": "/home/user/projects/ml-project",
-     "config_path": "/home/user/projects/ml-project/.srunx.json",
+     "config_path": "/home/user/projects/ml-project/srunx.json",
      "exists": true,
      "config": {
        "resources": {"gpus_per_node": 4, "time_limit": "8:00:00"},
@@ -974,7 +973,7 @@ Read ``.srunx.json`` from a mount's local directory.
 PUT /api/config/projects/{mount_name}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Save ``.srunx.json`` to a mount's local directory.
+Save ``srunx.json`` to a mount's local directory.
 
 **Request body:** A ``SrunxConfig`` object.
 
@@ -990,7 +989,7 @@ Save ``.srunx.json`` to a mount's local directory.
 POST /api/config/projects/{mount_name}/init
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Initialize ``.srunx.json`` with example values in a mount's local directory.
+Initialize ``srunx.json`` with example values in a mount's local directory.
 
 **Response:** The created project config response with example values.
 
@@ -998,7 +997,7 @@ Initialize ``.srunx.json`` with example values in a mount's local directory.
 
 * ``400`` — No active SSH profile
 * ``404`` — Mount not found
-* ``409`` — ``.srunx.json`` already exists
+* ``409`` — ``srunx.json`` already exists
 
 History
 -------

--- a/docs/tutorials/webui.rst
+++ b/docs/tutorials/webui.rst
@@ -175,7 +175,7 @@ The Settings page lets you manage all srunx configuration from the browser.
 
 5. On the **Notifications** tab, enter a Slack webhook URL to receive job notifications
 6. The **Environment** tab shows all active ``SRUNX_*`` variables (read-only)
-7. The **Project** tab lists projects from your mounts — initialize ``.srunx.json`` for per-project config overrides
+7. The **Project** tab lists projects from your mounts — initialize ``srunx.json`` for per-project config overrides
 
 .. note::
 

--- a/src/srunx/config.py
+++ b/src/srunx/config.py
@@ -89,7 +89,6 @@ def get_config_paths() -> list[Path]:
     paths.append(user_config_dir / "config.json")
 
     # Project-wide config (current working directory)
-    paths.append(Path.cwd() / ".srunx.json")
     paths.append(Path.cwd() / "srunx.json")
 
     return paths

--- a/src/srunx/web/frontend/src/pages/settings/ProjectTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/ProjectTab.tsx
@@ -102,7 +102,7 @@ export function ProjectTab() {
       setSaving(true);
       const resp = await configApi.initProject(mountName);
       setEditConfig(resp.config);
-      setSuccess(`Initialized .srunx.json for "${mountName}"`);
+      setSuccess(`Initialized srunx.json for "${mountName}"`);
       await load();
       setExpandedMount(mountName);
     } catch (e) {
@@ -238,7 +238,7 @@ export function ProjectTab() {
                   }
                   style={{ fontSize: "0.6rem" }}
                 >
-                  {proj.config_exists ? ".srunx.json" : "NO CONFIG"}
+                  {proj.config_exists ? "srunx.json" : "NO CONFIG"}
                 </span>
               </div>
               <div
@@ -329,7 +329,7 @@ export function ProjectTab() {
                     disabled={saving}
                   >
                     <Plus size={14} />
-                    Initialize .srunx.json
+                    Initialize srunx.json
                   </button>
                 ) : editConfig ? (
                   <div>

--- a/src/srunx/web/routers/config.py
+++ b/src/srunx/web/routers/config.py
@@ -62,7 +62,7 @@ async def update_config(body: dict[str, Any]) -> dict[str, Any]:
 @router.get("/paths")
 async def get_paths() -> list[ConfigPathInfo]:
     """Return all config file paths with their existence status."""
-    sources = ["system", "user", "project (.srunx.json)", "project (srunx.json)"]
+    sources = ["system", "user", "project"]
     paths = get_config_paths()
     return [
         ConfigPathInfo(
@@ -285,13 +285,9 @@ class ProjectConfigResponse(BaseModel):
 
 
 def _resolve_project_path(local_dir: str) -> Path:
-    """Find .srunx.json or srunx.json in a local directory."""
+    """Find srunx.json in a local directory."""
     local = Path(local_dir).expanduser().resolve()
-    for filename in [".srunx.json", "srunx.json"]:
-        candidate = local / filename
-        if candidate.exists():
-            return candidate
-    return local / ".srunx.json"
+    return local / "srunx.json"
 
 
 def _get_mount_from_profile(mount_name: str) -> tuple[str, str]:
@@ -345,7 +341,7 @@ async def list_projects() -> list[ProjectInfo]:
 
 @router.get("/projects/{mount_name}")
 async def get_project_config(mount_name: str) -> ProjectConfigResponse:
-    """Read .srunx.json from a mount's local directory."""
+    """Read srunx.json from a mount's local directory."""
     local, _ = _get_mount_from_profile(mount_name)
     config_path = _resolve_project_path(local)
 
@@ -372,7 +368,7 @@ async def get_project_config(mount_name: str) -> ProjectConfigResponse:
 async def update_project_config(
     mount_name: str, body: dict[str, Any]
 ) -> ProjectConfigResponse:
-    """Save .srunx.json to a mount's local directory."""
+    """Save srunx.json to a mount's local directory."""
     local, _ = _get_mount_from_profile(mount_name)
 
     try:
@@ -380,7 +376,7 @@ async def update_project_config(
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors()) from e
 
-    config_path = Path(local).expanduser().resolve() / ".srunx.json"
+    config_path = Path(local).expanduser().resolve() / "srunx.json"
     try:
         with open(config_path, "w", encoding="utf-8") as f:
             json.dump(config.model_dump(exclude_unset=True), f, indent=2)
@@ -400,9 +396,9 @@ async def update_project_config(
 
 @router.post("/projects/{mount_name}/init")
 async def init_project_config(mount_name: str) -> ProjectConfigResponse:
-    """Initialize .srunx.json in a mount's local directory."""
+    """Initialize srunx.json in a mount's local directory."""
     local, _ = _get_mount_from_profile(mount_name)
-    config_path = Path(local).expanduser().resolve() / ".srunx.json"
+    config_path = Path(local).expanduser().resolve() / "srunx.json"
 
     if config_path.exists():
         raise HTTPException(status_code=409, detail=f"{config_path} already exists")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -197,9 +197,7 @@ class TestConfigPaths:
     def test_get_config_paths(self):
         """Test getting configuration paths."""
         paths = get_config_paths()
-        assert (
-            len(paths) == 4
-        )  # system, user, project (.srunx.json), project (srunx.json)
+        assert len(paths) == 3  # system, user, project (srunx.json)
         assert all(isinstance(path, Path) for path in paths)
 
     @patch("os.name", "posix")
@@ -228,7 +226,6 @@ class TestConfigSaving:
                 mock_paths.return_value = [
                     Path("/etc/srunx/config.json"),  # system
                     user_config_path,  # user
-                    Path(".srunx.json"),  # project
                     Path("srunx.json"),  # project
                 ]
 


### PR DESCRIPTION
## Summary
- `.srunx.json` と `srunx.json` の冗長なプロジェクト設定ファイルを `srunx.json` に一本化
- ユーザーレベルのオーバーライドは `~/.config/srunx/config.json` が既に担っているため、プロジェクトレベルに2ファイルは不要
- コア、Web API、フロントエンド、テスト、ドキュメント全体で一貫して更新

## Test plan
- [x] `pytest tests/test_config.py` 全23テスト通過
- [x] pre-commit hooks 全通過 (ruff, mypy, tsc, pytest)
- [x] `grep -r '\.srunx\.json'` でプロジェクト全体に残留なし確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)