### PR TITLE
fix: remaining #47 items (M1, L3, L4, L9)

### DIFF
--- a/src/srunx/models.py
+++ b/src/srunx/models.py
@@ -320,6 +320,7 @@ class BaseJob(BaseModel):
     _status: JobStatus = PrivateAttr(default=JobStatus.PENDING)
     _parsed_dependencies: list[JobDependency] = PrivateAttr(default_factory=list)
     _retry_count: int = PrivateAttr(default=0)
+    _last_refresh: float = PrivateAttr(default=0.0)
 
     def model_post_init(self, __context) -> None:
         """Parse string dependencies into JobDependency objects after initialization."""
@@ -337,11 +338,15 @@ class BaseJob(BaseModel):
             ]
         return self._parsed_dependencies
 
+    # Minimum seconds between automatic sacct queries via the status property.
+    _REFRESH_INTERVAL: float = 5.0
+
     @property
     def status(self) -> JobStatus:
         """
-        Accessing ``job.status`` always triggers a lightweight refresh
-        (only if we have a ``job_id`` and the status isn't terminal).
+        Accessing ``job.status`` triggers a sacct refresh only when the job
+        is non-terminal and at least ``_REFRESH_INTERVAL`` seconds have
+        elapsed since the last query, preventing excessive subprocess calls.
         """
         if self.job_id is not None and self._status not in {
             JobStatus.COMPLETED,
@@ -349,7 +354,9 @@ class BaseJob(BaseModel):
             JobStatus.CANCELLED,
             JobStatus.TIMEOUT,
         }:
-            self.refresh()
+            now = time.time()
+            if now - self._last_refresh >= self._REFRESH_INTERVAL:
+                self.refresh()
         return self._status
 
     @status.setter
@@ -360,6 +367,7 @@ class BaseJob(BaseModel):
         """Query sacct and update ``_status`` in-place."""
         if self.job_id is None:
             return self
+        self._last_refresh = time.time()
 
         try:
             for retry in range(retries):

--- a/src/srunx/monitor/scheduler.py
+++ b/src/srunx/monitor/scheduler.py
@@ -290,7 +290,7 @@ class ScheduledReporter:
 
             completed = failed = cancelled = 0
             for line in result.stdout.strip().splitlines():
-                state = line.strip().split("+")[0]  # strip "CANCELLED by ..." suffix
+                state = line.strip().split("+")[0]  # strip SLURM truncation indicator
                 if state == "COMPLETED":
                     completed += 1
                 elif state == "FAILED":

--- a/src/srunx/monitor/scheduler.py
+++ b/src/srunx/monitor/scheduler.py
@@ -240,16 +240,11 @@ class ScheduledReporter:
             )
 
         # Count by status
-        pending = sum(1 for j in all_jobs if j.status == JobStatus.PENDING)
-        running = sum(1 for j in all_jobs if j.status == JobStatus.RUNNING)
+        pending = sum(1 for j in all_jobs if j._status == JobStatus.PENDING)
+        running = sum(1 for j in all_jobs if j._status == JobStatus.RUNNING)
 
-        # Get completed/failed/cancelled jobs within timeframe
-        # Note: This requires sacct which may not be available in all environments
-        # For now, we'll return 0 for historical stats
-        # TODO: Implement sacct-based historical job queries
-        completed = 0
-        failed = 0
-        cancelled = 0
+        # Query sacct for historical completed/failed/cancelled counts
+        completed, failed, cancelled = self._get_historical_counts()
 
         return JobStats(
             pending=pending,
@@ -258,6 +253,54 @@ class ScheduledReporter:
             failed=failed,
             cancelled=cancelled,
         )
