### PR TITLE
feat: show completed/failed/cancelled jobs in web UI

### DIFF
--- a/src/srunx/web/frontend/src/components/LogStream.tsx
+++ b/src/srunx/web/frontend/src/components/LogStream.tsx
@@ -111,6 +111,19 @@ export function LogStream({
           counterReset: "line",
         }}
       >
+        {lines.length === 0 && loading && (
+          <div
+            style={{
+              padding: "40px 16px",
+              textAlign: "center",
+              color: "var(--text-muted)",
+              fontFamily: "var(--font-body)",
+              fontSize: "0.85rem",
+            }}
+          >
+            Loading logs...
+          </div>
+        )}
         {lines.length === 0 && !loading && (
           <div
             style={{

--- a/src/srunx/web/frontend/src/pages/Jobs.tsx
+++ b/src/srunx/web/frontend/src/pages/Jobs.tsx
@@ -25,7 +25,7 @@ export function Jobs() {
     error,
     refetch,
   } = useApi(() => jobsApi.list(), [], {
-    pollInterval: 5000,
+    pollInterval: 10000,
   });
 
   const filtered = (jobList ?? []).filter((job) => {

--- a/src/srunx/web/frontend/src/pages/LogViewer.tsx
+++ b/src/srunx/web/frontend/src/pages/LogViewer.tsx
@@ -33,6 +33,7 @@ export function LogViewer() {
   const isRunning = job?.status === "RUNNING";
   const [stdoutLines, setStdoutLines] = useState<string[]>([]);
   const [stderrLines, setStderrLines] = useState<string[]>([]);
+  const [initialLoading, setInitialLoading] = useState(true);
   const offsetRef = useRef({ stdout: 0, stderr: 0 });
   const mountedRef = useRef(true);
 
@@ -56,12 +57,15 @@ export function LogViewer() {
       offsetRef.current.stderr = data.stderr_offset;
     } catch {
       // Ignore transient errors during polling
+    } finally {
+      if (mountedRef.current) setInitialLoading(false);
     }
   }, [id]);
 
   useEffect(() => {
     mountedRef.current = true;
     // Initial full fetch
+    setInitialLoading(true);
     fetchLogs();
     return () => {
       mountedRef.current = false;
@@ -160,7 +164,11 @@ export function LogViewer() {
                 color: "var(--text-muted)",
               }}
             >
-              {isRunning ? "Polling logs..." : "Static logs"}
+              {initialLoading
+                ? "Loading logs..."
+                : isRunning
+                  ? "Polling logs..."
+                  : "Static logs"}
             </span>
           </div>
         </div>
@@ -232,7 +240,7 @@ export function LogViewer() {
         <LogStream
           lines={activeTab === "stdout" ? stdoutLines : stderrLines}
           stream={activeTab}
-          loading={isRunning}
+          loading={isRunning || initialLoading}
         />
       </motion.div>
     </div>

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -27,6 +27,17 @@ _GPU_RE = re.compile(r"gpu[:/=](?:[^:]+:)?(\d+)", re.IGNORECASE)
 # Node states that should be excluded from available counts
 _UNAVAILABLE_STATES = {"down", "drain", "maint", "reserved"}
 
+# SLURM terminal job states (used to filter sacct output)
+_TERMINAL_STATES = {
+    "COMPLETED",
+    "FAILED",
+    "CANCELLED",
+    "TIMEOUT",
+    "NODE_FAIL",
+    "PREEMPTED",
+    "OUT_OF_MEMORY",
+}
+
 
 def _validate_identifier(value: str, name: str) -> None:
     """Validate a SLURM identifier to prevent shell injection."""
@@ -167,7 +178,8 @@ class SlurmSSHAdapter:
     # ── Job Operations ────────────────────────────
 
     def list_jobs(self, user: str | None = None) -> list[dict[str, Any]]:
-        """List SLURM jobs via squeue."""
+        """List SLURM jobs via squeue + recent completed/failed jobs via sacct."""
+        # --- Active jobs from squeue ---
         fmt = "%.18i %.9P %.30j %.12u %.8T %.10M %.9l %.6D %R %b"
         cmd = f'squeue --format "{fmt}" --noheader'
         if user:
@@ -176,6 +188,7 @@ class SlurmSSHAdapter:
 
         output = _run_slurm_cmd(self, cmd)
         jobs: list[dict[str, Any]] = []
+        seen_ids: set[int] = set()
 
         for line in output.strip().splitlines():
             parts = line.split()
@@ -196,6 +209,7 @@ class SlurmSSHAdapter:
                 if gpu_match:
                     gpus_per_node = int(gpu_match.group(1))
 
+            seen_ids.add(job_id)
             jobs.append(
                 {
                     "name": parts[2].strip(),
@@ -214,6 +228,77 @@ class SlurmSSHAdapter:
                     "gpus": gpus_per_node * num_nodes,
                     "elapsed_time": parts[5].strip(),
                 }
+            )
+
+        # --- Recently finished jobs from sacct (last 6 hours) ---
+        # NOTE: --state filter is omitted because some SLURM versions
+        # return empty output when --state is combined with --parsable2.
+        # We filter by status in Python instead.
+        try:
+            sacct_cmd = (
+                "sacct -S now-6hours "
+                "--format=JobID,JobName,State,Partition,NNodes,Elapsed,TimelimitRaw,AllocTRES "
+                "--noheader --parsable2"
+            )
+            if user:
+                sacct_cmd += f" --user {user}"
+
+            sacct_output = _run_slurm_cmd(self, sacct_cmd)
+
+            for line in sacct_output.strip().splitlines():
+                parts = line.split("|")
+                if len(parts) < 6:
+                    continue
+                # Skip sub-steps (e.g., "12345.batch", "12345.extern")
+                if "." in parts[0]:
+                    continue
+
+                try:
+                    job_id = int(parts[0].strip())
+                except ValueError:
+                    continue
+
+                if job_id in seen_ids:
+                    continue
+
+                # sacct may return e.g. "CANCELLED by 1000" — take first word only
+                # Skip non-terminal states (already covered by squeue)
+                raw_state = parts[2].strip()
+                status = raw_state.split()[0] if raw_state else "UNKNOWN"
+                if status not in _TERMINAL_STATES:
+                    continue
+
+                gpus = 0
+                if len(parts) >= 8:
+                    gpu_match = re.search(r"gpu=(\d+)", parts[7], re.IGNORECASE)
+                    if gpu_match:
+                        gpus = int(gpu_match.group(1))
+
+                num_nodes = int(parts[4]) if parts[4].strip().isdigit() else 1
+
+                seen_ids.add(job_id)
+                jobs.append(
+                    {
+                        "name": parts[1].strip(),
+                        "job_id": job_id,
+                        "status": status,
+                        "depends_on": [],
+                        "command": [],
+                        "resources": {
+                            "nodes": num_nodes,
+                            "gpus_per_node": gpus,
+                            "partition": parts[3].strip(),
+                            "time_limit": parts[6].strip() if len(parts) > 6 else None,
+                        },
+                        "partition": parts[3].strip(),
+                        "nodes": num_nodes,
+                        "gpus": gpus * num_nodes,
+                        "elapsed_time": parts[5].strip(),
+                    }
+                )
+        except Exception:
+            _logger.warning(
+                "sacct query failed; returning squeue results only", exc_info=True
             )
 
         return jobs


### PR DESCRIPTION
## Summary
- `list_jobs()` API に `sacct` クエリを追加し、過去6時間の終了済みジョブ（COMPLETED, FAILED, CANCELLED等）をsqueue結果とマージして返すように変更
- `sacct --state` フラグが一部SLURMバージョンで `--parsable2` と組み合わせると空を返す問題を回避し、Python側でステータスフィルタリング
- Jobs ページのポーリング間隔を 5s → 10s に変更（他ページと統一）
- LogViewer の初回フェッチ中に「Loading logs...」を表示し、「No output yet」と誤解されるのを防止

## Test plan
- [x] sacctのCANCELLED/COMPLETED/FAILEDジョブがJobs一覧に表示される
- [x] squeue のRUNNINGジョブと重複しない
- [x] sacct未対応環境でもsqueue結果のみで正常動作（graceful fallback）
- [x] LogViewer でフェッチ中に「Loading logs...」が表示される
- [x] ruff check / mypy / pytest / tsc 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)