### PR TITLE
feat: template CRUD from web UI

### DIFF
--- a/src/srunx/template.py
+++ b/src/srunx/template.py
@@ -1,8 +1,12 @@
 """Job template management for common use cases."""
 
+import json
+import os
+import re
 from importlib.resources import files
+from pathlib import Path
 
-TEMPLATES = {
+BUILTIN_TEMPLATES = {
     "base": {
         "name": "base",
         "description": "SLURM job template with full resource control and inter-job outputs",
@@ -11,54 +15,154 @@ TEMPLATES = {
     },
 }
 
+# Keep backward-compatible alias
+TEMPLATES = BUILTIN_TEMPLATES
+
+_VALID_NAME = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _user_templates_dir() -> Path:
+    """Return the user templates directory (~/.config/srunx/templates/)."""
+    if os.name == "posix":
+        base = Path.home() / ".config" / "srunx"
+    else:
+        base = Path.home() / "AppData" / "Roaming" / "srunx"
+    return base / "templates"
+
+
+def _user_meta_path() -> Path:
+    """Return the path to user templates metadata file."""
+    return _user_templates_dir() / "meta.json"
+
+
+def _load_user_meta() -> dict[str, dict[str, str]]:
+    """Load user template metadata from disk."""
+    meta_path = _user_meta_path()
+    if not meta_path.exists():
+        return {}
+    try:
+        with open(meta_path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_user_meta(meta: dict[str, dict[str, str]]) -> None:
+    """Save user template metadata to disk."""
+    meta_path = _user_meta_path()
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(meta_path, "w", encoding="utf-8") as f:
+        json.dump(meta, f, indent=2)
+
+
+def _user_template_file(name: str) -> Path:
+    """Return the path to a user template file."""
+    return _user_templates_dir() / f"{name}.slurm.jinja"
+
 
 def list_templates() -> list[dict[str, str]]:
-    """List all available templates.
-
-    Returns:
-        List of template information dictionaries.
-    """
-    return list(TEMPLATES.values())
+    """List all available templates (built-in + user)."""
+    result = list(BUILTIN_TEMPLATES.values())
+    for name, info in _load_user_meta().items():
+        result.append({"name": name, **info, "user_defined": "true"})
+    return result
 
 
 def get_template_path(template_name: str) -> str:
-    """Get the path to a template file.
+    """Get the path to a template file."""
+    if template_name in BUILTIN_TEMPLATES:
+        template_file = BUILTIN_TEMPLATES[template_name]["path"]
+        return str(files("srunx.templates").joinpath(template_file))
 
-    Args:
-        template_name: Name of the template (e.g., 'base')
+    user_file = _user_template_file(template_name)
+    if user_file.exists():
+        return str(user_file)
 
-    Returns:
-        Path to the template file.
-
-    Raises:
-        ValueError: If template name is not found.
-    """
-    if template_name not in TEMPLATES:
-        available = ", ".join(TEMPLATES.keys())
-        raise ValueError(
-            f"Template '{template_name}' not found. Available templates: {available}"
-        )
-
-    template_file = TEMPLATES[template_name]["path"]
-    return str(files("srunx.templates").joinpath(template_file))
+    all_names = list(BUILTIN_TEMPLATES.keys()) + list(_load_user_meta().keys())
+    available = ", ".join(all_names)
+    raise ValueError(
+        f"Template '{template_name}' not found. Available templates: {available}"
+    )
 
 
 def get_template_info(template_name: str) -> dict[str, str]:
-    """Get information about a specific template.
+    """Get information about a specific template."""
+    if template_name in BUILTIN_TEMPLATES:
+        return BUILTIN_TEMPLATES[template_name]
 
-    Args:
-        template_name: Name of the template
+    user_meta = _load_user_meta()
+    if template_name in user_meta:
+        return {"name": template_name, **user_meta[template_name]}
 
-    Returns:
-        Template information dictionary.
+    all_names = list(BUILTIN_TEMPLATES.keys()) + list(user_meta.keys())
+    available = ", ".join(all_names)
+    raise ValueError(
+        f"Template '{template_name}' not found. Available templates: {available}"
+    )
 
-    Raises:
-        ValueError: If template name is not found.
-    """
-    if template_name not in TEMPLATES:
-        available = ", ".join(TEMPLATES.keys())
+
+def create_user_template(
+    name: str, description: str, use_case: str, content: str
+) -> dict[str, str]:
+    """Create a new user-defined template."""
+    if not _VALID_NAME.match(name):
         raise ValueError(
-            f"Template '{template_name}' not found. Available templates: {available}"
+            f"Invalid template name '{name}'. Use only alphanumeric, hyphens, underscores."
         )
+    if name in BUILTIN_TEMPLATES:
+        raise ValueError(f"Cannot overwrite built-in template '{name}'.")
 
-    return TEMPLATES[template_name]
+    user_meta = _load_user_meta()
+    if name in user_meta:
+        raise ValueError(f"Template '{name}' already exists.")
+
+    template_file = _user_template_file(name)
+    template_file.parent.mkdir(parents=True, exist_ok=True)
+    template_file.write_text(content, encoding="utf-8")
+
+    user_meta[name] = {"description": description, "use_case": use_case}
+    _save_user_meta(user_meta)
+
+    return {"name": name, "description": description, "use_case": use_case}
+
+
+def update_user_template(
+    name: str,
+    description: str | None = None,
+    use_case: str | None = None,
+    content: str | None = None,
+) -> dict[str, str]:
+    """Update an existing user-defined template."""
+    if name in BUILTIN_TEMPLATES:
+        raise ValueError(f"Cannot modify built-in template '{name}'.")
+
+    user_meta = _load_user_meta()
+    if name not in user_meta:
+        raise ValueError(f"User template '{name}' not found.")
+
+    if description is not None:
+        user_meta[name]["description"] = description
+    if use_case is not None:
+        user_meta[name]["use_case"] = use_case
+    if content is not None:
+        _user_template_file(name).write_text(content, encoding="utf-8")
+
+    _save_user_meta(user_meta)
+    return {"name": name, **user_meta[name]}
+
+
+def delete_user_template(name: str) -> None:
+    """Delete a user-defined template."""
+    if name in BUILTIN_TEMPLATES:
+        raise ValueError(f"Cannot delete built-in template '{name}'.")
+
+    user_meta = _load_user_meta()
+    if name not in user_meta:
+        raise ValueError(f"User template '{name}' not found.")
+
+    template_file = _user_template_file(name)
+    if template_file.exists():
+        template_file.unlink()
+
+    del user_meta[name]
+    _save_user_meta(user_meta)

--- a/src/srunx/web/frontend/e2e/fixtures/mock-data.ts
+++ b/src/srunx/web/frontend/e2e/fixtures/mock-data.ts
@@ -168,6 +168,30 @@ export const MOCK_STATS = {
   avg_runtime_seconds: 3600,
 };
 
+export const MOCK_TEMPLATES = [
+  {
+    name: "base",
+    description:
+      "SLURM job template with full resource control and inter-job outputs",
+    use_case: "All job types including distributed training",
+  },
+  {
+    name: "gpu-single",
+    description: "Single GPU training template",
+    use_case: "Single GPU training jobs",
+    user_defined: true,
+  },
+];
+
+export const MOCK_TEMPLATE_DETAIL = {
+  name: "base",
+  description:
+    "SLURM job template with full resource control and inter-job outputs",
+  use_case: "All job types including distributed training",
+  content:
+    "#!/bin/bash\n#SBATCH --job-name={{ job_name }}\n#SBATCH --nodes={{ nodes }}\nsrun {{ command }}",
+};
+
 export const MOCK_LOGS = {
   stdout:
     "Epoch 1/10: loss=0.85 acc=0.72\nEpoch 2/10: loss=0.63 acc=0.81\nEpoch 3/10: loss=0.45 acc=0.88",

--- a/src/srunx/web/frontend/e2e/fixtures/mock-routes.ts
+++ b/src/srunx/web/frontend/e2e/fixtures/mock-routes.ts
@@ -6,6 +6,8 @@ import {
   MOCK_HISTORY,
   MOCK_STATS,
   MOCK_LOGS,
+  MOCK_TEMPLATES,
+  MOCK_TEMPLATE_DETAIL,
 } from "./mock-data.ts";
 
 /**
@@ -181,6 +183,44 @@ export async function setupMockRoutes(page: Page) {
 
   await page.route("**/api/history*", (route) => {
     return route.fulfill({ json: MOCK_HISTORY });
+  });
+
+  /* ── Templates ─────────────────────────────── */
+  await page.route("**/api/templates", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: MOCK_TEMPLATES });
+    }
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON();
+      return route.fulfill({
+        status: 201,
+        json: {
+          name: body.name,
+          description: body.description,
+          use_case: body.use_case,
+        },
+      });
+    }
+    return route.continue();
+  });
+
+  await page.route("**/api/templates/*", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: MOCK_TEMPLATE_DETAIL });
+    }
+    if (route.request().method() === "PUT") {
+      const body = route.request().postDataJSON();
+      return route.fulfill({
+        json: {
+          ...MOCK_TEMPLATE_DETAIL,
+          ...body,
+        },
+      });
+    }
+    if (route.request().method() === "DELETE") {
+      return route.fulfill({ status: 204 });
+    }
+    return route.continue();
   });
 }
 