+
+    def _get_historical_counts(self, user: str | None = None) -> tuple[int, int, int]:
+        """Query sacct for completed/failed/cancelled job counts within timeframe.
+
+        Args:
+            user: Optional username to filter results.
+
+        Returns:
+            Tuple of (completed, failed, cancelled) counts.
+        """
+        import subprocess
+
+        try:
+            cmd = [
+                "sacct",
+                "--starttime",
+                f"now-{self.config.timeframe}",
+                "--format",
+                "State",
+                "--noheader",
+                "--parsable2",
+                "--state",
+                "COMPLETED,FAILED,CANCELLED",
+            ]
+            if user:
+                cmd.extend(["--user", user])
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                return 0, 0, 0
+
+            completed = failed = cancelled = 0
+            for line in result.stdout.strip().splitlines():
+                state = line.strip().split("+")[0]  # strip "CANCELLED by ..." suffix
+                if state == "COMPLETED":
+                    completed += 1
+                elif state == "FAILED":
+                    failed += 1
+                elif state.startswith("CANCELLED"):
+                    cancelled += 1
+            return completed, failed, cancelled
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            logger.debug("sacct not available for historical job counts")
+            return 0, 0, 0
 
     def _get_resource_stats(self) -> ResourceStats:
         """Get GPU and node resource statistics.
@@ -317,13 +360,11 @@ class ScheduledReporter:
             )
 
         # Count by status
-        pending = sum(1 for j in user_jobs if j.status == JobStatus.PENDING)
-        running = sum(1 for j in user_jobs if j.status == JobStatus.RUNNING)
+        pending = sum(1 for j in user_jobs if j._status == JobStatus.PENDING)
+        running = sum(1 for j in user_jobs if j._status == JobStatus.RUNNING)
 
-        # Historical stats not yet implemented
-        completed = 0
-        failed = 0
-        cancelled = 0
+        # Historical counts from sacct
+        completed, failed, cancelled = self._get_historical_counts(user=target_user)
 
         return JobStats(
             pending=pending,
@@ -348,7 +389,7 @@ class ScheduledReporter:
             active_jobs = [
                 j
                 for j in all_jobs
-                if j.status in (JobStatus.RUNNING, JobStatus.PENDING)
+                if j._status in (JobStatus.RUNNING, JobStatus.PENDING)
             ]
             logger.debug(
                 f"Filtered to {len(active_jobs)} active jobs (RUNNING/PENDING)"
@@ -356,7 +397,10 @@ class ScheduledReporter:
 
             # Sort by status (running first) then by job_id
             active_jobs.sort(
-                key=lambda j: (0 if j.status == JobStatus.RUNNING else 1, j.job_id or 0)
+                key=lambda j: (
+                    0 if j._status == JobStatus.RUNNING else 1,
+                    j.job_id or 0,
+                )
             )
 
             # Limit to max_jobs
@@ -368,7 +412,7 @@ class ScheduledReporter:
             for job in active_jobs:
                 # Calculate runtime for running jobs
                 runtime = None
-                if job.status == JobStatus.RUNNING and job.elapsed_time:
+                if job._status == JobStatus.RUNNING and job.elapsed_time:
                     # elapsed_time is a string like "1-02:03:04" or "02:03:04"
                     runtime = self._parse_elapsed_time(job.elapsed_time)
 
@@ -377,7 +421,7 @@ class ScheduledReporter:
                         job_id=job.job_id or 0,
                         name=job.name,
                         user=job.user or "unknown",
-                        status=job.status.value,
+                        status=job._status.value,
                         partition=job.partition,
                         runtime=runtime,
                         nodes=job.nodes or 1,

--- a/src/srunx/web/frontend/src/pages/LogViewer.tsx
+++ b/src/srunx/web/frontend/src/pages/LogViewer.tsx
@@ -22,16 +22,6 @@ export function LogViewer() {
 
   const [activeTab, setActiveTab] = useState<"stdout" | "stderr">("stdout");
 
-  if (!isValidId) {
-    return (
-      <div
-        style={{ padding: 48, textAlign: "center", color: "var(--text-muted)" }}
-      >
-        Invalid job ID
-      </div>
-    );
-  }
-
   /* ── Incremental (offset-based) log polling ───── */
   const isRunning = job?.status === "RUNNING";
   const [stdoutLines, setStdoutLines] = useState<string[]>([]);
@@ -41,6 +31,7 @@ export function LogViewer() {
   const mountedRef = useRef(true);
 
   const fetchLogs = useCallback(async () => {
+    if (!isValidId) return;
     try {
       const data = await jobsApi.logs(id, {
         stdout_offset: offsetRef.current.stdout,
@@ -63,11 +54,10 @@ export function LogViewer() {
     } finally {
       if (mountedRef.current) setInitialLoading(false);
     }
-  }, [id]);
+  }, [id, isValidId]);
 
   useEffect(() => {
     mountedRef.current = true;
-    // Initial full fetch
     setInitialLoading(true);
     fetchLogs();
     return () => {
@@ -80,6 +70,16 @@ export function LogViewer() {
     const timer = setInterval(fetchLogs, 3000);
     return () => clearInterval(timer);
   }, [isRunning, fetchLogs]);
+
+  if (!isValidId) {
+    return (
+      <div
+        style={{ padding: 48, textAlign: "center", color: "var(--text-muted)" }}
+      >
+        Invalid job ID
+      </div>
+    );
+  }
 
   if (jobError) {
     return (
@@ -188,7 +188,7 @@ export function LogViewer() {
             a.href = url;
             a.download = `job-${id}-${activeTab}.log`;
             a.click();
-            URL.revokeObjectURL(url);
+            setTimeout(() => URL.revokeObjectURL(url), 100);
           }}
         >
           <Download size={14} />

--- a/src/srunx/web/frontend/src/pages/LogViewer.tsx
+++ b/src/srunx/web/frontend/src/pages/LogViewer.tsx
@@ -176,7 +176,21 @@ export function LogViewer() {
           </div>
         </div>
 
-        <button className="btn btn-ghost">
+        <button
+          className="btn btn-ghost"
+          onClick={() => {
+            const lines = activeTab === "stdout" ? stdoutLines : stderrLines;
+            const blob = new Blob([lines.join("\n")], {
+              type: "text/plain",
+            });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `job-${id}-${activeTab}.log`;
+            a.click();
+            URL.revokeObjectURL(url);
+          }}
+        >
           <Download size={14} />
           Download
         </button>

--- a/src/srunx/web/frontend/src/pages/WorkflowDetail.tsx
+++ b/src/srunx/web/frontend/src/pages/WorkflowDetail.tsx
@@ -78,16 +78,6 @@ export function WorkflowDetail() {
     { pollInterval: 10000 },
   );
 
-  if (!name || !mount) {
-    return (
-      <div
-        style={{ padding: 48, textAlign: "center", color: "var(--text-muted)" }}
-      >
-        {!name ? "Invalid workflow name" : "No mount specified"}
-      </div>
-    );
-  }
-
   /* ── Stop polling on unmount ──────────────── */
   useEffect(() => {
     return () => {
@@ -142,7 +132,7 @@ export function WorkflowDetail() {
     if (!window.confirm(`Delete workflow "${name}"? This cannot be undone.`))
       return;
     try {
-      await workflowsApi.delete(name, mount);
+      await workflowsApi.delete(name, mount ?? "");
       navigate("/workflows");
     } catch (err) {
       setRunError(
@@ -177,6 +167,16 @@ export function WorkflowDetail() {
       };
     });
   }, [workflow, runData]);
+
+  if (!name || !mount) {
+    return (
+      <div
+        style={{ padding: 48, textAlign: "center", color: "var(--text-muted)" }}
+      >
+        {!name ? "Invalid workflow name" : "No mount specified"}
+      </div>
+    );
+  }
 
   const selected = liveJobs.find((j) => j.name === selectedJob);
 

--- a/src/srunx/web/frontend/src/pages/WorkflowDetail.tsx
+++ b/src/srunx/web/frontend/src/pages/WorkflowDetail.tsx
@@ -62,7 +62,9 @@ export function WorkflowDetail() {
   /* ── Run state ──────────────────────────────── */
   const [runData, setRunData] = useState<WorkflowRun | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
-  const [showRunDialog, setShowRunDialog] = useState(false);
+  const [showRunDialog, setShowRunDialog] = useState(
+    searchParams.get("run") === "1",
+  );
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const {

--- a/src/srunx/web/frontend/src/pages/Workflows.tsx
+++ b/src/srunx/web/frontend/src/pages/Workflows.tsx
@@ -403,13 +403,15 @@ function WorkflowCard({ workflow, mount, index, onDelete }: WorkflowCardProps) {
             <Pencil size={13} />
             Edit
           </Link>
-          <button
+          <Link
+            to={`/workflows/${encodeURIComponent(workflow.name)}?mount=${encodeURIComponent(mount)}&run=1`}
             className="btn btn-primary"
             style={{ flex: 1, justifyContent: "center" }}
+            onClick={(e) => e.stopPropagation()}
           >
             <Play size={13} />
             Run
-          </button>
+          </Link>
         </div>
       </div>
     </motion.div>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1022,3 +1022,59 @@ class TestWorkflowAdd:
         job = Job(name="job1", command=["echo", "1"], depends_on=["nonexistent"])
         with pytest.raises(WorkflowValidationError, match="unknown job 'nonexistent'"):
             wf.add(job)
+
+
+class TestStatusThrottle:
+    """Test BaseJob.status throttle behavior (M1)."""
+
+    def test_throttle_skips_refresh_within_interval(self):
+        """Status access within _REFRESH_INTERVAL should not call refresh."""
+        import time
+
+        job = BaseJob(name="test", job_id=123)
+        job._status = JobStatus.RUNNING
+
+        # Simulate a recent refresh
+        job._last_refresh = time.time()
+
+        with patch.object(BaseJob, "refresh", wraps=lambda self: self) as mock_refresh:
+            _ = job.status
+            mock_refresh.assert_not_called()
+
+    def test_throttle_allows_refresh_after_interval(self):
+        """Status access after _REFRESH_INTERVAL should call refresh."""
+        job = BaseJob(name="test", job_id=123)
+        job._status = JobStatus.RUNNING
+
+        # Simulate stale refresh timestamp
+        job._last_refresh = 0.0
+
+        with patch.object(BaseJob, "refresh", return_value=job) as mock_refresh:
+            _ = job.status
+            mock_refresh.assert_called_once()
+
+    def test_terminal_status_never_refreshes(self):
+        """Terminal statuses should never trigger refresh regardless of time."""
+        for terminal in [
+            JobStatus.COMPLETED,
+            JobStatus.FAILED,
+            JobStatus.CANCELLED,
+            JobStatus.TIMEOUT,
+        ]:
+            job = BaseJob(name="test", job_id=123)
+            job._status = terminal
+            job._last_refresh = 0.0  # stale, but should not matter
+
+            with patch.object(BaseJob, "refresh") as mock_refresh:
+                assert job.status == terminal
+                mock_refresh.assert_not_called()
+
+    def test_no_job_id_never_refreshes(self):
+        """Jobs without a job_id should never trigger refresh."""
+        job = BaseJob(name="test")
+        job._status = JobStatus.RUNNING
+        job._last_refresh = 0.0
+
+        with patch.object(BaseJob, "refresh") as mock_refresh:
+            assert job.status == JobStatus.RUNNING
+            mock_refresh.assert_not_called()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,65 @@
+"""Tests for ScheduledReporter._get_historical_counts (L9)."""
+
+from unittest.mock import MagicMock, patch
+
+from srunx.monitor.report_types import ReportConfig
+from srunx.monitor.scheduler import ScheduledReporter
+
+
+def _make_reporter(timeframe: str = "24h") -> ScheduledReporter:
+    config = ReportConfig(schedule="1h", timeframe=timeframe)
+    return ScheduledReporter(
+        client=MagicMock(),
+        callback=MagicMock(),
+        config=config,
+    )
+
+
+class TestGetHistoricalCounts:
+    """Test sacct-based historical job counting."""
+
+    @patch("subprocess.run")
+    def test_parses_completed_failed_cancelled(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="COMPLETED\nCOMPLETED\nFAILED\nCANCELLED by 1000\nCOMPLETED\n",
+        )
+        reporter = _make_reporter()
+        c, f, ca = reporter._get_historical_counts()
+        assert c == 3
+        assert f == 1
+        assert ca == 1
+
+    @patch("subprocess.run")
+    def test_handles_empty_output(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        reporter = _make_reporter()
+        assert reporter._get_historical_counts() == (0, 0, 0)
+
+    @patch("subprocess.run")
+    def test_handles_sacct_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        reporter = _make_reporter()
+        assert reporter._get_historical_counts() == (0, 0, 0)
+
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_handles_sacct_not_found(self, _mock_run):
+        reporter = _make_reporter()
+        assert reporter._get_historical_counts() == (0, 0, 0)
+
+    @patch("subprocess.run")
+    def test_passes_user_filter(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="COMPLETED\n")
+        reporter = _make_reporter()
+        reporter._get_historical_counts(user="testuser")
+        cmd = mock_run.call_args[0][0]
+        assert "--user" in cmd
+        assert "testuser" in cmd
+
+    @patch("subprocess.run")
+    def test_uses_config_timeframe(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        reporter = _make_reporter(timeframe="48h")
+        reporter._get_historical_counts()
+        cmd = mock_run.call_args[0][0]
+        assert "now-48h" in cmd


### PR DESCRIPTION
## Summary
- **M1**: Add 5-second throttle to `BaseJob.status` property — prevents excessive `sacct` subprocess calls when status is accessed repeatedly (e.g., in loops or templates). Uses `_last_refresh` timestamp.
- **L3**: Implement LogViewer Download button — creates a Blob from the active log tab (stdout/stderr) and triggers a browser download as `job-{id}-{tab}.log`
- **L4**: Wire WorkflowCard Run button — navigates to `WorkflowDetail?run=1`, which auto-opens the existing `WorkflowRunDialog`
- **L9**: Implement `sacct`-based historical job counts in `scheduler.py`, replacing hardcoded `completed=0, failed=0, cancelled=0`. Supports optional `--user` filter. Also switches from `.status` to `._status` in scheduler to avoid triggering subprocess for freshly-fetched queue jobs.

## Test plan
- [x] All 684 tests pass
- [x] mypy clean
- [x] tsc clean
- [x] Pre-commit hooks pass

This PR completes all remaining items from #47 (except L1 test coverage and M2 which is already mitigated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)