--- a/src/srunx/web/frontend/e2e/templates.spec.ts
+++ b/src/srunx/web/frontend/e2e/templates.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from "@playwright/test";
+import { setupMockRoutes } from "./fixtures/mock-routes.ts";
+
+test.beforeEach(async ({ page }) => {
+  await setupMockRoutes(page);
+});
+
+test.describe("Templates", () => {
+  test("displays template list with built-in and user templates", async ({
+    page,
+  }) => {
+    await page.goto("/templates");
+
+    await expect(
+      page.getByRole("heading", { name: "Job Templates" }),
+    ).toBeVisible();
+
+    /* Both templates should be listed */
+    await expect(page.getByText("base")).toBeVisible();
+    await expect(page.getByText("gpu-single")).toBeVisible();
+
+    /* User-defined template shows "custom" badge */
+    await expect(page.getByText("custom")).toBeVisible();
+  });
+
+  test("New Template button opens create dialog", async ({ page }) => {
+    await page.goto("/templates");
+
+    await page.getByRole("button", { name: "New Template" }).click();
+
+    /* Dialog should appear */
+    await expect(
+      page.getByRole("heading", { name: "New Template" }),
+    ).toBeVisible();
+
+    /* Name field should be visible */
+    await expect(page.getByPlaceholder("my-template")).toBeVisible();
+
+    /* Content textarea should be visible */
+    await expect(page.locator("textarea")).toBeVisible();
+  });
+
+  test("create template submits POST and refreshes list", async ({ page }) => {
+    await page.goto("/templates");
+
+    let createCalled = false;
+    await page.route("**/api/templates", async (route) => {
+      if (route.request().method() === "POST") {
+        createCalled = true;
+        const body = route.request().postDataJSON();
+        return route.fulfill({
+          status: 201,
+          json: {
+            name: body.name,
+            description: body.description,
+            use_case: body.use_case,
+          },
+        });
+      }
+      return route.fallback();
+    });
+
+    await page.getByRole("button", { name: "New Template" }).click();
+    await page.getByPlaceholder("my-template").fill("test-template");
+    await page.getByPlaceholder("What this template does").fill("Test desc");
+    await page
+      .getByPlaceholder("e.g. Single GPU training jobs")
+      .fill("Testing");
+
+    await page.getByRole("button", { name: "Create" }).click();
+
+    /* Should have called the API */
+    expect(createCalled).toBe(true);
+
+    /* Success message should appear */
+    await expect(
+      page.getByText('Template "test-template" created'),
+    ).toBeVisible();
+  });
+
+  test("edit button opens edit dialog for user-defined template", async ({
+    page,
+  }) => {
+    await page.goto("/templates");
+
+    /* Click edit on the user-defined template (gpu-single) */
+    const gpuCard = page.locator(".panel", { hasText: "gpu-single" });
+    await gpuCard
+      .locator("button")
+      .filter({ has: page.locator("svg") })
+      .first()
+      .click();
+
+    /* Dialog should show "Edit: gpu-single" */
+    await expect(
+      page.getByRole("heading", { name: "Edit: gpu-single" }),
+    ).toBeVisible();
+  });
+
+  test("delete button sends DELETE request for user-defined template", async ({
+    page,
+  }) => {
+    await page.goto("/templates");
+
+    let deleteCalled = false;
+    await page.route("**/api/templates/gpu-single", async (route) => {
+      if (route.request().method() === "DELETE") {
+        deleteCalled = true;
+        return route.fulfill({ status: 204 });
+      }
+      return route.fallback();
+    });
+
+    /* Click delete on the user-defined template */
+    const gpuCard = page.locator(".panel", { hasText: "gpu-single" });
+    const deleteBtn = gpuCard
+      .locator("button")
+      .filter({ has: page.locator("svg") })
+      .last();
+    await deleteBtn.click();
+
+    expect(deleteCalled).toBe(true);
+    await expect(page.getByText('Template "gpu-single" deleted')).toBeVisible();
+  });
+
+  test("built-in template does not show edit/delete buttons", async ({
+    page,
+  }) => {
+    await page.goto("/templates");
+
+    const baseCard = page.locator(".panel", { hasText: "base" }).first();
+
+    /* base card should NOT have Pencil or Trash2 buttons in header */
+    await expect(baseCard.locator(".panel-header button")).toHaveCount(0);
+  });
+
+  test("clicking a template card expands detail section", async ({ page }) => {
+    await page.goto("/templates");
+
+    /* Click on base template */
+    await page.locator(".panel", { hasText: "base" }).first().click();
+
+    /* Detail panel with template source toggle should appear */
+    await expect(
+      page.getByRole("button", { name: "Template Source" }),
+    ).toBeVisible();
+
+    /* Command input should be visible */
+    await expect(
+      page.getByPlaceholder("python train.py --epochs 10"),
+    ).toBeVisible();
+  });
+
+  test("cancel button in create dialog closes it", async ({ page }) => {
+    await page.goto("/templates");
+
+    await page.getByRole("button", { name: "New Template" }).click();
+    await expect(
+      page.getByRole("heading", { name: "New Template" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Cancel" }).click();
+
+    /* Dialog should be closed */
+    await expect(
+      page.getByRole("heading", { name: "New Template" }),
+    ).not.toBeVisible();
+  });
+});

--- a/src/srunx/web/frontend/src/components/JobPropertyPanel.tsx
+++ b/src/srunx/web/frontend/src/components/JobPropertyPanel.tsx
@@ -1,12 +1,13 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { X, Trash2, FolderOpen } from "lucide-react";
 import type {
   BuilderJob,
   BuilderContainer,
   ContainerRuntime,
-  JobTemplate,
+  TemplateListItem,
 } from "../lib/types.ts";
+import { templates as templatesApi } from "../lib/api.ts";
 import { FileBrowser } from "./FileBrowser.tsx";
 import { KeyValueEditor, type KVEntry } from "./KeyValueEditor.tsx";
 
@@ -124,6 +125,17 @@ export function JobPropertyPanel({
       onUpdate({ venv: value, conda: null });
     }
   }
+
+  const [templateOptions, setTemplateOptions] = useState<TemplateListItem[]>(
+    [],
+  );
+
+  useEffect(() => {
+    templatesApi
+      .list()
+      .then(setTemplateOptions)
+      .catch(() => {});
+  }, []);
 
   const [browserTarget, setBrowserTarget] = useState<
     "command" | "work_dir" | "log_dir" | null
@@ -310,6 +322,33 @@ export function JobPropertyPanel({
         </div>
       </div>
 
+      {/* ── Template ─────────────────────────── */}
+      <div style={sectionDividerStyle}>
+        <div style={sectionTitleStyle}>Template</div>
+        <div style={fieldStyle}>
+          <select
+            className="input"
+            value={job.template}
+            onChange={(e) => onUpdate({ template: e.target.value })}
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: "0.8rem",
+            }}
+          >
+            {templateOptions.length > 0 ? (
+              templateOptions.map((t) => (
+                <option key={t.name} value={t.name}>
+                  {t.name}
+                  {t.description ? ` — ${t.description}` : ""}
+                </option>
+              ))
+            ) : (
+              <option value="base">base</option>
+            )}
+          </select>
+        </div>
+      </div>
+
       {/* ── Basic ─────────────────────────────── */}
       <div style={sectionDividerStyle}>
         <div style={sectionTitleStyle}>Basic</div>
@@ -354,23 +393,6 @@ export function JobPropertyPanel({
               <FolderOpen size={14} />
             </button>
           </div>
-        </div>
-
-        <div style={fieldStyle}>
-          <label style={labelStyle}>Template</label>
-          <select
-            className="input"
-            value={job.template}
-            onChange={(e) =>
-              onUpdate({ template: e.target.value as JobTemplate })
-            }
-            style={{
-              fontFamily: "var(--font-mono)",
-              fontSize: "0.8rem",
-            }}
-          >
-            <option value="base">Base</option>
-          </select>
         </div>
 
         <div style={gridStyle}>

--- a/src/srunx/web/frontend/src/lib/api.ts
+++ b/src/srunx/web/frontend/src/lib/api.ts
@@ -20,8 +20,10 @@ import type {
   SSHTestResult,
   SrunxConfig,
   SyncResult,
+  TemplateCreateRequest,
   TemplateDetail,
   TemplateListItem,
+  TemplateUpdateRequest,
   Workflow,
   WorkflowCreateRequest,
   WorkflowRun,
@@ -592,5 +594,44 @@ export const templates = {
       throw new Error(extractDetail(err, "Failed to apply template"));
     }
     return res.json();
+  },
+
+  create: async (body: TemplateCreateRequest): Promise<TemplateListItem> => {
+    const res = await fetch("/api/templates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to create template"));
+    }
+    return res.json();
+  },
+
+  update: async (
+    name: string,
+    body: TemplateUpdateRequest,
+  ): Promise<TemplateDetail> => {
+    const res = await fetch(`/api/templates/${encodeURIComponent(name)}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to update template"));
+    }
+    return res.json();
+  },
+
+  delete: async (name: string): Promise<void> => {
+    const res = await fetch(`/api/templates/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(extractDetail(err, "Failed to delete template"));
+    }
   },
 };

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -111,7 +111,7 @@ export type LogData = {
 
 export type ContainerRuntime = "pyxis" | "apptainer" | "singularity";
 
-export type JobTemplate = "base";
+export type JobTemplate = string;
 
 export type BuilderContainer = {
   runtime: ContainerRuntime;
@@ -341,6 +341,7 @@ export type TemplateListItem = {
   name: string;
   description: string;
   use_case: string;
+  user_defined?: boolean;
 };
 
 export type TemplateDetail = {
@@ -348,6 +349,19 @@ export type TemplateDetail = {
   description: string;
   use_case: string;
   content: string;
+};
+
+export type TemplateCreateRequest = {
+  name: string;
+  description: string;
+  use_case: string;
+  content: string;
+};
+
+export type TemplateUpdateRequest = {
+  description?: string;
+  use_case?: string;
+  content?: string;
 };
 
 /* ── Script preview ─────────────────────────── */

--- a/src/srunx/web/frontend/src/pages/Templates.tsx
+++ b/src/srunx/web/frontend/src/pages/Templates.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect, useCallback } from "react";
 import { motion } from "framer-motion";
-import { FileCode2, Play, Loader2, ChevronDown, ChevronUp } from "lucide-react";
+import {
+  FileCode2,
+  Play,
+  Loader2,
+  ChevronDown,
+  ChevronUp,
+  Plus,
+  Trash2,
+  Pencil,
+  X,
+} from "lucide-react";
 import { templates as templatesApi } from "../lib/api.ts";
 import type { TemplateListItem, TemplateDetail } from "../lib/types.ts";
 import { ScriptPreview } from "../components/ScriptPreview.tsx";
@@ -27,6 +37,21 @@ const EMPTY_FORM: ApplyForm = {
   conda: "",
 };
 
+type TemplateForm = {
+  name: string;
+  description: string;
+  use_case: string;
+  content: string;
+};
+
+const EMPTY_TEMPLATE_FORM: TemplateForm = {
+  name: "",
+  description: "",
+  use_case: "",
+  content:
+    "#!/bin/bash\n\n#SBATCH --job-name={{ job_name }}\n#SBATCH --nodes={{ nodes }}\n\nsrun {{ command }}\n",
+};
+
 export function Templates() {
   const [items, setItems] = useState<TemplateListItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -39,6 +64,14 @@ export function Templates() {
   const [form, setForm] = useState<ApplyForm>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [commandError, setCommandError] = useState(false);
+
+  // Template CRUD state
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<string | null>(null);
+  const [templateForm, setTemplateForm] =
+    useState<TemplateForm>(EMPTY_TEMPLATE_FORM);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
 
   const loadList = useCallback(async () => {
     try {
@@ -79,6 +112,81 @@ export function Templates() {
       setError(e instanceof Error ? e.message : "Failed to load template");
     } finally {
       setDetailLoading(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!templateForm.name.trim() || !templateForm.content.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await templatesApi.create(templateForm);
+      setSuccess(`Template "${templateForm.name}" created`);
+      setShowCreateDialog(false);
+      setTemplateForm(EMPTY_TEMPLATE_FORM);
+      await loadList();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create template");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleEdit = async (name: string) => {
+    try {
+      const d = await templatesApi.get(name);
+      setEditingTemplate(name);
+      setTemplateForm({
+        name: d.name,
+        description: d.description,
+        use_case: d.use_case,
+        content: d.content,
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load template");
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (!editingTemplate) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await templatesApi.update(editingTemplate, {
+        description: templateForm.description,
+        use_case: templateForm.use_case,
+        content: templateForm.content,
+      });
+      setSuccess(`Template "${editingTemplate}" updated`);
+      setEditingTemplate(null);
+      setTemplateForm(EMPTY_TEMPLATE_FORM);
+      if (selected === editingTemplate) {
+        const d = await templatesApi.get(editingTemplate);
+        setDetail(d);
+      }
+      await loadList();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update template");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    setDeleting(name);
+    setError(null);
+    try {
+      await templatesApi.delete(name);
+      setSuccess(`Template "${name}" deleted`);
+      if (selected === name) {
+        setSelected(null);
+        setDetail(null);
+      }
+      await loadList();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete template");
+    } finally {
+      setDeleting(null);
     }
   };
 
@@ -154,7 +262,26 @@ export function Templates() {
         gap: "var(--sp-4)",
       }}
     >
-      <h2 style={{ fontSize: "1.1rem", fontWeight: 600 }}>Job Templates</h2>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <h2 style={{ fontSize: "1.1rem", fontWeight: 600 }}>Job Templates</h2>
+        <button
+          className="btn btn-primary"
+          onClick={() => {
+            setShowCreateDialog(true);
+            setTemplateForm(EMPTY_TEMPLATE_FORM);
+          }}
+          style={{ gap: 6 }}
+        >
+          <Plus size={14} />
+          New Template
+        </button>
+      </div>
 
       {error && (
         <div
@@ -199,6 +326,7 @@ export function Templates() {
       >
         {items.map((t) => {
           const isSelected = selected === t.name;
+          const isUser = t.user_defined === true;
           return (
             <motion.div
               key={t.name}
@@ -216,6 +344,7 @@ export function Templates() {
                     display: "flex",
                     alignItems: "center",
                     gap: "var(--sp-2)",
+                    flex: 1,
                   }}
                 >
                   <FileCode2 size={14} />
@@ -228,7 +357,55 @@ export function Templates() {
                   >
                     {t.name}
                   </h3>
+                  {isUser && (
+                    <span
+                      style={{
+                        fontSize: "0.6rem",
+                        padding: "1px 6px",
+                        borderRadius: "var(--radius-sm)",
+                        background: "var(--accent-dim)",
+                        color: "var(--accent)",
+                        fontFamily: "var(--font-mono)",
+                      }}
+                    >
+                      custom
+                    </span>
+                  )}
                 </div>
+                {isUser && (
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: "var(--sp-1)",
+                    }}
+                  >
+                    <button
+                      className="btn btn-ghost"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEdit(t.name);
+                      }}
+                      style={{ padding: 4 }}
+                    >
+                      <Pencil size={12} />
+                    </button>
+                    <button
+                      className="btn btn-ghost"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(t.name);
+                      }}
+                      disabled={deleting === t.name}
+                      style={{ padding: 4, color: "var(--st-failed)" }}
+                    >
+                      {deleting === t.name ? (
+                        <Loader2 size={12} className="spin" />
+                      ) : (
+                        <Trash2 size={12} />
+                      )}
+                    </button>
+                  </div>
+                )}
               </div>
               <div className="panel-body">
                 <p
@@ -414,6 +591,201 @@ export function Templates() {
             </div>
           </div>
         </motion.div>
+      )}
+      {/* Create / Edit dialog */}
+      {(showCreateDialog || editingTemplate) && (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.5)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 100,
+          }}
+          onClick={() => {
+            setShowCreateDialog(false);
+            setEditingTemplate(null);
+            setTemplateForm(EMPTY_TEMPLATE_FORM);
+          }}
+        >
+          <motion.div
+            className="panel"
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: "min(640px, 90vw)",
+              maxHeight: "85vh",
+              overflow: "auto",
+            }}
+          >
+            <div className="panel-header">
+              <h3 style={{ textTransform: "none", letterSpacing: 0 }}>
+                {editingTemplate ? `Edit: ${editingTemplate}` : "New Template"}
+              </h3>
+              <button
+                className="btn btn-ghost"
+                onClick={() => {
+                  setShowCreateDialog(false);
+                  setEditingTemplate(null);
+                  setTemplateForm(EMPTY_TEMPLATE_FORM);
+                }}
+                style={{ padding: 4 }}
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <div
+              className="panel-body"
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "var(--sp-3)",
+              }}
+            >
+              {!editingTemplate && (
+                <div>
+                  <label
+                    style={{
+                      fontSize: "0.7rem",
+                      color: "var(--text-muted)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                    }}
+                  >
+                    Name <span style={{ color: "var(--st-failed)" }}>*</span>
+                  </label>
+                  <input
+                    className="input"
+                    placeholder="my-template"
+                    value={templateForm.name}
+                    onChange={(e) =>
+                      setTemplateForm({ ...templateForm, name: e.target.value })
+                    }
+                    style={{
+                      width: "100%",
+                      marginTop: 4,
+                      fontFamily: "var(--font-mono)",
+                    }}
+                  />
+                </div>
+              )}
+              <div>
+                <label
+                  style={{
+                    fontSize: "0.7rem",
+                    color: "var(--text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                  }}
+                >
+                  Description
+                </label>
+                <input
+                  className="input"
+                  placeholder="What this template does"
+                  value={templateForm.description}
+                  onChange={(e) =>
+                    setTemplateForm({
+                      ...templateForm,
+                      description: e.target.value,
+                    })
+                  }
+                  style={{ width: "100%", marginTop: 4 }}
+                />
+              </div>
+              <div>
+                <label
+                  style={{
+                    fontSize: "0.7rem",
+                    color: "var(--text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                  }}
+                >
+                  Use Case
+                </label>
+                <input
+                  className="input"
+                  placeholder="e.g. Single GPU training jobs"
+                  value={templateForm.use_case}
+                  onChange={(e) =>
+                    setTemplateForm({
+                      ...templateForm,
+                      use_case: e.target.value,
+                    })
+                  }
+                  style={{ width: "100%", marginTop: 4 }}
+                />
+              </div>
+              <div>
+                <label
+                  style={{
+                    fontSize: "0.7rem",
+                    color: "var(--text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                  }}
+                >
+                  Template Content (Jinja2){" "}
+                  <span style={{ color: "var(--st-failed)" }}>*</span>
+                </label>
+                <textarea
+                  className="input"
+                  value={templateForm.content}
+                  onChange={(e) =>
+                    setTemplateForm({
+                      ...templateForm,
+                      content: e.target.value,
+                    })
+                  }
+                  style={{
+                    width: "100%",
+                    marginTop: 4,
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.75rem",
+                    minHeight: 240,
+                    resize: "vertical",
+                    lineHeight: 1.6,
+                  }}
+                />
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  gap: "var(--sp-2)",
+                  justifyContent: "flex-end",
+                }}
+              >
+                <button
+                  className="btn btn-ghost"
+                  onClick={() => {
+                    setShowCreateDialog(false);
+                    setEditingTemplate(null);
+                    setTemplateForm(EMPTY_TEMPLATE_FORM);
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="btn btn-primary"
+                  onClick={editingTemplate ? handleUpdate : handleCreate}
+                  disabled={
+                    saving ||
+                    (!editingTemplate && !templateForm.name.trim()) ||
+                    !templateForm.content.trim()
+                  }
+                  style={{ gap: 6 }}
+                >
+                  {saving && <Loader2 size={14} className="spin" />}
+                  {editingTemplate ? "Update" : "Create"}
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </div>
       )}
     </div>
   );

--- a/src/srunx/web/routers/templates.py
+++ b/src/srunx/web/routers/templates.py
@@ -8,7 +8,11 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from srunx.template import get_template_info, get_template_path, list_templates
+from srunx.template import (
+    get_template_info,
+    get_template_path,
+    list_templates,
+)
 
 from ..deps import get_adapter
 from ..ssh_adapter import SlurmSSHAdapter  # noqa: F811
@@ -20,6 +24,7 @@ class TemplateListItem(BaseModel):
     name: str
     description: str
     use_case: str
+    user_defined: bool = False
 
 
 class TemplateDetail(BaseModel):
@@ -37,6 +42,7 @@ async def list_all_templates() -> list[TemplateListItem]:
             name=t["name"],
             description=t["description"],
             use_case=t["use_case"],
+            user_defined=t.get("user_defined") == "true",
         )
         for t in list_templates()
     ]
@@ -137,3 +143,77 @@ async def apply_template(
         raise HTTPException(status_code=502, detail=f"sbatch failed: {e}") from e
 
     return result
+
+
+# ── User template CRUD ───────────────────────────
+
+
+class TemplateCreateRequest(BaseModel):
+    name: str
+    description: str
+    use_case: str
+    content: str
+
+
+class TemplateUpdateRequest(BaseModel):
+    description: str | None = None
+    use_case: str | None = None
+    content: str | None = None
+
+
+@router.post("", status_code=201)
+async def create_template(req: TemplateCreateRequest) -> TemplateListItem:
+    """Create a new user-defined template."""
+    from srunx.template import create_user_template
+
+    try:
+        info = create_user_template(
+            name=req.name,
+            description=req.description,
+            use_case=req.use_case,
+            content=req.content,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+
+    return TemplateListItem(
+        name=info["name"],
+        description=info["description"],
+        use_case=info["use_case"],
+    )
+
+
+@router.put("/{name}")
+async def update_template(name: str, req: TemplateUpdateRequest) -> TemplateDetail:
+    """Update a user-defined template."""
+    from srunx.template import update_user_template
+
+    try:
+        info = update_user_template(
+            name=name,
+            description=req.description,
+            use_case=req.use_case,
+            content=req.content,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+    template_file = Path(get_template_path(name))
+    content = template_file.read_text(encoding="utf-8")
+    return TemplateDetail(
+        name=info["name"],
+        description=info["description"],
+        use_case=info["use_case"],
+        content=content,
+    )
+
+
+@router.delete("/{name}", status_code=204)
+async def delete_template(name: str) -> None:
+    """Delete a user-defined template."""
+    from srunx.template import delete_user_template
+
+    try:
+        delete_user_template(name)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -1083,12 +1083,12 @@ class TestTemplatesRouter:
     """Tests for GET/POST /api/templates endpoints."""
 
     def test_list_templates(self, client: TestClient) -> None:
-        """GET /api/templates returns all built-in templates."""
+        """GET /api/templates returns at least the built-in templates."""
         resp = client.get("/api/templates")
         assert resp.status_code == 200
         data = resp.json()
         assert isinstance(data, list)
-        assert len(data) == 1
+        assert len(data) >= 1
         names = {t["name"] for t in data}
         assert "base" in names
         # Verify structure


### PR DESCRIPTION
## Summary
- Web UIからユーザー定義テンプレートの作成・編集・削除が可能に
- テンプレートは `~/.config/srunx/templates/` に保存（ビルトインの `base` は保護）
- Workflow Builderのテンプレート選択がAPIから動的取得に変更、Basicセクションの上に独立表示

## Changes
### Backend
- `src/srunx/template.py` — ユーザーテンプレートCRUD関数を追加（`create_user_template`, `update_user_template`, `delete_user_template`）
- `src/srunx/web/routers/templates.py` — `POST /api/templates`, `PUT /api/templates/{name}`, `DELETE /api/templates/{name}` エンドポイント追加

### Frontend
- `Templates.tsx` — New Templateボタン、作成/編集モーダル、customバッジ、削除ボタン
- `JobPropertyPanel.tsx` — Templateドロップダウンをハードコードからapi取得に変更、Basicの上に移動
- `api.ts` / `types.ts` — テンプレートCRUD用メソッド・型追加

### Tests
- `e2e/templates.spec.ts` — 8テスト（一覧表示、作成、編集、削除、ビルトイン保護、ダイアログ操作）
- `mock-data.ts` / `mock-routes.ts` — テンプレートmock追加

## Test plan
- [x] Python lint (`ruff check`) — pass
- [x] Python type check (`mypy`) — pass
- [x] TypeScript type check (`tsc --noEmit`) — pass
- [x] Backend unit tests (125 passed) — pass
- [x] E2E tests (71 passed) — pass
- [x] Playwright MCP手動確認 — テンプレート一覧、作成ダイアログ、workflow builderドロップダウン

🤖 Generated with [Claude Code](https://claude.com/claude-code)