### PR TITLE
feat(db): SQLite-backed state persistence layer (PR 1/3)

### DIFF
--- a/.claude/specs/notification-and-state-persistence/design.md
+++ b/.claude/specs/notification-and-state-persistence/design.md
@@ -1,0 +1,950 @@
+# Design Document
+
+## Overview
+
+本 spec は srunx の通知配送と状態永続化を刷新する。既存の in-memory / file-based なバラバラな状態管理を、**単一の SQLite データベース (`srunx.db`)** に統合する。通知は Outbox パターンベースの耐久性ある配送(Watch / Subscription / Endpoint / Event / Delivery の5概念)で実現し、ワークフロー実行状態・ジョブ状態遷移・リソース時系列も同 DB に乗せる。
+
+全体は **3 つの長時間稼働タスク** を FastAPI lifespan 上で起動する single-process 構成を取る:
+
+- **ActiveWatchPoller**(Producer): open watch を走査し SLURM を poll、transition 検出、`events` と `deliveries` を生成
+- **DeliveryPoller**(Consumer): `deliveries` から claim して外部(Slack)へ送信
+- **ResourceSnapshotter**: 定期的に `resource_snapshots` を挿入
+
+これらは `PollerSupervisor` でラップされ、例外発生時にも web lifespan を巻き込まずに exponential backoff で再起動する。`--reload` モードでは全 poller が起動しない(二重配送事故防止)。
+
+既存の `SlackCallback` は `SlackWebhookDeliveryAdapter` として再利用し、`SlackCallback._sanitize_text` のロジックをそのまま流用する。
+
+## Steering Document Alignment
+
+### Technical Standards
+
+本プロジェクトには `tech.md` が存在しない。`CLAUDE.md` に記された以下の規約に従う:
+
+- **Python 3.12+** の型ヒント構文(`str | None`, `list[X]`)
+- **Pydantic v2** によるデータバリデーション(`BaseModel`, `Field`, `model_validator`)
+- **anyio** ベースの非同期処理(`asyncio` を直接使わない)
+- **uv** で依存管理(`uv add`, `uv sync`)
+- **ruff + mypy + pytest** で品質担保
+
+### Project Structure
+
+本プロジェクトには `structure.md` が存在しない。`CLAUDE.md` の "Current Modular Structure" に従い、新規コードを以下の配置とする:
+
+```
+src/srunx/
+├── db/                       # 新規: DB レイヤ
+│   ├── __init__.py
+│   ├── connection.py         # SQLite 接続、PRAGMA 設定、context manager
+│   ├── migrations.py         # スキーマ DDL + マイグレーション適用
+│   └── repositories/         # テーブルごとの CRUD
+│       ├── __init__.py
+│       ├── base.py           # BaseRepository(共通処理)
+│       ├── endpoints.py
+│       ├── watches.py
+│       ├── subscriptions.py
+│       ├── events.py
+│       ├── deliveries.py
+│       ├── workflow_runs.py
+│       ├── job_state_transitions.py
+│       ├── resource_snapshots.py
+│       └── jobs.py           # 既存 history.py の schema 拡張を吸収
+├── notifications/            # 新規: 通知ドメイン層
+│   ├── __init__.py
+│   ├── service.py            # NotificationService(fan-out ロジック)
+│   ├── sanitize.py           # sanitize_slack_text 共有ユーティリティ
+│   ├── adapters/
+│   │   ├── __init__.py
+│   │   ├── base.py           # DeliveryAdapter 抽象
+│   │   └── slack_webhook.py  # WebhookClient 直叩き + sanitize 使用
+│   └── presets.py            # preset → event kind フィルタ
+├── pollers/                  # 新規: 長時間稼働タスク
+│   ├── __init__.py
+│   ├── supervisor.py         # PollerSupervisor(例外回復 + shutdown 制御)
+│   ├── active_watch_poller.py
+│   ├── delivery_poller.py
+│   ├── resource_snapshotter.py
+│   └── reload_guard.py       # --reload 検出ユーティリティ(ユニットテスト可能)
+└── web/
+    ├── app.py                # lifespan で PollerSupervisor を起動(修正)
+    ├── routers/
+    │   ├── endpoints.py      # 新規: endpoint CRUD API
+    │   ├── subscriptions.py  # 新規: subscription CRUD API
+    │   ├── watches.py        # 新規: watch 一覧 API(読み取り中心)
+    │   ├── deliveries.py     # 新規: delivery の observability API
+    │   ├── jobs.py           # 修正: submit 時に watch/subscription 作成 + history.record_job
+    │   └── workflows.py      # 修正: workflow_runs 永続化、_monitor_run を poller に委譲
+    ├── state.py              # 削除: RunRegistry は DB-backed に置き換え
+    └── frontend/src/
+        ├── pages/settings/NotificationsTab.tsx  # 拡張: endpoint CRUD
+        └── pages/NotificationsCenter.tsx        # 新規: delivery / subscription 可視化
+```
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`src/srunx/callbacks.py` (`SlackCallback`)**: `_sanitize_text` を **新規 `src/srunx/notifications/sanitize.py` にユーティリティとして切り出し**、`SlackCallback`(CLI 経路で残存)と `SlackWebhookDeliveryAdapter`(新規)双方が同じ関数を参照する。`SlackWebhookDeliveryAdapter` は `SlackCallback` インスタンスを composition で保持せず、`slack_sdk.WebhookClient` を直接 instantiate する(`Event` 入力と `SlackCallback` の `Job/Workflow` 入力で型が合わず、composition だと wrapper が ugly になるため)。CLI 側 `SlackCallback` の挙動は `_sanitize_text` 移動以外は不変。
+- **`src/srunx/history.py`**: 既存の `init_db`, `record_job`, `update_job_completion`, `JobRecord` モデルのスキーマを新 DB(`srunx.db`)に移植。既存の SQLite 接続ロジックは新 `db/connection.py` に統合・拡張される。既存 `~/.srunx/history.db` は起動時削除。
+- **`src/srunx/config.py` (`SrunxConfig`, `get_config`)**: 設定ファイルパス解決ユーティリティ(`get_config_dir()`)を `$XDG_CONFIG_HOME` fallback 対応に拡張し、DB パス解決にも再利用する。`notifications.slack_webhook_url` フィールドは deprecated としてマーク(読み取りは残すが起動時に `endpoints` へ一度だけ移行)。
+- **`src/srunx/monitor/job_monitor.py` (`JobMonitor.watch_continuous`)**: Phase 1 では CLI 経路でのみ使用継続(R10.9)。**ただし状態遷移観測時に `JobStateTransitionRepository.insert(source='cli_monitor')` を呼び出すよう小変更する**(R6.1 の SSOT 要件を CLI 経路でも満たすため)。通知発火経路(CLI の `SlackCallback` 直叩き)はそのまま。Phase 2 で全面的に ActiveWatchPoller へ統合する。
+- **`src/srunx/monitor/resource_monitor.py` (`ResourceMonitor`, `ResourceSnapshot`)**: `ResourceSnapshotter` が `ResourceMonitor.get_current_snapshot()` を呼んで `resource_snapshots` に書き込む。既存 `ResourceSnapshot` モデル(`monitor/types.py:63`)を SQLite row とのマッパーに通す。
+- **`src/srunx/client.py` (`Slurm`)**: SLURM へのアクセスは既存 `Slurm` クライアント経由に統一。`ActiveWatchPoller` は `Slurm.queue()` と `Slurm.retrieve()` を batch で呼ぶ。
+- **`src/srunx/web/ssh_adapter.py` (`SlurmSSHAdapter`)**: Web 経由の submit パスで使用。**バグ修正(R5.1)の実装場所**: `SlurmSSHAdapter.submit_job` 自体は SLURM-only な責務に留め、**record 挿入は `web/routers/jobs.py` の router 層で実施**する(`adapter.submit_job` 成功後に `JobRepository.record_submission()` を呼ぶ)。adapter は pure SLURM 抽象、router はアプリケーションロジックという責務分離を維持するため。
+
+### Phase 1 で変更しない領域(明示)
+
+以下は Phase 1 の design スコープ外とし、現行動作を維持する:
+
+- **CLI 起動のワークフロー実行(`src/srunx/runner.py` の `WorkflowRunner`)**: Phase 1 では `workflow_runs` への書き込みを行わない。CLI-originated workflow の DB 永続化は Phase 2 で扱う。`workflow_runs.triggered_by` CHECK 制約は `'cli'` を含めるが、Phase 1 ではこの値で書き込まれる行は生まれない(将来のためにスキーマだけ予約)。
+- **`ScheduledReporter` の historical counts 実装**: 現行の `sacct` shell-out パス(`monitor/scheduler.py:257`)は Phase 1 では変更しない。R6.3 は「`job_state_transitions` + `jobs` への SQL クエリで**回答可能にする**」(可能性の宣言)であり、`ScheduledReporter` 側の置き換えは Phase 2。`JobRepository` 側に `count_by_status_in_range(...)` を Phase 1 で提供しておき、Phase 2 で `ScheduledReporter` が利用に切り替える。
+- **`ResourceMonitor` の API 自体**: 現行の live 取得 API は変更しない。Phase 1 では `ResourceSnapshotter` がそれを呼び、結果を `resource_snapshots` に書くのみ。
+
+### Integration Points
+
+- **FastAPI lifespan (`src/srunx/web/app.py`)**: 起動時に DB 初期化 → 必要なら migration 実行 → `PollerSupervisor.start_all()` で3つの poller を起動。shutdown 時に `PollerSupervisor.shutdown()` で grace period 5秒。
+- **Web submit router (`src/srunx/web/routers/jobs.py:81`)**: 現状の直接 Slack 送信ロジックを削除し、以下に差し替え:
+  1. `JobRepository.record_submission()` で `jobs` に登録(バグ修正)
+  2. 通知トグルがオンなら `WatchRepository.create()` + `SubscriptionRepository.create()`
+  3. `EventRepository.insert()` で `job.submitted` イベント挿入(preset `all` のみ fan-out)
+- **Workflow router (`src/srunx/web/routers/workflows.py`)**: `_monitor_run` の in-memory ループを削除。代わりに:
+  1. Workflow 起動時に `WorkflowRunRepository.create(status='pending')`
+  2. **この workflow_run に対して内部 watch を自動作成**(`WatchRepository.create(kind='workflow_run', target_ref=f'workflow_run:{run_id}')`)。通知 subscription 有無に関わらず、ActiveWatchPoller が監視・状態遷移検出・再起動後 resume を確実に拾えるようにするため(H C2 の修正)。
+  3. ユーザーが workflow_run 単位の通知を有効化した場合、上記 watch に対して `SubscriptionRepository.create()` を追加する。**subscription が存在しない auto-watch の場合、`NotificationService.fan_out` は空マッチ → `deliveries` は生成されない**(events は記録される)。これは正常挙動:watch は状態遷移検出と `workflow_runs.status` 更新のために存在し、通知配送は subscription が付いたときのみ発生
+  4. ジョブごとに **SLURM submit → `JobRepository.record_submission()` → `WorkflowRunJobRepository.create(workflow_run_id, job_id)`** の順で書き込む(H H3、FK が成立する順序)
+  5. 状態遷移の検出と `workflow_runs.status` 更新は `ActiveWatchPoller` に委譲
+  6. `/runs` API は `WorkflowRunRepository.list_all()` から返す
+- **Workflow API contract changes(M M9)**: 現行は status 値 `'syncing' | 'submitting' | ...` と run_id が **string UUID**。本 spec では status 値を `'pending' | 'running' | 'completed' | 'failed' | 'cancelled'` に、run_id を **integer autoincrement** に変更する。影響箇所として以下を同 PR で更新する必要がある:
+  - `src/srunx/web/frontend/src/lib/types.ts` の `WorkflowRun` 型
+  - `src/srunx/web/routers/workflows.py` の Pydantic response モデル
+  - 既存の E2E / API テスト(`tests/` 配下)
+- **設定 UI (`src/srunx/web/frontend/src/pages/settings/NotificationsTab.tsx`)**: 単一 webhook URL 入力を削除し、endpoint 一覧表示 + 追加/無効化/削除 UI に置き換え。新 API(`/api/endpoints`)経由。
+
+## Architecture
+
+### High-level Dataflow
+
+```mermaid
+flowchart LR
+    subgraph Web["Web UI / API"]
+        Submit[POST /jobs] 
+        WorkflowStart[POST /workflows/runs]
+        Settings[Notifications Settings]
+    end
+
+    subgraph DB["SQLite: srunx.db"]
+        Jobs[(jobs)]
+        WR[(workflow_runs)]
+        JST[(job_state_transitions)]
+        Watches[(watches)]
+        Subs[(subscriptions)]
+        Endpoints[(endpoints)]
+        Events[(events)]
+        Deliveries[(deliveries)]
+        Snapshots[(resource_snapshots)]
+    end
+
+    subgraph Pollers["Long-running tasks (lifespan)"]
+        AWP[ActiveWatchPoller]
+        DP[DeliveryPoller]
+        RS[ResourceSnapshotter]
+    end
+
+    subgraph External
+        SLURM[SLURM via SSH]
+        Slack[Slack Webhook]
+    end
+
+    Submit --> Jobs
+    Submit --> Watches
+    Submit --> Subs
+    Submit --> Events
+    WorkflowStart --> WR
+    WorkflowStart --> Watches
+    Settings --> Endpoints
+
+    AWP -->|poll| SLURM
+    AWP -->|read open| Watches
+    AWP -->|write| JST
+    AWP -->|update| WR
+    AWP -->|insert| Events
+    Events -->|fan-out same tx| Deliveries
+
+    DP -->|claim| Deliveries
+    DP -->|send| Slack
+    DP -->|update status| Deliveries
+
+    RS -->|snapshot| SLURM
+    RS -->|insert| Snapshots
+```
+
+### Delivery State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending: event fan-out
+    pending --> sending: claim (leased_until set)
+    sending --> delivered: send success
+    sending --> pending: send fail (attempt_count++)
+    sending --> abandoned: attempt_count >= max_retries
+    delivered --> [*]
+    abandoned --> [*]
+    
+    note right of sending
+        Lease expires →
+        自動的に pending に戻る
+        (crash recovery)
+    end note
+```
+
+### Submit → Terminal Notification Sequence
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Web as Web API (jobs.py)
+    participant DB as SQLite
+    participant AWP as ActiveWatchPoller
+    participant SLURM
+    participant DP as DeliveryPoller
+    participant Slack
+
+    User->>Web: POST /jobs {notify: true, endpoint_id: N}
+    Web->>DB: INSERT jobs (submission_source='web')
+    Web->>DB: INSERT watches (kind=job, closed_at=NULL)
+    Web->>DB: INSERT subscriptions (preset='terminal')
+    Web->>DB: INSERT events (job.submitted)
+    Note over Web,DB: preset=terminal so no delivery fan-out here
+    Web-->>User: 201 Created
+
+    loop every 15s
+        AWP->>DB: SELECT watches WHERE closed_at IS NULL
+        AWP->>SLURM: queue(job_ids)
+        SLURM-->>AWP: statuses
+
+        Note over AWP,DB: transition detected (PENDING→RUNNING)
+        AWP->>DB: BEGIN IMMEDIATE
+        AWP->>DB: INSERT job_state_transitions
+        AWP->>DB: INSERT events (job.status_changed, RUNNING)
+        Note over AWP,DB: preset=terminal → skip delivery
+        AWP->>DB: COMMIT
+
+        Note over AWP: next cycle: transition (RUNNING→COMPLETED)
+        AWP->>DB: BEGIN IMMEDIATE
+        AWP->>DB: INSERT job_state_transitions
+        AWP->>DB: INSERT events (job.status_changed, COMPLETED)
+        AWP->>DB: INSERT deliveries (pending, idempotency_key)
+        AWP->>DB: UPDATE watches SET closed_at
+        AWP->>DB: COMMIT
+    end
+
+    loop every 10s
+        DP->>DB: BEGIN IMMEDIATE
+        DP->>DB: SELECT pending deliveries WHERE next_attempt_at<=now
+        DP->>DB: UPDATE set leased_until, worker_id, status='sending'
+        DP->>DB: COMMIT (short transaction)
+
+        DP->>Slack: POST webhook
+        Slack-->>DP: 200 OK
+
+        DP->>DB: UPDATE deliveries SET status='delivered'
+    end
+```
+
+### Poller Lifecycle (Supervisor)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Starting: lifespan startup
+    Starting --> RunningAll: --reload=false AND SRUNX_DISABLE_POLLER unset
+    Starting --> Disabled: --reload=true OR SRUNX_DISABLE_POLLER=1
+    RunningAll --> Restarting: poller raised exception
+    Restarting --> RunningAll: backoff elapsed
+    RunningAll --> ShuttingDown: lifespan shutdown
+    ShuttingDown --> Grace: signal pollers
+    Grace --> [*]: 5s elapsed or all done
+    Disabled --> [*]: lifespan shutdown
+```
+
+## Components and Interfaces
+
+### DB Layer
+
+#### `db/connection.py`
+
+- **Purpose**: SQLite 接続管理。PRAGMA 設定(`foreign_keys=ON`, `journal_mode=WAL`, `busy_timeout=5000`)。接続プーリングは不要(SQLite は shared cache + WAL で十分)。
+- **Interfaces**:
+  - `get_db_path() -> Path`: `$XDG_CONFIG_HOME/srunx/srunx.db` または `~/.config/srunx/srunx.db` を返す(R5.5)。
+  - `open_connection() -> sqlite3.Connection`: `Connection` を開き、PRAGMA 適用、`row_factory = sqlite3.Row` を設定。
+  - `@contextmanager transaction(conn, mode='DEFERRED'|'IMMEDIATE')`: `BEGIN ... COMMIT/ROLLBACK` をラップ。
+  - `init_db()`:
+    1. 親ディレクトリ(`~/.config/srunx/`)が存在しなければ 0700 で作成
+    2. DB ファイルが未作成なら作成し、**`chmod 0600` を明示的に適用**(NFR Security)
+    3. 接続を開いて PRAGMA 適用
+    4. `migrations.py` の `apply_migrations()` を呼ぶ
+    5. `~/.srunx/history.db` が存在すれば削除(失敗時は `.broken` にリネーム)
+- **Dependencies**: `sqlite3`, `pathlib`, `os`, `stat`
+- **Reuses**: 既存 `history.py:_get_db_path` の位置計算ロジックを XDG 対応に拡張。
+
+#### `db/migrations.py`
+
+- **Purpose**: スキーマ DDL の適用。`schema_version` テーブルで管理。「適用済みか?」はテーブルに行が存在するかで判定する(version number 比較ではなく name-based の idempotent マイグレーション)。
+- **Interfaces**:
+  - `MIGRATIONS: list[Migration]`(`Migration(version=1, name='v1_initial', sql=...)`等)
+  - `apply_migrations(conn)`: `schema_version` にない name の migration を `BEGIN IMMEDIATE` で1つずつ適用し、成功時に `schema_version` へ行を追加。**全マイグレーションは transaction 内で実行**(失敗時ロールバック、部分適用を防止)。
+  - `bootstrap_from_config(conn, config)`:
+    1. `schema_version` に `name='bootstrap_slack_webhook_url'` が既に存在するか確認
+    2. 存在すれば no-op(once-only 保証)
+    3. 存在しなければ `config.notifications.slack_webhook_url` を読む
+    4. **値が None / 空**の場合:移行対象なし → `schema_version` に記録(次回以降もスキップ、無駄な読み取り回避)
+    5. **値がある場合**:`BEGIN IMMEDIATE` 内で `endpoints` に挿入し、成功したときのみ同 transaction 内で `schema_version` に記録。INSERT が例外(例: 既に同名 endpoint が手動登録されている等)になった場合は両方 rollback し、**`schema_version` には記録しない**(M M10:失敗時に「移行済み」扱いしないため、起動時に再試行可能)。例外はログ warning で顕在化。
+- **Dependencies**: DB schema 定義 SQL(本 document の Data Models 章)
+
+#### Repository 群(`db/repositories/*.py`)
+
+各テーブルに対応する薄い CRUD 層。Pydantic モデルで入出力をバリデートしつつ、SQL はパラメータ化クエリ(`?` プレースホルダ)で書く。全 repository は `BaseRepository` を継承し `Connection` を注入可能。
+
+- **`BaseRepository`**: `__init__(conn)`。共通の row → model 変換ヘルパ。
+- **`EndpointRepository`**: `create`, `get`, `list`, `disable`, `delete`, `update`(webhook URL 検証は service 層で実施)
+- **`WatchRepository`**: `create`, `get`, `list_open` (`closed_at IS NULL` のみ), `close`(`closed_at=datetime('now')`)
+- **`SubscriptionRepository`**: `create`, `get`, `list_by_watch`, `list_active_by_event` (`events.kind` ベースで fan-out 対象を返す)
+- **`EventRepository`**: `insert`, `get`
+- **`DeliveryRepository`**:
+  - `insert`(`idempotency_key` UNIQUE 違反は `INSERT OR IGNORE` で黙殺)
+  - `reclaim_expired_leases()`: 以下の SQL を実行。`DeliveryPoller.run_cycle()` の冒頭で呼ぶ(**crash/shutdown で置き去りになった行を pending に戻す**)。
+    ```sql
+    UPDATE deliveries
+       SET status = 'pending', leased_until = NULL, worker_id = NULL
+     WHERE status = 'sending'
+       AND leased_until < strftime('%Y-%m-%dT%H:%M:%fZ','now');
+    ```
+  - `claim_one(worker_id, lease_duration_secs=300)`: **SQLite では `UPDATE ... LIMIT ... RETURNING` が標準ビルドで使えない**ため、以下の2段階で実装(全体を `BEGIN IMMEDIATE` で包む):
+    ```sql
+    -- Step 1: find one candidate (single-worker 前提なので limit=1)
+    SELECT id FROM deliveries
+     WHERE status = 'pending'
+       AND next_attempt_at <= strftime('%Y-%m-%dT%H:%M:%fZ','now')
+       AND endpoint_id IN (SELECT id FROM endpoints WHERE disabled_at IS NULL)
+     ORDER BY next_attempt_at
+     LIMIT 1;
+    -- Step 2: claim by id
+    UPDATE deliveries
+       SET status = 'sending',
+           leased_until = strftime('%Y-%m-%dT%H:%M:%fZ','now','+' || :lease_secs || ' seconds'),
+           worker_id = :worker_id
+     WHERE id = :id
+       AND status = 'pending'
+     RETURNING *;
+    ```
+    `limit=1` にする理由(H H7): single-worker 前提では batch 化の性能利点がほぼ無く、`shutdown` 時の「in-flight 1件完走 + 残り放棄」の意味論が自然に成立するため。
+  - `mark_delivered(id)`, `mark_retry(id, error)`(`attempt_count++`, `next_attempt_at = strftime('%Y-%m-%dT%H:%M:%fZ','now','+' || :backoff_secs || ' seconds')`, `status='pending'`, `leased_until=NULL`), `mark_abandoned(id, error)`
+  - `count_stuck_pending(older_than_sec=300)` → int(observability)
+
+- **`EventRepository`**:
+  - `insert(event)`: deterministic `source_ref + kind + to_status` をベースに**論理的な dedup を担保**。SQL レベルでは下記 UNIQUE を使う(producer 二重起動時の defense-in-depth, H H5):
+    ```sql
+    CREATE UNIQUE INDEX idx_events_dedup ON events(kind, source_ref, payload_hash);
+    ```
+    `payload_hash` は `payload` の deterministic sub-field(`to_status` 等)を含む short hash として `events` 挿入時に計算・保存(payload_hash カラムを追加)。
+- **`WorkflowRunRepository`**: `create`, `get`, `list`, `list_incomplete`(再起動後 resume 用), `update_status`, `update_error`
+- **`WorkflowRunJobRepository`**: `create`, `list_by_run`
+- **`JobStateTransitionRepository`**: `insert`, `latest_for_job`(dedup 判定用), `history_for_job`
+- **`ResourceSnapshotRepository`**: `insert`, `list_range`(時間範囲フィルタ), `delete_older_than(days)`(R7.5 pruning 関数)
+- **`JobRepository`**: 既存 `history.py` を移植・拡張(`jobs.job_id` に UNIQUE 追加、`workflow_run_id` / `submission_source` 列追加)。interfaces: `record_submission`(R5.1 のバグ修正経路), `update_status(job_id, status, started_at, completed_at, duration_secs)`(ActiveWatchPoller から terminal transition 時に呼ぶ), `update_completion`, `get`, `list`, `count_by_status_in_range(from_at, to_at, statuses)`(Phase 2 の ScheduledReporter 置換用に Phase 1 で提供)
+
+### Notifications Domain
+
+#### `notifications/service.py`
+
+- **Purpose**: イベントから subscription への fan-out を司る。
+- **Interfaces**:
+  - `NotificationService.fan_out(event: Event, conn) -> list[DeliveryId]`:
+    1. `event.source_ref` と `event.kind` にマッチする open watch(`closed_at IS NULL`)を検索
+    2. 各 watch の subscription を列挙し、`presets.should_deliver` で preset フィルタ
+    3. **endpoint が `disabled_at IS NULL` のもののみ fan-out 対象**にする
+    4. deterministic `idempotency_key` を生成し `DeliveryRepository.insert`(UNIQUE 違反は黙殺)
+    5. 全てを caller が開いている同一 `BEGIN IMMEDIATE` 内で実行(events 挿入と atomicity を保つ)
+  - `NotificationService.create_watch_for_job(job_id, endpoint_id, preset) -> WatchId`: 便宜 API。
+  - `NotificationService.create_watch_for_workflow_run(run_id, endpoint_id, preset) -> WatchId`: 便宜 API。
+- **Dependencies**: `WatchRepository`, `SubscriptionRepository`, `EventRepository`, `DeliveryRepository`, `EndpointRepository`, `presets`
+- **Reuses**: —(新規)
+
+#### `notifications/presets.py`
+
+- **Purpose**: preset(`terminal` / `running_and_terminal` / `all` / `digest`)と event kind のマッピングを pure function で提供。
+- **Interfaces**:
+  - `should_deliver(preset: str, event_kind: str, to_status: str | None) -> bool`
+
+#### `notifications/adapters/base.py`
+
+- **Purpose**: Delivery adapter の抽象。
+- **Interfaces**:
+  ```python
+  class DeliveryAdapter(Protocol):
+      kind: str  # 'slack_webhook' 等
+      def send(self, event: Event, endpoint_config: dict) -> None: ...
+  ```
+- **Dependencies**: `Event` model
+
+#### `notifications/sanitize.py`(新規・ユーティリティ)
+
+- **Purpose**: Slack メッセージ用のテキストサニタイズを両経路(既存 `SlackCallback` と新 adapter)で共有(L L12)。
+- **Interfaces**: `sanitize_slack_text(text: str) -> str`
+- **Dependencies**: なし(pure function)
+- **Reuses**: 実体は既存 `SlackCallback._sanitize_text` のロジックそのまま。`SlackCallback` 側は `from srunx.notifications.sanitize import sanitize_slack_text` に書き換え、内部で同関数を呼ぶ(挙動不変)。
+
+#### `notifications/adapters/slack_webhook.py`
+
+- **Purpose**: Slack webhook 配送。
+- **Interfaces**: `SlackWebhookDeliveryAdapter.send(event, endpoint_config)`。`endpoint_config["webhook_url"]` から `slack_sdk.WebhookClient` を直接 instantiate し、event kind/payload に応じた Slack blocks を構築して送信。
+- **Reuses**: `notifications.sanitize.sanitize_slack_text` を使用。`SlackCallback` クラス自体は composition しない(`Event` 入力と `SlackCallback` の `Job/Workflow` 入力で型が合わず wrapper が不自然になるため、直叩き方針)。
+
+### Pollers
+
+#### `pollers/supervisor.py`
+
+- **Purpose**: 複数 long-running task のライフサイクル管理。例外捕捉、exponential backoff 再起動、grace shutdown。
+- **Interfaces**:
+  ```python
+  class PollerSupervisor:
+      def __init__(self, pollers: list[Poller]): ...
+      async def start_all(self) -> None: ...
+      async def shutdown(self, grace_seconds: float = 5.0) -> None: ...
+  
+  class Poller(Protocol):
+      name: str
+      async def run_cycle(self) -> None: ...
+      interval_seconds: float
+  ```
+- **動作詳細**:
+  - `start_all()`: `anyio.create_task_group()` 内で各 poller を `_run_with_backoff(poller)` で wrap。例外発生時は 1→2→4→...→60 秒の exponential backoff で再起動、web lifespan は巻き込まない。
+  - `shutdown()`: supervisor 内部の `anyio.Event` を set。各 poller は `run_cycle` の間に event を check、set されていれば即座に return。その後 `anyio.move_on_after(grace_seconds)` で残り time box を管理、超過すれば `CancelScope.cancel()` で強制停止。in-flight の Slack HTTP POST は時間が足りなければ abort(`leased_until` 残存のまま → 次回起動時に `DeliveryRepository.reclaim_expired_leases` で回収)。
+
+**Crash 回復フロー**(全 poller 共通):
+1. lifespan 起動
+2. `DeliveryPoller` が最初の `run_cycle` 冒頭で `reclaim_expired_leases()` を呼ぶ(sending かつ `leased_until < now` な行を pending に戻す)
+3. `ActiveWatchPoller` が最初の `run_cycle` で open watches を読む時点で、`job_state_transitions.latest_for_job` を参照して「最後に観測された state」を取得(R10.8、重複通知防止)
+4. 以降通常動作
+- **Dependencies**: `anyio`(`create_task_group`, `Event`, `CancelScope`, `move_on_after`), structured logging(loguru)
+- **Reuses**: —
+
+#### `pollers/reload_guard.py`
+
+- **Purpose**: uvicorn `--reload` モード検出(R8.3)。ユニットテスト容易にするため pure function で分離。
+- **Interfaces**:
+  - `is_reload_mode(env: Mapping[str, str] = os.environ, argv: list[str] = sys.argv) -> bool`
+    - `env` に `UVICORN_RELOAD` がある、または `argv` に `--reload` が含まれている場合 True。
+  - `should_start_pollers(env, argv) -> bool`: reload mode または `SRUNX_DISABLE_POLLER=1` なら False。
+
+#### `pollers/active_watch_poller.py`
+
+- **Purpose**: SLURM を poll してジョブ/ワークフロー状態遷移を検出、events と deliveries を生成、**`jobs` / `workflow_runs` の状態列も更新する**(R10 + H H4)。
+- **Interfaces**:
+  - `ActiveWatchPoller(slurm_client, repos, notification_service)`
+  - `async run_cycle()`:
+    1. `WatchRepository.list_open()` で open watch を取得
+    2. ジョブ種 watch は SLURM に batch query、workflow_run 種 watch は DB 上の `workflow_run_jobs` の集約状態を評価
+    3. 状態変化を検出したジョブについて、`BEGIN IMMEDIATE` transaction 内で:
+       - `JobStateTransitionRepository.insert(job_id, from_status, to_status, source='poller')`
+       - **`JobRepository.update_status(job_id, status, started_at, completed_at, duration_secs)`**(H H4:履歴 API が終端状態を読めるように)
+       - `EventRepository.insert(kind='job.status_changed', payload={from,to,...})`。payload_hash UNIQUE 違反は `INSERT OR IGNORE`(H H5:producer 二重起動時の dedup)
+       - INSERT が成功したら `NotificationService.fan_out(event, conn)` で subscription matching → `deliveries` 挿入
+       - 終端状態ならその job が属する watches を `close`
+    4. workflow_run watch の場合は、所属ジョブ集約で `workflow_runs.status` を計算・更新、`workflow_run.status_changed` イベント挿入、fan-out
+- **Dependencies**: `Slurm`(or `SlurmSSHAdapter`、web 実行時), `WatchRepository`, `JobStateTransitionRepository`, `EventRepository`, **`JobRepository`**, `WorkflowRunRepository`, `WorkflowRunJobRepository`, `NotificationService`
+- **Reuses**: `Slurm.queue()` を batch query として使用。
+
+#### `pollers/delivery_poller.py`
+
+- **Purpose**: `deliveries` から claim して外部送信(R3, R8)。
+- **Interfaces**:
+  - `DeliveryPoller(repos, adapter_registry)`
+  - `async run_cycle()`:
+    1. `reclaim_expired_leases()` を呼んで crash/shutdown 置き去り行を回収
+    2. `claim_one(worker_id)` で1行を lease(`BEGIN IMMEDIATE` → SELECT → UPDATE → commit、短いトランザクション)。`None` なら cycle 終了
+    3. claim された delivery について対応 adapter を呼ぶ(`anyio.to_thread.run_sync(adapter.send, ...)`)
+    4. 結果に応じて `mark_delivered` / `mark_retry` / `mark_abandoned`(これらは個別の短いトランザクション)
+    5. interval を待たずに即座に次の `claim_one` を試行するオプションフロー(backlog 消化高速化)。ただし空クレームが続いたら interval で sleep
+- **Dependencies**: `DeliveryRepository`, `EndpointRepository`, `EventRepository`, `DeliveryAdapter` registry, `anyio`
+- **Reuses**: `SlackWebhookDeliveryAdapter`
+
+#### `pollers/resource_snapshotter.py`
+
+- **Purpose**: 定期的にリソーススナップショットを記録(R7.2)。
+- **Interfaces**:
+  - `ResourceSnapshotter(resource_monitor, repo, interval_seconds=300)`
+  - `async run_cycle()`: `ResourceMonitor.get_current_snapshot()` を呼び、`ResourceSnapshotRepository.insert()`。
+- **起動ガード**(M M8): `SRUNX_DISABLE_RESOURCE_SNAPSHOTTER='1'` の場合は PollerSupervisor 構築時に除外する。PollerSupervisor は poller リストを受け取るだけなので、個別 enable 判定は lifespan 起動側(`web/app.py`)で行う。
+- **Dependencies**: `ResourceMonitor`(既存), `ResourceSnapshotRepository`
+- **Reuses**: `src/srunx/monitor/resource_monitor.py`
+
+### Web Router Changes
+
+#### `web/routers/endpoints.py`(新規)
+
+- **Endpoints**:
+  - `GET /api/endpoints` → 一覧
+  - `POST /api/endpoints` → 作成(kind, name, config)。`slack_webhook` の場合は webhook URL 正規表現を bbackend で再検証(R4.2, Security NFR)
+  - `PATCH /api/endpoints/{id}` → disable/enable、name 変更
+  - `DELETE /api/endpoints/{id}` → ハード削除(subscriptions は ON DELETE CASCADE)
+
+#### `web/routers/subscriptions.py`(新規)
+
+- `GET /api/subscriptions?watch_id=`
+- `POST /api/subscriptions` → { watch_id, endpoint_id, preset }
+- `DELETE /api/subscriptions/{id}`
+
+#### `web/routers/watches.py`(新規・読み取り中心)
+
+- `GET /api/watches?open=true|false` → 一覧
+- watch 作成は submit フローに付随するので直接の `POST` 公開はしない(Phase 1)
+
+#### `web/routers/deliveries.py`(新規・observability)
+
+- `GET /api/deliveries?subscription_id=&status=` → 履歴・状態
+- `GET /api/deliveries/stuck` → `count_stuck_pending` を返す(R Observability)
+
+#### `web/routers/jobs.py`(修正)
+
+- 現状の直接 Slack 送信ブロック(L125-143)を削除
+- 新しい流れ:
+  1. `JobRepository.record_submission(...)`(バグ修正)
+  2. リクエストに `notify=true, endpoint_id=N, preset='terminal'` が含まれる場合:
+     - `WatchRepository.create(kind='job', target_ref=f'job:{job_id}')`
+     - `SubscriptionRepository.create(watch_id, endpoint_id, preset)`
+     - `EventRepository.insert(kind='job.submitted', ...)`(preset=all のみ fan-out)
+
+#### `web/routers/workflows.py`(修正)
+
+- `_monitor_run` バックグラウンドタスクを削除
+- 新規 flow:
+  1. `POST /workflows/runs`:
+     - `WorkflowRunRepository.create(status='pending')`
+     - ワークフロー定義から各ジョブを enumerate し `WorkflowRunJobRepository.create` + `JobRepository.record_submission`
+     - 初回ジョブ submit 成功後 `WorkflowRunRepository.update_status('running')` + `events.workflow_run.status_changed` 挿入
+     - オプションで workflow_run 単位の watch 作成(UI からの指定で)
+  2. `GET /runs` → `WorkflowRunRepository.list()`(再起動後も DB から返る)
+
+#### `web/app.py`(修正)
+
+- lifespan 起動フック:
+  1. `db.init_db()`(初回は schema 適用 + 旧 history.db 削除 + 0600 permissions)
+  2. `db.migrations.bootstrap_from_config(config)`(1 回限りの移行)
+  3. `should_start = reload_guard.should_start_pollers(os.environ, sys.argv)`
+  4. `should_start` が True なら、個別 env var を見て poller リストを組み立て:
+     ```python
+     pollers = []
+     if os.environ.get('SRUNX_DISABLE_ACTIVE_WATCH_POLLER') != '1':
+         pollers.append(ActiveWatchPoller(...))
+     if os.environ.get('SRUNX_DISABLE_DELIVERY_POLLER') != '1':
+         pollers.append(DeliveryPoller(...))
+     if os.environ.get('SRUNX_DISABLE_RESOURCE_SNAPSHOTTER') != '1':
+         pollers.append(ResourceSnapshotter(...))
+     supervisor = PollerSupervisor(pollers)
+     await supervisor.start_all()
+     ```
+- lifespan 終了フック: `await supervisor.shutdown(grace_seconds=5.0)`
+
+### Frontend Changes
+
+- **`NotificationsTab.tsx`**: 単一 webhook URL 入力を削除。endpoint 一覧(kind / name / status)をテーブル表示。追加フォーム(kind select は Phase 1 では `slack_webhook` のみ)。行ごとに enable/disable / delete。**デフォルト endpoint / デフォルト preset** の選択 UI もここに含める(`SrunxConfig` の `notifications.default_endpoint_name` と `notifications.default_preset` フィールドを追加して永続化、R9.3)。
+- **Submit dialog**(`SubmitDialog.tsx` 想定): 通知トグル + endpoint select(複数ある場合) + preset select。デフォルト値は `SrunxConfig` の設定から読み込む。endpoint 未登録時は UI 側で案内表示(R9.4)。
+- **新規 `NotificationsCenter.tsx`**: subscription 一覧、最新の delivery status、stuck pending 件数のダッシュボード(Phase 1 では最小限の API 経由の読み取り UI)。
+
+## Data Models
+
+### Schema DDL(SQLite)
+
+以下を `db/migrations.py` の `SCHEMA_V1` 定数として保持する。
+
+```sql
+-- Minimum SQLite version: **3.35** (for RETURNING; GENERATED ALWAYS AS ... STORED requires 3.31).
+--
+-- PRAGMAs applied at every connection open:
+--   PRAGMA foreign_keys = ON;
+--   PRAGMA journal_mode = WAL;
+--   PRAGMA busy_timeout = 5000;
+--
+-- Timestamp policy (C1):
+--   All TEXT timestamp columns store **ISO 8601 UTC** with millisecond precision,
+--   formatted as `YYYY-MM-DDTHH:MM:SS.sssZ` (e.g. '2026-04-18T03:14:15.926Z').
+--   Python-side: always write via `datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00','Z')`.
+--   SQL-side: use `strftime('%Y-%m-%dT%H:%M:%fZ','now')` to match format.
+--   String comparison is lexicographically correct for UTC ISO 8601, so ORDER BY / <,> work.
+--
+-- Table creation order is significant: parent tables must be declared before
+-- tables that reference them via FK.
+--
+-- NOTE on UPDATE ... LIMIT RETURNING:
+--   The stock Python stdlib sqlite3 is not compiled with
+--   SQLITE_ENABLE_UPDATE_DELETE_LIMIT. DO NOT use `UPDATE ... LIMIT` in this spec.
+--   The claim pattern uses SELECT to pick one id, then UPDATE WHERE id=:id RETURNING.
+--   See `DeliveryRepository.claim_one` in Components section.
+
+-- ============================================================
+-- schema_version: migration tracking
+-- One row per applied migration. Idempotency is checked by `name`
+-- (not by version comparison), so bootstraps can coexist with
+-- schema bumps.
+--   `version` is reserved for future major schema bumps (v2, v3...).
+--              In Phase 1 all migrations use version=1.
+--   `name`    is a unique identifier per migration step
+--              (e.g. 'v1_initial', 'bootstrap_slack_webhook_url').
+-- ============================================================
+CREATE TABLE schema_version (
+    version    INTEGER NOT NULL,
+    name       TEXT NOT NULL,
+    applied_at TEXT NOT NULL,
+    PRIMARY KEY (version, name)
+);
+
+-- ============================================================
+-- workflow_runs: replaces in-memory RunRegistry
+-- ============================================================
+CREATE TABLE workflow_runs (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_name      TEXT NOT NULL,
+    workflow_yaml_path TEXT,
+    status             TEXT NOT NULL
+                         CHECK (status IN ('pending','running','completed','failed','cancelled')),
+    started_at         TEXT NOT NULL,
+    completed_at       TEXT,
+    args               TEXT,                                 -- JSON: workflow args snapshot
+    error              TEXT,
+    triggered_by       TEXT NOT NULL CHECK (triggered_by IN ('cli','web','schedule'))
+);
+CREATE INDEX idx_workflow_runs_status     ON workflow_runs(status);
+CREATE INDEX idx_workflow_runs_started_at ON workflow_runs(started_at);
+
+-- ============================================================
+-- jobs: migrated from ~/.srunx/history.db, extended
+-- ============================================================
+CREATE TABLE jobs (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id            INTEGER NOT NULL UNIQUE,              -- SLURM job ID
+    name              TEXT NOT NULL,
+    command           TEXT,                                  -- JSON array
+    status            TEXT NOT NULL,
+    nodes             INTEGER,
+    gpus_per_node     INTEGER,
+    memory_per_node   TEXT,
+    time_limit        TEXT,
+    partition         TEXT,
+    nodelist          TEXT,
+    conda             TEXT,
+    venv              TEXT,
+    container         TEXT,
+    env_vars          TEXT,                                  -- JSON
+    submitted_at      TEXT NOT NULL,
+    started_at        TEXT,
+    completed_at      TEXT,
+    duration_secs     INTEGER,
+    workflow_run_id   INTEGER REFERENCES workflow_runs(id) ON DELETE SET NULL,
+    submission_source TEXT NOT NULL CHECK (submission_source IN ('cli','web','workflow')),
+    log_file          TEXT,
+    metadata          TEXT                                   -- JSON
+);
+CREATE INDEX idx_jobs_status          ON jobs(status);
+CREATE INDEX idx_jobs_submitted_at    ON jobs(submitted_at);
+CREATE INDEX idx_jobs_workflow_run_id ON jobs(workflow_run_id);
+
+-- ============================================================
+-- workflow_run_jobs: membership
+-- FK to jobs(job_id) uses ON DELETE SET NULL to tolerate job row
+-- insertion lagging the workflow membership row (rare, but possible
+-- on submit failure retries).
+-- ============================================================
+CREATE TABLE workflow_run_jobs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_run_id INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    job_id          INTEGER REFERENCES jobs(job_id) ON DELETE SET NULL,
+    job_name        TEXT NOT NULL,
+    depends_on      TEXT,                                    -- JSON array of job names
+    UNIQUE (workflow_run_id, job_name)
+);
+CREATE INDEX idx_wrj_run ON workflow_run_jobs(workflow_run_id);
+
+-- ============================================================
+-- job_state_transitions: SSOT for state changes
+-- FK to jobs(job_id) is SET NULL because transitions may be observed
+-- for jobs whose history row was pruned or (rarely) never inserted.
+-- ============================================================
+CREATE TABLE job_state_transitions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id      INTEGER REFERENCES jobs(job_id) ON DELETE SET NULL,
+    from_status TEXT,                                        -- NULL = first observation
+    to_status   TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    source      TEXT NOT NULL CHECK (source IN ('poller','cli_monitor','webhook'))
+);
+CREATE INDEX idx_jst_job_id      ON job_state_transitions(job_id, observed_at);
+CREATE INDEX idx_jst_observed_at ON job_state_transitions(observed_at);
+
+-- ============================================================
+-- resource_snapshots: time-series
+-- ============================================================
+CREATE TABLE resource_snapshots (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    observed_at     TEXT NOT NULL,
+    partition       TEXT,                                    -- NULL = cluster-wide
+    gpus_total      INTEGER NOT NULL,
+    gpus_available  INTEGER NOT NULL,
+    gpus_in_use     INTEGER NOT NULL,
+    nodes_total     INTEGER NOT NULL,
+    nodes_idle      INTEGER NOT NULL,
+    nodes_down      INTEGER NOT NULL,
+    gpu_utilization REAL GENERATED ALWAYS AS (
+        CASE WHEN gpus_total > 0
+             THEN CAST(gpus_in_use AS REAL) / gpus_total
+             ELSE NULL END
+    ) STORED
+);
+CREATE INDEX idx_rs_observed_at ON resource_snapshots(observed_at);
+CREATE INDEX idx_rs_partition   ON resource_snapshots(partition, observed_at);
+
+-- ============================================================
+-- endpoints: delivery destinations
+-- ============================================================
+CREATE TABLE endpoints (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind        TEXT NOT NULL CHECK (kind IN ('slack_webhook','generic_webhook','email','slack_bot')),
+    name        TEXT NOT NULL,
+    config      TEXT NOT NULL,                               -- JSON: kind-specific
+    created_at  TEXT NOT NULL,
+    disabled_at TEXT,
+    UNIQUE (kind, name)
+);
+
+-- ============================================================
+-- watches: observation targets
+-- ============================================================
+CREATE TABLE watches (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind       TEXT NOT NULL CHECK (kind IN ('job','workflow_run','resource_threshold','scheduled_report')),
+    target_ref TEXT NOT NULL,                                -- e.g. "job:12345", "workflow_run:42"
+    filter     TEXT,                                         -- JSON: optional event-type filter
+    created_at TEXT NOT NULL,
+    closed_at  TEXT                                          -- set when target reaches terminal
+);
+CREATE INDEX idx_watches_kind_target ON watches(kind, target_ref);
+CREATE INDEX idx_watches_open        ON watches(closed_at) WHERE closed_at IS NULL;
+
+-- ============================================================
+-- subscriptions: watch × endpoint × preset
+-- ============================================================
+CREATE TABLE subscriptions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    watch_id    INTEGER NOT NULL REFERENCES watches(id) ON DELETE CASCADE,
+    endpoint_id INTEGER NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+    preset      TEXT NOT NULL CHECK (preset IN ('terminal','running_and_terminal','all','digest')),
+    created_at  TEXT NOT NULL,
+    UNIQUE (watch_id, endpoint_id)
+);
+CREATE INDEX idx_subs_watch_id    ON subscriptions(watch_id);
+CREATE INDEX idx_subs_endpoint_id ON subscriptions(endpoint_id);
+
+-- ============================================================
+-- events: universal shape for fan-out input
+-- payload_hash is a deterministic fingerprint of the event's logical
+-- identity. It is computed as SHA-256 hex of the same logical key
+-- string used for `deliveries.idempotency_key` (see Idempotency Key
+-- Generation Policy section):
+--   - 'job.submitted'             -> f"job:{job_id}:submitted"
+--   - 'job.status_changed'        -> f"job:{job_id}:status:{to_status}"
+--   - 'workflow_run.status_changed' -> f"workflow_run:{run_id}:status:{to_status}"
+--   - 'resource.threshold_crossed'  -> f"resource:{partition}:{threshold_id}:{window_iso}"
+--   - 'scheduled_report.due'        -> f"scheduled_report:{schedule_id}:{scheduled_run_at_iso}"
+-- Populated at INSERT time by the Python layer. The UNIQUE index on
+-- (kind, source_ref, payload_hash) provides producer-side deduplication
+-- as defense-in-depth (H H5): if two ActiveWatchPoller instances race
+-- (e.g. --reload misdetection), only one logical event row survives.
+-- ============================================================
+CREATE TABLE events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind         TEXT NOT NULL CHECK (kind IN (
+        'job.submitted',
+        'job.status_changed',
+        'workflow_run.status_changed',
+        'resource.threshold_crossed',
+        'scheduled_report.due'
+    )),
+    source_ref   TEXT NOT NULL,                              -- "job:12345", "workflow_run:42"
+    payload      TEXT NOT NULL,                              -- JSON: kind-specific
+    payload_hash TEXT NOT NULL,                              -- deterministic dedup key
+    observed_at  TEXT NOT NULL
+);
+CREATE UNIQUE INDEX idx_events_dedup      ON events(kind, source_ref, payload_hash);
+CREATE INDEX        idx_events_source_ref ON events(source_ref, observed_at);
+CREATE INDEX        idx_events_kind       ON events(kind, observed_at);
+
+-- ============================================================
+-- deliveries: outbox
+-- ============================================================
+CREATE TABLE deliveries (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    subscription_id INTEGER NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    endpoint_id     INTEGER NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+    idempotency_key TEXT NOT NULL,
+    status          TEXT NOT NULL
+                      CHECK (status IN ('pending','sending','delivered','abandoned')),
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TEXT NOT NULL,
+    leased_until    TEXT,
+    worker_id       TEXT,
+    last_error      TEXT,
+    delivered_at    TEXT,
+    created_at      TEXT NOT NULL,
+    UNIQUE (endpoint_id, idempotency_key)
+);
+-- `status` values: pending (awaiting claim) | sending (leased and being delivered)
+--                  | delivered (terminal success) | abandoned (terminal failure).
+-- There is no persistent `failed` state: a failed send transitions sending→pending
+-- with incremented attempt_count, or sending→abandoned if retries exhausted.
+--
+-- partial index for claim query performance
+CREATE INDEX idx_deliveries_claim ON deliveries(next_attempt_at)
+    WHERE status = 'pending';
+CREATE INDEX idx_deliveries_event_id     ON deliveries(event_id);
+CREATE INDEX idx_deliveries_lease_active ON deliveries(leased_until)
+    WHERE status = 'sending';
+```
+
+### Pydantic Models(代表)
+
+```python
+# db/models.py(新規。repository が内部で用いる)
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+class Endpoint(BaseModel):
+    id: int | None = None
+    kind: str  # validated by CHECK
+    name: str
+    config: dict  # serialized to JSON at persist
+    created_at: datetime
+    disabled_at: datetime | None = None
+
+class Watch(BaseModel):
+    id: int | None = None
+    kind: str
+    target_ref: str
+    filter: dict | None = None
+    created_at: datetime
+    closed_at: datetime | None = None
+
+class Event(BaseModel):
+    id: int | None = None
+    kind: str
+    source_ref: str
+    payload: dict
+    observed_at: datetime
+
+class Delivery(BaseModel):
+    id: int | None = None
+    event_id: int
+    subscription_id: int
+    endpoint_id: int
+    idempotency_key: str
+    status: str
+    attempt_count: int = 0
+    next_attempt_at: datetime
+    leased_until: datetime | None = None
+    worker_id: str | None = None
+    last_error: str | None = None
+    delivered_at: datetime | None = None
+    created_at: datetime
+```
+
+### Idempotency Key 生成ポリシー
+
+**決定論的(deterministic)**に生成する。同じ transition を再観測(例: crash 後 resume)しても同じキーになることで、`(endpoint_id, idempotency_key)` UNIQUE が「同じ転移を2回配送しない」を DB レベルで担保する。
+
+- `job.submitted`: `f"job:{job_id}:submitted"`
+- `job.status_changed`: `f"job:{job_id}:status:{to_status}"` (timestamp を含めない。同一 `to_status` への再観測は同一キーになり UNIQUE で弾かれる)
+- `workflow_run.status_changed`: `f"workflow_run:{run_id}:status:{to_status}"`
+- `resource.threshold_crossed`: `f"resource:{partition_or_all}:{threshold_id}:{observation_window_iso}"` (これは window 単位で分岐するため時間成分を含むが、window 境界は事前に離散化)
+- `scheduled_report.due`: `f"scheduled_report:{schedule_id}:{scheduled_run_at_iso}"` (schedule 定義が決まった時刻なので deterministic)
+
+`(endpoint_id, idempotency_key)` が UNIQUE なので、同じ transition が**複数 subscription に fan-out** された場合でも endpoint が異なれば別行になる(1 transition → 複数 endpoint への扇形配信が可能)。
+
+**subscription の一意性**(M M11):`subscriptions` は `UNIQUE (watch_id, endpoint_id)` を持つため、同一 (watch, endpoint) ペアに複数 preset を持つことはできない。preset を変更したい場合は既存 subscription を更新するか削除して再作成する。この仕様は Phase 1 では十分(個人ユースで同一 endpoint に異なる preset の複数購読を要求する場面が想定されない)。将来必要になれば `UNIQUE (watch_id, endpoint_id, preset)` への変更は軽微なマイグレーションで済む。
+
+### Retry Schedule
+
+- base = 10s, factor = 2, max = 3600s
+- `attempt_count` に応じて `next_attempt_at = now + min(base * 2^attempt_count, max)`
+- 最大 5 回(0〜4 の attempt_count、5 回目失敗で `abandoned`)
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Slack webhook が 5xx / タイムアウト**
+   - **Handling**: `DeliveryPoller` が `mark_failed(next_attempt_at=retry_schedule)` を呼び、`attempt_count` を増加。`last_error` に応答ボディ / 例外文を保存。
+   - **User Impact**: 最終的に `abandoned` になった場合、`GET /api/deliveries?status=abandoned` で可視化。UI はエラー文を表示(R Usability)。
+
+2. **SLURM へのアクセス失敗(SSH 切断等)**
+   - **Handling**: `ActiveWatchPoller.run_cycle()` が例外で終了 → `PollerSupervisor` が例外ログ出力 → exponential backoff(base 1s, max 60s)で再起動。
+   - **User Impact**: 一時的に状態遷移検出が遅延するが通知は落ちない。
+
+3. **DB ロック競合(busy_timeout 超過)**
+   - **Handling**: sqlite3 が `OperationalError` を raise → repository 層が内部 retry(最大 3 回、各 100ms 間隔)→ なおダメなら上位へ伝播 → supervisor が回復。
+   - **User Impact**: 通常は発生しない(WAL + busy_timeout=5s で十分)。頻発する場合はログ警告で顕在化。
+
+4. **`--reload` ガードが誤作動して poller が二重起動した場合**
+   - **Producer 側 (ActiveWatchPoller x2) の defense**: `events(kind, source_ref, payload_hash)` UNIQUE 制約で同一論理イベントの重複 INSERT を弾く(片方のみ成功、もう片方は `IntegrityError` を飲み込んで noop)。`job_state_transitions` は挿入前に `latest_for_job` で state 比較するので同一 transition の重複挿入も抑制される(race 時は UNIQUE がないので稀に2行入るが、通知側は events UNIQUE で守られる)。
+   - **Consumer 側 (DeliveryPoller x2) の defense**: `claim_one` の `BEGIN IMMEDIATE` でどちらか一方だけが行を取得(片方は空クレームを返す)。`deliveries(endpoint_id, idempotency_key)` UNIQUE も fan-out 側で同一配送の重複を拒む。
+   - **User Impact**: 最悪でも Slack への重複送信が1通増える可能性があるのみ(at-least-once の範疇)。起動誤判定の検知はログで顕在化。
+
+5. **Web server crash 中の in-flight delivery**
+   - **Handling**: 次回起動時の `DeliveryPoller.run_cycle()` 冒頭で `reclaim_expired_leases()` が実行され、`sending` かつ `leased_until < now` の行が `pending` に戻される(`attempt_count` はそのまま、`leased_until=NULL`, `worker_id=NULL`)。
+   - **User Impact**: 通知の重複可能性(at-least-once)。`(endpoint_id, idempotency_key)` UNIQUE で同一 subscription への重複**挿入**は防ぐが、`sending` 中に Slack 到達したが DB 更新前に crash したケースでは、回収後の再送で Slack 側に同一テキストが2回届く可能性がある。受信側で冪等性が必要な用途では本仕様は推奨しない(Phase 1 の制約)。
+
+6. **Endpoint が削除された直後の in-flight delivery**
+   - **Handling**: `ON DELETE CASCADE` で deliveries も削除されるため、`DeliveryPoller` の send 前に行が消える。送信中だった場合は例外で mark_failed になるが、次回 claim で 404 になるので no-op。
+   - **User Impact**: 削除直前に作られた通知は届かないことがある(Phase 1 では許容)。
+
+7. **Migration 失敗(既存 `~/.srunx/history.db` 削除失敗など)**
+   - **Handling**: `OSError` を捕捉してログ警告、`~/.srunx/history.db.broken` にリネームして起動続行。ユーザーへ視認可能なログを出す。
+   - **User Impact**: 古い DB が邪魔にならずに新規動作継続。
+
+8. **`--reload` 判定ミス(環境変数欠落等)**
+   - **Handling**: `reload_guard.should_start_pollers` をユニットテストで網羅(env 有無、argv 有無の組み合わせ)。予期せぬ2重起動は lease 機構で defense-in-depth。
+   - **User Impact**: 開発時の重複送信を二重に防御。
+
+## Testing Strategy
+
+### Unit Testing
+
+- **`db/connection.py`**: パス解決(`XDG_CONFIG_HOME` あり/なし)、PRAGMA 適用、`~/.srunx/history.db` の削除処理。
+- **`db/repositories/*`**: 各 CRUD。特に `DeliveryRepository.claim_one` の lease 取得が複数同時呼び出しで衝突しないこと(2 connection から同時 claim テスト、片方だけが行を取得、片方は `None` が返ること)。`reclaim_expired_leases` は `leased_until` が過去の `sending` 行のみを `pending` に戻すこと。
+- **`notifications/presets.py`**: `should_deliver` の真理値表(4 preset × 5 event kind)。
+- **`notifications/adapters/slack_webhook.py`**: `WebhookClient` をモックし、payload 構造と `_sanitize_text` 適用を確認。
+- **`pollers/reload_guard.py`**: `is_reload_mode`, `should_start_pollers` の全組み合わせ(env/argv × SRUNX_DISABLE_POLLER)。
+- **`pollers/supervisor.py`**: Poller を raise するダミーに差し替え、backoff で再起動されること。grace shutdown で in-flight が完走すること。
+- **Idempotency key 生成**: 同一 transition に対して同じキー、異なる transition で異なるキー。
+
+### Integration Testing
+
+以下は一時ディレクトリに一時 DB を作って実施:
+
+- **Submit → watch 作成 → state transition → delivery**: SLURM をモックした状態で、`ActiveWatchPoller.run_cycle()` を手動駆動し、PENDING→RUNNING→COMPLETED の系列で events と deliveries が期待通り生成されることを確認。
+- **Delivery retry**: `SlackWebhookDeliveryAdapter` を例外 raise するモックに差し替え、5 回リトライ後 `abandoned` になることを確認。
+- **Crash recovery**: `status='sending'` で `leased_until` を過去にセットした行を仕込み、`DeliveryPoller.run_cycle()` 冒頭の `reclaim_expired_leases()` が当該行を `pending` に戻し、続く `claim_one` で再取得されることを確認。
+- **Workflow run persistence**: `POST /workflows/runs` → 再起動 → `GET /runs` で同じ run が返る。
+- **Bug fix verification**: Web UI からの submit 相当のコードパス実行後に `jobs` テーブルへの行挿入を確認(R5.1)。
+- **`config.json` 移行**: 初回起動時に `slack_webhook_url` が `endpoints` に1度だけ移行され、2回目以降は重複しないこと。
+
+### End-to-End Testing
+
+- **Playwright** で web UI を経由した:
+  1. Settings で endpoint 追加
+  2. ジョブ submit(通知オン)
+  3. SLURM をモック状態遷移させる
+  4. Slack webhook のダミー(local http サーバー)で通知受信を確認
+- **`--reload` 有/無** で poller 起動有無を確認。uvicorn を実プロセス起動して `ps` / `lsof` で確認。
+
+### Load / Soak Testing(Phase 1 の範囲外だが推奨)
+
+- 1000 件のジョブを一度に submit し、`deliveries` の backlog が 10分以内に drain されること(個人ローカルの想定負荷ピーク)。
+- `resource_snapshots` が 30日間蓄積されても `list_range` が 100ms 以内に返ること。

--- a/.claude/specs/notification-and-state-persistence/requirements.md
+++ b/.claude/specs/notification-and-state-persistence/requirements.md
@@ -1,0 +1,211 @@
+# Requirements Document
+
+## Introduction
+
+srunx の通知システムと状態永続化を刷新する。現状は以下の欠陥を抱えており、ユーザーが SLURM ジョブを安心して管理できる状態ではない:
+
+- **submit-only 通知**: Web UI で Slack 通知をオンにして submit しても、「SUBMITTED」が1回飛ぶだけで、RUNNING/COMPLETED/FAILED は通知されない。
+- **in-memory ワークフロー状態**: `web/state.py` の `RunRegistry` が in-memory のため、Web server 再起動で実行中ワークフローの状態が消失する。Web UI の Runs ページがサーバー再起動後に空になる。
+- **Web submit が履歴に記録されない**: `SlurmSSHAdapter.submit_job` が `history.record_job` を呼んでいないバグにより、Web 経由の submit が SQLite 履歴 DB に残らない。
+- **状態遷移通知の重複**: `JobMonitor._previous_states` が in-memory のため、再起動後に全ジョブの状態遷移が再通知される(または通知が欠落する)。
+- **リソース時系列データ欠落**: `ResourceSnapshot` が都度生成されるのみで蓄積されず、GPU 需要のトレンド分析ができない。
+
+本 spec では、通知配送を耐久性のある outbox パターンで実現し、Watch/Subscription/Endpoint/Event/Delivery の5概念をデータモデルの核とする。同時に、ワークフロー実行状態・ジョブ状態遷移・リソース時系列を同じ SQLite DB に統合し、再起動耐性と観測可能性を獲得する。
+
+## Alignment with Product Vision
+
+srunx は個人ユーザーが自分のローカルマシンから SLURM クラスタを操作するツール。チーム共有運用や platform 化は想定しない。本 spec もこの前提に従い、以下の設計判断を採用する:
+
+- **単一プロセス前提**: `uvicorn --workers 1` 固定、独立デーモンは導入しない。
+- **ローカル SQLite のみ**: RDBMS 運用は負担過多なので採用しない。
+- **XDG 準拠**: DB と設定ファイルを `~/.config/srunx/` に統一する(既存 `~/.srunx/history.db` は後方互換性なしで削除)。
+- **将来の platform 化への拡張余地を確保**: データモデルは Watch/Subscription/Endpoint/Event/Delivery の5概念を分離し、lease 機構も完全実装する(将来独立プロセスへ切り出す際のリファクタを最小化)。
+
+Phase 1 では Slack webhook を唯一の endpoint 種別として実装する。他の種別(generic webhook, email, slack bot)は Phase 2+ で拡張する。
+
+**CLI のスコープ**: Phase 1 では CLI からの submit 時通知は**現状動作を変更しない**(既存の `--slack` フラグと `SlackCallback` 直接生成パスはそのまま残す)。CLI を subscription API に寄せて Web UI と統合するのは Phase 2 で扱う。これは CLI 利用者への regression 回避と Phase 1 PR サイズ抑制のため。
+
+## Requirements
+
+### Requirement 1: ジョブのライフサイクル通知(Web UI)
+
+**User Story:** Web UI からジョブを submit したユーザーとして、SUBMITTED に加えて RUNNING/COMPLETED/FAILED/CANCELLED/TIMEOUT の状態遷移も通知されてほしい。そうすれば別画面を見続けなくてもジョブの進行を追える。
+
+#### Acceptance Criteria
+
+1. WHEN ユーザーが Web UI の submit 時に通知をオンにする THEN システム SHALL そのジョブを対象とする watch と、選択された endpoint を結ぶ subscription を作成する。
+2. WHEN ジョブ submit が成功する AND watch が作成されている THEN システム SHALL `job.submitted` イベントを `events` に記録し、subscription の preset が `all` の場合のみ配送する(デフォルト `terminal` では配送しない)。
+3. WHEN SLURM 上でジョブの状態が PENDING→RUNNING に遷移する THEN システム SHALL 対応する watch の subscription に従って通知を配送する(preset が `running_and_terminal` または `all` の場合)。
+4. WHEN SLURM 上でジョブが COMPLETED/FAILED/CANCELLED/TIMEOUT のいずれかに到達する THEN システム SHALL 対応する watch の subscription に従って通知を配送する(preset が `terminal` / `running_and_terminal` / `all` のいずれの場合も)。
+5. WHEN ジョブが終端状態(COMPLETED/FAILED/CANCELLED/TIMEOUT)に到達する THEN システム SHALL 対応する watch の `closed_at` をセットし以降の通知判定から除外する。
+6. IF ユーザーが subscription の preset を `terminal` に設定する THEN システム SHALL RUNNING 遷移では通知せず終端状態のみ通知する。
+7. WHEN 同一 subscription に対して同じ state transition イベントが重複して観測される THEN システム SHALL idempotency_key により重複配送を抑止する。
+
+### Requirement 2: ワークフロー実行の通知と永続化
+
+**User Story:** Web UI からワークフローを起動したユーザーとして、ワークフロー全体の開始・完了・失敗・キャンセルを通知されてほしい。また Web server を再起動しても実行中のワークフロー状態が失われないでほしい。
+
+#### Acceptance Criteria
+
+1. WHEN ユーザーがワークフローを起動する THEN システム SHALL `workflow_runs` テーブルにレコードを作成し(`status='pending'`)、所属ジョブを `workflow_run_jobs` テーブルに登録する。
+2. WHEN ワークフローの最初のジョブ submit が成功する THEN システム SHALL `workflow_runs.status` を `running` に更新し `workflow_run.status_changed` イベント(`from=pending, to=running`)を発火する。
+3. WHEN ワークフローの全ジョブが COMPLETED に到達する THEN システム SHALL `workflow_runs.status` を `completed` に更新し `workflow_run.status_changed` イベント(`to=completed`)を発火する。
+4. WHEN ワークフロー実行中にいずれかのジョブが FAILED または TIMEOUT で終了する THEN システム SHALL `workflow_runs.status` を `failed` に更新し `workflow_run.status_changed` イベント(`to=failed`, error 詳細付き)を発火する。
+5. WHEN ユーザーがワークフローをキャンセルする OR いずれかのジョブが CANCELLED で終了する THEN システム SHALL `workflow_runs.status` を `cancelled` に更新し `workflow_run.status_changed` イベント(`to=cancelled`)を発火する。
+6. IF ジョブ submit 自体が失敗する(sbatch エラー等) THEN システム SHALL `workflow_runs.status` を `failed` に更新し、`error` カラムに原因を記録する。
+7. WHEN Web server が shutdown する AND workflow_runs に `running` 状態のレコードがある THEN システム SHALL 次回 Web server 起動時に `/runs` API エンドポイントがそれらを返し、Active Watch Poller(R10)が monitoring を再開する。
+8. IF ユーザーが workflow_run 単位の watch を作成している THEN システム SHALL `workflow_run.status_changed` イベントに対して subscription に従って通知を配送する。
+9. WHEN Web UI の `/runs` ページが開かれる THEN システム SHALL 再起動前の実行中 run を含め、全 workflow_runs を DB から読み込んで表示する(in-memory 消失しない)。
+
+### Requirement 3: 耐久性のある通知配送(Outbox)
+
+**User Story:** srunx ユーザーとして、Slack 側の一時的な障害やネットワーク断があっても、ジョブ完了通知が失われないでほしい。
+
+#### Acceptance Criteria
+
+1. WHEN ジョブまたはワークフローの状態変化が検出される THEN システム SHALL `events` テーブルに1行挿入してからマッチする subscription の fan-out を行う。
+2. WHEN イベントが subscription にマッチする THEN システム SHALL `deliveries` テーブルに `pending` 状態の行を1件以上挿入する(配送前)。
+3. WHEN poller が `deliveries` の pending 行を処理する THEN システム SHALL まず lease 取得(`leased_until`, `worker_id` を更新)の transaction を commit し、その後に外部送信を実行する(claim と送信は別 transaction)。
+4. IF 外部送信が失敗する THEN システム SHALL `attempt_count` を増やし、exponential backoff に基づいた `next_attempt_at` を設定し、`last_error` にエラー内容を記録する。
+5. WHEN lease 期限(`leased_until`)が現在時刻を過ぎた delivery が存在する THEN システム SHALL 次の poll cycle で自動的に再取得して処理を継続する(crash 回復)。
+6. WHEN `attempt_count` が設定された最大リトライ回数(デフォルト 5)に到達しても失敗が続く THEN システム SHALL `status` を `abandoned` に変更し、以降の処理対象から除外する。
+7. WHEN 外部送信が成功する THEN システム SHALL `status` を `delivered` に更新し `delivered_at` を記録する。
+8. IF 同じ `(endpoint_id, idempotency_key)` の組み合わせで delivery を挿入しようとする THEN システム SHALL UNIQUE 制約により重複挿入を拒否し、重複配送を起こさない。
+
+### Requirement 4: 通知購読とエンドポイントの管理
+
+**User Story:** ユーザーとして、複数の Slack webhook を登録し、ジョブごとに使い分けたい(例: 短時間ジョブは個人 DM、長時間ジョブはチームチャンネル)。
+
+#### Acceptance Criteria
+
+1. WHEN ユーザーが Settings > Notifications 画面で新しい endpoint を追加する THEN システム SHALL `endpoints` テーブルに新規レコードを作成する(kind, name, 設定 JSON を保存)。
+2. WHEN ユーザーが endpoint の webhook URL を入力する THEN システム SHALL Slack webhook URL の正規表現(`^https://hooks\.slack\.com/services/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$`)で検証し、不正な形式ならエラーを返す。
+3. WHEN ユーザーがジョブ submit 時に通知をオンにする THEN システム SHALL 使用する endpoint を(複数登録がある場合)選択できる UI を提示する。
+4. WHEN ユーザーが subscription を作成する THEN システム SHALL watch×endpoint×preset の組み合わせを `subscriptions` テーブルに保存する。
+5. IF endpoint が削除される THEN システム SHALL 参照している subscriptions も ON DELETE CASCADE で削除される。
+6. WHEN ユーザーが endpoint を「無効化」する THEN システム SHALL `disabled_at` をセットし、以降の配送対象から除外するが、過去の delivery 履歴は保持する。
+
+### Requirement 5: 統合ジョブ履歴(バグ修正含む)
+
+**User Story:** srunx ユーザーとして、Web UI から submit したジョブも CLI から submit したジョブも、同一の履歴 DB に記録されてほしい。現状 Web 経由の submit が欠落しているバグを修正してほしい。
+
+#### Acceptance Criteria
+
+1. WHEN ユーザーが Web UI からジョブを submit する THEN システム SHALL `jobs` テーブルに記録する(現状は記録されないバグ)。
+2. WHEN ジョブがどのルート(CLI / Web / workflow)から submit されたかを記録する THEN システム SHALL `jobs.submission_source` カラム(`'cli'|'web'|'workflow'`)に値を保存する。
+3. WHEN ワークフロー実行中にジョブが submit される THEN システム SHALL `jobs.workflow_run_id` に `workflow_runs.id` への参照を保存する。
+4. IF 既存 `~/.srunx/history.db` が存在する THEN システム SHALL 起動時にそれを削除する(後方互換性は持たない。無視ではなく削除を選ぶのは、古いファイルが残ると以後のユーザー混乱源になるため)。
+5. WHEN DB ファイルパスが決定される THEN システム SHALL `$XDG_CONFIG_HOME/srunx/srunx.db` を使用し、`$XDG_CONFIG_HOME` が未設定の場合は `~/.config/srunx/srunx.db` にフォールバックする(XDG Base Directory Specification 準拠)。
+
+### Requirement 6: ジョブ状態遷移の single source of truth
+
+**User Story:** srunx 開発者として、ジョブ状態遷移の正しい履歴が1箇所にまとまっていてほしい。現状 4箇所(history.jobs、RunRegistry、JobMonitor._previous_states、SLURM 本体)に分散しているため、dedup とトレンド分析が不可能。
+
+#### Acceptance Criteria
+
+1. WHEN `JobMonitor` がジョブの状態変化を検出する THEN システム SHALL `job_state_transitions` テーブルに `from_status`, `to_status`, `observed_at`, `source` を記録する。
+2. WHEN poller が状態遷移イベントを生成する THEN システム SHALL `job_state_transitions` の最新行と比較して重複を抑止する(`_previous_states` の in-memory dedup を置き換え)。
+3. WHEN `ScheduledReporter._get_historical_counts` 相当の処理が必要になる THEN システム SHALL `job_state_transitions` と `jobs` への SQL クエリで履歴集計を回答可能にする(既存の `sacct` パスは Phase 1 中は共存を許容)。
+4. WHEN Web server が再起動される THEN システム SHALL `job_state_transitions` の最新状態を各ジョブの「最後に観測された state」として読み込み、再起動後の初回 poll で重複通知を起こさない。
+
+### Requirement 7: リソース時系列スナップショット
+
+**User Story:** srunx ユーザーとして、GPU の空き状況の履歴を後から参照したい。「先週の水曜 3pm は GPU が空いていたか」のような問いに答えたい。
+
+#### Acceptance Criteria
+
+1. WHEN `ResourceMonitor` または `ScheduledReporter` が `ResourceSnapshot` を生成する THEN システム SHALL `resource_snapshots` テーブルに1行挿入する(timestamp, partition, GPU/node metrics)。
+2. WHEN Web server lifespan が起動する AND `SRUNX_DISABLE_RESOURCE_SNAPSHOTTER` が未設定 THEN システム SHALL 定期 ResourceSnapshotter タスクを起動し、デフォルト 5 分間隔でクラスタ全体のスナップショットを取得して `resource_snapshots` に挿入する(Phase 1 で `resource_snapshots` が実質的に蓄積されることを保証)。
+3. WHEN partition を指定しないクラスタ全体のスナップショットが取得される THEN システム SHALL `partition` カラムを NULL で保存する。
+4. WHEN `gpu_utilization` が必要となる THEN システム SHALL 生成カラム(`GENERATED ALWAYS AS`)で計算する。`gpus_total = 0` の場合の値は **NULL** とする(ゼロ除算による実装固有エラーを避け、集計時に IS NOT NULL で除外可能にするため)。
+5. WHEN 蓄積件数が増えすぎる THEN システム SHALL デフォルト保持期間 90 日を超える古いスナップショットを削除する pruning 関数 `delete_older_than(days)` を提供する(Phase 1 では関数提供のみ、自動スケジュール実行は Phase 2 で導入)。
+
+### Requirement 8: Poller の実行モデル
+
+**User Story:** srunx 開発者として、Web server を起動すれば自動的に通知 poller が立ち上がり、開発中(`--reload`)でも二重起動事故を起こさないでほしい。
+
+#### Acceptance Criteria
+
+1. WHEN FastAPI lifespan が起動する AND 環境変数 `SRUNX_DISABLE_POLLER` が unset または `'0'` AND uvicorn が `--reload` フラグなしで起動されている THEN システム SHALL `DeliveryPoller` を1つだけ起動する。
+2. IF 環境変数 `SRUNX_DISABLE_POLLER` が `'1'` にセットされている OR uvicorn が `--reload` フラグ付きで起動されている THEN システム SHALL `DeliveryPoller` を起動しない(開発時の二重配送事故を防止)。
+3. WHEN uvicorn の `--reload` 状態を判定する THEN システム SHALL 環境変数 `UVICORN_RELOAD`(uvicorn 本体が設定)または sys.argv の検査により判定し、判定ロジックをユニットテスト可能な関数として切り出す。
+4. WHEN poller のメインループが例外で終了する THEN システム SHALL supervisor ラッパが exception をログ出力し、exponential backoff(base 1秒、最大 60 秒)で poller ループを再起動する。この再起動は web 全体の lifespan を巻き込まない。
+5. WHEN lifespan shutdown が発火する THEN システム SHALL poller に shutdown シグナルを送り、最大5秒の grace period 内で in-flight delivery を1件完走させ、残りの lease は放棄する(次回起動時に lease expiry で自動回収される)。
+6. WHEN Slack webhook 送信が行われる THEN システム SHALL `anyio.to_thread.run_sync` 経由で sync な slack-sdk 呼び出しを実行し、イベントループをブロックしない。
+
+### Requirement 9: Notifications 設定 UI の拡張
+
+**User Story:** Web UI ユーザーとして、Settings > Notifications 画面で endpoint を複数追加・削除でき、デフォルトの preset を設定できるようにしてほしい。
+
+#### Acceptance Criteria
+
+1. WHEN ユーザーが Settings > Notifications 画面を開く THEN システム SHALL 登録済みの endpoint 一覧と、それぞれの kind / name / 状態(有効/無効)を表示する。
+2. WHEN ユーザーが新しい endpoint を追加する THEN システム SHALL kind = `slack_webhook` のみを Phase 1 で選択可能とし、webhook URL の入力欄と検証を提供する。
+3. WHEN ユーザーがジョブ submit 画面で通知トグルをオンにする THEN システム SHALL デフォルト endpoint と preset を `terminal` で初期選択する(設定画面でデフォルトを変更可能)。
+4. IF endpoint が1つも登録されていない状態でユーザーが submit 時に通知をオンにする THEN システム SHALL 「endpoint を先に Settings で追加してください」の案内を表示し、通知トグルを有効化できないようにする。
+
+### Requirement 10: Active Watch Poller(イベント生産者)
+
+**User Story:** srunx 開発者として、作成された watch が実際に SLURM を監視して状態遷移を検出し、`events` テーブルにイベントを生み出す「生産者」の責務が明確であってほしい。生産者が曖昧だと outbox(consumer 側)だけ堅牢でも、通知が永久に発火しない。
+
+**Note:** R3 / R8 は consumer 側(fan-out と delivery)の責務、R10 は producer 側の責務を定義する。
+
+#### Acceptance Criteria
+
+1. WHEN Web server lifespan が起動する AND `SRUNX_DISABLE_POLLER` が unset AND `--reload` モードではない THEN システム SHALL `ActiveWatchPoller` を1つ起動する(`DeliveryPoller` とは別タスク、同一 lifespan 内で supervisor ラップ)。
+2. WHEN `ActiveWatchPoller` が poll cycle を実行する THEN システム SHALL `watches` テーブルの `closed_at IS NULL` な行をすべて読み込み、対応する SLURM ジョブ状態(job watch)またはワークフロー run 状態(workflow_run watch)を SLURM / DB から取得する。
+3. WHEN `ActiveWatchPoller` がジョブの現在状態を `job_state_transitions` の最新行と比較する AND 状態が変化している THEN システム SHALL `job_state_transitions` に新規行を挿入し、対応する `events`(`job.status_changed`)を1件挿入する(同一 transaction 内)。
+4. WHEN `ActiveWatchPoller` がワークフロー run の現在状態を評価する AND workflow_runs のステータスが変化している THEN システム SHALL `workflow_runs` を更新し、対応する `events`(`workflow_run.status_changed`)を1件挿入する(同一 transaction 内)。
+5. WHEN `ActiveWatchPoller` が新規 `events` を挿入する THEN システム SHALL 同一 transaction 内でマッチする subscription を fan-out し、`deliveries` に `pending` 行を作成する(events と deliveries の結合書き込み原子性を保つ)。
+6. WHEN ジョブまたはワークフロー run が終端状態に到達する AND 対応する watch が存在する THEN システム SHALL `watches.closed_at` をセットし、以降の poll cycle で当該 watch を処理対象から除外する。
+7. WHEN `ActiveWatchPoller` のポーリング間隔が設定される THEN システム SHALL デフォルト 15 秒で実行する(設定変更可能)。
+8. WHEN Web server が再起動される AND `watches.closed_at IS NULL` の行が残っている THEN システム SHALL 再起動後の初回 poll cycle で `job_state_transitions` の最新行を「最後に観測された state」として扱い、すでに観測済みの transition は重複通知しない。
+9. WHEN 既存の CLI 側 `JobMonitor.watch_continuous()` が呼ばれる THEN システム SHALL Phase 1 では現状のまま動作させる(CLI は `ActiveWatchPoller` を使わない。両者の統合は Phase 2)。
+
+## Non-Functional Requirements
+
+### Performance
+
+- **DeliveryPoller ポーリング間隔**: デフォルト 10 秒。設定変更可能。
+- **ActiveWatchPoller ポーリング間隔**: デフォルト 15 秒。設定変更可能。SLURM への `squeue` 発行頻度を考慮し DeliveryPoller より長めに。
+- **ResourceSnapshotter 間隔**: デフォルト 5 分。1 日あたり 288 行、90 日で約 26,000 行(クラスタ全体 1 partition の場合)。個人ローカル SQLite で問題ない規模。
+- **DB 書き込みバッチング**: `events` と `deliveries` は同一 transaction で書き込む(`BEGIN IMMEDIATE` + 短時間コミット)。
+- **DB ロック保持時間**: 外部送信中は transaction を保持しない。`claim` と `send` は別 transaction に分離する。
+
+### Security
+
+- **Webhook URL の検証**: Slack webhook URL のパターンに合致することを UI とバックエンド双方で検証する(現状のフロント検証を踏襲しつつバックエンドでも再検証)。
+- **通知メッセージのサニタイズ**: 現状の `SlackCallback._sanitize_text` を継承し、ジョブ名などに含まれる制御文字・markdown 記号・HTML をエスケープする。
+- **SQL injection 防止**: 全 DB アクセスはパラメータ化クエリ経由とし、文字列連結は禁止。
+- **DB ファイルパーミッション**: `~/.config/srunx/srunx.db` は 0600(所有者のみ読み書き)。
+
+### Reliability
+
+- **At-least-once 配送**: exactly-once は狙わない。`idempotency_key` で受信側の重複抑止可能性を担保する。
+- **Crash 回復**: Web server の crash・再起動・kill -9 後、次回起動時の poll cycle で `leased_until` が過去の delivery を自動回収する。
+- **トランザクション境界**: `claim` と外部送信は別 transaction。ネットワーク I/O 中に DB トランザクションを保持しない。
+- **WAL + busy_timeout**: SQLite を `journal_mode=WAL`, `busy_timeout=5000`, `foreign_keys=ON` で開く。
+- **最大リトライ**: デフォルト 5 回。exponential backoff の base 10 秒、最大 1 時間。
+
+### Usability
+
+- **設定の場所**: `~/.config/srunx/config.json`(既存)と `~/.config/srunx/srunx.db`(新規)が同ディレクトリにまとまる。
+- **エラー表示**: 通知配送失敗時、該当 delivery の `last_error` を Web UI の Notifications 画面で確認できる(Phase 1 では最低限、該当 subscription に紐づく最新の failed delivery のエラー文を表示する API を提供)。
+- **デフォルト値の合理性**: submit 時の通知デフォルト preset は `terminal`(RUNNING は opt-in)。「届きすぎ」を避けるための選択。
+- **ドキュメント**: `CLAUDE.md` に新しい DB 位置と通知モデルの概要を追記する(実装タスクに含める)。
+
+### Observability
+
+- **Poller ヘルス**: poller は起動時・各 cycle 完了時に構造化ログを出力し、処理件数・失敗件数・平均レイテンシを記録する。
+- **Stuck delivery の可視化**: `pending` 状態で `next_attempt_at < now - 5min` の delivery 件数を取得する API を Phase 1 で提供する(Web UI への組み込みは Phase 2 で対応)。
+
+### Retention / Growth
+
+- **`deliveries` / `events` の成長**: Phase 1 では pruning を自動実行しない。個人ローカル前提かつ `delivered` / `abandoned` 行のサイズが小さいため、数年単位で許容範囲。Phase 2 で `resource_snapshots` と同じ `delete_older_than(days)` パターンを適用する。
+
+### Migration / Compatibility
+
+- **既存 DB の扱い**: `~/.srunx/history.db` が存在する場合は起動時に削除する(R5.4)。後方互換性は持たない(個人ローカル前提のため移行パスは不要)。
+- **既存設定の扱い(webhook)**: `config.json` の `notifications.slack_webhook_url` が設定されている場合、起動時に1回限り自動で `endpoints` テーブルに `kind=slack_webhook`, `name='default'` として移行する。移行後は `config.json` の `notifications.slack_webhook_url` フィールドを **deprecated** として扱い、**以降はバックエンドも UI も `endpoints` テーブルを唯一の真実の源とする**(config.json 側に値が残っていても無視し、Settings UI で変更した場合は DB のみを書き換える)。
+- **通知設定の Single Source of Truth**: 移行完了後、通知の配送先情報(webhook URL, email アドレス等)は `endpoints` テーブルのみに保持する。`SrunxConfig` / config.json / 環境変数 / submit dialog が独立に Slack URL を持つ split-brain 状態を解消する。
+- **v2 スキーマ変更への配慮**: 将来 platform 化に備えて、`deliveries.leased_until` / `worker_id` は Phase 1 から実装する(カラム予約だけで済ませない)。

--- a/.claude/specs/notification-and-state-persistence/tasks.md
+++ b/.claude/specs/notification-and-state-persistence/tasks.md
@@ -1,0 +1,840 @@
+# Implementation Plan
+
+## Task Overview
+
+実装は以下のレイヤ順で積み上げる:
+
+**(A0) 共通基盤抽象**(SLURM Protocol) → **(A) DB レイヤ** → **(A.3) 既存 history.py 呼び出しサイト移行** → **(B) Notifications ドメイン** → **(C) Pollers** → **(D) JobMonitor SSOT** → **(E) Web ルータ + lifespan + DB provider** → **(F) フロントエンド** → **(G) 統合テスト** → **(H) ドキュメント** → **(I) 最終 cleanup**
+
+下位から上位への一方向依存。既存バグ修正(R5.1: Web submit が履歴に残らない)は (E) の `jobs.py` 改修内で自然に閉じる。
+
+## PR 分割戦略
+
+合計 ~90 タスクを1 PR にまとめるとレビュー困難・branch 不安定になるため、3 PR に分割する:
+
+| PR | 範囲 | 含むタスク |
+|---|---|---|
+| **PR 1: DB Foundation + history migration** | DB 層 + 既存 `history.py` 呼び出しサイトの全移行(shim 込み)、SLURM Protocol 抽象 | A0, A, A.1, A.2, A.3, および conftest 共通 fixture |
+| **PR 2: Notifications + Pollers + Lifecycle** | notifications ドメイン / 3 つの poller / DB connection provider / adapter registry / JobMonitor SSOT hook / web lifespan 配線 | B, C, D, E の lifespan/provider 部分のみ |
+| **PR 3: Web routes + Frontend + E2E + Docs** | 新規 router 群、既存 `jobs.py` / `workflows.py` 改修、frontend 全更新、E2E、ドキュメント | E の routers、F、G、H、I |
+
+各 PR の終端で `uv run pytest && uv run mypy . && uv run ruff check .` が通ることを条件とする。
+
+## Steering Document Compliance
+
+`CLAUDE.md` のディレクトリ配置(`src/srunx/db/`, `src/srunx/notifications/`, `src/srunx/pollers/`)、Python 3.12+ 型ヒント(`str | None`)、Pydantic v2、`anyio`、`uv` 使用、ruff/mypy/pytest に準拠する。
+
+## Logging Convention
+
+新規モジュールは `loguru.logger` を直接 import せず、`from srunx.logging import get_logger; logger = get_logger(__name__)` を使う(既存慣習に合わせる)。構造化ログは `logger.bind(cycle_id=..., counts=...).info("poller cycle completed")` のように bind で付随データを付ける。
+
+## Atomic Task Requirements
+
+- 各タスクは **1〜3 ファイル** を touch する
+- **15〜30 分**で完了可能
+- **single purpose / single testable outcome**
+- 既存コードへの **_Leverage_** と **_Requirements_** を必ず参照
+
+## Tasks
+
+### A0. SLURM Protocol 共通抽象(PR 1)
+
+- [ ] 0a. Define `SlurmClientProtocol` in `src/srunx/client_protocol.py`
+  - File: `src/srunx/client_protocol.py`
+  - `Protocol` with `async queue_by_ids(job_ids: list[int]) -> dict[int, JobStatusInfo]` signature (returns mapping of job_id to current state)
+  - `JobStatusInfo` TypedDict/dataclass: `status, started_at, completed_at, duration_secs, nodelist` 等
+  - Purpose: Both `Slurm`(local)と `SlurmSSHAdapter`(web)が同じ呼び出し口を持つための契約
+  - _Leverage: 既存 `src/srunx/client.py` (`Slurm`), `src/srunx/web/ssh_adapter.py` (`SlurmSSHAdapter`)_
+  - _Requirements: 10.2_
+
+- [ ] 0b. Implement `Slurm.queue_by_ids()` in `src/srunx/client.py`
+  - File: `src/srunx/client.py`(modify)
+  - Add method that calls `squeue` filtered by job id list, parses into `dict[int, JobStatusInfo]`
+  - Reuse existing squeue-parsing helpers
+  - Purpose: ローカル SLURM 経由の batch 取得
+  - _Leverage: 既存 `Slurm.queue()` の squeue 呼び出しロジック_
+  - _Requirements: 10.2_
+
+- [ ] 0c. Implement `SlurmSSHAdapter.queue_by_ids()` in `src/srunx/web/ssh_adapter.py`
+  - File: `src/srunx/web/ssh_adapter.py`(modify)
+  - SSH 経由で `squeue --jobs=<id,id,...>` を実行、パース
+  - Purpose: SSH 経由の batch 取得
+  - _Leverage: 既存 `SlurmSSHAdapter` の SSH 呼び出し基盤_
+  - _Requirements: 10.2_
+
+- [ ] 0d. Unit tests for `queue_by_ids` in `tests/test_client_protocol.py`
+  - File: `tests/test_client_protocol.py`
+  - Test: mocked squeue returns parsed dict correctly
+  - Test: empty job_ids list returns empty dict
+  - Test: missing/terminal jobs are represented with their final status (from sacct fallback or marked as unknown)
+  - _Requirements: 10.2_
+
+### A. DB レイヤ(PR 1)
+
+- [ ] 1. Create `src/srunx/db/__init__.py` as empty package marker
+  - File: `src/srunx/db/__init__.py`
+  - Empty file (re-exports added in later tasks as needed)
+  - Purpose: Initialize db package
+  - _Requirements: 5.5_
+
+- [ ] 2. Add XDG-compliant DB path resolution to `src/srunx/db/connection.py`
+  - File: `src/srunx/db/connection.py`
+  - Function `get_db_path() -> Path`: `$XDG_CONFIG_HOME/srunx/srunx.db` or fallback `~/.config/srunx/srunx.db`
+  - Create parent directory with mode 0700 if missing
+  - Purpose: Provide single authoritative DB path helper
+  - _Leverage: `src/srunx/config.py`(`get_config_dir` がある場合は流用)_
+  - _Requirements: 5.5_
+
+- [ ] 3. Add `open_connection()` and `transaction()` context manager to `src/srunx/db/connection.py`
+  - File: `src/srunx/db/connection.py`(continue from task 2)
+  - `open_connection()`: `sqlite3.connect(path)` + PRAGMA `foreign_keys=ON`, `journal_mode=WAL`, `busy_timeout=5000`, set `row_factory=sqlite3.Row`, `chmod 0600` on first creation
+  - `transaction(conn, mode='DEFERRED'|'IMMEDIATE')`: contextmanager wrapping `BEGIN ... COMMIT/ROLLBACK`
+  - Purpose: Standardize DB connection and transaction handling
+  - _Requirements: 5.5, Non-Functional Reliability, Security_
+
+- [ ] 4. Write schema SQL constant `SCHEMA_V1` in `src/srunx/db/migrations.py`
+  - File: `src/srunx/db/migrations.py`
+  - Define `SCHEMA_V1: str` containing DDL for all 10 tables (schema_version, workflow_runs, jobs, workflow_run_jobs, job_state_transitions, resource_snapshots, endpoints, watches, subscriptions, events, deliveries) in correct FK order
+  - Include all CHECK constraints, UNIQUE indexes, partial indexes as specified in design.md Data Models section
+  - Purpose: Ship the entire v1 schema as one atomic migration
+  - _Requirements: 3.8, 5.5, 6.1, 7.1, 7.2, 7.4_
+
+- [ ] 5. Add `apply_migrations(conn)` to `src/srunx/db/migrations.py`
+  - File: `src/srunx/db/migrations.py`(continue from task 4)
+  - `Migration` dataclass with `version`, `name`, `sql`
+  - `MIGRATIONS: list[Migration]` containing `(1, 'v1_initial', SCHEMA_V1)`
+  - `apply_migrations(conn)`: for each migration, check `schema_version` table existence + row existence; if missing, run SQL inside `BEGIN IMMEDIATE` transaction and insert row
+  - Purpose: Idempotent schema application
+  - _Requirements: 5.4, 5.5_
+
+- [ ] 6. Add `bootstrap_from_config(conn, config)` to `src/srunx/db/migrations.py`
+  - File: `src/srunx/db/migrations.py`(continue from task 5)
+  - Check `schema_version` for `name='bootstrap_slack_webhook_url'`; no-op if present
+  - Read `config.notifications.slack_webhook_url`; if empty/None, record `schema_version` row and return
+  - If non-empty, inside `BEGIN IMMEDIATE`: INSERT into `endpoints` (kind='slack_webhook', name='default', config JSON), then INSERT into `schema_version`; on failure, ROLLBACK and log warning (no schema_version row written)
+  - Purpose: One-time migration of legacy webhook URL to endpoints table
+  - _Leverage: `src/srunx/config.py`_
+  - _Requirements: Migration NFR_
+
+- [ ] 7. Add `init_db()` function to `src/srunx/db/connection.py`
+  - File: `src/srunx/db/connection.py`(continue from task 3)
+  - Steps: ensure parent dir (0700), create connection (chmod 0600 on first creation), apply PRAGMAs, call `apply_migrations(conn)`, delete `~/.srunx/history.db` if exists (on OSError rename to `.broken` and log warning)
+  - Purpose: Single entrypoint for DB initialization from lifespan
+  - _Leverage: `src/srunx/db/migrations.py`_
+  - _Requirements: 5.4, 5.5, Security NFR_
+
+- [ ] 8. Unit tests for `db/connection.py` in `tests/db/test_connection.py`
+  - File: `tests/db/test_connection.py`
+  - Test: `get_db_path()` with/without `XDG_CONFIG_HOME` env var
+  - Test: `open_connection()` sets all PRAGMAs, `row_factory`
+  - Test: `init_db()` creates file with mode 0600, removes legacy `~/.srunx/history.db`, applies schema
+  - Use `tmp_path` and monkeypatch for env isolation
+  - Purpose: Verify DB bootstrapping edge cases
+  - _Requirements: 5.5, Security NFR_
+
+- [ ] 9. Unit tests for `db/migrations.py` in `tests/db/test_migrations.py`
+  - File: `tests/db/test_migrations.py`
+  - Test: `apply_migrations` idempotent(2 回呼び出しで行数不変)
+  - Test: `bootstrap_from_config` with None URL records schema_version once
+  - Test: `bootstrap_from_config` with valid URL creates endpoint and records schema_version
+  - Test: `bootstrap_from_config` on INSERT failure does NOT record schema_version
+  - Purpose: Guard migration correctness and once-only semantics
+  - _Requirements: Migration NFR_
+
+### A.1 Pydantic モデル層(PR 1)
+
+- [ ] 10. Create `src/srunx/db/models.py` with core Pydantic models
+  - File: `src/srunx/db/models.py`
+  - Define: `Endpoint`, `Watch`, `Subscription`, `Event`, `Delivery`, `WorkflowRun`, `WorkflowRunJob`, `JobStateTransition`, `ResourceSnapshot`, `Job` as `pydantic.BaseModel` v2
+  - Use `datetime | None` for timestamps, `dict | None` for JSON columns
+  - Purpose: Typed row representations shared by repositories
+  - _Requirements: R1-R7, R10_
+
+### A.2 Repository 群(PR 1)
+
+- [ ] 11. Create `src/srunx/db/repositories/__init__.py` as empty package marker
+  - File: `src/srunx/db/repositories/__init__.py`
+  - Purpose: Initialize repositories package
+  - _Requirements: Structure (CLAUDE.md conventions)_
+
+- [ ] 12. Create `BaseRepository` in `src/srunx/db/repositories/base.py`
+  - File: `src/srunx/db/repositories/base.py`
+  - `BaseRepository(conn)`: store connection, provide `_row_to_model(row, Model)` helper that parses JSON columns and datetime strings
+  - ISO 8601 UTC serialization helper `now_iso() -> str` returning `datetime.now(timezone.utc).isoformat(timespec='milliseconds').replace('+00:00','Z')`
+  - Purpose: Shared repository utilities and timestamp policy enforcement
+  - _Requirements: R3 Performance NFR(timestamp format)_
+
+- [ ] 13. Create `JobRepository` in `src/srunx/db/repositories/jobs.py`
+  - File: `src/srunx/db/repositories/jobs.py`
+  - Methods: `record_submission(job, submission_source, workflow_run_id)`, `update_status(job_id, status, started_at, completed_at, duration_secs)`, `update_completion(...)`, `get(job_id)`, `list(limit, offset)`, `count_by_status_in_range(from_at, to_at, statuses)`
+  - Port existing `history.py:record_job` / `update_job_completion` logic; add new columns
+  - Purpose: Centralize jobs table CRUD
+  - _Leverage: `src/srunx/history.py` の既存実装をロジックの下敷きにする_
+  - _Requirements: 5.1, 5.2, 5.3, 6.3_
+
+- [ ] 14. Create `WorkflowRunRepository` in `src/srunx/db/repositories/workflow_runs.py`
+  - File: `src/srunx/db/repositories/workflow_runs.py`
+  - Methods: `create(workflow_name, yaml_path, args, triggered_by)`, `get(id)`, `list()`, `list_incomplete()`, `update_status(id, status, error=None)`, `update_error(id, error)`
+  - Purpose: Replace in-memory `RunRegistry` with durable storage
+  - _Requirements: 2.1, 2.7, 2.9_
+
+- [ ] 15. Create `WorkflowRunJobRepository` in `src/srunx/db/repositories/workflow_run_jobs.py`
+  - File: `src/srunx/db/repositories/workflow_run_jobs.py`
+  - Methods: `create(workflow_run_id, job_id, job_name, depends_on)`, `list_by_run(workflow_run_id)`, `update_job_id(wrj_id, job_id)` (for delayed association if needed)
+  - Purpose: Manage job-to-run membership
+  - _Requirements: 2.1_
+
+- [ ] 16. Create `JobStateTransitionRepository` in `src/srunx/db/repositories/job_state_transitions.py`
+  - File: `src/srunx/db/repositories/job_state_transitions.py`
+  - Methods: `insert(job_id, from_status, to_status, source)`, `latest_for_job(job_id) -> JobStateTransition | None`, `history_for_job(job_id)`, `count_by_status_in_range(...)`
+  - Purpose: SSOT for state transitions, supports dedup via `latest_for_job`
+  - _Requirements: 6.1, 6.2, 6.4_
+
+- [ ] 17. Create `ResourceSnapshotRepository` in `src/srunx/db/repositories/resource_snapshots.py`
+  - File: `src/srunx/db/repositories/resource_snapshots.py`
+  - Methods: `insert(snapshot)`, `list_range(from_at, to_at, partition=None)`, `delete_older_than(days)`
+  - Purpose: Time-series GPU utilization storage
+  - _Leverage: `src/srunx/monitor/types.py` (`ResourceSnapshot`)_
+  - _Requirements: 7.1, 7.3, 7.5_
+
+- [ ] 18. Create `EndpointRepository` in `src/srunx/db/repositories/endpoints.py`
+  - File: `src/srunx/db/repositories/endpoints.py`
+  - Methods: `create(kind, name, config)`, `get(id)`, `list(include_disabled=True)`, `update(id, ...)`, `disable(id)`, `enable(id)`, `delete(id)`
+  - Webhook URL regex validation done in service layer, not here
+  - Purpose: Endpoints table CRUD
+  - _Requirements: 4.1, 4.5, 4.6_
+
+- [ ] 19. Create `WatchRepository` in `src/srunx/db/repositories/watches.py`
+  - File: `src/srunx/db/repositories/watches.py`
+  - Methods: `create(kind, target_ref, filter=None)`, `get(id)`, `list_open()`, `close(id)`
+  - Purpose: Watch CRUD with open/closed semantics
+  - _Requirements: 1.5, 10.6_
+
+- [ ] 20. Create `SubscriptionRepository` in `src/srunx/db/repositories/subscriptions.py`
+  - File: `src/srunx/db/repositories/subscriptions.py`
+  - Methods: `create(watch_id, endpoint_id, preset)`, `get(id)`, `list_by_watch(watch_id)`, `delete(id)`
+  - Purpose: Subscription CRUD with ON DELETE CASCADE semantics
+  - _Requirements: 4.4_
+
+- [ ] 21. Create `EventRepository` with payload_hash computation in `src/srunx/db/repositories/events.py`
+  - File: `src/srunx/db/repositories/events.py`
+  - Methods: `insert(event)` — computes `payload_hash` as SHA-256 hex of logical key string per design.md idempotency policy; uses `INSERT OR IGNORE` on UNIQUE violation, returns the inserted row id or None
+  - `get(id)`, `list_recent(limit)`
+  - `_compute_payload_hash(kind, source_ref, payload) -> str` as static helper (testable)
+  - Purpose: Event insertion with producer-side dedup
+  - _Requirements: 3.1, 10.3, 10.4, Error Handling #4_
+
+- [ ] 22. Create `DeliveryRepository` with claim/retry in `src/srunx/db/repositories/deliveries.py`
+  - File: `src/srunx/db/repositories/deliveries.py`
+  - Methods: `insert(event_id, subscription_id, endpoint_id, idempotency_key)` using `INSERT OR IGNORE`, `reclaim_expired_leases()`, `claim_one(worker_id, lease_duration_secs=300)` using SELECT then UPDATE pattern inside `BEGIN IMMEDIATE`, `mark_delivered(id)`, `mark_retry(id, error, backoff_secs)`, `mark_abandoned(id, error)`, `count_stuck_pending(older_than_sec=300)`
+  - Retry schedule helper `_backoff_secs(attempt_count, base=10, factor=2, cap=3600)`
+  - Purpose: Outbox CRUD with lease mechanics
+  - _Requirements: 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, Observability NFR_
+
+- [ ] 23. Unit tests for `JobRepository` in `tests/db/repositories/test_jobs.py`
+  - File: `tests/db/repositories/test_jobs.py`
+  - Test: `record_submission` inserts with correct `submission_source`, `workflow_run_id`
+  - Test: `update_status` updates terminal fields correctly
+  - Test: `count_by_status_in_range` returns expected counts
+  - _Requirements: 5.1, 5.2, 5.3, 6.3_
+
+- [ ] 24. Unit tests for `WorkflowRunRepository` in `tests/db/repositories/test_workflow_runs.py`
+  - File: `tests/db/repositories/test_workflow_runs.py`
+  - Test: `create` → `list_incomplete` returns pending/running runs only
+  - Test: `update_status` transitions through pending → running → completed/failed/cancelled
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.7_
+
+- [ ] 25. Unit tests for `EventRepository.payload_hash` in `tests/db/repositories/test_events.py`
+  - File: `tests/db/repositories/test_events.py`
+  - Test: `_compute_payload_hash` deterministic for same (kind, source_ref, logical key)
+  - Test: `_compute_payload_hash` differs across event kinds
+  - Test: `insert` dedup via UNIQUE — second insert returns None / no new row
+  - _Requirements: 3.1, 10.3, Error Handling #4_
+
+- [ ] 26. Unit tests for `DeliveryRepository` in `tests/db/repositories/test_deliveries.py`
+  - File: `tests/db/repositories/test_deliveries.py`
+  - Test: `claim_one` returns row and marks status=sending
+  - Test: concurrent claim from 2 connections — only one gets the row
+  - Test: `reclaim_expired_leases` converts stale sending rows back to pending
+  - Test: `mark_retry` increments `attempt_count` and sets `next_attempt_at` per exponential backoff
+  - Test: `mark_abandoned` sets terminal status
+  - Test: `INSERT OR IGNORE` prevents duplicates with same `(endpoint_id, idempotency_key)`
+  - _Requirements: 3.2, 3.3, 3.4, 3.5, 3.6, 3.8_
+
+- [ ] 27. Unit tests for `WatchRepository`, `SubscriptionRepository`, `EndpointRepository` in `tests/db/repositories/test_endpoints_watches_subs.py`
+  - File: `tests/db/repositories/test_endpoints_watches_subs.py`
+  - Test: Endpoint disable/enable cycle
+  - Test: Watch `close`, `list_open` filters
+  - Test: Endpoint deletion CASCADE removes subscriptions
+  - _Requirements: 1.5, 4.1, 4.5, 4.6, 10.6_
+
+### A.3 既存 history.py 呼び出しサイト移行(PR 1)
+
+**目的**: `~/.srunx/history.db` への旧来の読み書きを全て `src/srunx/db/repositories/jobs.py`(`JobRepository`)経由に置き換える。移行漏れがあると旧 DB が再作成されて SSOT が割れる(Codex Critical #1 対応)。
+
+- [ ] 27a. Add `get_job_repo()` helper in `src/srunx/db/__init__.py`
+  - File: `src/srunx/db/__init__.py`(modify)
+  - Export a convenience function that opens a connection and returns a `JobRepository` bound to it (context-manager style)
+  - Purpose: 既存 call site 置換を短い1行差分に収める
+  - _Requirements: 5.1, 5.2, 5.3, 5.5_
+
+- [ ] 27b. Replace `history` usage in `src/srunx/client.py`
+  - File: `src/srunx/client.py`(modify, 1 file)
+  - Lines `151-156`(submit 時の history 書き込み)と `337-341`(完了時)を `JobRepository.record_submission(..., submission_source='cli')` / `JobRepository.update_status(...)` に置換
+  - Purpose: CLI submit/retrieve 経路を新 DB に寄せる
+  - _Leverage: `src/srunx/db/repositories/jobs.py`_
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 27c. Replace `history` usage in `src/srunx/runner.py`
+  - File: `src/srunx/runner.py`(modify, 1 file)
+  - Lines `721-724` 周辺の history 呼び出しを `JobRepository` 経由に置換
+  - `WorkflowRunner` が生成するジョブは引き続き `triggered_by='cli'` + `submission_source='workflow'` で記録(CLI 起動 workflow run 自体の DB 永続化は Phase 2 だが、ジョブ単位の履歴は Phase 1 で揃える)
+  - _Leverage: `src/srunx/db/repositories/jobs.py`_
+  - _Requirements: 5.2, 5.3_
+
+- [ ] 27d. Replace `history` usage in `src/srunx/cli/main.py`
+  - File: `src/srunx/cli/main.py`(modify, 1 file)
+  - Lines `1191-1281` 周辺の history コマンド実装(`srunx history` 等)を `JobRepository.list/get` 経由に置換
+  - 表示ロジック / フォーマットは変更せず、データソースのみ差し替える
+  - _Leverage: `src/srunx/db/repositories/jobs.py`_
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 27e. Replace `history` usage in `src/srunx/web/routers/history.py`
+  - File: `src/srunx/web/routers/history.py`(modify, 1 file)
+  - Lines `18-48` の API 実装を `JobRepository` 経由に置換
+  - レスポンス shape は変更しないようにする(frontend 互換維持)
+  - _Leverage: `src/srunx/db/repositories/jobs.py`_
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 27f. Replace `history` usage in `src/srunx/web/deps.py`
+  - File: `src/srunx/web/deps.py`(modify)
+  - Lines `60-61` の `get_history` dependency を `get_job_repo` ベースに書き換え
+  - 既存の dependency injection を使っている側のシグネチャも合わせて一括更新
+  - _Leverage: `src/srunx/db/repositories/jobs.py`_
+  - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 27g. Mark `src/srunx/history.py` as deprecated shim
+  - File: `src/srunx/history.py`(modify)
+  - Replace all top-level functions with deprecation warnings that raise `DeprecationWarning` and delegate to `JobRepository` equivalents via a lazy-opened connection (backward-compat shim for any missed call site)
+  - Add module docstring: "Deprecated. Use `srunx.db.repositories.jobs.JobRepository` instead. This module will be removed in a future version."
+  - Purpose: Any missed caller surfaces as a warning, not a silent split-brain
+  - _Requirements: 5.1, 5.4_
+
+- [ ] 27h. Grep-verify no remaining `srunx.history` imports outside shim and tests
+  - Run: `grep -rn "from srunx.history\|import srunx.history" src/ tests/`
+  - Expected result: only `src/srunx/history.py`(shim 自身)と `tests/` 内の互換性テストのみ参照している状態
+  - If any other site is found: **stop and file a new task in this document**(do NOT modify the site inside this task — keeps task atomic)
+  - Purpose: Gating verification of 27b-g completeness; detects missed call sites
+  - _Requirements: 5.1_
+
+- [ ] 27i. Shared pytest DB fixture in `tests/conftest.py`
+  - File: `tests/conftest.py`(modify — extend existing file)
+  - Fixture `tmp_srunx_db`(scope='function'):
+    - Creates a temporary directory via `tmp_path`
+    - Monkeypatches `XDG_CONFIG_HOME` to that dir
+    - Calls `init_db()` to create and migrate the DB
+    - Yields connection + path
+    - Closes connection after test
+  - **File-backed tmp SQLite, NOT `:memory:`**(WAL + multi-connection と矛盾するため、Codex Medium 指摘対応)
+  - Purpose: All new tests (db/, notifications/, pollers/, e2e/) share a single consistent DB bootstrap
+  - _Leverage: `tmp_path`, `monkeypatch` built-in fixtures_
+  - _Requirements: test 基盤整合_
+
+### B. Notifications ドメイン(PR 2)
+
+- [ ] 28. Create `src/srunx/notifications/__init__.py` as empty marker
+  - File: `src/srunx/notifications/__init__.py`
+  - Purpose: Package initialization
+  - _Requirements: Structure (CLAUDE.md conventions)_
+
+- [ ] 29. Extract `sanitize_slack_text` to `src/srunx/notifications/sanitize.py`
+  - File: `src/srunx/notifications/sanitize.py`
+  - Copy body of `SlackCallback._sanitize_text` as a standalone `sanitize_slack_text(text: str) -> str`
+  - Preserve exact current replacement table (HTML entities, markdown escapes, control chars)
+  - Purpose: Share sanitizer between CLI callback and new delivery adapter
+  - _Leverage: `src/srunx/callbacks.py:_sanitize_text`_
+  - _Requirements: Security NFR_
+
+- [ ] 30. Update `src/srunx/callbacks.py` to use `notifications.sanitize`
+  - File: `src/srunx/callbacks.py`(modify)
+  - Replace `_sanitize_text` body with `from srunx.notifications.sanitize import sanitize_slack_text; return sanitize_slack_text(text)`
+  - Keep method signature for backward compat
+  - Purpose: Eliminate duplication while preserving CLI behavior
+  - _Leverage: `src/srunx/notifications/sanitize.py`_
+  - _Requirements: Security NFR_
+
+- [ ] 31. Create preset filter in `src/srunx/notifications/presets.py`
+  - File: `src/srunx/notifications/presets.py`
+  - `should_deliver(preset: str, event_kind: str, to_status: str | None) -> bool`
+  - Truth table: `terminal` → terminal status_changed only; `running_and_terminal` → RUNNING + terminal; `all` → all; `digest` → returns False (digest is Phase 2, flag only for now)
+  - Pure function, zero dependencies
+  - Purpose: Centralize preset matching logic
+  - _Requirements: 1.2, 1.3, 1.4, 1.6_
+
+- [ ] 32. Unit tests for `presets.py` in `tests/notifications/test_presets.py`
+  - File: `tests/notifications/test_presets.py`
+  - Test all 4 presets × 5 event kinds truth table
+  - Test `terminal` does not fire for `job.submitted` or RUNNING
+  - _Requirements: 1.2, 1.3, 1.4, 1.6_
+
+- [ ] 33. Create `DeliveryAdapter` protocol in `src/srunx/notifications/adapters/base.py`
+  - File: `src/srunx/notifications/adapters/__init__.py`, `src/srunx/notifications/adapters/base.py`
+  - `class DeliveryAdapter(Protocol): kind: str; def send(event: Event, endpoint_config: dict) -> None`
+  - Custom exception `DeliveryError`
+  - Purpose: Abstract contract for delivery channels
+  - _Requirements: 3.3, Phase 1 scope_
+
+- [ ] 34. Create `SlackWebhookDeliveryAdapter` in `src/srunx/notifications/adapters/slack_webhook.py`
+  - File: `src/srunx/notifications/adapters/slack_webhook.py`
+  - Class with `kind='slack_webhook'` and `send(event, endpoint_config)`:
+    - Parse `webhook_url` from endpoint_config
+    - Build Slack blocks from event kind+payload using `sanitize_slack_text`
+    - Instantiate `slack_sdk.WebhookClient(webhook_url)` and call `send(text=..., blocks=...)`
+    - Check response status; raise `DeliveryError` on non-OK
+  - Purpose: Concrete Slack delivery implementation
+  - _Leverage: `src/srunx/notifications/sanitize.py`, `slack_sdk.WebhookClient`_
+  - _Requirements: 3.3, 8.5, Security NFR_
+
+- [ ] 35. Unit tests for `slack_webhook` adapter in `tests/notifications/adapters/test_slack_webhook.py`
+  - File: `tests/notifications/adapters/test_slack_webhook.py`
+  - Mock `slack_sdk.WebhookClient.send`; verify payload structure per event kind
+  - Test sanitization applied to job name containing `<`, `&`, control chars
+  - Test non-OK response raises `DeliveryError`
+  - _Requirements: 3.3, 8.5, Security NFR_
+
+- [ ] 36. Create `NotificationService` in `src/srunx/notifications/service.py`
+  - File: `src/srunx/notifications/service.py`
+  - Class `NotificationService(watch_repo, subscription_repo, event_repo, delivery_repo, endpoint_repo, now_iso_fn)`
+  - Methods:
+    - `fan_out(event, conn)`: query open watches matching `event.source_ref`; for each, query subscriptions with endpoint NOT disabled; apply `should_deliver` preset filter; compute `idempotency_key`; insert via `delivery_repo.insert` (INSERT OR IGNORE)
+    - `create_watch_for_job(job_id, endpoint_id, preset) -> int`
+    - `create_watch_for_workflow_run(run_id, endpoint_id | None, preset | None) -> int`(endpoint/preset optional to support auto-watch)
+  - `_idempotency_key(event)` deterministic per design policy
+  - Purpose: Orchestrate event → deliveries fan-out in a single transaction
+  - _Leverage: repositories from tasks 18-22_
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.6, 2.8, 4.4, 4.6, 10.5_
+
+- [ ] 37. Unit tests for `NotificationService` in `tests/notifications/test_service.py`
+  - File: `tests/notifications/test_service.py`
+  - Test: `fan_out` matches open watches only
+  - Test: `fan_out` skips disabled endpoints
+  - Test: `fan_out` applies preset filter
+  - Test: `fan_out` uses deterministic `idempotency_key` — re-calling with same event produces same deliveries (UNIQUE prevents duplicates)
+  - Test: `create_watch_for_workflow_run` without endpoint_id creates watch with no subscription
+  - _Requirements: 1.1-1.6, 2.8, 4.6, 10.5_
+
+- [ ] 37a. Create adapter registry in `src/srunx/notifications/adapters/registry.py`
+  - File: `src/srunx/notifications/adapters/registry.py`
+  - `ADAPTERS: dict[str, DeliveryAdapter] = { 'slack_webhook': SlackWebhookDeliveryAdapter() }` module-level singleton
+  - `get_adapter(kind: str) -> DeliveryAdapter` lookup with `KeyError` on unknown
+  - Purpose: Centralize adapter discovery for `DeliveryPoller`(Codex Low 対応)
+  - _Leverage: `notifications/adapters/slack_webhook.py`_
+  - _Requirements: 3.3, 4.1_
+
+### C. Pollers(PR 2)
+
+- [ ] 38. Create `src/srunx/pollers/__init__.py` as empty marker
+  - File: `src/srunx/pollers/__init__.py`
+  - Purpose: Package initialization
+  - _Requirements: Structure (CLAUDE.md conventions)_
+
+- [ ] 39. Create `reload_guard.py` in `src/srunx/pollers/reload_guard.py`
+  - File: `src/srunx/pollers/reload_guard.py`
+  - Pure functions: `is_reload_mode(env=os.environ, argv=sys.argv) -> bool`; `should_start_pollers(env, argv) -> bool`
+  - `is_reload_mode`: True if `UVICORN_RELOAD` env set, or `--reload` in argv
+  - `should_start_pollers`: False if reload mode or `SRUNX_DISABLE_POLLER=='1'`
+  - Purpose: Testable guard function for poller startup
+  - _Requirements: 8.1, 8.2, 8.3_
+
+- [ ] 40. Unit tests for `reload_guard.py` in `tests/pollers/test_reload_guard.py`
+  - File: `tests/pollers/test_reload_guard.py`
+  - Test all combinations: env var set/unset, `--reload` in argv or not, `SRUNX_DISABLE_POLLER=1/0/unset`
+  - Purpose: Cover guard matrix fully
+  - _Requirements: 8.1, 8.2, 8.3_
+
+- [ ] 41. Create `PollerSupervisor` in `src/srunx/pollers/supervisor.py`
+  - File: `src/srunx/pollers/supervisor.py`
+  - `Poller` Protocol with `name`, `interval_seconds`, `async run_cycle()`
+  - `PollerSupervisor(pollers, shutdown_event=anyio.Event())`
+  - `start_all()`: `anyio.create_task_group()`; per poller, run `_run_with_backoff(poller)` loop that catches exceptions and applies `1→2→4→...→60s` backoff; each cycle checks `shutdown_event` between sleeps
+  - `shutdown(grace_seconds=5.0)`: set event; `anyio.move_on_after(grace_seconds)`; on timeout cancel scope
+  - Purpose: Long-running task lifecycle with crash recovery and grace shutdown
+  - _Requirements: 8.3, 8.4_
+
+- [ ] 42. Unit tests for `PollerSupervisor` in `tests/pollers/test_supervisor.py`
+  - File: `tests/pollers/test_supervisor.py`
+  - Test: failing poller restarts after backoff; web-level failure not propagated
+  - Test: shutdown signal halts pollers within grace period
+  - Test: two pollers run concurrently without interference
+  - Use dummy pollers that raise/sleep to simulate conditions
+  - _Requirements: 8.3, 8.4_
+
+- [ ] 43a. Create `ActiveWatchPoller` skeleton with open-watch loading in `src/srunx/pollers/active_watch_poller.py`
+  - File: `src/srunx/pollers/active_watch_poller.py`
+  - Constructor takes `slurm_client: SlurmClientProtocol`, repos bundle, `NotificationService`, `interval_seconds=15`, `logger`
+  - `async run_cycle()` skeleton: load open watches via `WatchRepository.list_open()`, split by kind (`job` vs `workflow_run`), batch-query `slurm_client.queue_by_ids(job_ids)` via `anyio.to_thread.run_sync` for job watches
+  - Emit structured log at cycle start/end with counts (open_watches, transitions_detected, events_emitted, elapsed_ms) — Observability NFR
+  - Purpose: Foundation for producer loop; no transition logic yet
+  - _Leverage: `src/srunx/client.py` (`Slurm`), `src/srunx/db/repositories/watches.py`_
+  - _Requirements: 10.1, 10.2, 10.7, Observability NFR_
+
+- [ ] 43b. Add job transition detection and fan-out to `ActiveWatchPoller`
+  - File: `src/srunx/pollers/active_watch_poller.py`(continue from task 43a)
+  - For each job whose SLURM status differs from `JobStateTransitionRepository.latest_for_job(job_id)`, within `transaction(conn, 'IMMEDIATE')`:
+    - Insert `job_state_transitions` row (`source='poller'`)
+    - Call `JobRepository.update_status(job_id, status, started_at, completed_at, duration_secs)` (R5.1 completion persistence)
+    - Insert `events(kind='job.status_changed', ...)`; rely on `INSERT OR IGNORE` to skip duplicates (producer-side dedup)
+    - If inserted (non-None id), call `NotificationService.fan_out(event, conn)`
+    - If terminal (COMPLETED/FAILED/CANCELLED/TIMEOUT), close associated watches
+  - Purpose: Core transition-to-delivery producer logic for jobs
+  - _Leverage: repositories from A.2, `NotificationService` from task 36_
+  - _Requirements: 1.2-1.5, 6.1, 6.2, 10.3, 10.5, 10.6_
+
+- [ ] 43c. Add workflow_run aggregation logic to `ActiveWatchPoller`
+  - File: `src/srunx/pollers/active_watch_poller.py`(continue from task 43b)
+  - For each open `workflow_run` watch:
+    - Query `WorkflowRunJobRepository.list_by_run(run_id)` for child jobs
+    - Aggregate child job statuses into workflow-level status per R2 rules (all COMPLETED → completed; any FAILED/TIMEOUT → failed; any CANCELLED → cancelled; otherwise running)
+    - If aggregated status differs from current `workflow_runs.status`, within `transaction` run `WorkflowRunRepository.update_status(...)`, insert `events(kind='workflow_run.status_changed', ...)`, fan-out, close watch if terminal
+  - Purpose: Workflow-level status detection layered on top of job transitions
+  - _Leverage: WorkflowRunRepository, WorkflowRunJobRepository, NotificationService_
+  - _Requirements: 2.3, 2.4, 2.5, 10.4_
+
+- [ ] 44. Create `DeliveryPoller` in `src/srunx/pollers/delivery_poller.py`
+  - File: `src/srunx/pollers/delivery_poller.py`
+  - Constructor takes `delivery_repo`, `endpoint_repo`, `event_repo`, `adapter_registry: dict[str, DeliveryAdapter]`, `worker_id`, `interval_seconds=10`, `max_retries=5`, `logger`
+  - `async run_cycle()`:
+    1. `delivery_repo.reclaim_expired_leases()`
+    2. Loop: `delivery = delivery_repo.claim_one(worker_id)`; break if None
+    3. Fetch `event` via `event_repo.get`, `endpoint` via `endpoint_repo.get`, pick adapter by `endpoint.kind`
+    4. `await anyio.to_thread.run_sync(adapter.send, event, endpoint.config)`
+    5. On success: `mark_delivered(id)`
+    6. On `DeliveryError`: if `attempt_count+1 >= max_retries`, `mark_abandoned(id, error)`; else `mark_retry(id, error, backoff_secs)`
+  - Emit structured log per cycle with counts (claimed, delivered, retried, abandoned, elapsed_ms) — Observability NFR
+  - Purpose: Consumer side — deliver pending deliveries with retry/abandon semantics
+  - _Leverage: repositories from task 22, adapters from task 34_
+  - _Requirements: 3.2-3.8, 8.5, Observability NFR_
+
+- [ ] 45. Create `ResourceSnapshotter` in `src/srunx/pollers/resource_snapshotter.py`
+  - File: `src/srunx/pollers/resource_snapshotter.py`
+  - Constructor `(resource_monitor, snapshot_repo, interval_seconds=300, logger)`
+  - `async run_cycle()`: call `anyio.to_thread.run_sync(resource_monitor.get_current_snapshot)`; insert via `snapshot_repo.insert`
+  - Emit structured log per cycle with (partition, gpus_total, gpus_available, elapsed_ms) — Observability NFR
+  - Purpose: Periodically capture cluster GPU state
+  - _Leverage: `src/srunx/monitor/resource_monitor.py`_
+  - _Requirements: 7.1, 7.2, Observability NFR_
+
+- [ ] 46. Integration tests for pollers in `tests/pollers/test_poller_integration.py`
+  - File: `tests/pollers/test_poller_integration.py`
+  - With tmp DB and mocked `Slurm`:
+    - `ActiveWatchPoller.run_cycle()` detects PENDING→RUNNING, emits event, fan-outs to deliveries
+    - Terminal transition closes watch and updates `jobs.status`
+    - `DeliveryPoller` with failing adapter retries 5 times and abandons
+  - _Requirements: R1, R3, R10_
+
+### D. JobMonitor SSOT 更新(PR 2)
+
+- [ ] 47. Update `src/srunx/monitor/job_monitor.py` to write transitions
+  - File: `src/srunx/monitor/job_monitor.py`(modify)
+  - Inject optional `JobStateTransitionRepository` in `__init__`; `None` → no-op (preserves existing tests)
+  - **Exact hook location**: `job_monitor.py:110-115` — the point where both `previous_status` and `current_status` are simultaneously in scope(NOT `_notify_transition()` which loses `from_status`, nor `watch_continuous()` which is too coarse)
+  - Call `repo.insert(job_id, from_status=previous_status, to_status=current_status, source='cli_monitor')` when `previous_status != current_status`
+  - Purpose: CLI observations contribute to SSOT without changing user-facing behavior
+  - _Leverage: existing JobMonitor internals_
+  - _Requirements: 6.1, 10.9_
+
+- [ ] 48. Unit test for JobMonitor SSOT writes in `tests/monitor/test_job_monitor_ssot.py`
+  - File: `tests/monitor/test_job_monitor_ssot.py`
+  - Inject in-memory repo; run JobMonitor against mocked SLURM with synthetic transitions; verify `insert` calls
+  - _Requirements: 6.1_
+
+### E. Web ルータ(PR 3、ただし 48a/48b/59a/59b は PR 2 先行)
+
+- [ ] 48a. Add DB connection provider in `src/srunx/web/deps.py`
+  - File: `src/srunx/web/deps.py`(modify)
+  - Add FastAPI dependency `get_db_conn()` (contextmanager-style or generator) that opens a new sqlite3 connection with PRAGMAs applied for each request, and closes it at request end
+  - **Important**: `sqlite3.Connection` is threadlocal default; web request handlers MUST NOT share connections with lifespan poller tasks. Each request gets its own connection. Pollers own their own connection(s) separately.
+  - Purpose: Connection ownership strategy(Codex High #3 対応)
+  - _Leverage: `src/srunx/db/connection.py:open_connection`_
+  - _Requirements: 5.5, Non-Functional Reliability_
+
+- [ ] 48b. Add repository dependency factories in `src/srunx/web/deps.py`
+  - File: `src/srunx/web/deps.py`(continue from 48a)
+  - Add `get_job_repo(conn=Depends(get_db_conn))`, `get_workflow_run_repo(conn=...)`, `get_endpoint_repo(conn=...)`, etc. for each repository used by routers
+  - Purpose: Clean DI for router handlers
+  - _Requirements: 5.5_
+
+- [ ] 49. Add `default_endpoint_name` and `default_preset` to `SrunxConfig`
+  - File: `src/srunx/config.py`(modify)
+  - Add to `NotificationDefaults` (or equivalent existing nested model): `default_endpoint_name: str | None = None`, `default_preset: str = 'terminal'`
+  - Mark `slack_webhook_url` as deprecated in docstring (kept for migration only)
+  - Purpose: Persist user-selected defaults for submit dialog
+  - _Requirements: 9.3, Migration NFR_
+
+- [ ] 50. Create `web/routers/endpoints.py` with CRUD endpoints
+  - File: `src/srunx/web/routers/endpoints.py`
+  - `GET /api/endpoints`, `POST /api/endpoints`, `PATCH /api/endpoints/{id}` (disable/enable/rename), `DELETE /api/endpoints/{id}`
+  - Validate Slack webhook URL regex in `POST` body; return 422 on invalid
+  - Purpose: Endpoint management API surface
+  - _Leverage: `src/srunx/db/repositories/endpoints.py`_
+  - _Requirements: 4.1, 4.2, 4.5, 4.6, 9.1, 9.2, Security NFR_
+
+- [ ] 51. Create `web/routers/subscriptions.py` with CRUD endpoints
+  - File: `src/srunx/web/routers/subscriptions.py`
+  - `GET /api/subscriptions?watch_id=`, `POST /api/subscriptions`, `DELETE /api/subscriptions/{id}`
+  - Purpose: Subscription management API surface
+  - _Leverage: `src/srunx/db/repositories/subscriptions.py`_
+  - _Requirements: 4.4_
+
+- [ ] 52. Create `web/routers/watches.py` read-only listing
+  - File: `src/srunx/web/routers/watches.py`
+  - `GET /api/watches?open=true|false`
+  - Purpose: Observability into current watches
+  - _Leverage: `src/srunx/db/repositories/watches.py`_
+  - _Requirements: Observability NFR_
+
+- [ ] 53. Create `web/routers/deliveries.py` observability endpoints
+  - File: `src/srunx/web/routers/deliveries.py`
+  - `GET /api/deliveries?subscription_id=&status=`, `GET /api/deliveries/stuck`
+  - Purpose: Visibility into delivery outbox state
+  - _Leverage: `src/srunx/db/repositories/deliveries.py`_
+  - _Requirements: Observability NFR, Usability NFR_
+
+- [ ] 54a. Update `JobSubmitRequest` schema in `web/routers/jobs.py`
+  - File: `src/srunx/web/routers/jobs.py`(modify, lines ~73-79)
+  - Remove `notify_slack: bool = False` field
+  - Add `notify: bool = False`, `endpoint_id: int | None = None`, `preset: str = 'terminal'`
+  - Add Pydantic validator: if `notify` is True, `endpoint_id` MUST be present
+  - Purpose: Request schema aligned with new notification model
+  - _Requirements: 1.1, 4.3, 9.3, 9.4_
+
+- [ ] 54b. Modify `web/routers/jobs.py` submit handler body
+  - File: `src/srunx/web/routers/jobs.py`(continue from 54a, lines ~116-143)
+  - **Differencing starts at line 116** (after `result = await anyio.to_thread.run_sync(...)` success)
+  - Remove direct Slack-send block (lines ~125-143)
+  - New flow:
+    1. `JobRepository.record_submission(job, submission_source='web', workflow_run_id=None)` (bug fix R5.1)
+    2. If `req.notify`: `watch_id = NotificationService.create_watch_for_job(job_id, req.endpoint_id, req.preset)`
+    3. Insert `job.submitted` event via `EventRepository` (inside same `BEGIN IMMEDIATE` transaction as step 2)
+    4. If `req.preset == 'all'`, `NotificationService.fan_out` runs; otherwise `events` is recorded but no deliveries generated
+  - Inject `get_db_conn`, `get_job_repo`, `NotificationService` factory via `Depends()`
+  - Purpose: Integrate notification creation into Web submit and fix history bug
+  - _Leverage: repos from A.2, `NotificationService` from task 36, DI from 48a/48b_
+  - _Requirements: 1.1, 1.2, 5.1, 5.2, 5.3_
+
+- [ ] 55a. Rewrite `web/routers/workflows.py` POST /workflows/runs — creation + auto-watch
+  - File: `src/srunx/web/routers/workflows.py`(modify)
+  - Replace the initial handler block:
+    1. `WorkflowRunRepository.create(status='pending', triggered_by='web')` returning `run_id`
+    2. `WatchRepository.create(kind='workflow_run', target_ref=f'workflow_run:{run_id}')` (auto-watch, always)
+    3. If request body includes `notify=True` + `endpoint_id` + `preset`: `SubscriptionRepository.create(watch_id, endpoint_id, preset)`
+  - Purpose: Durable workflow run creation + auto-watch for resume
+  - _Leverage: `WorkflowRunRepository`, `WatchRepository`, `SubscriptionRepository`_
+  - _Requirements: 2.1, 2.8, 10.5_
+
+- [ ] 55b. Per-job submit loop with history + membership writes
+  - File: `src/srunx/web/routers/workflows.py`(continue from 55a)
+  - In the per-job submit loop:
+    1. Submit job to SLURM via adapter, get `job_id`
+    2. `JobRepository.record_submission(job, submission_source='workflow', workflow_run_id=run_id)` (order matters for FK)
+    3. `WorkflowRunJobRepository.create(workflow_run_id=run_id, job_id=job_id, job_name, depends_on)`
+    4. On first successful submit, `WorkflowRunRepository.update_status(run_id, 'running')` + insert `workflow_run.status_changed` event
+  - Purpose: Persist membership with correct FK order
+  - _Leverage: `JobRepository`, `WorkflowRunJobRepository`, `WorkflowRunRepository`, `EventRepository`_
+  - _Requirements: 2.1, 2.2, 2.6, 5.3_
+
+- [ ] 55c. Remove `_monitor_run` and in-memory `run_registry` sites from `web/routers/workflows.py`
+  - File: `src/srunx/web/routers/workflows.py`(continue from 55b)
+  - **Targeted line ranges(Codex High #4 対応)**: 324-357, 503-543, 626-628, 785-789, 832-901
+  - Delete `_monitor_run` function and any `asyncio.create_task`/`BackgroundTasks` that spawn it
+  - Replace references to in-memory `run_registry` with `WorkflowRunRepository` calls
+  - **`cancel_run()`**(存在する場合): `WorkflowRunRepository.update_status(run_id, 'cancelled')` + `SLURM cancel` + events 挿入に置換
+  - Purpose: Eliminate duplicate monitoring loop and in-memory state fully
+  - _Leverage: `WorkflowRunRepository`, `WorkflowRunJobRepository`, `EventRepository`_
+  - _Requirements: 2.5, 2.5 (full coverage)_
+
+- [ ] 56. Update `web/routers/workflows.py` GET /runs and status endpoints
+  - File: `src/srunx/web/routers/workflows.py`(continue from task 55)
+  - `GET /runs`: return `WorkflowRunRepository.list()` results, including `running` runs post-restart (R2.9)
+  - Remove references to in-memory `run_registry`
+  - Update response model to use integer `run_id` and new `status` enum (`pending/running/completed/failed/cancelled`)
+  - Purpose: Expose durable run state to Web UI
+  - _Requirements: 2.7, 2.9, API contract NFR_
+
+- [ ] 57. Remove `web/state.py` RunRegistry usage
+  - File: `src/srunx/web/state.py`(delete or stub out), and any import sites
+  - Delete `RunRegistry` class and global `run_registry` singleton
+  - Replace remaining call sites (found via grep) with repository calls
+  - Purpose: Eliminate in-memory workflow state
+  - _Leverage: `WorkflowRunRepository`_
+  - _Requirements: 2.5_
+
+- [ ] 58. Update `web/ssh_adapter.py` docstring to clarify recording responsibility
+  - File: `src/srunx/web/ssh_adapter.py`(modify)
+  - Update `SlurmSSHAdapter.submit_job` docstring to explicitly state that history recording is the caller's (router's) responsibility (clarifies the R5.1 bug fix boundary)
+  - No logic change; pure docs improvement
+  - Purpose: Prevent future regression where someone re-adds history.record_job inside the adapter
+  - _Requirements: 5.1_
+
+- [ ] 59a. Wire DB init + bootstrap into `web/app.py` lifespan
+  - File: `src/srunx/web/app.py`(modify)
+  - In `lifespan` startup:
+    1. `init_db()`(creates and migrates DB, sets 0600 perms)
+    2. Open a dedicated lifespan connection via `open_connection()` for bootstrap
+    3. `bootstrap_from_config(conn, get_config())` then close
+  - Store the config / supervisor references on `app.state` for access from handlers
+  - Purpose: DB boot + migration on web start
+  - _Leverage: tasks 7, 6_
+  - _Requirements: 5.5, Migration NFR_
+
+- [ ] 59b. Build poller list and start `PollerSupervisor` in `web/app.py`
+  - File: `src/srunx/web/app.py`(continue from 59a)
+  - After DB init:
+    1. `should_start = should_start_pollers(os.environ, sys.argv)`
+    2. If `should_start`, enumerate pollers per env var:
+       - `ActiveWatchPoller` unless `SRUNX_DISABLE_ACTIVE_WATCH_POLLER=1`
+       - `DeliveryPoller` unless `SRUNX_DISABLE_DELIVERY_POLLER=1`
+       - `ResourceSnapshotter` unless `SRUNX_DISABLE_RESOURCE_SNAPSHOTTER=1`
+    3. Construct `PollerSupervisor(pollers)` and `await supervisor.start_all()`
+    4. Register `app.state.supervisor = supervisor`
+  - In shutdown: `await app.state.supervisor.shutdown(grace_seconds=5.0)`
+  - Purpose: Start background pollers with individual env guards
+  - _Leverage: tasks 39, 41, 43-45, adapter registry task 37a_
+  - _Requirements: 8.1-8.5, 7.2_
+
+- [ ] 59c. Register new routers in `web/app.py`
+  - File: `src/srunx/web/app.py`(continue from 59b, lines ~247-253 area)
+  - Add `app.include_router(...)` calls for `endpoints`, `subscriptions`, `watches`, `deliveries` routers created in tasks 50-53
+  - Purpose: Expose new API endpoints(Codex Medium #11 対応)
+  - _Leverage: tasks 50-53_
+  - _Requirements: 4.1, 4.4, Observability NFR_
+
+- [ ] 60. API integration tests for new endpoints in `tests/web/test_notifications_api.py`
+  - File: `tests/web/test_notifications_api.py`
+  - Use FastAPI TestClient with `tmp_srunx_db` fixture from `tests/conftest.py`(task 27i)
+  - **NOTE(Codex Medium)**: Use file-backed tmp SQLite, NOT `:memory:`(multi-connection + WAL と矛盾するため)
+  - Test: CRUD endpoint flow for `/api/endpoints`, `/api/subscriptions`
+  - Test: submit with `notify=true` creates watch/subscription
+  - Test: workflow run POST creates workflow_run + auto-watch
+  - Test: `GET /runs` returns persisted runs
+  - _Leverage: task 27i shared fixture_
+  - _Requirements: R1, R2, R4, R9_
+
+### F. Frontend(PR 3)
+
+- [ ] 61. Update `lib/types.ts` for new workflow run shape
+  - File: `src/srunx/web/frontend/src/lib/types.ts`(modify)
+  - Change `WorkflowRun.id` from string to number; change `status` enum to `'pending'|'running'|'completed'|'failed'|'cancelled'`
+  - Add `Endpoint`, `Subscription`, `Delivery` types
+  - Purpose: Align TS types with new API contract
+  - _Requirements: API contract NFR_
+
+- [ ] 61a. Update `lib/api.ts` client functions
+  - File: `src/srunx/web/frontend/src/lib/api.ts`(modify, lines ~73-95, 177-205)
+  - `jobs.submit(...)` signature: remove `notifySlack: boolean`, add `notify: boolean`, `endpointId: number | null`, `preset: string`
+  - Workflow run endpoints: update response type to new integer run_id / new status enum
+  - Add endpoint CRUD functions: `endpoints.list()`, `endpoints.create()`, `endpoints.update()`, `endpoints.delete()`
+  - Add subscription CRUD functions
+  - Add deliveries query functions for NotificationsCenter
+  - Purpose: Frontend API client aligned with new backend(Codex High #7 対応)
+  - _Leverage: tasks 50-53 API contracts_
+  - _Requirements: API contract NFR, 4.1, 4.4_
+
+- [ ] 61b. Update `pages/WorkflowDetail.tsx` for new run shape
+  - File: `src/srunx/web/frontend/src/pages/WorkflowDetail.tsx`(modify, lines ~36-52, 103-149)
+  - Replace string UUID `run_id` with integer
+  - Replace old status names (`syncing`, `submitting`) with new(`pending`, `running`, `completed`, `failed`, `cancelled`)
+  - Update any status rendering / color mapping / icon logic to match new enum
+  - Purpose: Workflow detail page aligned with new API(Codex High #7 対応)
+  - _Leverage: task 61 types_
+  - _Requirements: 2.7, 2.9, API contract NFR_
+
+- [ ] 62. Rewrite `NotificationsTab.tsx` with endpoint list CRUD
+  - File: `src/srunx/web/frontend/src/pages/settings/NotificationsTab.tsx`(modify)
+  - Remove single webhook URL input
+  - Add: endpoints table (kind/name/status), add form with Slack URL validation, row actions (enable/disable/delete)
+  - Add: default endpoint and default preset selectors bound to `SrunxConfig`
+  - Purpose: Multi-endpoint management UI
+  - _Leverage: task 50 API_
+  - _Requirements: 9.1, 9.2, 9.3_
+
+- [ ] 63. Update submit UI with notification controls
+  - File: `src/srunx/web/frontend/src/components/FileExplorer.tsx`(modify — submit flow currently lives here at lines ~246-520 with `notifySlack` toggle)
+  - Replace current `notifySlack` boolean with: notify toggle, endpoint select (disabled if no endpoints from `/api/endpoints`), preset select with values `terminal`/`running_and_terminal`/`all`
+  - Show guidance banner when no endpoints exist (R9.4) — disable notify toggle
+  - Read defaults (default_endpoint_name, default_preset) from `SrunxConfig` via config API
+  - Update `jobs.submit(...)` call signature to pass `{notify, endpoint_id, preset}` instead of `notifySlack` boolean
+  - Purpose: Per-submit notification configuration matching new backend API
+  - _Leverage: `/api/endpoints` (task 50), `SrunxConfig` defaults (task 49)_
+  - _Requirements: 4.3, 9.3, 9.4_
+
+- [ ] 64. Create `NotificationsCenter.tsx` dashboard
+  - File: `src/srunx/web/frontend/src/pages/NotificationsCenter.tsx`
+  - Sections: subscription list, recent deliveries table (filter by status), stuck pending count
+  - Use `/api/deliveries` and `/api/subscriptions`
+  - Purpose: Observability UI for notifications
+  - _Requirements: Observability NFR, Usability NFR_
+
+- [ ] 65. Update Sidebar / routing to include NotificationsCenter
+  - File: `src/srunx/web/frontend/src/components/Sidebar.tsx`(modify), routing config
+  - Add nav entry linking to NotificationsCenter
+  - Purpose: Expose new dashboard page
+  - _Requirements: Observability NFR_
+
+- [ ] 66. Frontend E2E test update for workflow run lifecycle
+  - File: Existing Playwright specs under `src/srunx/web/frontend/e2e/`(modify 1-2 files)
+  - Update assertions from UUID string to integer, from old status names to new
+  - Add coverage for endpoint CRUD and submit-with-notification flow
+  - _Requirements: API contract NFR, R9_
+
+### G. 統合テスト(PR 3)
+
+- [ ] 67. E2E test: submit → state transition → delivery in `tests/e2e/test_submit_to_slack.py`
+  - File: `tests/e2e/test_submit_to_slack.py`
+  - Local HTTP mock Slack; start FastAPI TestClient with real tmp DB
+  - Sequence: add endpoint → POST submit (notify=true, preset=terminal) → manually drive `ActiveWatchPoller.run_cycle` with mocked SLURM states → `DeliveryPoller.run_cycle` → verify mock received expected payload
+  - _Requirements: R1, R3_
+
+- [ ] 68. E2E test: workflow run resume in `tests/e2e/test_workflow_resume.py`
+  - File: `tests/e2e/test_workflow_resume.py`
+  - Start app, create workflow run with `running` status + open auto-watch, shut down
+  - Restart app; confirm `/runs` returns the run and `ActiveWatchPoller` picks it up on first cycle
+  - _Requirements: 2.7, 2.9_
+
+- [ ] 69. E2E test: --reload guard in `tests/e2e/test_reload_guard.py`
+  - File: `tests/e2e/test_reload_guard.py`
+  - Simulate env with `UVICORN_RELOAD=1`; verify `should_start_pollers` returns False
+  - Smoke-run lifespan with guard active; verify no `events` or `deliveries` are written over 5s
+  - _Requirements: 8.1, 8.2, 8.3_
+
+- [ ] 70. E2E test: config.json webhook migration in `tests/e2e/test_bootstrap_migration.py`
+  - File: `tests/e2e/test_bootstrap_migration.py`
+  - Seed `config.json` with `notifications.slack_webhook_url`; run `bootstrap_from_config`; verify endpoint created and `schema_version` row present
+  - Run a second time; verify no additional endpoint row
+  - Test failure path: pre-create conflicting endpoint name, verify bootstrap does NOT record `schema_version`
+  - _Requirements: Migration NFR_
+
+### H. Documentation(PR 3)
+
+- [ ] 71. Update `CLAUDE.md` with new DB location and notification model
+  - File: `CLAUDE.md`(modify)
+  - Add: new DB path `~/.config/srunx/srunx.db`, removal of `~/.srunx/history.db`
+  - Add: notification model (endpoints / watches / subscriptions / deliveries) summary under Architecture
+  - Add: env vars `SRUNX_DISABLE_POLLER`, `SRUNX_DISABLE_ACTIVE_WATCH_POLLER`, `SRUNX_DISABLE_DELIVERY_POLLER`, `SRUNX_DISABLE_RESOURCE_SNAPSHOTTER`
+  - Purpose: Keep project guidance current
+  - _Requirements: Usability NFR (documentation)_
+
+- [ ] 72. Add migration note to README or changelog (if exists)
+  - File: Check `README.md` or `CHANGELOG.md`(modify if exists; skip if neither)
+  - Note breaking change: old `~/.srunx/history.db` deleted; Slack webhook URL moved from config.json to DB
+  - _Requirements: Migration NFR_
+
+### I. Final Cleanup(各 PR の終端で都度実施)
+
+- [ ] 73. Run quality gates and fix failures scoped to this feature
+  - Run: `uv run pytest && uv run mypy . && uv run ruff check .`
+  - Fix any test / type / lint failures introduced by tasks 1-72
+  - Do not expand scope to pre-existing issues in unrelated modules
+  - Rerun until all three commands pass
+  - Purpose: Pre-commit quality gate per CLAUDE.md convention
+  - _Requirements: All_

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -9,6 +9,7 @@ import time
 from collections.abc import Sequence
 from importlib.resources import files
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from srunx.callbacks import Callback
 from srunx.logging import get_logger
@@ -23,6 +24,9 @@ from srunx.models import (
     render_shell_job_script,
 )
 from srunx.utils import GPU_TRES_RE, get_job_status, job_status_msg  # noqa: E402
+
+if TYPE_CHECKING:
+    from srunx.client_protocol import JobStatusInfo
 
 logger = get_logger(__name__)
 
@@ -266,6 +270,108 @@ class Slurm:
                 jobs.append(job)
 
         return jobs
+
+    def queue_by_ids(self, job_ids: list[int]) -> dict[int, "JobStatusInfo"]:
+        """Return a mapping of ``job_id`` -> :class:`JobStatusInfo` for active jobs.
+
+        Active jobs are read from ``squeue``. Jobs that have already left
+        the queue are looked up via ``sacct``. Jobs found in neither source
+        are omitted from the returned dict.
+
+        Args:
+            job_ids: SLURM job IDs to query. An empty list yields ``{}``.
+
+        Returns:
+            Dict keyed by job_id. Missing jobs are absent from the dict.
+        """
+        from srunx.client_protocol import (
+            JobStatusInfo,
+            parse_slurm_datetime,
+            parse_slurm_duration,
+        )
+
+        if not job_ids:
+            return {}
+
+        results: dict[int, JobStatusInfo] = {}
+        id_arg = ",".join(str(i) for i in job_ids)
+
+        # --- squeue: active (PENDING / RUNNING / etc.) ---
+        squeue_cmd = [
+            "squeue",
+            "--jobs",
+            id_arg,
+            "--format",
+            "%i|%T|%S|%M|%N",
+            "--noheader",
+        ]
+        try:
+            squeue_res = subprocess.run(
+                squeue_cmd, capture_output=True, text=True, check=False
+            )
+        except FileNotFoundError:
+            squeue_res = None
+
+        if squeue_res and squeue_res.returncode == 0:
+            for line in squeue_res.stdout.strip().splitlines():
+                parts = line.split("|")
+                if len(parts) < 5:
+                    continue
+                try:
+                    jid = int(parts[0].strip())
+                except ValueError:
+                    continue
+                results[jid] = JobStatusInfo(
+                    status=parts[1].strip(),
+                    started_at=parse_slurm_datetime(parts[2]),
+                    duration_secs=parse_slurm_duration(parts[3]),
+                    nodelist=(parts[4].strip() or None),
+                )
+
+        # --- sacct fallback: terminal jobs ---
+        missing = [j for j in job_ids if j not in results]
+        if missing:
+            sacct_cmd = [
+                "sacct",
+                "--jobs",
+                ",".join(str(i) for i in missing),
+                "--format=JobID,State,Start,End,Elapsed,NodeList",
+                "--noheader",
+                "--parsable2",
+            ]
+            try:
+                sacct_res = subprocess.run(
+                    sacct_cmd, capture_output=True, text=True, check=False
+                )
+            except FileNotFoundError:
+                sacct_res = None
+
+            if sacct_res and sacct_res.returncode == 0:
+                for line in sacct_res.stdout.strip().splitlines():
+                    parts = line.split("|")
+                    if len(parts) < 6:
+                        continue
+                    # Skip sub-steps like "12345.batch"
+                    raw_id = parts[0].strip()
+                    if "." in raw_id:
+                        continue
+                    try:
+                        jid = int(raw_id)
+                    except ValueError:
+                        continue
+                    if jid in results:
+                        continue
+                    raw_state = parts[1].strip()
+                    status = raw_state.split()[0] if raw_state else "UNKNOWN"
+                    results[jid] = JobStatusInfo(
+                        status=status,
+                        started_at=parse_slurm_datetime(parts[2]),
+                        completed_at=parse_slurm_datetime(parts[3]),
+                        duration_secs=parse_slurm_duration(parts[4]),
+                        nodelist=(parts[5].strip() or None),
+                    )
+
+        return results
 
     def monitor(
         self,

--- a/src/srunx/client_protocol.py
+++ b/src/srunx/client_protocol.py
@@ -1,0 +1,100 @@
+"""Unified SLURM client protocol.
+
+Defines the interface that both the local ``Slurm`` client and the
+``SlurmSSHAdapter`` implement, so that notification pollers and other
+downstream consumers can target either transparently.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel
+
+
+class JobStatusInfo(BaseModel):
+    """Point-in-time snapshot of a SLURM job's status.
+
+    Produced from ``squeue`` output for active jobs and ``sacct`` output
+    for jobs that have already left the queue.
+    """
+
+    status: str
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    duration_secs: int | None = None
+    nodelist: str | None = None
+
+
+@runtime_checkable
+class SlurmClientProtocol(Protocol):
+    """Abstract interface for batch-querying SLURM job state.
+
+    Implementations must be safe to call from a background thread (the
+    notification poller wraps invocations in ``anyio.to_thread.run_sync``).
+    """
+
+    def queue_by_ids(self, job_ids: list[int]) -> dict[int, JobStatusInfo]:
+        """Return a mapping of ``job_id`` to :class:`JobStatusInfo`.
+
+        Active jobs are looked up via ``squeue``; jobs that are no longer
+        in the queue fall back to ``sacct``. Jobs that cannot be found in
+        either source are omitted from the returned dict. An empty
+        ``job_ids`` list yields an empty dict.
+        """
+        ...
+
+
+def parse_slurm_datetime(value: str | None) -> datetime | None:
+    """Parse a SLURM-formatted timestamp.
+
+    SLURM emits timestamps like ``2026-04-18T10:00:00``. ``"N/A"``,
+    ``"Unknown"``, empty strings, and parse failures all return ``None``.
+    """
+    if not value:
+        return None
+    cleaned = value.strip()
+    if not cleaned or cleaned in {"N/A", "Unknown", "None"}:
+        return None
+    try:
+        return datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def parse_slurm_duration(value: str | None) -> int | None:
+    """Parse a SLURM elapsed-time string into integer seconds.
+
+    Accepts ``DD-HH:MM:SS``, ``HH:MM:SS``, and ``MM:SS`` formats. Returns
+    ``None`` if the value is missing or unparseable.
+    """
+    if not value:
+        return None
+    cleaned = value.strip()
+    if not cleaned or cleaned in {"N/A", "Unknown"}:
+        return None
+
+    days = 0
+    if "-" in cleaned:
+        days_str, cleaned = cleaned.split("-", 1)
+        try:
+            days = int(days_str)
+        except ValueError:
+            return None
+
+    parts = cleaned.split(":")
+    try:
+        nums = [int(p) for p in parts]
+    except ValueError:
+        return None
+
+    if len(nums) == 3:
+        hours, minutes, seconds = nums
+    elif len(nums) == 2:
+        hours = 0
+        minutes, seconds = nums
+    else:
+        return None
+
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds

--- a/src/srunx/db/__init__.py
+++ b/src/srunx/db/__init__.py
@@ -1,0 +1,42 @@
+"""Durable storage layer for srunx (SQLite).
+
+See ``.claude/specs/notification-and-state-persistence/design.md`` for
+the full schema and architecture.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+from srunx.db.connection import init_db, open_connection
+from srunx.db.repositories.jobs import JobRepository
+
+
+@contextlib.contextmanager
+def get_job_repo(
+    db_path: Path | None = None,
+) -> Iterator[tuple[JobRepository, sqlite3.Connection]]:
+    """Yield a ``(JobRepository, connection)`` pair bound to a fresh conn.
+
+    Convenience helper for callers that want a short-lived repository
+    without pulling in FastAPI-style DI. The DB is auto-migrated on first
+    use via ``init_db``.
+
+    Example::
+
+        with get_job_repo() as (repo, conn):
+            repo.record_submission(job_id=12345, name="t", status="PENDING",
+                                    submission_source="cli")
+    """
+    init_db(db_path, delete_legacy=False)
+    conn = open_connection(db_path)
+    try:
+        yield JobRepository(conn), conn
+    finally:
+        conn.close()
+
+
+__all__ = ["JobRepository", "get_job_repo", "init_db", "open_connection"]

--- a/src/srunx/db/connection.py
+++ b/src/srunx/db/connection.py
@@ -1,0 +1,164 @@
+"""SQLite connection management for the srunx state DB.
+
+Design reference: ``.claude/specs/notification-and-state-persistence/design.md``.
+
+Key invariants enforced here:
+
+- DB path resolution honours ``$XDG_CONFIG_HOME`` with a ``~/.config`` fallback.
+- Every opened connection applies ``foreign_keys=ON``, ``journal_mode=WAL``,
+  and ``busy_timeout=5000``.
+- The DB file is created with mode ``0o600`` and its parent directory with
+  mode ``0o700``.
+- :func:`init_db` deletes the legacy ``~/.srunx/history.db`` (or renames it
+  to ``.broken`` on OSError) — no backward-compat shim.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sqlite3
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+from srunx.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+LEGACY_HISTORY_DB_PATH = Path.home() / ".srunx" / "history.db"
+
+
+def get_config_dir() -> Path:
+    """Return the XDG-compliant srunx config directory.
+
+    Resolves ``$XDG_CONFIG_HOME/srunx`` when the env var is set, otherwise
+    ``~/.config/srunx`` on POSIX, ``~/AppData/Roaming/srunx`` on Windows.
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "srunx"
+    if os.name == "posix":
+        return Path.home() / ".config" / "srunx"
+    return Path.home() / "AppData" / "Roaming" / "srunx"
+
+
+def get_db_path() -> Path:
+    """Return the DB path: ``<config_dir>/srunx.db``."""
+    return get_config_dir() / "srunx.db"
+
+
+def _ensure_parent_dir(path: Path) -> None:
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    # Tighten perms if possible (POSIX only; best-effort on Windows).
+    try:
+        parent.chmod(stat.S_IRWXU)  # 0o700
+    except OSError:
+        pass
+
+
+def _apply_pragmas(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA busy_timeout = 5000")
+
+
+def open_connection(db_path: Path | None = None) -> sqlite3.Connection:
+    """Open a sqlite3 connection with srunx's required PRAGMAs applied.
+
+    On first creation, the DB file is chmod'd to ``0o600``. Caller owns the
+    returned connection and must close it (or use a ``with`` block).
+    """
+    path = db_path or get_db_path()
+    created = not path.exists()
+    _ensure_parent_dir(path)
+    # isolation_level=None puts the driver in autocommit mode, leaving
+    # transaction boundaries under explicit control of the caller. This
+    # is required for the outbox claim pattern (BEGIN IMMEDIATE ... COMMIT)
+    # because the default "deferred" mode auto-starts a transaction on
+    # the first DML and then refuses BEGIN.
+    conn = sqlite3.connect(path, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    _apply_pragmas(conn)
+    if created:
+        try:
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
+        except OSError:
+            logger.warning("Could not set 0600 perms on %s", path)
+    return conn
+
+
+@contextlib.contextmanager
+def transaction(
+    conn: sqlite3.Connection, mode: str = "DEFERRED"
+) -> Iterator[sqlite3.Connection]:
+    """Wrap ``BEGIN ... COMMIT/ROLLBACK`` around a block.
+
+    ``mode`` is ``'DEFERRED'`` (default) or ``'IMMEDIATE'``. Use
+    ``'IMMEDIATE'`` for any write transaction that needs to block
+    concurrent writers up-front (e.g. the delivery claim loop).
+    """
+    mode_upper = mode.upper()
+    if mode_upper not in {"DEFERRED", "IMMEDIATE", "EXCLUSIVE"}:
+        raise ValueError(f"Unsupported transaction mode: {mode}")
+    conn.execute(f"BEGIN {mode_upper}")
+    try:
+        yield conn
+    except BaseException:
+        conn.rollback()
+        raise
+    else:
+        conn.commit()
+
+
+def _delete_legacy_history_db() -> None:
+    """Remove the legacy ``~/.srunx/history.db`` if present.
+
+    On OSError (permission / in-use), rename to ``.broken`` and log a
+    warning rather than block startup.
+    """
+    if not LEGACY_HISTORY_DB_PATH.exists():
+        return
+    try:
+        LEGACY_HISTORY_DB_PATH.unlink()
+        logger.info("Removed legacy history DB at %s", LEGACY_HISTORY_DB_PATH)
+    except OSError:
+        broken = LEGACY_HISTORY_DB_PATH.with_suffix(".db.broken")
+        try:
+            LEGACY_HISTORY_DB_PATH.rename(broken)
+            logger.warning("Could not remove legacy history DB; renamed to %s", broken)
+        except OSError as exc:
+            logger.warning(
+                "Could not remove or rename legacy history DB %s: %s",
+                LEGACY_HISTORY_DB_PATH,
+                exc,
+            )
+
+
+def init_db(db_path: Path | None = None, *, delete_legacy: bool = True) -> Path:
+    """Initialize the srunx SQLite DB.
+
+    Steps:
+
+    1. Resolve path and ensure parent directory exists (mode ``0o700``).
+    2. Create the DB file if missing, set permissions to ``0o600``.
+    3. Apply PRAGMAs and run outstanding migrations.
+    4. If ``delete_legacy`` is True (default), remove the legacy
+       ``~/.srunx/history.db``. Set to False during Phase 1 co-existence
+       where the old DB still serves CLI history via :mod:`srunx.history`.
+
+    Returns the resolved DB path for downstream callers.
+    """
+    from srunx.db.migrations import apply_migrations
+
+    path = db_path or get_db_path()
+    conn = open_connection(path)
+    try:
+        apply_migrations(conn)
+    finally:
+        conn.close()
+    if delete_legacy:
+        _delete_legacy_history_db()
+    return path

--- a/src/srunx/db/migrations.py
+++ b/src/srunx/db/migrations.py
@@ -1,0 +1,338 @@
+"""Schema migrations for the srunx state DB.
+
+Design reference: ``.claude/specs/notification-and-state-persistence/design.md``.
+
+Idempotency model: migrations are keyed by ``name`` (not by version
+comparison). The ``schema_version`` table stores one row per applied
+migration; ``apply_migrations`` skips any row that already exists there.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from srunx.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# v1 schema
+# ---------------------------------------------------------------------------
+
+SCHEMA_V1 = """
+-- schema_version is bootstrap infrastructure created by
+-- _ensure_schema_version_table() before any migration runs; it is NOT
+-- re-declared here to avoid "table already exists" errors.
+
+CREATE TABLE workflow_runs (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_name      TEXT NOT NULL,
+    workflow_yaml_path TEXT,
+    status             TEXT NOT NULL
+                         CHECK (status IN ('pending','running','completed','failed','cancelled')),
+    started_at         TEXT NOT NULL,
+    completed_at       TEXT,
+    args               TEXT,
+    error              TEXT,
+    triggered_by       TEXT NOT NULL CHECK (triggered_by IN ('cli','web','schedule'))
+);
+CREATE INDEX idx_workflow_runs_status     ON workflow_runs(status);
+CREATE INDEX idx_workflow_runs_started_at ON workflow_runs(started_at);
+
+CREATE TABLE jobs (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id            INTEGER NOT NULL UNIQUE,
+    name              TEXT NOT NULL,
+    command           TEXT,
+    status            TEXT NOT NULL,
+    nodes             INTEGER,
+    gpus_per_node     INTEGER,
+    memory_per_node   TEXT,
+    time_limit        TEXT,
+    partition         TEXT,
+    nodelist          TEXT,
+    conda             TEXT,
+    venv              TEXT,
+    container         TEXT,
+    env_vars          TEXT,
+    submitted_at      TEXT NOT NULL,
+    started_at        TEXT,
+    completed_at      TEXT,
+    duration_secs     INTEGER,
+    workflow_run_id   INTEGER REFERENCES workflow_runs(id) ON DELETE SET NULL,
+    submission_source TEXT NOT NULL CHECK (submission_source IN ('cli','web','workflow')),
+    log_file          TEXT,
+    metadata          TEXT
+);
+CREATE INDEX idx_jobs_status          ON jobs(status);
+CREATE INDEX idx_jobs_submitted_at    ON jobs(submitted_at);
+CREATE INDEX idx_jobs_workflow_run_id ON jobs(workflow_run_id);
+
+CREATE TABLE workflow_run_jobs (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_run_id INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    job_id          INTEGER REFERENCES jobs(job_id) ON DELETE SET NULL,
+    job_name        TEXT NOT NULL,
+    depends_on      TEXT,
+    UNIQUE (workflow_run_id, job_name)
+);
+CREATE INDEX idx_wrj_run ON workflow_run_jobs(workflow_run_id);
+
+CREATE TABLE job_state_transitions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id      INTEGER REFERENCES jobs(job_id) ON DELETE SET NULL,
+    from_status TEXT,
+    to_status   TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    source      TEXT NOT NULL CHECK (source IN ('poller','cli_monitor','webhook'))
+);
+CREATE INDEX idx_jst_job_id      ON job_state_transitions(job_id, observed_at);
+CREATE INDEX idx_jst_observed_at ON job_state_transitions(observed_at);
+
+CREATE TABLE resource_snapshots (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    observed_at     TEXT NOT NULL,
+    partition       TEXT,
+    gpus_total      INTEGER NOT NULL,
+    gpus_available  INTEGER NOT NULL,
+    gpus_in_use     INTEGER NOT NULL,
+    nodes_total     INTEGER NOT NULL,
+    nodes_idle      INTEGER NOT NULL,
+    nodes_down      INTEGER NOT NULL,
+    gpu_utilization REAL GENERATED ALWAYS AS (
+        CASE WHEN gpus_total > 0
+             THEN CAST(gpus_in_use AS REAL) / gpus_total
+             ELSE NULL END
+    ) STORED
+);
+CREATE INDEX idx_rs_observed_at ON resource_snapshots(observed_at);
+CREATE INDEX idx_rs_partition   ON resource_snapshots(partition, observed_at);
+
+CREATE TABLE endpoints (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind        TEXT NOT NULL CHECK (kind IN ('slack_webhook','generic_webhook','email','slack_bot')),
+    name        TEXT NOT NULL,
+    config      TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    disabled_at TEXT,
+    UNIQUE (kind, name)
+);
+
+CREATE TABLE watches (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind       TEXT NOT NULL CHECK (kind IN ('job','workflow_run','resource_threshold','scheduled_report')),
+    target_ref TEXT NOT NULL,
+    filter     TEXT,
+    created_at TEXT NOT NULL,
+    closed_at  TEXT
+);
+CREATE INDEX idx_watches_kind_target ON watches(kind, target_ref);
+CREATE INDEX idx_watches_open        ON watches(closed_at) WHERE closed_at IS NULL;
+
+CREATE TABLE subscriptions (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    watch_id    INTEGER NOT NULL REFERENCES watches(id) ON DELETE CASCADE,
+    endpoint_id INTEGER NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+    preset      TEXT NOT NULL CHECK (preset IN ('terminal','running_and_terminal','all','digest')),
+    created_at  TEXT NOT NULL,
+    UNIQUE (watch_id, endpoint_id)
+);
+CREATE INDEX idx_subs_watch_id    ON subscriptions(watch_id);
+CREATE INDEX idx_subs_endpoint_id ON subscriptions(endpoint_id);
+
+CREATE TABLE events (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind         TEXT NOT NULL CHECK (kind IN (
+        'job.submitted',
+        'job.status_changed',
+        'workflow_run.status_changed',
+        'resource.threshold_crossed',
+        'scheduled_report.due'
+    )),
+    source_ref   TEXT NOT NULL,
+    payload      TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    observed_at  TEXT NOT NULL
+);
+CREATE UNIQUE INDEX idx_events_dedup      ON events(kind, source_ref, payload_hash);
+CREATE INDEX        idx_events_source_ref ON events(source_ref, observed_at);
+CREATE INDEX        idx_events_kind       ON events(kind, observed_at);
+
+CREATE TABLE deliveries (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id        INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    subscription_id INTEGER NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    endpoint_id     INTEGER NOT NULL REFERENCES endpoints(id) ON DELETE CASCADE,
+    idempotency_key TEXT NOT NULL,
+    status          TEXT NOT NULL
+                      CHECK (status IN ('pending','sending','delivered','abandoned')),
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at TEXT NOT NULL,
+    leased_until    TEXT,
+    worker_id       TEXT,
+    last_error      TEXT,
+    delivered_at    TEXT,
+    created_at      TEXT NOT NULL,
+    UNIQUE (endpoint_id, idempotency_key)
+);
+CREATE INDEX idx_deliveries_claim        ON deliveries(next_attempt_at) WHERE status = 'pending';
+CREATE INDEX idx_deliveries_event_id     ON deliveries(event_id);
+CREATE INDEX idx_deliveries_lease_active ON deliveries(leased_until) WHERE status = 'sending';
+"""
+
+
+# ---------------------------------------------------------------------------
+# Migration registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Migration:
+    version: int
+    name: str
+    sql: str
+
+
+MIGRATIONS: list[Migration] = [
+    Migration(version=1, name="v1_initial", sql=SCHEMA_V1),
+]
+
+
+def _ensure_schema_version_table(conn: sqlite3.Connection) -> None:
+    """Create ``schema_version`` if it does not yet exist.
+
+    This is needed because the table itself is declared inside the v1
+    migration, so a fresh DB lacks it before any migration runs.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_version (
+            version    INTEGER NOT NULL,
+            name       TEXT NOT NULL,
+            applied_at TEXT NOT NULL,
+            PRIMARY KEY (version, name)
+        )
+        """
+    )
+
+
+def _applied_names(conn: sqlite3.Connection) -> set[str]:
+    _ensure_schema_version_table(conn)
+    cur = conn.execute("SELECT name FROM schema_version")
+    return {row[0] for row in cur.fetchall()}
+
+
+def apply_migrations(conn: sqlite3.Connection) -> list[str]:
+    """Apply every pending migration in :data:`MIGRATIONS` order.
+
+    Each migration runs inside its own transaction; on failure the whole
+    migration is rolled back and no ``schema_version`` row is written.
+    Returns the list of migration names that were applied in this call.
+    """
+    applied_already = _applied_names(conn)
+    newly_applied: list[str] = []
+
+    for mig in MIGRATIONS:
+        if mig.name in applied_already:
+            continue
+        logger.info("Applying migration %s (v%d)", mig.name, mig.version)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.executescript(mig.sql)
+            # v1_initial creates schema_version itself; the IF NOT EXISTS
+            # guard earlier ensures the insert below always succeeds.
+            conn.execute(
+                "INSERT INTO schema_version (version, name, applied_at) VALUES (?, ?, ?)",
+                (mig.version, mig.name, _now_iso()),
+            )
+            conn.commit()
+            newly_applied.append(mig.name)
+        except Exception:
+            conn.rollback()
+            logger.error("Migration %s failed; rolled back", mig.name)
+            raise
+
+    return newly_applied
+
+
+# ---------------------------------------------------------------------------
+# Legacy config bootstrap
+# ---------------------------------------------------------------------------
+
+
+_BOOTSTRAP_NAME = "bootstrap_slack_webhook_url"
+_BOOTSTRAP_VERSION = 1
+
+
+def _bootstrap_already_applied(conn: sqlite3.Connection) -> bool:
+    cur = conn.execute(
+        "SELECT 1 FROM schema_version WHERE name = ? LIMIT 1",
+        (_BOOTSTRAP_NAME,),
+    )
+    return cur.fetchone() is not None
+
+
+def bootstrap_from_config(conn: sqlite3.Connection, config: Any) -> bool:
+    """Migrate ``config.notifications.slack_webhook_url`` into ``endpoints``.
+
+    Runs at most once per DB (guarded by a ``schema_version`` row named
+    ``bootstrap_slack_webhook_url``). If the config has no webhook URL the
+    guard row is still recorded so subsequent startups short-circuit.
+
+    On INSERT failure (e.g. a conflicting endpoint already exists), both
+    the INSERT and the guard row are rolled back, so the migration can be
+    retried on the next startup.
+
+    Returns True if an endpoint row was inserted, False otherwise.
+    """
+    if _bootstrap_already_applied(conn):
+        return False
+
+    webhook_url: str | None = None
+    try:
+        webhook_url = config.notifications.slack_webhook_url
+    except AttributeError:
+        webhook_url = None
+
+    # Case: nothing to migrate — still record so we don't re-read next time.
+    if not webhook_url:
+        conn.execute(
+            "INSERT INTO schema_version (version, name, applied_at) VALUES (?, ?, ?)",
+            (_BOOTSTRAP_VERSION, _BOOTSTRAP_NAME, _now_iso()),
+        )
+        conn.commit()
+        return False
+
+    # Case: migrate, record guard, commit atomically.
+    payload = json.dumps({"webhook_url": webhook_url})
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "INSERT INTO endpoints (kind, name, config, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("slack_webhook", "default", payload, _now_iso()),
+        )
+        conn.execute(
+            "INSERT INTO schema_version (version, name, applied_at) VALUES (?, ?, ?)",
+            (_BOOTSTRAP_VERSION, _BOOTSTRAP_NAME, _now_iso()),
+        )
+        conn.commit()
+        logger.info("Bootstrapped 'default' Slack webhook endpoint from config.json")
+        return True
+    except Exception:
+        conn.rollback()
+        logger.warning(
+            "Failed to bootstrap Slack webhook from config.json; "
+            "will retry on next startup",
+            exc_info=True,
+        )
+        return False

--- a/src/srunx/db/models.py
+++ b/src/srunx/db/models.py
@@ -1,0 +1,186 @@
+"""Pydantic models mirroring the ``srunx.db`` schema.
+
+These types are produced by the repository layer when reading rows and
+consumed by callers (poller, routers, notification service). They are
+deliberately close to the SQL shape — JSON columns are typed as ``dict``
+and (de)serialized in the repository, timestamps are ``datetime``.
+
+See ``.claude/specs/notification-and-state-persistence/design.md`` for
+the full schema.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+# Reusable config: allow population by alias / from ORM-style row objects and
+# permit arbitrary types so ``dict`` payload fields round-trip cleanly.
+_MODEL_CONFIG = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# Notification domain
+# ---------------------------------------------------------------------------
+
+EndpointKind = Literal["slack_webhook", "generic_webhook", "email", "slack_bot"]
+WatchKind = Literal["job", "workflow_run", "resource_threshold", "scheduled_report"]
+SubscriptionPreset = Literal["terminal", "running_and_terminal", "all", "digest"]
+EventKind = Literal[
+    "job.submitted",
+    "job.status_changed",
+    "workflow_run.status_changed",
+    "resource.threshold_crossed",
+    "scheduled_report.due",
+]
+DeliveryStatus = Literal["pending", "sending", "delivered", "abandoned"]
+TransitionSource = Literal["poller", "cli_monitor", "webhook"]
+SubmissionSource = Literal["cli", "web", "workflow"]
+WorkflowRunStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
+WorkflowRunTriggeredBy = Literal["cli", "web", "schedule"]
+
+
+class Endpoint(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    kind: EndpointKind
+    name: str
+    config: dict
+    created_at: datetime
+    disabled_at: datetime | None = None
+
+
+class Watch(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    kind: WatchKind
+    target_ref: str
+    filter: dict | None = None
+    created_at: datetime
+    closed_at: datetime | None = None
+
+
+class Subscription(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    watch_id: int
+    endpoint_id: int
+    preset: SubscriptionPreset
+    created_at: datetime
+
+
+class Event(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    kind: EventKind
+    source_ref: str
+    payload: dict
+    payload_hash: str
+    observed_at: datetime
+
+
+class Delivery(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    event_id: int
+    subscription_id: int
+    endpoint_id: int
+    idempotency_key: str
+    status: DeliveryStatus
+    attempt_count: int = 0
+    next_attempt_at: datetime
+    leased_until: datetime | None = None
+    worker_id: str | None = None
+    last_error: str | None = None
+    delivered_at: datetime | None = None
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Workflow & job persistence
+# ---------------------------------------------------------------------------
+
+
+class WorkflowRun(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    workflow_name: str
+    workflow_yaml_path: str | None = None
+    status: WorkflowRunStatus
+    started_at: datetime
+    completed_at: datetime | None = None
+    args: dict | None = None
+    error: str | None = None
+    triggered_by: WorkflowRunTriggeredBy
+
+
+class WorkflowRunJob(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    workflow_run_id: int
+    job_id: int | None = None  # filled after SLURM submit
+    job_name: str
+    depends_on: list[str] | None = None
+
+
+class JobStateTransition(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    job_id: int | None = None
+    from_status: str | None = None
+    to_status: str
+    observed_at: datetime
+    source: TransitionSource
+
+
+class ResourceSnapshot(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    observed_at: datetime
+    partition: str | None = None
+    gpus_total: int
+    gpus_available: int
+    gpus_in_use: int
+    nodes_total: int
+    nodes_idle: int
+    nodes_down: int
+    gpu_utilization: float | None = None  # computed column
+
+
+class Job(BaseModel):
+    model_config = _MODEL_CONFIG
+
+    id: int | None = None
+    job_id: int
+    name: str
+    command: list[str] | None = None
+    status: str
+    nodes: int | None = None
+    gpus_per_node: int | None = None
+    memory_per_node: str | None = None
+    time_limit: str | None = None
+    partition: str | None = None
+    nodelist: str | None = None
+    conda: str | None = None
+    venv: str | None = None
+    container: str | None = None
+    env_vars: dict | None = None
+    submitted_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    duration_secs: int | None = None
+    workflow_run_id: int | None = None
+    submission_source: SubmissionSource
+    log_file: str | None = None
+    metadata: dict | None = None

--- a/src/srunx/db/repositories/__init__.py
+++ b/src/srunx/db/repositories/__init__.py
@@ -1,0 +1,6 @@
+"""Repositories for the srunx state DB.
+
+Each repository wraps a single table and accepts a ``sqlite3.Connection``
+in its constructor so that callers can compose multiple repositories
+inside a single transaction.
+"""

--- a/src/srunx/db/repositories/base.py
+++ b/src/srunx/db/repositories/base.py
@@ -1,0 +1,100 @@
+"""Shared helpers for repository implementations."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+M = TypeVar("M", bound=BaseModel)
+
+
+def now_iso() -> str:
+    """Return the current UTC time as a SLURM-DB-canonical ISO string.
+
+    Format: ``YYYY-MM-DDTHH:MM:SS.sssZ`` — lexicographically sortable,
+    aligned with ``strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`` on the SQL side.
+    """
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    """Parse a stored TEXT timestamp back into a ``datetime``.
+
+    Returns ``None`` for ``None`` / empty strings. Accepts both the canonical
+    ``...Z`` form written by :func:`now_iso` and plain ISO 8601.
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value
+    s = str(value)
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(s)
+    except ValueError:
+        return None
+
+
+def _maybe_json_load(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _maybe_json_dump(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+class BaseRepository:
+    """Base class for all repositories.
+
+    Holds the connection and exposes shared row-to-model conversion. JSON
+    columns and timestamp columns are parsed up-front for the given set
+    of field names (passed per-subclass).
+    """
+
+    # Fields whose stored string form should be JSON-decoded on read
+    # and JSON-encoded on write. Override in subclasses.
+    JSON_FIELDS: tuple[str, ...] = ()
+
+    # Fields whose stored string form should be datetime-parsed on read.
+    DATETIME_FIELDS: tuple[str, ...] = ()
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self.conn = conn
+
+    def _row_to_dict(self, row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        data: dict[str, Any] = dict(row)
+        for field in self.JSON_FIELDS:
+            if field in data:
+                data[field] = _maybe_json_load(data[field])
+        for field in self.DATETIME_FIELDS:
+            if field in data:
+                data[field] = _parse_dt(data[field])
+        return data
+
+    def _row_to_model(self, row: sqlite3.Row | None, model_cls: type[M]) -> M | None:
+        data = self._row_to_dict(row)
+        if data is None:
+            return None
+        return model_cls.model_validate(data)
+
+    @staticmethod
+    def _encode_json(value: Any) -> str | None:
+        return _maybe_json_dump(value)

--- a/src/srunx/db/repositories/deliveries.py
+++ b/src/srunx/db/repositories/deliveries.py
@@ -1,0 +1,305 @@
+"""Repository for the ``deliveries`` table.
+
+See design.md § ``DeliveryRepository``. This is the Outbox: one row per
+``(event, subscription)`` pair, with a ``pending → sending →
+delivered|abandoned`` state machine. Workers lease rows using
+:meth:`DeliveryRepository.claim_one` — because the stock Python
+``sqlite3`` build does NOT ship with ``SQLITE_ENABLE_UPDATE_DELETE_LIMIT``,
+we implement the "pick one row" step as ``SELECT ... LIMIT 1`` followed
+by an ``UPDATE ... WHERE id = ? AND status = 'pending'`` that races
+cleanly against concurrent workers.
+
+All timestamp writes use :func:`srunx.db.repositories.base.now_iso` or
+``strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`` so that string comparisons
+remain lexicographically correct across Python and SQL code paths.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from srunx.db.models import Delivery
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class DeliveryRepository(BaseRepository):
+    """CRUD + outbox claim/lease mechanics for the ``deliveries`` table."""
+
+    DATETIME_FIELDS = (
+        "next_attempt_at",
+        "leased_until",
+        "delivered_at",
+        "created_at",
+    )
+
+    _COLUMNS = (
+        "id",
+        "event_id",
+        "subscription_id",
+        "endpoint_id",
+        "idempotency_key",
+        "status",
+        "attempt_count",
+        "next_attempt_at",
+        "leased_until",
+        "worker_id",
+        "last_error",
+        "delivered_at",
+        "created_at",
+    )
+
+    # -- backoff -----------------------------------------------------------
+
+    @staticmethod
+    def _backoff_secs(
+        attempt_count: int, base: int = 10, factor: int = 2, cap: int = 3600
+    ) -> int:
+        """Return the exponential backoff in seconds for ``attempt_count``.
+
+        ``min(base * factor**attempt_count, cap)``. Uses integer math
+        throughout so callers can pass the result straight into SQL.
+        Truth table (base=10, factor=2, cap=3600):
+
+        - attempt_count=0 → 10
+        - attempt_count=1 → 20
+        - attempt_count=2 → 40
+        - attempt_count=10 → 3600 (capped)
+        """
+        return min(base * (factor**attempt_count), cap)
+
+    # -- CRUD --------------------------------------------------------------
+
+    def insert(
+        self,
+        event_id: int,
+        subscription_id: int,
+        endpoint_id: int,
+        idempotency_key: str,
+        *,
+        next_attempt_at: str | None = None,
+    ) -> int | None:
+        """Create a new pending delivery row.
+
+        Uses ``INSERT OR IGNORE`` against the UNIQUE
+        ``(endpoint_id, idempotency_key)`` index: a deterministic
+        idempotency key means duplicate fan-out attempts for the same
+        logical transition are silently collapsed. Returns the new
+        row's ``id`` on success, or ``None`` when the UNIQUE
+        constraint absorbed the insert.
+        """
+        created_at = now_iso()
+        scheduled = next_attempt_at or created_at
+        cur = self.conn.execute(
+            """
+            INSERT OR IGNORE INTO deliveries (
+                event_id, subscription_id, endpoint_id, idempotency_key,
+                status, attempt_count, next_attempt_at,
+                leased_until, worker_id, last_error, delivered_at,
+                created_at
+            ) VALUES (?, ?, ?, ?, 'pending', 0, ?, NULL, NULL, NULL, NULL, ?)
+            """,
+            (
+                event_id,
+                subscription_id,
+                endpoint_id,
+                idempotency_key,
+                scheduled,
+                created_at,
+            ),
+        )
+        if cur.rowcount == 0:
+            return None
+        last = cur.lastrowid
+        return int(last) if last else None
+
+    def get(self, id: int) -> Delivery | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM deliveries WHERE id = ?",
+            (id,),
+        ).fetchone()
+        return self._row_to_model(row, Delivery)
+
+    def list_by_subscription(
+        self,
+        subscription_id: int,
+        status: str | None = None,
+    ) -> list[Delivery]:
+        """Return deliveries for a subscription, newest first.
+
+        When ``status`` is given, only rows with that ``status`` are
+        returned.
+        """
+        if status is None:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM deliveries "
+                "WHERE subscription_id = ? "
+                "ORDER BY created_at DESC"
+            )
+            params: list[Any] = [subscription_id]
+        else:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM deliveries "
+                "WHERE subscription_id = ? AND status = ? "
+                "ORDER BY created_at DESC"
+            )
+            params = [subscription_id, status]
+
+        rows: list[sqlite3.Row] = self.conn.execute(sql, params).fetchall()
+        return [self._row_to_model(r, Delivery) for r in rows if r is not None]  # type: ignore[misc]
+
+    # -- lease mechanics ---------------------------------------------------
+
+    def reclaim_expired_leases(self) -> int:
+        """Revert stale ``sending`` rows back to ``pending``.
+
+        Called at the top of every :class:`DeliveryPoller` cycle to
+        recover rows whose owning worker crashed or was terminated
+        mid-send. Returns the number of rows touched.
+        """
+        cur = self.conn.execute(
+            """
+            UPDATE deliveries
+               SET status = 'pending',
+                   leased_until = NULL,
+                   worker_id = NULL
+             WHERE status = 'sending'
+               AND leased_until < strftime('%Y-%m-%dT%H:%M:%fZ','now')
+            """
+        )
+        return int(cur.rowcount)
+
+    def claim_one(
+        self, worker_id: str, lease_duration_secs: int = 300
+    ) -> Delivery | None:
+        """Lease the next due ``pending`` delivery for ``worker_id``.
+
+        Implemented as SELECT-then-UPDATE inside ``BEGIN IMMEDIATE``
+        because the Python stdlib sqlite3 build lacks
+        ``UPDATE ... LIMIT RETURNING``. Skips rows whose endpoint is
+        disabled. Returns ``None`` when nothing is due, or when the
+        caller lost the race to another worker mid-transaction.
+        """
+        # Wrap in IMMEDIATE so concurrent workers serialise on the
+        # write lock. Any pre-existing transaction on this connection
+        # must be committed by the caller before calling claim_one.
+        self.conn.execute("BEGIN IMMEDIATE")
+        try:
+            candidate = self.conn.execute(
+                """
+                SELECT id FROM deliveries
+                 WHERE status = 'pending'
+                   AND next_attempt_at <= strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                   AND endpoint_id IN (
+                       SELECT id FROM endpoints WHERE disabled_at IS NULL
+                   )
+                 ORDER BY next_attempt_at
+                 LIMIT 1
+                """
+            ).fetchone()
+            if candidate is None:
+                self.conn.commit()
+                return None
+
+            delivery_id = int(candidate["id"])
+            # The WHERE status='pending' guards against a concurrent
+            # worker having already claimed this row between our SELECT
+            # and UPDATE (defense-in-depth; the IMMEDIATE lock makes
+            # that physically unreachable on one DB, but the pattern is
+            # the right one for correctness-by-construction).
+            row = self.conn.execute(
+                f"""
+                UPDATE deliveries
+                   SET status = 'sending',
+                       leased_until = strftime(
+                           '%Y-%m-%dT%H:%M:%fZ', 'now',
+                           '+' || ? || ' seconds'
+                       ),
+                       worker_id = ?
+                 WHERE id = ?
+                   AND status = 'pending'
+                 RETURNING {", ".join(self._COLUMNS)}
+                """,
+                (lease_duration_secs, worker_id, delivery_id),
+            ).fetchone()
+            self.conn.commit()
+        except BaseException:
+            self.conn.rollback()
+            raise
+
+        return self._row_to_model(row, Delivery) if row is not None else None
+
+    # -- terminal state transitions ---------------------------------------
+
+    def mark_delivered(self, id: int) -> bool:
+        """Mark a delivery ``delivered``. Clears lease fields."""
+        cur = self.conn.execute(
+            """
+            UPDATE deliveries
+               SET status = 'delivered',
+                   delivered_at = ?,
+                   leased_until = NULL,
+                   worker_id = NULL
+             WHERE id = ?
+            """,
+            (now_iso(), id),
+        )
+        return cur.rowcount > 0
+
+    def mark_retry(self, id: int, error: str, backoff_secs: int) -> bool:
+        """Transition ``sending → pending`` with an incremented attempt.
+
+        Uses SQL-side ``strftime(..., '+N seconds')`` for the new
+        ``next_attempt_at`` so timestamps stay consistent with the
+        claim query.
+        """
+        cur = self.conn.execute(
+            """
+            UPDATE deliveries
+               SET status = 'pending',
+                   attempt_count = attempt_count + 1,
+                   next_attempt_at = strftime(
+                       '%Y-%m-%dT%H:%M:%fZ', 'now', '+' || ? || ' seconds'
+                   ),
+                   leased_until = NULL,
+                   worker_id = NULL,
+                   last_error = ?
+             WHERE id = ?
+            """,
+            (backoff_secs, error, id),
+        )
+        return cur.rowcount > 0
+
+    def mark_abandoned(self, id: int, error: str) -> bool:
+        """Mark a delivery terminally ``abandoned`` with a reason."""
+        cur = self.conn.execute(
+            """
+            UPDATE deliveries
+               SET status = 'abandoned',
+                   last_error = ?,
+                   leased_until = NULL,
+                   worker_id = NULL
+             WHERE id = ?
+            """,
+            (error, id),
+        )
+        return cur.rowcount > 0
+
+    # -- observability -----------------------------------------------------
+
+    def count_stuck_pending(self, older_than_sec: int = 300) -> int:
+        """Count pending rows whose ``next_attempt_at`` is older than N seconds.
+
+        Surface metric for "is the delivery poller stuck?" dashboards.
+        """
+        row = self.conn.execute(
+            """
+            SELECT COUNT(*) AS c FROM deliveries
+             WHERE status = 'pending'
+               AND next_attempt_at < strftime(
+                   '%Y-%m-%dT%H:%M:%fZ', 'now', '-' || ? || ' seconds'
+               )
+            """,
+            (older_than_sec,),
+        ).fetchone()
+        return int(row["c"]) if row is not None else 0

--- a/src/srunx/db/repositories/endpoints.py
+++ b/src/srunx/db/repositories/endpoints.py
@@ -1,0 +1,126 @@
+"""Repository for the ``endpoints`` table.
+
+See design.md § ``EndpointRepository``. Endpoints represent external
+notification sinks (Slack webhook, generic webhook, email, Slack bot).
+The ``config`` column is a JSON blob whose shape depends on ``kind`` —
+schema-level validation is performed in the service layer, not here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from srunx.db.models import Endpoint
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class EndpointRepository(BaseRepository):
+    """CRUD for the ``endpoints`` table."""
+
+    JSON_FIELDS = ("config",)
+    DATETIME_FIELDS = ("created_at", "disabled_at")
+
+    _COLUMNS = (
+        "id",
+        "kind",
+        "name",
+        "config",
+        "created_at",
+        "disabled_at",
+    )
+
+    def create(self, kind: str, name: str, config: dict) -> int:
+        """Insert a new endpoint row and return its ``id``."""
+        cur = self.conn.execute(
+            """
+            INSERT INTO endpoints (kind, name, config, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (kind, name, self._encode_json(config), now_iso()),
+        )
+        return int(cur.lastrowid or 0)
+
+    def get(self, id: int) -> Endpoint | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM endpoints WHERE id = ?",
+            (id,),
+        ).fetchone()
+        return self._row_to_model(row, Endpoint)
+
+    def get_by_name(self, kind: str, name: str) -> Endpoint | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM endpoints "
+            "WHERE kind = ? AND name = ?",
+            (kind, name),
+        ).fetchone()
+        return self._row_to_model(row, Endpoint)
+
+    def list(self, include_disabled: bool = True) -> list[Endpoint]:
+        """Return endpoints ordered by ``created_at`` ascending.
+
+        When ``include_disabled=False``, rows with a non-NULL
+        ``disabled_at`` are filtered out.
+        """
+        if include_disabled:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM endpoints "
+                "ORDER BY created_at ASC"
+            )
+            params: list[Any] = []
+        else:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM endpoints "
+                "WHERE disabled_at IS NULL "
+                "ORDER BY created_at ASC"
+            )
+            params = []
+
+        rows = self.conn.execute(sql, params).fetchall()
+        return [self._row_to_model(r, Endpoint) for r in rows if r is not None]  # type: ignore[misc]
+
+    def update(
+        self,
+        id: int,
+        name: str | None = None,
+        config: dict | None = None,
+    ) -> bool:
+        """Partially update an endpoint. Returns True if a row was touched."""
+        sets: list[str] = []
+        vals: list[Any] = []
+        if name is not None:
+            sets.append("name = ?")
+            vals.append(name)
+        if config is not None:
+            sets.append("config = ?")
+            vals.append(self._encode_json(config))
+
+        if not sets:
+            return False
+
+        vals.append(id)
+        cur = self.conn.execute(
+            f"UPDATE endpoints SET {', '.join(sets)} WHERE id = ?",
+            vals,
+        )
+        return cur.rowcount > 0
+
+    def disable(self, id: int) -> bool:
+        """Mark an endpoint disabled (sets ``disabled_at = now_iso()``)."""
+        cur = self.conn.execute(
+            "UPDATE endpoints SET disabled_at = ? WHERE id = ?",
+            (now_iso(), id),
+        )
+        return cur.rowcount > 0
+
+    def enable(self, id: int) -> bool:
+        """Re-enable an endpoint (clears ``disabled_at``)."""
+        cur = self.conn.execute(
+            "UPDATE endpoints SET disabled_at = NULL WHERE id = ?",
+            (id,),
+        )
+        return cur.rowcount > 0
+
+    def delete(self, id: int) -> bool:
+        """Delete an endpoint. Cascades to ``subscriptions`` via FK."""
+        cur = self.conn.execute("DELETE FROM endpoints WHERE id = ?", (id,))
+        return cur.rowcount > 0

--- a/src/srunx/db/repositories/events.py
+++ b/src/srunx/db/repositories/events.py
@@ -1,0 +1,138 @@
+"""Repository for the ``events`` table.
+
+See design.md § ``EventRepository``. Events are the input side of the
+Outbox pattern: every state transition / scheduled tick that may need
+to produce notifications lands here first. A deterministic
+``payload_hash`` provides producer-side deduplication — the UNIQUE
+index on ``(kind, source_ref, payload_hash)`` protects against the
+"poller accidentally started twice" class of bugs (see Error Handling
+scenario #4 in design.md).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+
+from srunx.db.models import Event
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class EventRepository(BaseRepository):
+    """CRUD for the ``events`` table."""
+
+    JSON_FIELDS = ("payload",)
+    DATETIME_FIELDS = ("observed_at",)
+
+    _COLUMNS = (
+        "id",
+        "kind",
+        "source_ref",
+        "payload",
+        "payload_hash",
+        "observed_at",
+    )
+
+    # -- internal helpers --------------------------------------------------
+
+    @staticmethod
+    def _extract_source_id(source_ref: str) -> str:
+        """Return the id portion of a ``"<kind>:<id>"`` source_ref.
+
+        Falls back to the full string when no ``:`` is present.
+        """
+        if ":" in source_ref:
+            return source_ref.split(":", 1)[1]
+        return source_ref
+
+    @staticmethod
+    def _compute_payload_hash(kind: str, source_ref: str, payload: dict) -> str:
+        """Return a deterministic SHA-256 hex digest for dedup.
+
+        The input is a kind-specific logical key string (matching the
+        idempotency-key policy in design.md § "Idempotency Key 生成ポリシー"
+        and documented inline on the ``events`` table). A second INSERT
+        with the same ``(kind, source_ref, payload_hash)`` triple is
+        silently ignored by the UNIQUE index.
+        """
+        source_id = EventRepository._extract_source_id(source_ref)
+
+        if kind == "job.submitted":
+            logical = f"job:{source_id}:submitted"
+        elif kind == "job.status_changed":
+            to_status = payload.get("to_status", "")
+            logical = f"job:{source_id}:status:{to_status}"
+        elif kind == "workflow_run.status_changed":
+            to_status = payload.get("to_status", "")
+            logical = f"workflow_run:{source_id}:status:{to_status}"
+        elif kind == "resource.threshold_crossed":
+            partition = payload.get("partition", "")
+            threshold_id = payload.get("threshold_id", "")
+            window_iso = payload.get("window_iso", "")
+            logical = f"resource:{partition}:{threshold_id}:{window_iso}"
+        elif kind == "scheduled_report.due":
+            schedule_id = payload.get("schedule_id", "")
+            scheduled_run_at_iso = payload.get("scheduled_run_at_iso", "")
+            logical = f"scheduled_report:{schedule_id}:{scheduled_run_at_iso}"
+        else:
+            # Defensive fallback: any unknown kind still dedups stably,
+            # keyed on the full payload content.
+            logical = f"{kind}:{source_ref}:{json.dumps(payload, sort_keys=True)}"
+
+        return hashlib.sha256(logical.encode("utf-8")).hexdigest()
+
+    # -- CRUD --------------------------------------------------------------
+
+    def insert(
+        self,
+        kind: str,
+        source_ref: str,
+        payload: dict,
+        observed_at: str | None = None,
+    ) -> int | None:
+        """Insert a new event row.
+
+        Uses ``INSERT OR IGNORE`` against the UNIQUE
+        ``(kind, source_ref, payload_hash)`` index. Returns the new
+        row's ``id`` on success, or ``None`` when the UNIQUE
+        constraint silently absorbed the insert (i.e. a duplicate
+        event — the caller should treat this as a no-op).
+        """
+        payload_hash = self._compute_payload_hash(kind, source_ref, payload)
+        observed_at = observed_at or now_iso()
+
+        cur = self.conn.execute(
+            """
+            INSERT OR IGNORE INTO events (
+                kind, source_ref, payload, payload_hash, observed_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                kind,
+                source_ref,
+                self._encode_json(payload),
+                payload_hash,
+                observed_at,
+            ),
+        )
+        if cur.rowcount == 0:
+            return None
+        last = cur.lastrowid
+        return int(last) if last else None
+
+    def get(self, id: int) -> Event | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM events WHERE id = ?",
+            (id,),
+        ).fetchone()
+        return self._row_to_model(row, Event)
+
+    def list_recent(self, limit: int = 100) -> list[Event]:
+        """Return recent events ordered by ``observed_at`` descending."""
+        rows: list[sqlite3.Row] = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM events "
+            "ORDER BY observed_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [self._row_to_model(r, Event) for r in rows if r is not None]  # type: ignore[misc]

--- a/src/srunx/db/repositories/job_state_transitions.py
+++ b/src/srunx/db/repositories/job_state_transitions.py
@@ -1,0 +1,73 @@
+"""Repository for the ``job_state_transitions`` table.
+
+Design reference: ``.claude/specs/notification-and-state-persistence/design.md``
+§ Repositories. Records every observed job status change (SSOT for
+:class:`~srunx.pollers.active_watch_poller.ActiveWatchPoller` and CLI
+monitor alike).
+"""
+
+from __future__ import annotations
+
+from srunx.db.models import JobStateTransition, TransitionSource
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class JobStateTransitionRepository(BaseRepository):
+    """Append-only log of job status transitions."""
+
+    DATETIME_FIELDS = ("observed_at",)
+
+    _COLUMNS = (
+        "id",
+        "job_id",
+        "from_status",
+        "to_status",
+        "observed_at",
+        "source",
+    )
+
+    def insert(
+        self,
+        job_id: int,
+        from_status: str | None,
+        to_status: str,
+        source: TransitionSource,
+        observed_at: str | None = None,
+    ) -> int:
+        """Insert a new transition row. Returns the row's ``id``."""
+        observed_at = observed_at or now_iso()
+        cur = self.conn.execute(
+            """
+            INSERT OR REPLACE INTO job_state_transitions (
+                job_id, from_status, to_status, observed_at, source
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (job_id, from_status, to_status, observed_at, source),
+        )
+        return int(cur.lastrowid or 0)
+
+    def latest_for_job(self, job_id: int) -> JobStateTransition | None:
+        """Return the most recent transition for ``job_id``, or ``None``.
+
+        Used by the poller for dedup: it only writes when the observed
+        ``to_status`` differs from the stored latest.
+        """
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM job_state_transitions "
+            "WHERE job_id = ? ORDER BY observed_at DESC, id DESC LIMIT 1",
+            (job_id,),
+        ).fetchone()
+        return self._row_to_model(row, JobStateTransition)
+
+    def history_for_job(self, job_id: int) -> list[JobStateTransition]:
+        """Return all transitions for ``job_id`` in chronological order."""
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM job_state_transitions "
+            "WHERE job_id = ? ORDER BY observed_at ASC, id ASC",
+            (job_id,),
+        ).fetchall()
+        return [
+            self._row_to_model(r, JobStateTransition)  # type: ignore[misc]
+            for r in rows
+            if r is not None
+        ]

--- a/src/srunx/db/repositories/jobs.py
+++ b/src/srunx/db/repositories/jobs.py
@@ -1,0 +1,243 @@
+"""Repository for the ``jobs`` table.
+
+Replaces the legacy ``srunx.history.JobHistory`` pair (``record_job`` +
+``update_job_completion``) with a narrower, typed API that the new DB
+stack uses. See design.md § JobRepository.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from srunx.db.models import Job, SubmissionSource
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class JobRepository(BaseRepository):
+    """CRUD for the ``jobs`` table."""
+
+    JSON_FIELDS = ("command", "env_vars", "metadata")
+    DATETIME_FIELDS = ("submitted_at", "started_at", "completed_at")
+
+    _COLUMNS = (
+        "id",
+        "job_id",
+        "name",
+        "command",
+        "status",
+        "nodes",
+        "gpus_per_node",
+        "memory_per_node",
+        "time_limit",
+        "partition",
+        "nodelist",
+        "conda",
+        "venv",
+        "container",
+        "env_vars",
+        "submitted_at",
+        "started_at",
+        "completed_at",
+        "duration_secs",
+        "workflow_run_id",
+        "submission_source",
+        "log_file",
+        "metadata",
+    )
+
+    def record_submission(
+        self,
+        *,
+        job_id: int,
+        name: str,
+        status: str,
+        submission_source: SubmissionSource,
+        command: list[str] | None = None,
+        nodes: int | None = None,
+        gpus_per_node: int | None = None,
+        memory_per_node: str | None = None,
+        time_limit: str | None = None,
+        partition: str | None = None,
+        nodelist: str | None = None,
+        conda: str | None = None,
+        venv: str | None = None,
+        container: str | None = None,
+        env_vars: dict | None = None,
+        submitted_at: str | None = None,
+        workflow_run_id: int | None = None,
+        log_file: str | None = None,
+        metadata: dict | None = None,
+    ) -> int:
+        """Insert a new row for a just-submitted job.
+
+        Uses ``INSERT OR REPLACE`` on ``job_id``: a resubmission under the
+        same SLURM ID replaces the prior record. Returns the row's ``id``.
+        """
+        submitted_at = submitted_at or now_iso()
+        cur = self.conn.execute(
+            """
+            INSERT OR REPLACE INTO jobs (
+                job_id, name, command, status,
+                nodes, gpus_per_node, memory_per_node, time_limit,
+                partition, nodelist,
+                conda, venv, container, env_vars,
+                submitted_at,
+                workflow_run_id, submission_source,
+                log_file, metadata
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job_id,
+                name,
+                self._encode_json(command),
+                status,
+                nodes,
+                gpus_per_node,
+                memory_per_node,
+                time_limit,
+                partition,
+                nodelist,
+                conda,
+                venv,
+                container,
+                self._encode_json(env_vars),
+                submitted_at,
+                workflow_run_id,
+                submission_source,
+                log_file,
+                self._encode_json(metadata),
+            ),
+        )
+        return int(cur.lastrowid or 0)
+
+    def update_status(
+        self,
+        job_id: int,
+        status: str,
+        *,
+        started_at: str | None = None,
+        completed_at: str | None = None,
+        duration_secs: int | None = None,
+        nodelist: str | None = None,
+    ) -> bool:
+        """Update a live job's status and lifecycle timestamps.
+
+        Called by :class:`~srunx.pollers.active_watch_poller.ActiveWatchPoller`
+        on every detected transition. Returns True if a row was updated.
+        """
+        sets: list[str] = ["status = ?"]
+        vals: list[Any] = [status]
+        if started_at is not None:
+            sets.append("started_at = ?")
+            vals.append(started_at)
+        if completed_at is not None:
+            sets.append("completed_at = ?")
+            vals.append(completed_at)
+        if duration_secs is not None:
+            sets.append("duration_secs = ?")
+            vals.append(duration_secs)
+        if nodelist is not None:
+            sets.append("nodelist = ?")
+            vals.append(nodelist)
+        vals.append(job_id)
+
+        cur = self.conn.execute(
+            f"UPDATE jobs SET {', '.join(sets)} WHERE job_id = ?",
+            vals,
+        )
+        return cur.rowcount > 0
+
+    def update_completion(
+        self,
+        job_id: int,
+        status: str,
+        completed_at: str | None = None,
+    ) -> bool:
+        """Compatibility wrapper for the historical ``update_job_completion``.
+
+        Computes ``duration_secs`` from ``submitted_at`` when not provided.
+        """
+        completed_at = completed_at or now_iso()
+        row = self.conn.execute(
+            "SELECT submitted_at FROM jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()
+        duration: int | None = None
+        if row is not None:
+            from srunx.db.repositories.base import _parse_dt
+
+            submitted = _parse_dt(row["submitted_at"])
+            done = _parse_dt(completed_at)
+            if submitted and done:
+                duration = int((done - submitted).total_seconds())
+
+        return self.update_status(
+            job_id,
+            status,
+            completed_at=completed_at,
+            duration_secs=duration,
+        )
+
+    def get(self, job_id: int) -> Job | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM jobs WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+        return self._row_to_model(row, Job)
+
+    def list_all(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        workflow_run_id: int | None = None,
+    ) -> list[Job]:
+        sql = f"SELECT {', '.join(self._COLUMNS)} FROM jobs"
+        params: list[Any] = []
+        if workflow_run_id is not None:
+            sql += " WHERE workflow_run_id = ?"
+            params.append(workflow_run_id)
+        sql += " ORDER BY submitted_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+
+        rows = self.conn.execute(sql, params).fetchall()
+        return [self._row_to_model(r, Job) for r in rows if r is not None]  # type: ignore[misc]
+
+    def count_by_status_in_range(
+        self,
+        from_at: str,
+        to_at: str,
+        statuses: list[str] | None = None,
+    ) -> dict[str, int]:
+        """Return per-status counts for jobs submitted in ``[from_at, to_at)``.
+
+        Provided for the future ``ScheduledReporter`` replacement
+        (design.md § "Phase 1 で変更しない領域"). ``statuses=None`` counts
+        every distinct status.
+        """
+        if statuses:
+            placeholders = ",".join(["?"] * len(statuses))
+            sql = (
+                "SELECT status, COUNT(*) AS c FROM jobs "
+                f"WHERE submitted_at >= ? AND submitted_at < ? AND status IN ({placeholders}) "
+                "GROUP BY status"
+            )
+            params: list[Any] = [from_at, to_at, *statuses]
+        else:
+            sql = (
+                "SELECT status, COUNT(*) AS c FROM jobs "
+                "WHERE submitted_at >= ? AND submitted_at < ? "
+                "GROUP BY status"
+            )
+            params = [from_at, to_at]
+
+        rows = self.conn.execute(sql, params).fetchall()
+        return {r["status"]: int(r["c"]) for r in rows}
+
+    def delete(self, job_id: int) -> bool:
+        cur = self.conn.execute("DELETE FROM jobs WHERE job_id = ?", (job_id,))
+        return cur.rowcount > 0
+
+    # Convenience — for callers that hold the raw connection/cursor.
+    def _raw(self) -> sqlite3.Connection:
+        return self.conn

--- a/src/srunx/db/repositories/resource_snapshots.py
+++ b/src/srunx/db/repositories/resource_snapshots.py
@@ -1,0 +1,117 @@
+"""Repository for the ``resource_snapshots`` table.
+
+See design.md § ``ResourceSnapshotRepository``. Writes are performed by
+:class:`~srunx.pollers.resource_snapshotter.ResourceSnapshotter`; reads
+serve history APIs and the Phase-2 scheduled reporter. The
+``gpu_utilization`` column is a SQL generated column and never written
+directly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from srunx.db.models import ResourceSnapshot
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class ResourceSnapshotRepository(BaseRepository):
+    """CRUD for the ``resource_snapshots`` table."""
+
+    DATETIME_FIELDS = ("observed_at",)
+
+    _COLUMNS = (
+        "id",
+        "observed_at",
+        "partition",
+        "gpus_total",
+        "gpus_available",
+        "gpus_in_use",
+        "nodes_total",
+        "nodes_idle",
+        "nodes_down",
+        "gpu_utilization",
+    )
+
+    def insert(self, snapshot: ResourceSnapshot) -> int:
+        """Insert a snapshot row and return its ``id``.
+
+        All columns are written except ``gpu_utilization``, which is a
+        STORED generated column. ``observed_at`` is serialized via
+        :func:`now_iso` semantics when it arrives as a ``datetime``.
+        """
+        observed_at: Any = snapshot.observed_at
+        if isinstance(observed_at, datetime):
+            observed_at = observed_at.isoformat(timespec="milliseconds").replace(
+                "+00:00", "Z"
+            )
+        elif observed_at is None:
+            observed_at = now_iso()
+
+        cur = self.conn.execute(
+            """
+            INSERT INTO resource_snapshots (
+                observed_at, partition,
+                gpus_total, gpus_available, gpus_in_use,
+                nodes_total, nodes_idle, nodes_down
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                observed_at,
+                snapshot.partition,
+                snapshot.gpus_total,
+                snapshot.gpus_available,
+                snapshot.gpus_in_use,
+                snapshot.nodes_total,
+                snapshot.nodes_idle,
+                snapshot.nodes_down,
+            ),
+        )
+        return int(cur.lastrowid or 0)
+
+    def list_range(
+        self,
+        from_at: str,
+        to_at: str,
+        partition: str | None = None,
+    ) -> list[ResourceSnapshot]:
+        """Return snapshots in ``[from_at, to_at)`` for the given partition.
+
+        ``partition=None`` selects cluster-wide snapshots (rows where the
+        ``partition`` column is NULL), not all partitions.
+        """
+        if partition is None:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM resource_snapshots "
+                "WHERE observed_at >= ? AND observed_at < ? "
+                "AND partition IS NULL "
+                "ORDER BY observed_at ASC"
+            )
+            params: list[Any] = [from_at, to_at]
+        else:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM resource_snapshots "
+                "WHERE observed_at >= ? AND observed_at < ? "
+                "AND partition = ? "
+                "ORDER BY observed_at ASC"
+            )
+            params = [from_at, to_at, partition]
+
+        rows = self.conn.execute(sql, params).fetchall()
+        return [self._row_to_model(r, ResourceSnapshot) for r in rows if r is not None]  # type: ignore[misc]
+
+    def delete_older_than(self, days: int) -> int:
+        """Delete snapshots older than ``days`` days. Returns deleted count.
+
+        Uses SQLite's ``strftime`` to compute the cutoff so the comparison
+        is symmetric with :func:`now_iso`.
+        """
+        cur = self.conn.execute(
+            """
+            DELETE FROM resource_snapshots
+            WHERE observed_at < strftime('%Y-%m-%dT%H:%M:%fZ','now',?)
+            """,
+            (f"-{int(days)} days",),
+        )
+        return cur.rowcount

--- a/src/srunx/db/repositories/subscriptions.py
+++ b/src/srunx/db/repositories/subscriptions.py
@@ -1,0 +1,67 @@
+"""Repository for the ``subscriptions`` table.
+
+See design.md § ``SubscriptionRepository``. A subscription links a
+``watch`` to an ``endpoint`` with a delivery ``preset`` (``terminal`` /
+``running_and_terminal`` / ``all`` / ``digest``). Both foreign keys are
+ON DELETE CASCADE, so removing the owning endpoint or watch removes all
+its subscriptions automatically.
+"""
+
+from __future__ import annotations
+
+from srunx.db.models import Subscription
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class SubscriptionRepository(BaseRepository):
+    """CRUD for the ``subscriptions`` table."""
+
+    DATETIME_FIELDS = ("created_at",)
+
+    _COLUMNS = (
+        "id",
+        "watch_id",
+        "endpoint_id",
+        "preset",
+        "created_at",
+    )
+
+    def create(self, watch_id: int, endpoint_id: int, preset: str) -> int:
+        """Insert a new subscription row and return its ``id``."""
+        cur = self.conn.execute(
+            """
+            INSERT INTO subscriptions (watch_id, endpoint_id, preset, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (watch_id, endpoint_id, preset, now_iso()),
+        )
+        return int(cur.lastrowid or 0)
+
+    def get(self, id: int) -> Subscription | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM subscriptions WHERE id = ?",
+            (id,),
+        ).fetchone()
+        return self._row_to_model(row, Subscription)
+
+    def list_by_watch(self, watch_id: int) -> list[Subscription]:
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM subscriptions "
+            "WHERE watch_id = ? "
+            "ORDER BY created_at ASC",
+            (watch_id,),
+        ).fetchall()
+        return [self._row_to_model(r, Subscription) for r in rows if r is not None]  # type: ignore[misc]
+
+    def list_by_endpoint(self, endpoint_id: int) -> list[Subscription]:
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM subscriptions "
+            "WHERE endpoint_id = ? "
+            "ORDER BY created_at ASC",
+            (endpoint_id,),
+        ).fetchall()
+        return [self._row_to_model(r, Subscription) for r in rows if r is not None]  # type: ignore[misc]
+
+    def delete(self, id: int) -> bool:
+        cur = self.conn.execute("DELETE FROM subscriptions WHERE id = ?", (id,))
+        return cur.rowcount > 0

--- a/src/srunx/db/repositories/watches.py
+++ b/src/srunx/db/repositories/watches.py
@@ -1,0 +1,95 @@
+"""Repository for the ``watches`` table.
+
+See design.md § ``WatchRepository``. A watch represents an ongoing
+interest in a SLURM object (job / workflow run / resource threshold /
+scheduled report). Closing a watch is done with ``close(id)`` — watches
+are **never deleted** as a side effect; downstream ``subscriptions`` are
+CASCADE-deleted only when the watch row itself is explicitly DELETEd.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from srunx.db.models import Watch
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class WatchRepository(BaseRepository):
+    """CRUD for the ``watches`` table."""
+
+    JSON_FIELDS = ("filter",)
+    DATETIME_FIELDS = ("created_at", "closed_at")
+
+    _COLUMNS = (
+        "id",
+        "kind",
+        "target_ref",
+        "filter",
+        "created_at",
+        "closed_at",
+    )
+
+    def create(
+        self,
+        kind: str,
+        target_ref: str,
+        filter: dict | None = None,
+    ) -> int:
+        """Insert a new open watch row and return its ``id``."""
+        cur = self.conn.execute(
+            """
+            INSERT INTO watches (kind, target_ref, filter, created_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (kind, target_ref, self._encode_json(filter), now_iso()),
+        )
+        return int(cur.lastrowid or 0)
+
+    def get(self, id: int) -> Watch | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM watches WHERE id = ?",
+            (id,),
+        ).fetchone()
+        return self._row_to_model(row, Watch)
+
+    def list_open(self) -> list[Watch]:
+        """Return all open watches ordered by ``created_at`` ascending."""
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM watches "
+            "WHERE closed_at IS NULL "
+            "ORDER BY created_at ASC"
+        ).fetchall()
+        return [self._row_to_model(r, Watch) for r in rows if r is not None]  # type: ignore[misc]
+
+    def list_by_target(
+        self,
+        kind: str,
+        target_ref: str,
+        only_open: bool = True,
+    ) -> list[Watch]:
+        """Return watches for a given ``(kind, target_ref)`` pair."""
+        if only_open:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM watches "
+                "WHERE kind = ? AND target_ref = ? AND closed_at IS NULL "
+                "ORDER BY created_at ASC"
+            )
+        else:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM watches "
+                "WHERE kind = ? AND target_ref = ? "
+                "ORDER BY created_at ASC"
+            )
+        params: list[Any] = [kind, target_ref]
+
+        rows = self.conn.execute(sql, params).fetchall()
+        return [self._row_to_model(r, Watch) for r in rows if r is not None]  # type: ignore[misc]
+
+    def close(self, id: int) -> bool:
+        """Mark a watch closed (sets ``closed_at = now_iso()``)."""
+        cur = self.conn.execute(
+            "UPDATE watches SET closed_at = ? WHERE id = ?",
+            (now_iso(), id),
+        )
+        return cur.rowcount > 0

--- a/src/srunx/db/repositories/workflow_run_jobs.py
+++ b/src/srunx/db/repositories/workflow_run_jobs.py
@@ -1,0 +1,72 @@
+"""Repository for the ``workflow_run_jobs`` table.
+
+Design reference: ``.claude/specs/notification-and-state-persistence/design.md``
+§ Repositories.
+"""
+
+from __future__ import annotations
+
+from srunx.db.models import WorkflowRunJob
+from srunx.db.repositories.base import BaseRepository
+
+
+class WorkflowRunJobRepository(BaseRepository):
+    """CRUD for the ``workflow_run_jobs`` table."""
+
+    JSON_FIELDS = ("depends_on",)
+
+    _COLUMNS = (
+        "id",
+        "workflow_run_id",
+        "job_id",
+        "job_name",
+        "depends_on",
+    )
+
+    def create(
+        self,
+        workflow_run_id: int,
+        job_name: str,
+        depends_on: list[str] | None = None,
+        job_id: int | None = None,
+    ) -> int:
+        """Insert (or replace) a workflow_run_jobs row.
+
+        ``job_id`` is typically ``None`` until the underlying SLURM job has
+        been submitted; callers then invoke :meth:`update_job_id`. Returns
+        the new row's ``id``.
+        """
+        cur = self.conn.execute(
+            """
+            INSERT OR REPLACE INTO workflow_run_jobs (
+                workflow_run_id, job_id, job_name, depends_on
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (
+                workflow_run_id,
+                job_id,
+                job_name,
+                self._encode_json(depends_on),
+            ),
+        )
+        return int(cur.lastrowid or 0)
+
+    def update_job_id(self, row_id: int, job_id: int) -> bool:
+        """Associate a SLURM ``job_id`` with a previously-created row.
+
+        Returns True if a row was updated.
+        """
+        cur = self.conn.execute(
+            "UPDATE workflow_run_jobs SET job_id = ? WHERE id = ?",
+            (job_id, row_id),
+        )
+        return cur.rowcount > 0
+
+    def list_by_run(self, workflow_run_id: int) -> list[WorkflowRunJob]:
+        """Return every row belonging to ``workflow_run_id`` in insertion order."""
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM workflow_run_jobs "
+            "WHERE workflow_run_id = ? ORDER BY id ASC",
+            (workflow_run_id,),
+        ).fetchall()
+        return [self._row_to_model(r, WorkflowRunJob) for r in rows if r is not None]  # type: ignore[misc]

--- a/src/srunx/db/repositories/workflow_runs.py
+++ b/src/srunx/db/repositories/workflow_runs.py
@@ -1,0 +1,112 @@
+"""Repository for the ``workflow_runs`` table.
+
+Design reference: ``.claude/specs/notification-and-state-persistence/design.md``
+§ Repositories.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from srunx.db.models import WorkflowRun, WorkflowRunTriggeredBy
+from srunx.db.repositories.base import BaseRepository, now_iso
+
+
+class WorkflowRunRepository(BaseRepository):
+    """CRUD for the ``workflow_runs`` table."""
+
+    JSON_FIELDS = ("args",)
+    DATETIME_FIELDS = ("started_at", "completed_at")
+
+    _COLUMNS = (
+        "id",
+        "workflow_name",
+        "workflow_yaml_path",
+        "status",
+        "started_at",
+        "completed_at",
+        "args",
+        "error",
+        "triggered_by",
+    )
+
+    def create(
+        self,
+        workflow_name: str,
+        yaml_path: str | None,
+        args: dict | None,
+        triggered_by: WorkflowRunTriggeredBy,
+    ) -> int:
+        """Insert a new workflow run in ``pending`` status.
+
+        Uses ``INSERT OR REPLACE`` for parity with the other repositories.
+        Returns the new row's ``id``.
+        """
+        cur = self.conn.execute(
+            """
+            INSERT OR REPLACE INTO workflow_runs (
+                workflow_name, workflow_yaml_path, status, started_at,
+                args, triggered_by
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                workflow_name,
+                yaml_path,
+                "pending",
+                now_iso(),
+                self._encode_json(args),
+                triggered_by,
+            ),
+        )
+        return int(cur.lastrowid or 0)
+
+    def get(self, id: int) -> WorkflowRun | None:
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM workflow_runs WHERE id = ?",
+            (id,),
+        ).fetchone()
+        return self._row_to_model(row, WorkflowRun)
+
+    def list_all(self) -> list[WorkflowRun]:
+        """Return every workflow run ordered by ``started_at`` DESC."""
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM workflow_runs "
+            "ORDER BY started_at DESC"
+        ).fetchall()
+        return [self._row_to_model(r, WorkflowRun) for r in rows if r is not None]  # type: ignore[misc]
+
+    def list_incomplete(self) -> list[WorkflowRun]:
+        """Return runs still in ``pending`` or ``running`` (for resume)."""
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM workflow_runs "
+            "WHERE status IN ('pending','running') "
+            "ORDER BY started_at DESC"
+        ).fetchall()
+        return [self._row_to_model(r, WorkflowRun) for r in rows if r is not None]  # type: ignore[misc]
+
+    def update_status(
+        self,
+        id: int,
+        status: str,
+        error: str | None = None,
+        completed_at: str | None = None,
+    ) -> bool:
+        """Update a workflow run's status and lifecycle fields.
+
+        Returns True if a row was updated.
+        """
+        sets: list[str] = ["status = ?"]
+        vals: list[Any] = [status]
+        if error is not None:
+            sets.append("error = ?")
+            vals.append(error)
+        if completed_at is not None:
+            sets.append("completed_at = ?")
+            vals.append(completed_at)
+        vals.append(id)
+
+        cur = self.conn.execute(
+            f"UPDATE workflow_runs SET {', '.join(sets)} WHERE id = ?",
+            vals,
+        )
+        return cur.rowcount > 0

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -11,6 +11,11 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
+from srunx.client_protocol import (
+    JobStatusInfo,
+    parse_slurm_datetime,
+    parse_slurm_duration,
+)
 from srunx.logging import get_logger
 from srunx.ssh.core.client import SSHSlurmClient
 from srunx.ssh.core.config import ConfigManager
@@ -300,6 +305,88 @@ class SlurmSSHAdapter:
             )
 
         return jobs
+
+    def queue_by_ids(self, job_ids: list[int]) -> dict[int, JobStatusInfo]:
+        """Return a mapping of ``job_id`` -> :class:`JobStatusInfo` for active jobs.
+
+        Implements :class:`SlurmClientProtocol`. Active jobs are queried via
+        ``squeue --jobs=...``; jobs no longer in the queue fall back to
+        ``sacct``. Jobs found in neither source are omitted.
+        """
+        if not job_ids:
+            return {}
+
+        for jid in job_ids:
+            if jid <= 0:
+                raise ValueError(f"Invalid job_id: {jid}")
+
+        id_arg = ",".join(str(i) for i in job_ids)
+        results: dict[int, JobStatusInfo] = {}
+
+        # --- squeue: active jobs ---
+        try:
+            squeue_out = _run_slurm_cmd(
+                self,
+                f'squeue --jobs {id_arg} --format "%i|%T|%S|%M|%N" --noheader',
+            )
+        except RuntimeError:
+            # squeue may fail if NO job IDs are currently in the queue;
+            # this is normal when all queried jobs have already completed.
+            squeue_out = ""
+
+        for line in squeue_out.strip().splitlines():
+            parts = line.split("|")
+            if len(parts) < 5:
+                continue
+            try:
+                jid = int(parts[0].strip())
+            except ValueError:
+                continue
+            results[jid] = JobStatusInfo(
+                status=parts[1].strip(),
+                started_at=parse_slurm_datetime(parts[2]),
+                duration_secs=parse_slurm_duration(parts[3]),
+                nodelist=(parts[4].strip() or None),
+            )
+
+        # --- sacct fallback: terminal jobs ---
+        missing = [j for j in job_ids if j not in results]
+        if missing:
+            missing_arg = ",".join(str(i) for i in missing)
+            try:
+                sacct_out = _run_slurm_cmd(
+                    self,
+                    f"sacct --jobs {missing_arg} "
+                    f"--format=JobID,State,Start,End,Elapsed,NodeList "
+                    f"--noheader --parsable2",
+                )
+            except RuntimeError:
+                sacct_out = ""
+
+            for line in sacct_out.strip().splitlines():
+                parts = line.split("|")
+                if len(parts) < 6:
+                    continue
+                raw_id = parts[0].strip()
+                if "." in raw_id:
+                    continue
+                try:
+                    jid = int(raw_id)
+                except ValueError:
+                    continue
+                if jid in results:
+                    continue
+                raw_state = parts[1].strip()
+                status = raw_state.split()[0] if raw_state else "UNKNOWN"
+                results[jid] = JobStatusInfo(
+                    status=status,
+                    started_at=parse_slurm_datetime(parts[2]),
+                    completed_at=parse_slurm_datetime(parts[3]),
+                    duration_secs=parse_slurm_duration(parts[4]),
+                    nodelist=(parts[5].strip() or None),
+                )
+
+        return results
 
     def get_job(self, job_id: int) -> dict[str, Any]:
         """Get detailed job info via sacct."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,27 @@ def temp_dir():
 
 
 @pytest.fixture
+def tmp_srunx_db(tmp_path, monkeypatch):
+    """Yield an isolated, file-backed srunx SQLite DB.
+
+    Monkeypatches ``XDG_CONFIG_HOME`` so ``get_db_path()`` resolves under
+    the per-test tmp dir, bootstraps the schema via ``init_db``, and
+    yields an opened connection. **File-backed (NOT ``:memory:``)** so
+    that multi-connection + WAL semantics work correctly for the outbox
+    concurrency tests.
+    """
+    from srunx.db.connection import init_db, open_connection
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    db_path = init_db(delete_legacy=False)
+    conn = open_connection(db_path)
+    try:
+        yield conn, db_path
+    finally:
+        conn.close()
+
+
+@pytest.fixture
 def sample_job():
     """Create a sample job for testing."""
     return Job(

--- a/tests/db/repositories/test_deliveries.py
+++ b/tests/db/repositories/test_deliveries.py
@@ -1,0 +1,623 @@
+"""Tests for :class:`srunx.db.repositories.deliveries.DeliveryRepository`.
+
+Covers the outbox claim/lease mechanics (the hot path of the delivery
+poller) plus the straightforward CRUD + state-transition methods.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.base import now_iso
+from srunx.db.repositories.deliveries import DeliveryRepository
+
+# ---------------------------------------------------------------------------
+# Fixtures: seed an endpoint + watch + subscription + event so we can insert
+# deliveries against valid FKs. All helpers write rows directly via SQL to
+# keep these tests isolated from the other repositories.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    connection = open_connection(db)
+    apply_migrations(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def _seed_endpoint(
+    conn: sqlite3.Connection,
+    *,
+    name: str = "default",
+    disabled: bool = False,
+) -> int:
+    disabled_at = now_iso() if disabled else None
+    cur = conn.execute(
+        "INSERT INTO endpoints (kind, name, config, created_at, disabled_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("slack_webhook", name, "{}", now_iso(), disabled_at),
+    )
+    conn.commit()
+    return int(cur.lastrowid or 0)
+
+
+def _seed_watch(conn: sqlite3.Connection, target_ref: str = "job:1") -> int:
+    cur = conn.execute(
+        "INSERT INTO watches (kind, target_ref, filter, created_at) "
+        "VALUES (?, ?, NULL, ?)",
+        ("job", target_ref, now_iso()),
+    )
+    conn.commit()
+    return int(cur.lastrowid or 0)
+
+
+def _seed_subscription(
+    conn: sqlite3.Connection,
+    watch_id: int,
+    endpoint_id: int,
+    preset: str = "terminal",
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO subscriptions (watch_id, endpoint_id, preset, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (watch_id, endpoint_id, preset, now_iso()),
+    )
+    conn.commit()
+    return int(cur.lastrowid or 0)
+
+
+def _seed_event(
+    conn: sqlite3.Connection,
+    *,
+    source_ref: str = "job:1",
+    payload_hash: str = "hash-1",
+) -> int:
+    cur = conn.execute(
+        "INSERT INTO events (kind, source_ref, payload, payload_hash, observed_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (
+            "job.status_changed",
+            source_ref,
+            '{"to_status": "COMPLETED"}',
+            payload_hash,
+            now_iso(),
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid or 0)
+
+
+@pytest.fixture
+def setup_fks(conn: sqlite3.Connection) -> dict[str, int]:
+    """Return a dict of seeded FK ids usable by the tests."""
+    endpoint_id = _seed_endpoint(conn)
+    watch_id = _seed_watch(conn)
+    subscription_id = _seed_subscription(conn, watch_id, endpoint_id)
+    event_id = _seed_event(conn)
+    return {
+        "endpoint_id": endpoint_id,
+        "watch_id": watch_id,
+        "subscription_id": subscription_id,
+        "event_id": event_id,
+    }
+
+
+@pytest.fixture
+def repo(conn: sqlite3.Connection) -> DeliveryRepository:
+    return DeliveryRepository(conn)
+
+
+# ---------------------------------------------------------------------------
+# _backoff_secs truth table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "attempt_count,expected",
+    [
+        (0, 10),
+        (1, 20),
+        (2, 40),
+        (3, 80),
+        (4, 160),
+        (10, 3600),  # capped
+        (100, 3600),  # still capped
+    ],
+)
+def test_backoff_secs_truth_table(attempt_count: int, expected: int) -> None:
+    assert DeliveryRepository._backoff_secs(attempt_count) == expected
+
+
+def test_backoff_secs_custom_base_and_cap() -> None:
+    assert DeliveryRepository._backoff_secs(0, base=5, factor=3, cap=100) == 5
+    assert DeliveryRepository._backoff_secs(1, base=5, factor=3, cap=100) == 15
+    assert DeliveryRepository._backoff_secs(10, base=5, factor=3, cap=100) == 100
+
+
+# ---------------------------------------------------------------------------
+# insert
+# ---------------------------------------------------------------------------
+
+
+def test_insert_returns_positive_id(
+    repo: DeliveryRepository, setup_fks: dict[str, int]
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "job:1:status:COMPLETED",
+    )
+    assert delivery_id is not None
+    assert delivery_id > 0
+
+
+def test_insert_sets_pending_defaults(
+    repo: DeliveryRepository, setup_fks: dict[str, int]
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "job:1:status:COMPLETED",
+    )
+    assert delivery_id is not None
+    loaded = repo.get(delivery_id)
+    assert loaded is not None
+    assert loaded.status == "pending"
+    assert loaded.attempt_count == 0
+    assert loaded.leased_until is None
+    assert loaded.worker_id is None
+    assert loaded.last_error is None
+    assert loaded.delivered_at is None
+
+
+def test_insert_duplicate_idempotency_key_returns_none(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    first = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "dup-key",
+    )
+    # Add a second event so we can try to insert a second delivery row
+    # against the same endpoint + idempotency key — the UNIQUE
+    # (endpoint_id, idempotency_key) should absorb it.
+    other_event = _seed_event(conn, source_ref="job:2", payload_hash="hash-2")
+    second = repo.insert(
+        other_event,
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "dup-key",
+    )
+    assert first is not None
+    assert second is None
+
+
+def test_insert_accepts_explicit_next_attempt_at(
+    repo: DeliveryRepository, setup_fks: dict[str, int]
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k",
+        next_attempt_at="2099-01-01T00:00:00.000Z",
+    )
+    assert delivery_id is not None
+    loaded = repo.get(delivery_id)
+    assert loaded is not None
+    assert loaded.next_attempt_at.year == 2099
+
+
+# ---------------------------------------------------------------------------
+# get / list_by_subscription
+# ---------------------------------------------------------------------------
+
+
+def test_get_missing_returns_none(repo: DeliveryRepository) -> None:
+    assert repo.get(9999) is None
+
+
+def test_list_by_subscription_filters_and_orders(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k1",
+    )
+    time.sleep(0.02)
+    other_event = _seed_event(conn, source_ref="job:3", payload_hash="hash-3")
+    repo.insert(
+        other_event,
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k2",
+    )
+
+    rows = repo.list_by_subscription(setup_fks["subscription_id"])
+    assert len(rows) == 2
+    # newest first by created_at — the timestamps are millisecond-precision
+    # ISO strings so a 20 ms gap guarantees a stable lexicographic order.
+    idempotency_keys = {r.idempotency_key for r in rows}
+    assert idempotency_keys == {"k1", "k2"}
+    # And ORDER BY created_at DESC should put k2 first.
+    assert rows[0].idempotency_key == "k2"
+    assert rows[1].idempotency_key == "k1"
+
+    # filter by status
+    pending_rows = repo.list_by_subscription(
+        setup_fks["subscription_id"], status="pending"
+    )
+    assert len(pending_rows) == 2
+
+    delivered_rows = repo.list_by_subscription(
+        setup_fks["subscription_id"], status="delivered"
+    )
+    assert delivered_rows == []
+
+
+# ---------------------------------------------------------------------------
+# claim_one
+# ---------------------------------------------------------------------------
+
+
+def test_claim_one_marks_sending(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k",
+    )
+    assert delivery_id is not None
+    conn.commit()  # close the implicit Python transaction before claim_one
+
+    claimed = repo.claim_one(worker_id="worker-1", lease_duration_secs=300)
+    assert claimed is not None
+    assert claimed.id == delivery_id
+    assert claimed.status == "sending"
+    assert claimed.worker_id == "worker-1"
+    assert claimed.leased_until is not None
+
+
+def test_claim_one_returns_none_when_no_pending(repo: DeliveryRepository) -> None:
+    assert repo.claim_one(worker_id="worker-1") is None
+
+
+def test_claim_one_skips_disabled_endpoints(
+    repo: DeliveryRepository, conn: sqlite3.Connection
+) -> None:
+    disabled_endpoint = _seed_endpoint(conn, name="disabled-ep", disabled=True)
+    watch_id = _seed_watch(conn, target_ref="job:50")
+    sub_id = _seed_subscription(conn, watch_id, disabled_endpoint)
+    event_id = _seed_event(conn, source_ref="job:50", payload_hash="disabled-hash")
+
+    delivery_id = repo.insert(event_id, sub_id, disabled_endpoint, "k-disabled")
+    assert delivery_id is not None
+    conn.commit()
+
+    # claim_one must skip this because the endpoint is disabled
+    assert repo.claim_one(worker_id="worker-1") is None
+
+
+def test_claim_one_skips_future_next_attempt_at(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "future-k",
+        next_attempt_at="2099-01-01T00:00:00.000Z",
+    )
+    assert delivery_id is not None
+    conn.commit()
+    assert repo.claim_one(worker_id="worker-1") is None
+
+
+def test_claim_one_concurrent_second_connection_misses(
+    tmp_path: Path, setup_fks: dict[str, int], conn: sqlite3.Connection
+) -> None:
+    """When the same pending row is visible to two connections, only one
+    claim_one call should return it; the other should return ``None``.
+
+    We can't run the two calls truly in parallel inside a single pytest
+    process without threads, but the correctness invariant is that the
+    UPDATE's ``WHERE status = 'pending'`` clause will fail for any
+    worker that races in after another worker already flipped the row
+    to ``sending``. To exercise that path we emulate the race by:
+
+    1. inserting one pending delivery on connection A
+    2. opening a second connection B to the same on-disk DB (WAL mode
+       with busy_timeout PRAGMAs from ``open_connection``)
+    3. calling claim_one() from connection A (commits the flip)
+    4. calling claim_one() from connection B (must see status='sending'
+       and return None)
+
+    This verifies both that the SELECT+UPDATE+RETURNING pattern is
+    visible across connections AND that the ``WHERE status='pending'``
+    in the UPDATE filters out already-claimed rows.
+    """
+    # Seed a pending delivery on the shared DB via conn A.
+    repo_a = DeliveryRepository(conn)
+    delivery_id = repo_a.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "race-k",
+    )
+    assert delivery_id is not None
+    conn.commit()  # make row visible to the second connection + close tx
+
+    # Find the DB path by reading from the connection's pragma;
+    # simpler: tmp_path-based fixture doesn't expose it, so reopen
+    # against the same path used by ``conn`` fixture. We rebuild it
+    # here using the same tmp_path.
+    db_path = tmp_path / "srunx.db"
+    conn_b = open_connection(db_path)
+    try:
+        repo_b = DeliveryRepository(conn_b)
+
+        # Worker A wins first.
+        claimed_a = repo_a.claim_one(worker_id="worker-A")
+        assert claimed_a is not None
+        assert claimed_a.id == delivery_id
+
+        # Worker B, running the same claim_one, must not see any
+        # pending row any more.
+        claimed_b = repo_b.claim_one(worker_id="worker-B")
+        assert claimed_b is None
+    finally:
+        conn_b.close()
+
+
+# ---------------------------------------------------------------------------
+# reclaim_expired_leases
+# ---------------------------------------------------------------------------
+
+
+def test_reclaim_expired_leases_reverts_stale_sending(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    # Insert a pending row, then flip it to 'sending' with a leased_until
+    # in the past to simulate a crashed worker.
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "expired-k",
+    )
+    assert delivery_id is not None
+    conn.execute(
+        """
+        UPDATE deliveries
+           SET status = 'sending',
+               leased_until = ?,
+               worker_id = 'crashed-worker'
+         WHERE id = ?
+        """,
+        ("2000-01-01T00:00:00.000Z", delivery_id),
+    )
+    conn.commit()
+
+    reclaimed = repo.reclaim_expired_leases()
+    assert reclaimed == 1
+
+    loaded = repo.get(delivery_id)
+    assert loaded is not None
+    assert loaded.status == "pending"
+    assert loaded.leased_until is None
+    assert loaded.worker_id is None
+
+
+def test_reclaim_expired_leases_leaves_active_leases_alone(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "active-k",
+    )
+    assert delivery_id is not None
+    # Future leased_until — active lease.
+    conn.execute(
+        """
+        UPDATE deliveries
+           SET status = 'sending',
+               leased_until = ?,
+               worker_id = 'worker-1'
+         WHERE id = ?
+        """,
+        ("2099-01-01T00:00:00.000Z", delivery_id),
+    )
+    conn.commit()
+
+    reclaimed = repo.reclaim_expired_leases()
+    assert reclaimed == 0
+
+    loaded = repo.get(delivery_id)
+    assert loaded is not None
+    assert loaded.status == "sending"
+    assert loaded.worker_id == "worker-1"
+
+
+def test_reclaim_expired_leases_empty_returns_zero(
+    repo: DeliveryRepository,
+) -> None:
+    assert repo.reclaim_expired_leases() == 0
+
+
+# ---------------------------------------------------------------------------
+# mark_delivered / mark_retry / mark_abandoned
+# ---------------------------------------------------------------------------
+
+
+def test_mark_delivered_sets_status_and_timestamp(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k",
+    )
+    assert delivery_id is not None
+    conn.commit()
+
+    # Lease it first so we can prove mark_delivered clears lease fields.
+    claimed = repo.claim_one(worker_id="w")
+    assert claimed is not None
+
+    assert repo.mark_delivered(delivery_id) is True
+
+    loaded = repo.get(delivery_id)
+    assert loaded is not None
+    assert loaded.status == "delivered"
+    assert loaded.delivered_at is not None
+    assert loaded.leased_until is None
+    assert loaded.worker_id is None
+
+
+def test_mark_delivered_returns_false_on_missing(
+    repo: DeliveryRepository,
+) -> None:
+    assert repo.mark_delivered(9999) is False
+
+
+def test_mark_retry_increments_attempt_and_schedules_backoff(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k",
+    )
+    assert delivery_id is not None
+    conn.commit()
+
+    claimed = repo.claim_one(worker_id="w")
+    assert claimed is not None
+
+    assert repo.mark_retry(delivery_id, "HTTP 500", backoff_secs=30) is True
+    conn.commit()
+
+    loaded = repo.get(delivery_id)
+    assert loaded is not None
+    assert loaded.status == "pending"
+    assert loaded.attempt_count == 1
+    assert loaded.leased_until is None
+    assert loaded.worker_id is None
+    assert loaded.last_error == "HTTP 500"
+
+    # next_attempt_at was scheduled by backoff_secs=30 — but the second
+    # claim needs the row to be due, so rewrite it to "now-ish".
+    conn.execute(
+        "UPDATE deliveries SET next_attempt_at = "
+        "strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = ?",
+        (delivery_id,),
+    )
+    conn.commit()
+
+    # Second retry: attempt_count should compound.
+    claimed2 = repo.claim_one(worker_id="w")
+    assert claimed2 is not None
+    assert repo.mark_retry(delivery_id, "HTTP 502", backoff_secs=60) is True
+    loaded2 = repo.get(delivery_id)
+    assert loaded2 is not None
+    assert loaded2.attempt_count == 2
+
+
+def test_mark_abandoned_sets_terminal_status(
+    repo: DeliveryRepository, setup_fks: dict[str, int]
+) -> None:
+    delivery_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k",
+    )
+    assert delivery_id is not None
+    assert repo.mark_abandoned(delivery_id, "too many failures") is True
+
+    loaded = repo.get(delivery_id)
+    assert loaded is not None
+    assert loaded.status == "abandoned"
+    assert loaded.last_error == "too many failures"
+
+
+def test_mark_abandoned_returns_false_on_missing(
+    repo: DeliveryRepository,
+) -> None:
+    assert repo.mark_abandoned(9999, "x") is False
+
+
+# ---------------------------------------------------------------------------
+# count_stuck_pending
+# ---------------------------------------------------------------------------
+
+
+def test_count_stuck_pending_counts_old_rows(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    # Row 1: stuck (very old next_attempt_at).
+    stuck_id = repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "stuck-k",
+        next_attempt_at="2000-01-01T00:00:00.000Z",
+    )
+    assert stuck_id is not None
+
+    # Row 2: fresh pending (next_attempt_at in the near future / now).
+    other_event = _seed_event(conn, source_ref="job:99", payload_hash="hash-99")
+    fresh_id = repo.insert(
+        other_event,
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "fresh-k",
+    )
+    assert fresh_id is not None
+
+    # older_than_sec=60 → only the 2000-era row qualifies.
+    assert repo.count_stuck_pending(older_than_sec=60) == 1
+
+
+def test_count_stuck_pending_empty(repo: DeliveryRepository) -> None:
+    assert repo.count_stuck_pending() == 0

--- a/tests/db/repositories/test_endpoints.py
+++ b/tests/db/repositories/test_endpoints.py
@@ -1,0 +1,201 @@
+"""Tests for ``srunx.db.repositories.endpoints``."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.endpoints import EndpointRepository
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    c = open_connection(db)
+    apply_migrations(c)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def test_create_and_get_roundtrip(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    row_id = repo.create(
+        "slack_webhook",
+        "default",
+        {"webhook_url": "https://hooks.slack.com/services/A/B/C"},
+    )
+    conn.commit()
+
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.id == row_id
+    assert got.kind == "slack_webhook"
+    assert got.name == "default"
+    assert got.config == {"webhook_url": "https://hooks.slack.com/services/A/B/C"}
+    assert got.created_at is not None
+    assert got.disabled_at is None
+
+
+def test_get_returns_none_for_missing_row(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    assert repo.get(99999) is None
+
+
+def test_get_by_name_returns_endpoint(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    repo.create("slack_webhook", "default", {"webhook_url": "https://example.com"})
+    conn.commit()
+
+    got = repo.get_by_name("slack_webhook", "default")
+    assert got is not None
+    assert got.name == "default"
+
+    miss = repo.get_by_name("slack_webhook", "nope")
+    assert miss is None
+
+
+def test_create_unique_violation_on_duplicate_kind_name(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = EndpointRepository(conn)
+    repo.create("slack_webhook", "default", {"webhook_url": "https://example.com"})
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.create("slack_webhook", "default", {"webhook_url": "https://other"})
+
+
+def test_list_respects_include_disabled(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    active_id = repo.create("slack_webhook", "active", {"webhook_url": "a"})
+    disabled_id = repo.create("slack_webhook", "old", {"webhook_url": "b"})
+    repo.disable(disabled_id)
+    conn.commit()
+
+    all_rows = repo.list(include_disabled=True)
+    assert {e.id for e in all_rows} == {active_id, disabled_id}
+
+    active_only = repo.list(include_disabled=False)
+    assert [e.id for e in active_only] == [active_id]
+
+
+def test_list_orders_by_created_at(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    first = repo.create("slack_webhook", "first", {"u": "a"})
+    second = repo.create("slack_webhook", "second", {"u": "b"})
+    conn.commit()
+
+    rows = repo.list()
+    ids = [e.id for e in rows]
+    assert ids.index(first) < ids.index(second)
+
+
+def test_update_partial_fields(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    row_id = repo.create("slack_webhook", "name1", {"webhook_url": "a"})
+    conn.commit()
+
+    assert repo.update(row_id, name="name2") is True
+    conn.commit()
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.name == "name2"
+    assert got.config == {"webhook_url": "a"}
+
+    assert repo.update(row_id, config={"webhook_url": "b"}) is True
+    conn.commit()
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.config == {"webhook_url": "b"}
+
+
+def test_update_no_fields_returns_false(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    row_id = repo.create("slack_webhook", "x", {"u": "a"})
+    conn.commit()
+    assert repo.update(row_id) is False
+
+
+def test_update_missing_row_returns_false(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    assert repo.update(999, name="nope") is False
+
+
+def test_disable_and_enable(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    row_id = repo.create("slack_webhook", "x", {"u": "a"})
+    conn.commit()
+
+    assert repo.disable(row_id) is True
+    conn.commit()
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.disabled_at is not None
+
+    assert repo.enable(row_id) is True
+    conn.commit()
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.disabled_at is None
+
+
+def test_disable_missing_row_returns_false(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    assert repo.disable(999) is False
+
+
+def test_enable_missing_row_returns_false(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    assert repo.enable(999) is False
+
+
+def test_delete_removes_row(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    row_id = repo.create("slack_webhook", "x", {"u": "a"})
+    conn.commit()
+
+    assert repo.delete(row_id) is True
+    conn.commit()
+    assert repo.get(row_id) is None
+
+
+def test_delete_missing_row_returns_false(conn: sqlite3.Connection) -> None:
+    repo = EndpointRepository(conn)
+    assert repo.delete(999) is False
+
+
+def test_delete_cascades_to_subscriptions(conn: sqlite3.Connection) -> None:
+    """Endpoint delete must CASCADE-delete related subscriptions."""
+    repo = EndpointRepository(conn)
+    endpoint_id = repo.create("slack_webhook", "x", {"u": "a"})
+
+    # Create a watch + subscription referencing this endpoint via raw SQL
+    # (we intentionally don't import sibling repos here to keep the test
+    # focused on EndpointRepository behavior).
+    conn.execute(
+        "INSERT INTO watches (kind, target_ref, created_at) VALUES (?, ?, ?)",
+        ("job", "job:1", "2026-04-18T00:00:00.000Z"),
+    )
+    watch_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO subscriptions (watch_id, endpoint_id, preset, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (watch_id, endpoint_id, "terminal", "2026-04-18T00:00:00.000Z"),
+    )
+    conn.commit()
+
+    assert repo.delete(endpoint_id) is True
+    conn.commit()
+
+    remaining = conn.execute(
+        "SELECT COUNT(*) FROM subscriptions WHERE endpoint_id = ?",
+        (endpoint_id,),
+    ).fetchone()[0]
+    assert remaining == 0

--- a/tests/db/repositories/test_events.py
+++ b/tests/db/repositories/test_events.py
@@ -1,0 +1,272 @@
+"""Tests for :class:`srunx.db.repositories.events.EventRepository`."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.events import EventRepository
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    connection = open_connection(db)
+    apply_migrations(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def repo(conn: sqlite3.Connection) -> EventRepository:
+    return EventRepository(conn)
+
+
+# ---------------------------------------------------------------------------
+# _compute_payload_hash
+# ---------------------------------------------------------------------------
+
+
+def test_compute_payload_hash_is_deterministic() -> None:
+    h1 = EventRepository._compute_payload_hash(
+        "job.status_changed",
+        "job:12345",
+        {"from_status": "PENDING", "to_status": "RUNNING"},
+    )
+    h2 = EventRepository._compute_payload_hash(
+        "job.status_changed",
+        "job:12345",
+        {"from_status": "PENDING", "to_status": "RUNNING"},
+    )
+    assert h1 == h2
+    # Sanity: SHA-256 hex digest is 64 chars
+    assert len(h1) == 64
+
+
+def test_compute_payload_hash_same_status_stable_across_extra_fields() -> None:
+    """Hash only uses the logical key — extra payload fields don't change it.
+
+    The design chose a logical-key hash (not a full-payload hash) so
+    that the same transition observed twice with slightly different
+    metadata still dedupes.
+    """
+    h1 = EventRepository._compute_payload_hash(
+        "job.status_changed",
+        "job:42",
+        {"to_status": "COMPLETED"},
+    )
+    h2 = EventRepository._compute_payload_hash(
+        "job.status_changed",
+        "job:42",
+        {"to_status": "COMPLETED", "extra": "ignored"},
+    )
+    assert h1 == h2
+
+
+def test_compute_payload_hash_differs_across_kinds() -> None:
+    payload = {"to_status": "COMPLETED"}
+    h_status = EventRepository._compute_payload_hash(
+        "job.status_changed", "job:1", payload
+    )
+    h_submitted = EventRepository._compute_payload_hash(
+        "job.submitted", "job:1", payload
+    )
+    h_workflow = EventRepository._compute_payload_hash(
+        "workflow_run.status_changed", "workflow_run:1", payload
+    )
+    assert h_status != h_submitted
+    assert h_status != h_workflow
+    assert h_submitted != h_workflow
+
+
+def test_compute_payload_hash_differs_across_to_status() -> None:
+    h_running = EventRepository._compute_payload_hash(
+        "job.status_changed", "job:5", {"to_status": "RUNNING"}
+    )
+    h_completed = EventRepository._compute_payload_hash(
+        "job.status_changed", "job:5", {"to_status": "COMPLETED"}
+    )
+    assert h_running != h_completed
+
+
+def test_compute_payload_hash_resource_threshold() -> None:
+    h1 = EventRepository._compute_payload_hash(
+        "resource.threshold_crossed",
+        "resource:gpu",
+        {
+            "partition": "gpu",
+            "threshold_id": "t1",
+            "window_iso": "2026-04-18T00:00:00Z",
+        },
+    )
+    h2 = EventRepository._compute_payload_hash(
+        "resource.threshold_crossed",
+        "resource:gpu",
+        {
+            "partition": "gpu",
+            "threshold_id": "t1",
+            "window_iso": "2026-04-18T00:00:00Z",
+        },
+    )
+    h3 = EventRepository._compute_payload_hash(
+        "resource.threshold_crossed",
+        "resource:gpu",
+        {
+            "partition": "gpu",
+            "threshold_id": "t1",
+            "window_iso": "2026-04-18T00:05:00Z",  # different window
+        },
+    )
+    assert h1 == h2
+    assert h1 != h3
+
+
+def test_compute_payload_hash_scheduled_report() -> None:
+    h1 = EventRepository._compute_payload_hash(
+        "scheduled_report.due",
+        "scheduled_report:99",
+        {
+            "schedule_id": "99",
+            "scheduled_run_at_iso": "2026-04-18T00:00:00Z",
+        },
+    )
+    h2 = EventRepository._compute_payload_hash(
+        "scheduled_report.due",
+        "scheduled_report:99",
+        {
+            "schedule_id": "99",
+            "scheduled_run_at_iso": "2026-04-18T00:00:00Z",
+        },
+    )
+    assert h1 == h2
+
+
+def test_compute_payload_hash_unknown_kind_uses_fallback() -> None:
+    # Two calls with the same dict content must collide; reordering
+    # keys must not matter because json.dumps uses sort_keys=True.
+    h1 = EventRepository._compute_payload_hash("unknown.kind", "x:1", {"a": 1, "b": 2})
+    h2 = EventRepository._compute_payload_hash("unknown.kind", "x:1", {"b": 2, "a": 1})
+    assert h1 == h2
+
+
+# ---------------------------------------------------------------------------
+# insert
+# ---------------------------------------------------------------------------
+
+
+def test_insert_returns_positive_id(repo: EventRepository) -> None:
+    event_id = repo.insert(
+        "job.submitted",
+        "job:1001",
+        {"job_id": 1001},
+    )
+    assert event_id is not None
+    assert event_id > 0
+
+
+def test_insert_round_trips_payload_json(repo: EventRepository) -> None:
+    payload = {"from_status": "PENDING", "to_status": "RUNNING", "extra": [1, 2, 3]}
+    event_id = repo.insert("job.status_changed", "job:7", payload)
+    assert event_id is not None
+
+    loaded = repo.get(event_id)
+    assert loaded is not None
+    assert loaded.payload == payload
+    assert loaded.kind == "job.status_changed"
+    assert loaded.source_ref == "job:7"
+
+
+def test_insert_duplicate_returns_none(repo: EventRepository) -> None:
+    payload = {"to_status": "COMPLETED"}
+    first = repo.insert("job.status_changed", "job:42", payload)
+    second = repo.insert("job.status_changed", "job:42", payload)
+    assert first is not None
+    assert second is None
+
+
+def test_insert_different_to_status_not_duplicate(repo: EventRepository) -> None:
+    first = repo.insert("job.status_changed", "job:42", {"to_status": "RUNNING"})
+    second = repo.insert("job.status_changed", "job:42", {"to_status": "COMPLETED"})
+    assert first is not None
+    assert second is not None
+    assert first != second
+
+
+def test_insert_same_kind_different_source_ref_not_duplicate(
+    repo: EventRepository,
+) -> None:
+    first = repo.insert("job.status_changed", "job:1", {"to_status": "RUNNING"})
+    second = repo.insert("job.status_changed", "job:2", {"to_status": "RUNNING"})
+    assert first is not None
+    assert second is not None
+    assert first != second
+
+
+def test_insert_uses_provided_observed_at(repo: EventRepository) -> None:
+    event_id = repo.insert(
+        "job.submitted",
+        "job:900",
+        {"job_id": 900},
+        observed_at="2026-04-18T12:00:00.000Z",
+    )
+    assert event_id is not None
+    loaded = repo.get(event_id)
+    assert loaded is not None
+    assert loaded.observed_at.year == 2026
+    assert loaded.observed_at.month == 4
+
+
+# ---------------------------------------------------------------------------
+# get / list_recent
+# ---------------------------------------------------------------------------
+
+
+def test_get_missing_returns_none(repo: EventRepository) -> None:
+    assert repo.get(9999) is None
+
+
+def test_list_recent_orders_by_observed_at_desc(repo: EventRepository) -> None:
+    repo.insert(
+        "job.submitted",
+        "job:1",
+        {"job_id": 1},
+        observed_at="2026-04-18T00:00:00.000Z",
+    )
+    repo.insert(
+        "job.submitted",
+        "job:2",
+        {"job_id": 2},
+        observed_at="2026-04-18T00:01:00.000Z",
+    )
+    repo.insert(
+        "job.submitted",
+        "job:3",
+        {"job_id": 3},
+        observed_at="2026-04-18T00:02:00.000Z",
+    )
+
+    recent = repo.list_recent(limit=10)
+    assert [e.source_ref for e in recent] == ["job:3", "job:2", "job:1"]
+
+
+def test_list_recent_respects_limit(repo: EventRepository) -> None:
+    for i in range(5):
+        repo.insert(
+            "job.submitted",
+            f"job:{i}",
+            {"job_id": i},
+        )
+
+    recent = repo.list_recent(limit=2)
+    assert len(recent) == 2
+
+
+def test_list_recent_empty(repo: EventRepository) -> None:
+    assert repo.list_recent() == []

--- a/tests/db/repositories/test_job_state_transitions.py
+++ b/tests/db/repositories/test_job_state_transitions.py
@@ -1,0 +1,142 @@
+"""Tests for :class:`srunx.db.repositories.job_state_transitions.JobStateTransitionRepository`."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.job_state_transitions import (
+    JobStateTransitionRepository,
+)
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    connection = open_connection(db)
+    apply_migrations(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def repo(conn: sqlite3.Connection) -> JobStateTransitionRepository:
+    return JobStateTransitionRepository(conn)
+
+
+def _seed_job(conn: sqlite3.Connection, job_id: int) -> None:
+    """Insert a minimal jobs row so the FK on ``job_state_transitions.job_id`` holds."""
+    conn.execute(
+        "INSERT INTO jobs (job_id, name, status, submitted_at, submission_source) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (job_id, f"job_{job_id}", "PENDING", "2026-04-18T00:00:00Z", "cli"),
+    )
+    conn.commit()
+
+
+def test_insert_returns_positive_id(
+    conn: sqlite3.Connection, repo: JobStateTransitionRepository
+) -> None:
+    _seed_job(conn, 1)
+    row_id = repo.insert(1, None, "PENDING", "poller")
+    assert row_id > 0
+
+
+def test_insert_default_observed_at_is_parseable(
+    conn: sqlite3.Connection, repo: JobStateTransitionRepository
+) -> None:
+    _seed_job(conn, 1)
+    repo.insert(1, None, "PENDING", "poller")
+    latest = repo.latest_for_job(1)
+    assert latest is not None
+    assert isinstance(latest.observed_at, datetime)
+
+
+def test_insert_with_explicit_observed_at(
+    conn: sqlite3.Connection, repo: JobStateTransitionRepository
+) -> None:
+    _seed_job(conn, 1)
+    repo.insert(
+        1, "PENDING", "RUNNING", "cli_monitor", observed_at="2026-04-18T01:02:03.000Z"
+    )
+    latest = repo.latest_for_job(1)
+    assert latest is not None
+    assert latest.from_status == "PENDING"
+    assert latest.to_status == "RUNNING"
+    assert latest.source == "cli_monitor"
+    assert isinstance(latest.observed_at, datetime)
+    assert latest.observed_at.year == 2026
+    assert latest.observed_at.hour == 1
+
+
+def test_latest_for_job_missing_returns_none(
+    repo: JobStateTransitionRepository,
+) -> None:
+    assert repo.latest_for_job(9999) is None
+
+
+def test_latest_for_job_picks_most_recent(
+    conn: sqlite3.Connection, repo: JobStateTransitionRepository
+) -> None:
+    _seed_job(conn, 1)
+    repo.insert(1, None, "PENDING", "poller", observed_at="2026-04-18T00:00:00Z")
+    repo.insert(1, "PENDING", "RUNNING", "poller", observed_at="2026-04-18T00:05:00Z")
+    repo.insert(1, "RUNNING", "COMPLETED", "poller", observed_at="2026-04-18T00:10:00Z")
+    latest = repo.latest_for_job(1)
+    assert latest is not None
+    assert latest.to_status == "COMPLETED"
+
+
+def test_history_for_job_empty(repo: JobStateTransitionRepository) -> None:
+    assert repo.history_for_job(9999) == []
+
+
+def test_history_for_job_is_chronological(
+    conn: sqlite3.Connection, repo: JobStateTransitionRepository
+) -> None:
+    _seed_job(conn, 1)
+    # Insert out of chronological order — repo must still return ASC by observed_at.
+    repo.insert(1, "RUNNING", "COMPLETED", "poller", observed_at="2026-04-18T00:10:00Z")
+    repo.insert(1, None, "PENDING", "poller", observed_at="2026-04-18T00:00:00Z")
+    repo.insert(1, "PENDING", "RUNNING", "poller", observed_at="2026-04-18T00:05:00Z")
+
+    history = repo.history_for_job(1)
+    assert [t.to_status for t in history] == ["PENDING", "RUNNING", "COMPLETED"]
+    # Ensure datetime conversion happened for every row.
+    assert all(isinstance(t.observed_at, datetime) for t in history)
+
+
+def test_history_scoped_by_job(
+    conn: sqlite3.Connection, repo: JobStateTransitionRepository
+) -> None:
+    _seed_job(conn, 1)
+    _seed_job(conn, 2)
+    repo.insert(1, None, "PENDING", "poller")
+    repo.insert(2, None, "RUNNING", "webhook")
+    assert [t.to_status for t in repo.history_for_job(1)] == ["PENDING"]
+    assert [t.to_status for t in repo.history_for_job(2)] == ["RUNNING"]
+
+
+def test_job_delete_sets_job_id_null(
+    conn: sqlite3.Connection, repo: JobStateTransitionRepository
+) -> None:
+    _seed_job(conn, 1)
+    repo.insert(1, None, "PENDING", "poller")
+    # FK is ON DELETE SET NULL; transition row survives but job_id goes NULL.
+    conn.execute("DELETE FROM jobs WHERE job_id = 1")
+    conn.commit()
+
+    assert repo.latest_for_job(1) is None
+    orphan = conn.execute(
+        "SELECT job_id, to_status FROM job_state_transitions"
+    ).fetchone()
+    assert orphan["job_id"] is None
+    assert orphan["to_status"] == "PENDING"

--- a/tests/db/repositories/test_jobs.py
+++ b/tests/db/repositories/test_jobs.py
@@ -1,0 +1,219 @@
+"""Tests for :class:`srunx.db.repositories.jobs.JobRepository`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.jobs import JobRepository
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> JobRepository:
+    conn = open_connection(tmp_path / "t.db")
+    apply_migrations(conn)
+    return JobRepository(conn)
+
+
+def test_record_submission_roundtrip(repo: JobRepository) -> None:
+    row_id = repo.record_submission(
+        job_id=101,
+        name="train",
+        status="PENDING",
+        submission_source="cli",
+        command=["python", "train.py"],
+        nodes=2,
+        gpus_per_node=4,
+        memory_per_node="64GB",
+        time_limit="2:00:00",
+        partition="gpu",
+        conda="ml",
+        env_vars={"CUDA_VISIBLE_DEVICES": "0,1"},
+        metadata={"run_id": "abc"},
+    )
+    assert row_id > 0
+
+    job = repo.get(101)
+    assert job is not None
+    assert job.job_id == 101
+    assert job.name == "train"
+    assert job.status == "PENDING"
+    assert job.submission_source == "cli"
+    assert job.command == ["python", "train.py"]
+    assert job.nodes == 2
+    assert job.gpus_per_node == 4
+    assert job.env_vars == {"CUDA_VISIBLE_DEVICES": "0,1"}
+    assert job.metadata == {"run_id": "abc"}
+
+
+def test_record_submission_is_idempotent_on_same_job_id(
+    repo: JobRepository,
+) -> None:
+    repo.record_submission(
+        job_id=202, name="first", status="PENDING", submission_source="web"
+    )
+    # Re-submission replaces the record via INSERT OR REPLACE.
+    repo.record_submission(
+        job_id=202, name="second", status="PENDING", submission_source="web"
+    )
+    job = repo.get(202)
+    assert job is not None
+    assert job.name == "second"
+
+
+def test_update_status_fills_optional_fields(repo: JobRepository) -> None:
+    repo.record_submission(
+        job_id=303, name="j", status="PENDING", submission_source="web"
+    )
+    updated = repo.update_status(
+        303,
+        "RUNNING",
+        started_at="2026-04-19T01:00:00.000Z",
+        nodelist="node01",
+    )
+    assert updated is True
+    job = repo.get(303)
+    assert job is not None
+    assert job.status == "RUNNING"
+    assert job.nodelist == "node01"
+    assert job.started_at is not None
+
+
+def test_update_status_returns_false_for_missing(repo: JobRepository) -> None:
+    assert repo.update_status(99999, "RUNNING") is False
+
+
+def test_update_completion_computes_duration(repo: JobRepository) -> None:
+    repo.record_submission(
+        job_id=404,
+        name="t",
+        status="PENDING",
+        submission_source="cli",
+        submitted_at="2026-04-19T10:00:00.000Z",
+    )
+    ok = repo.update_completion(
+        404, "COMPLETED", completed_at="2026-04-19T11:00:00.000Z"
+    )
+    assert ok is True
+    job = repo.get(404)
+    assert job is not None
+    assert job.status == "COMPLETED"
+    assert job.duration_secs == 3600
+
+
+def test_update_completion_defaults_completed_at_to_now(
+    repo: JobRepository,
+) -> None:
+    repo.record_submission(
+        job_id=405, name="t", status="PENDING", submission_source="cli"
+    )
+    assert repo.update_completion(405, "COMPLETED") is True
+    job = repo.get(405)
+    assert job is not None and job.completed_at is not None
+
+
+def test_list_all_orders_and_filters(repo: JobRepository) -> None:
+    # Seed a workflow_run so the FK on jobs.workflow_run_id can point to it.
+    repo.conn.execute(
+        "INSERT INTO workflow_runs (id, workflow_name, status, started_at, triggered_by) "
+        "VALUES (42, 'wf', 'running', '2026-04-19T00:00:00.000Z', 'cli')"
+    )
+    for jid in (501, 502, 503):
+        repo.record_submission(
+            job_id=jid,
+            name=f"j{jid}",
+            status="PENDING",
+            submission_source="cli",
+            submitted_at=f"2026-04-19T0{jid - 500}:00:00.000Z",
+        )
+    repo.record_submission(
+        job_id=504,
+        name="w",
+        status="PENDING",
+        submission_source="workflow",
+        workflow_run_id=42,
+        submitted_at="2026-04-19T04:00:00.000Z",
+    )
+
+    all_rows = repo.list_all(limit=10)
+    ids = [j.job_id for j in all_rows]
+    assert ids == [504, 503, 502, 501]
+
+    wf_rows = repo.list_all(workflow_run_id=42)
+    assert [j.job_id for j in wf_rows] == [504]
+
+
+def test_list_all_respects_limit_and_offset(repo: JobRepository) -> None:
+    for jid in range(601, 606):
+        repo.record_submission(
+            job_id=jid,
+            name=f"j{jid}",
+            status="PENDING",
+            submission_source="cli",
+            submitted_at=f"2026-04-19T{jid - 601:02d}:00:00.000Z",
+        )
+    page1 = repo.list_all(limit=2)
+    page2 = repo.list_all(limit=2, offset=2)
+    assert {j.job_id for j in page1} != {j.job_id for j in page2}
+    assert len(page1) == 2 and len(page2) == 2
+
+
+def test_count_by_status_in_range(repo: JobRepository) -> None:
+    for jid, status in [(701, "COMPLETED"), (702, "COMPLETED"), (703, "FAILED")]:
+        repo.record_submission(
+            job_id=jid,
+            name=f"j{jid}",
+            status=status,
+            submission_source="cli",
+            submitted_at="2026-04-19T12:00:00.000Z",
+        )
+    repo.record_submission(
+        job_id=704,
+        name="j704",
+        status="COMPLETED",
+        submission_source="cli",
+        submitted_at="2025-12-31T12:00:00.000Z",
+    )
+
+    counts = repo.count_by_status_in_range(
+        "2026-04-19T00:00:00Z", "2026-04-20T00:00:00Z"
+    )
+    assert counts == {"COMPLETED": 2, "FAILED": 1}
+
+
+def test_count_by_status_in_range_filters_statuses(repo: JobRepository) -> None:
+    repo.record_submission(
+        job_id=801,
+        name="a",
+        status="COMPLETED",
+        submission_source="cli",
+        submitted_at="2026-04-19T00:00:00Z",
+    )
+    repo.record_submission(
+        job_id=802,
+        name="b",
+        status="FAILED",
+        submission_source="cli",
+        submitted_at="2026-04-19T00:00:00Z",
+    )
+    counts = repo.count_by_status_in_range(
+        "2026-04-19T00:00:00Z",
+        "2026-04-20T00:00:00Z",
+        statuses=["COMPLETED"],
+    )
+    assert counts == {"COMPLETED": 1}
+
+
+def test_delete_existing_returns_true(repo: JobRepository) -> None:
+    repo.record_submission(
+        job_id=901, name="t", status="PENDING", submission_source="cli"
+    )
+    assert repo.delete(901) is True
+    assert repo.get(901) is None
+
+
+def test_delete_missing_returns_false(repo: JobRepository) -> None:
+    assert repo.delete(99999) is False

--- a/tests/db/repositories/test_resource_snapshots.py
+++ b/tests/db/repositories/test_resource_snapshots.py
@@ -1,0 +1,201 @@
+"""Tests for ``srunx.db.repositories.resource_snapshots``."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.models import ResourceSnapshot
+from srunx.db.repositories.resource_snapshots import ResourceSnapshotRepository
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    c = open_connection(db)
+    apply_migrations(c)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _make_snapshot(
+    observed_at: datetime,
+    *,
+    partition: str | None = None,
+    gpus_total: int = 8,
+    gpus_available: int = 2,
+    gpus_in_use: int = 6,
+    nodes_total: int = 2,
+    nodes_idle: int = 0,
+    nodes_down: int = 0,
+) -> ResourceSnapshot:
+    return ResourceSnapshot(
+        observed_at=observed_at,
+        partition=partition,
+        gpus_total=gpus_total,
+        gpus_available=gpus_available,
+        gpus_in_use=gpus_in_use,
+        nodes_total=nodes_total,
+        nodes_idle=nodes_idle,
+        nodes_down=nodes_down,
+    )
+
+
+def test_insert_assigns_rowid_and_computes_utilization(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = ResourceSnapshotRepository(conn)
+    snap = _make_snapshot(datetime(2026, 4, 18, 12, 0, tzinfo=UTC))
+
+    row_id = repo.insert(snap)
+    conn.commit()
+
+    assert row_id > 0
+    row = conn.execute(
+        "SELECT gpus_total, gpu_utilization FROM resource_snapshots WHERE id = ?",
+        (row_id,),
+    ).fetchone()
+    assert row["gpus_total"] == 8
+    assert row["gpu_utilization"] == pytest.approx(0.75)
+
+
+def test_insert_zero_total_yields_null_utilization(conn: sqlite3.Connection) -> None:
+    repo = ResourceSnapshotRepository(conn)
+    snap = _make_snapshot(
+        datetime(2026, 4, 18, 12, 0, tzinfo=UTC),
+        gpus_total=0,
+        gpus_available=0,
+        gpus_in_use=0,
+        nodes_total=1,
+        nodes_idle=1,
+    )
+    row_id = repo.insert(snap)
+    conn.commit()
+
+    row = conn.execute(
+        "SELECT gpus_total, gpu_utilization FROM resource_snapshots WHERE id = ?",
+        (row_id,),
+    ).fetchone()
+    assert row["gpus_total"] == 0
+    assert row["gpu_utilization"] is None
+
+
+def test_insert_serializes_datetime_to_canonical_iso(conn: sqlite3.Connection) -> None:
+    repo = ResourceSnapshotRepository(conn)
+    snap = _make_snapshot(datetime(2026, 4, 18, 12, 0, 0, 123000, tzinfo=UTC))
+    row_id = repo.insert(snap)
+    conn.commit()
+
+    raw = conn.execute(
+        "SELECT observed_at FROM resource_snapshots WHERE id = ?", (row_id,)
+    ).fetchone()
+    assert raw["observed_at"].endswith("Z")
+    assert "2026-04-18T12:00:00" in raw["observed_at"]
+
+
+def test_list_range_filters_by_partition_none_means_cluster_wide(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = ResourceSnapshotRepository(conn)
+    # 3 snapshots in range: 2 cluster-wide (NULL), 1 on partition 'gpu'
+    repo.insert(
+        _make_snapshot(datetime(2026, 4, 18, 10, 0, tzinfo=UTC), partition=None)
+    )
+    repo.insert(
+        _make_snapshot(datetime(2026, 4, 18, 11, 0, tzinfo=UTC), partition=None)
+    )
+    repo.insert(
+        _make_snapshot(datetime(2026, 4, 18, 11, 30, tzinfo=UTC), partition="gpu")
+    )
+    # 1 outside range
+    repo.insert(
+        _make_snapshot(datetime(2026, 4, 18, 15, 0, tzinfo=UTC), partition=None)
+    )
+    conn.commit()
+
+    cluster = repo.list_range(
+        "2026-04-18T09:00:00.000Z",
+        "2026-04-18T12:00:00.000Z",
+        partition=None,
+    )
+    assert len(cluster) == 2
+    assert all(s.partition is None for s in cluster)
+
+    gpu = repo.list_range(
+        "2026-04-18T09:00:00.000Z",
+        "2026-04-18T12:00:00.000Z",
+        partition="gpu",
+    )
+    assert len(gpu) == 1
+    assert gpu[0].partition == "gpu"
+
+
+def test_list_range_orders_ascending(conn: sqlite3.Connection) -> None:
+    repo = ResourceSnapshotRepository(conn)
+    for h in (11, 9, 10):
+        repo.insert(_make_snapshot(datetime(2026, 4, 18, h, 0, tzinfo=UTC)))
+    conn.commit()
+
+    results = repo.list_range(
+        "2026-04-18T00:00:00.000Z", "2026-04-18T23:59:00.000Z", partition=None
+    )
+    hours = [s.observed_at.hour for s in results if s.observed_at is not None]
+    assert hours == sorted(hours)
+
+
+def test_list_range_empty_when_no_matches(conn: sqlite3.Connection) -> None:
+    repo = ResourceSnapshotRepository(conn)
+    assert (
+        repo.list_range(
+            "2026-04-18T00:00:00.000Z",
+            "2026-04-18T01:00:00.000Z",
+        )
+        == []
+    )
+
+
+def test_delete_older_than_removes_old_rows(conn: sqlite3.Connection) -> None:
+    # Insert one clearly old row (raw SQL, past timestamp) and one current one.
+    conn.execute(
+        """
+        INSERT INTO resource_snapshots
+            (observed_at, partition, gpus_total, gpus_available, gpus_in_use,
+             nodes_total, nodes_idle, nodes_down)
+        VALUES (?, NULL, 8, 2, 6, 2, 0, 0)
+        """,
+        ("2020-01-01T00:00:00.000Z",),
+    )
+    conn.execute(
+        """
+        INSERT INTO resource_snapshots
+            (observed_at, partition, gpus_total, gpus_available, gpus_in_use,
+             nodes_total, nodes_idle, nodes_down)
+        VALUES (strftime('%Y-%m-%dT%H:%M:%fZ','now'), NULL, 8, 2, 6, 2, 0, 0)
+        """,
+    )
+    conn.commit()
+
+    repo = ResourceSnapshotRepository(conn)
+    deleted = repo.delete_older_than(30)
+    conn.commit()
+    assert deleted == 1
+
+    remaining = conn.execute("SELECT COUNT(*) FROM resource_snapshots").fetchone()[0]
+    assert remaining == 1
+
+
+def test_delete_older_than_zero_matches_returns_zero(conn: sqlite3.Connection) -> None:
+    repo = ResourceSnapshotRepository(conn)
+    repo.insert(_make_snapshot(datetime.now(UTC)))
+    conn.commit()
+
+    # Very generous window — nothing should be deleted.
+    assert repo.delete_older_than(3650) == 0

--- a/tests/db/repositories/test_subscriptions.py
+++ b/tests/db/repositories/test_subscriptions.py
@@ -1,0 +1,162 @@
+"""Tests for ``srunx.db.repositories.subscriptions``."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.subscriptions import SubscriptionRepository
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    c = open_connection(db)
+    apply_migrations(c)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _seed_endpoint(conn: sqlite3.Connection, name: str = "ep") -> int:
+    conn.execute(
+        "INSERT INTO endpoints (kind, name, config, created_at) VALUES (?, ?, ?, ?)",
+        ("slack_webhook", name, "{}", "2026-04-18T00:00:00.000Z"),
+    )
+    row = conn.execute("SELECT last_insert_rowid()").fetchone()
+    return int(row[0])
+
+
+def _seed_watch(conn: sqlite3.Connection, target_ref: str = "job:1") -> int:
+    conn.execute(
+        "INSERT INTO watches (kind, target_ref, created_at) VALUES (?, ?, ?)",
+        ("job", target_ref, "2026-04-18T00:00:00.000Z"),
+    )
+    row = conn.execute("SELECT last_insert_rowid()").fetchone()
+    return int(row[0])
+
+
+def test_create_and_get_roundtrip(conn: sqlite3.Connection) -> None:
+    endpoint_id = _seed_endpoint(conn)
+    watch_id = _seed_watch(conn)
+    conn.commit()
+
+    repo = SubscriptionRepository(conn)
+    sub_id = repo.create(watch_id, endpoint_id, "terminal")
+    conn.commit()
+
+    got = repo.get(sub_id)
+    assert got is not None
+    assert got.watch_id == watch_id
+    assert got.endpoint_id == endpoint_id
+    assert got.preset == "terminal"
+    assert got.created_at is not None
+
+
+def test_get_returns_none_for_missing_row(conn: sqlite3.Connection) -> None:
+    repo = SubscriptionRepository(conn)
+    assert repo.get(999) is None
+
+
+def test_create_rejects_invalid_preset(conn: sqlite3.Connection) -> None:
+    endpoint_id = _seed_endpoint(conn)
+    watch_id = _seed_watch(conn)
+    conn.commit()
+
+    repo = SubscriptionRepository(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.create(watch_id, endpoint_id, "bogus")
+
+
+def test_create_rejects_duplicate_watch_endpoint_pair(
+    conn: sqlite3.Connection,
+) -> None:
+    endpoint_id = _seed_endpoint(conn)
+    watch_id = _seed_watch(conn)
+    conn.commit()
+
+    repo = SubscriptionRepository(conn)
+    repo.create(watch_id, endpoint_id, "terminal")
+    conn.commit()
+
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.create(watch_id, endpoint_id, "all")
+
+
+def test_create_fails_on_unknown_watch_id_fk(conn: sqlite3.Connection) -> None:
+    endpoint_id = _seed_endpoint(conn)
+    conn.commit()
+
+    repo = SubscriptionRepository(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.create(9999, endpoint_id, "terminal")
+        conn.commit()
+
+
+def test_list_by_watch_returns_only_matching(conn: sqlite3.Connection) -> None:
+    e1 = _seed_endpoint(conn, name="a")
+    e2 = _seed_endpoint(conn, name="b")
+    w1 = _seed_watch(conn, target_ref="job:1")
+    w2 = _seed_watch(conn, target_ref="job:2")
+    conn.commit()
+
+    repo = SubscriptionRepository(conn)
+    s1 = repo.create(w1, e1, "terminal")
+    s2 = repo.create(w1, e2, "all")
+    other = repo.create(w2, e1, "terminal")
+    conn.commit()
+
+    rows = repo.list_by_watch(w1)
+    ids = {s.id for s in rows}
+    assert ids == {s1, s2}
+    assert other not in ids
+
+
+def test_list_by_endpoint_returns_only_matching(conn: sqlite3.Connection) -> None:
+    e1 = _seed_endpoint(conn, name="a")
+    e2 = _seed_endpoint(conn, name="b")
+    w1 = _seed_watch(conn, target_ref="job:1")
+    w2 = _seed_watch(conn, target_ref="job:2")
+    conn.commit()
+
+    repo = SubscriptionRepository(conn)
+    s1 = repo.create(w1, e1, "terminal")
+    s2 = repo.create(w2, e1, "all")
+    other = repo.create(w1, e2, "terminal")
+    conn.commit()
+
+    rows = repo.list_by_endpoint(e1)
+    ids = {s.id for s in rows}
+    assert ids == {s1, s2}
+    assert other not in ids
+
+
+def test_list_empty_for_unknown_parent(conn: sqlite3.Connection) -> None:
+    repo = SubscriptionRepository(conn)
+    assert repo.list_by_watch(9999) == []
+    assert repo.list_by_endpoint(9999) == []
+
+
+def test_delete_removes_row(conn: sqlite3.Connection) -> None:
+    endpoint_id = _seed_endpoint(conn)
+    watch_id = _seed_watch(conn)
+    conn.commit()
+
+    repo = SubscriptionRepository(conn)
+    sub_id = repo.create(watch_id, endpoint_id, "terminal")
+    conn.commit()
+
+    assert repo.delete(sub_id) is True
+    conn.commit()
+    assert repo.get(sub_id) is None
+
+
+def test_delete_missing_row_returns_false(conn: sqlite3.Connection) -> None:
+    repo = SubscriptionRepository(conn)
+    assert repo.delete(999) is False

--- a/tests/db/repositories/test_watches.py
+++ b/tests/db/repositories/test_watches.py
@@ -1,0 +1,170 @@
+"""Tests for ``srunx.db.repositories.watches``."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.watches import WatchRepository
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    c = open_connection(db)
+    apply_migrations(c)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def test_create_and_get_roundtrip_with_filter(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    row_id = repo.create("job", "job:42", filter={"min_duration": 60})
+    conn.commit()
+
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.kind == "job"
+    assert got.target_ref == "job:42"
+    assert got.filter == {"min_duration": 60}
+    assert got.created_at is not None
+    assert got.closed_at is None
+
+
+def test_create_without_filter(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    row_id = repo.create("workflow_run", "workflow_run:1")
+    conn.commit()
+
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.filter is None
+
+
+def test_get_returns_none_for_missing_row(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    assert repo.get(999) is None
+
+
+def test_create_rejects_invalid_kind_via_check_constraint(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = WatchRepository(conn)
+    with pytest.raises(sqlite3.IntegrityError):
+        repo.create("bogus_kind", "job:1")
+
+
+def test_list_open_returns_only_open_watches(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    open1 = repo.create("job", "job:1")
+    to_close = repo.create("job", "job:2")
+    open2 = repo.create("workflow_run", "workflow_run:1")
+    repo.close(to_close)
+    conn.commit()
+
+    rows = repo.list_open()
+    ids = [w.id for w in rows]
+    assert open1 in ids
+    assert open2 in ids
+    assert to_close not in ids
+
+
+def test_list_open_ordered_ascending_by_created_at(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    first = repo.create("job", "job:1")
+    second = repo.create("job", "job:2")
+    third = repo.create("job", "job:3")
+    conn.commit()
+
+    rows = repo.list_open()
+    assert [w.id for w in rows] == [first, second, third]
+
+
+def test_list_by_target_only_open_by_default(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    open_id = repo.create("job", "job:7")
+    closed_id = repo.create("job", "job:7")
+    repo.close(closed_id)
+    other = repo.create("job", "job:8")
+    conn.commit()
+
+    rows = repo.list_by_target("job", "job:7")
+    ids = [w.id for w in rows]
+    assert ids == [open_id]
+
+    # Sanity: other target_ref not returned
+    assert all(w.id != other for w in rows)
+
+
+def test_list_by_target_includes_closed_when_requested(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = WatchRepository(conn)
+    open_id = repo.create("job", "job:7")
+    closed_id = repo.create("job", "job:7")
+    repo.close(closed_id)
+    conn.commit()
+
+    rows = repo.list_by_target("job", "job:7", only_open=False)
+    assert {w.id for w in rows} == {open_id, closed_id}
+
+
+def test_close_sets_closed_at(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    row_id = repo.create("job", "job:1")
+    conn.commit()
+    assert repo.close(row_id) is True
+    conn.commit()
+
+    got = repo.get(row_id)
+    assert got is not None
+    assert got.closed_at is not None
+
+
+def test_close_missing_row_returns_false(conn: sqlite3.Connection) -> None:
+    repo = WatchRepository(conn)
+    assert repo.close(9999) is False
+
+
+def test_close_does_not_delete_watch_or_subscriptions(
+    conn: sqlite3.Connection,
+) -> None:
+    """Closing a watch must leave the row and its subscriptions intact.
+
+    Watches are lifecycle-managed via ``closed_at``; CASCADE-deletion only
+    fires on explicit DELETE of the watch row.
+    """
+    repo = WatchRepository(conn)
+    watch_id = repo.create("job", "job:1")
+
+    # Seed an endpoint + subscription via raw SQL
+    conn.execute(
+        "INSERT INTO endpoints (kind, name, config, created_at) VALUES (?, ?, ?, ?)",
+        ("slack_webhook", "ep", "{}", "2026-04-18T00:00:00.000Z"),
+    )
+    endpoint_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO subscriptions (watch_id, endpoint_id, preset, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        (watch_id, endpoint_id, "terminal", "2026-04-18T00:00:00.000Z"),
+    )
+    conn.commit()
+
+    assert repo.close(watch_id) is True
+    conn.commit()
+
+    # Watch row still present
+    assert repo.get(watch_id) is not None
+    # Subscription still present
+    sub_count = conn.execute(
+        "SELECT COUNT(*) FROM subscriptions WHERE watch_id = ?",
+        (watch_id,),
+    ).fetchone()[0]
+    assert sub_count == 1

--- a/tests/db/repositories/test_workflow_run_jobs.py
+++ b/tests/db/repositories/test_workflow_run_jobs.py
@@ -1,0 +1,119 @@
+"""Tests for :class:`srunx.db.repositories.workflow_run_jobs.WorkflowRunJobRepository`."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.workflow_run_jobs import WorkflowRunJobRepository
+from srunx.db.repositories.workflow_runs import WorkflowRunRepository
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    connection = open_connection(db)
+    apply_migrations(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def run_id(conn: sqlite3.Connection) -> int:
+    return WorkflowRunRepository(conn).create("wf", None, None, "cli")
+
+
+@pytest.fixture
+def repo(conn: sqlite3.Connection) -> WorkflowRunJobRepository:
+    return WorkflowRunJobRepository(conn)
+
+
+def test_create_minimal_returns_positive_id(
+    repo: WorkflowRunJobRepository, run_id: int
+) -> None:
+    row_id = repo.create(run_id, "train")
+    assert row_id > 0
+
+
+def test_create_persists_fields(repo: WorkflowRunJobRepository, run_id: int) -> None:
+    row_id = repo.create(run_id, "train", depends_on=["preprocess"], job_id=None)
+    rows = repo.list_by_run(run_id)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == row_id
+    assert row.workflow_run_id == run_id
+    assert row.job_name == "train"
+    assert row.depends_on == ["preprocess"]
+    assert row.job_id is None
+
+
+def test_update_job_id_associates_slurm_id(
+    conn: sqlite3.Connection,
+    repo: WorkflowRunJobRepository,
+    run_id: int,
+) -> None:
+    # FK: workflow_run_jobs.job_id references jobs(job_id). Insert a matching row.
+    conn.execute(
+        "INSERT INTO jobs (job_id, name, status, submitted_at, submission_source) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (101, "train", "PENDING", "2026-04-18T00:00:00Z", "workflow"),
+    )
+    conn.commit()
+
+    row_id = repo.create(run_id, "train")
+    assert repo.update_job_id(row_id, 101) is True
+
+    rows = repo.list_by_run(run_id)
+    assert rows[0].job_id == 101
+
+
+def test_update_job_id_returns_false_on_missing(
+    repo: WorkflowRunJobRepository,
+) -> None:
+    assert repo.update_job_id(9999, 1) is False
+
+
+def test_list_by_run_empty(repo: WorkflowRunJobRepository, run_id: int) -> None:
+    assert repo.list_by_run(run_id) == []
+
+
+def test_list_by_run_orders_by_insertion(
+    repo: WorkflowRunJobRepository, run_id: int
+) -> None:
+    a = repo.create(run_id, "a")
+    b = repo.create(run_id, "b", depends_on=["a"])
+    c = repo.create(run_id, "c", depends_on=["b"])
+
+    rows = repo.list_by_run(run_id)
+    assert [r.id for r in rows] == [a, b, c]
+    assert [r.job_name for r in rows] == ["a", "b", "c"]
+
+
+def test_list_by_run_is_run_scoped(
+    conn: sqlite3.Connection, repo: WorkflowRunJobRepository, run_id: int
+) -> None:
+    other_run = WorkflowRunRepository(conn).create("other", None, None, "cli")
+    repo.create(run_id, "job_a")
+    repo.create(other_run, "job_b")
+    assert [r.job_name for r in repo.list_by_run(run_id)] == ["job_a"]
+    assert [r.job_name for r in repo.list_by_run(other_run)] == ["job_b"]
+
+
+def test_cascade_delete_on_workflow_run(
+    conn: sqlite3.Connection, repo: WorkflowRunJobRepository, run_id: int
+) -> None:
+    repo.create(run_id, "a")
+    repo.create(run_id, "b")
+    assert len(repo.list_by_run(run_id)) == 2
+
+    conn.execute("DELETE FROM workflow_runs WHERE id = ?", (run_id,))
+    conn.commit()
+
+    assert repo.list_by_run(run_id) == []

--- a/tests/db/repositories/test_workflow_runs.py
+++ b/tests/db/repositories/test_workflow_runs.py
@@ -1,0 +1,122 @@
+"""Tests for :class:`srunx.db.repositories.workflow_runs.WorkflowRunRepository`."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+from srunx.db.repositories.workflow_runs import WorkflowRunRepository
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db = tmp_path / "srunx.db"
+    connection = open_connection(db)
+    apply_migrations(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def repo(conn: sqlite3.Connection) -> WorkflowRunRepository:
+    return WorkflowRunRepository(conn)
+
+
+def test_create_returns_positive_id(repo: WorkflowRunRepository) -> None:
+    run_id = repo.create("ml_pipeline", "/tmp/wf.yaml", {"model": "resnet"}, "cli")
+    assert run_id > 0
+
+
+def test_create_sets_pending_status(repo: WorkflowRunRepository) -> None:
+    run_id = repo.create("wf", None, None, "web")
+    run = repo.get(run_id)
+    assert run is not None
+    assert run.status == "pending"
+    assert run.workflow_name == "wf"
+    assert run.workflow_yaml_path is None
+    assert run.args is None
+    assert run.triggered_by == "web"
+    assert isinstance(run.started_at, datetime)
+    assert run.completed_at is None
+
+
+def test_create_serializes_args_dict(repo: WorkflowRunRepository) -> None:
+    run_id = repo.create("wf", None, {"x": 1, "y": "z"}, "cli")
+    run = repo.get(run_id)
+    assert run is not None
+    assert run.args == {"x": 1, "y": "z"}
+
+
+def test_get_missing_returns_none(repo: WorkflowRunRepository) -> None:
+    assert repo.get(9999) is None
+
+
+def test_list_orders_by_started_at_desc(repo: WorkflowRunRepository) -> None:
+    first = repo.create("a", None, None, "cli")
+    second = repo.create("b", None, None, "cli")
+    third = repo.create("c", None, None, "cli")
+
+    runs = repo.list_all()
+    assert [r.id for r in runs] == [third, second, first]
+
+
+def test_list_empty(repo: WorkflowRunRepository) -> None:
+    assert repo.list_all() == []
+
+
+def test_list_incomplete_filters_by_status(repo: WorkflowRunRepository) -> None:
+    a = repo.create("a", None, None, "cli")  # pending
+    b = repo.create("b", None, None, "cli")  # will go running
+    c = repo.create("c", None, None, "cli")  # will go completed
+    d = repo.create("d", None, None, "cli")  # will go failed
+
+    repo.update_status(b, "running")
+    repo.update_status(c, "completed", completed_at="2026-04-18T00:00:00Z")
+    repo.update_status(d, "failed", error="boom")
+
+    incomplete_ids = {r.id for r in repo.list_incomplete()}
+    assert incomplete_ids == {a, b}
+
+
+def test_update_status_returns_true_on_match(repo: WorkflowRunRepository) -> None:
+    run_id = repo.create("wf", None, None, "cli")
+    assert repo.update_status(run_id, "running") is True
+
+
+def test_update_status_returns_false_on_missing(
+    repo: WorkflowRunRepository,
+) -> None:
+    assert repo.update_status(9999, "running") is False
+
+
+def test_update_status_sets_error_and_completed_at(
+    repo: WorkflowRunRepository,
+) -> None:
+    run_id = repo.create("wf", None, None, "cli")
+    completed = "2026-04-18T12:34:56.000Z"
+    repo.update_status(run_id, "failed", error="kaboom", completed_at=completed)
+
+    run = repo.get(run_id)
+    assert run is not None
+    assert run.status == "failed"
+    assert run.error == "kaboom"
+    assert isinstance(run.completed_at, datetime)
+    assert run.completed_at.year == 2026
+
+
+def test_update_status_only_status(repo: WorkflowRunRepository) -> None:
+    run_id = repo.create("wf", None, None, "cli")
+    repo.update_status(run_id, "running")
+    run = repo.get(run_id)
+    assert run is not None
+    assert run.status == "running"
+    assert run.error is None
+    assert run.completed_at is None

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -1,0 +1,173 @@
+"""Tests for ``srunx.db.connection``."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from srunx.db import connection as conn_mod
+from srunx.db.connection import (
+    get_config_dir,
+    get_db_path,
+    init_db,
+    open_connection,
+    transaction,
+)
+
+# ---- Path resolution ----
+
+
+def test_get_config_dir_uses_xdg_when_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert get_config_dir() == tmp_path / "srunx"
+
+
+def test_get_config_dir_falls_back_without_xdg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    got = get_config_dir()
+    # Don't assert exact path (platform-dependent); just assert it ends with
+    # 'srunx' and includes the user's home.
+    assert got.name == "srunx"
+    assert str(Path.home()) in str(got)
+
+
+def test_get_db_path_is_under_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert get_db_path() == tmp_path / "srunx" / "srunx.db"
+
+
+# ---- open_connection ----
+
+
+def test_open_connection_applies_pragmas(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
+        journal = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        busy = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert fk == 1
+    assert journal.lower() == "wal"
+    assert busy == 5000
+
+
+def test_open_connection_creates_file_with_mode_0600(tmp_path: Path) -> None:
+    db = tmp_path / "sub" / "srunx.db"
+    conn = open_connection(db)
+    conn.close()
+    assert db.exists()
+    if os.name == "posix":
+        mode = stat.S_IMODE(db.stat().st_mode)
+        assert mode == 0o600
+
+
+def test_open_connection_sets_row_factory(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER, name TEXT)")
+        conn.execute("INSERT INTO t VALUES (1, 'hello')")
+        row = conn.execute("SELECT id, name FROM t").fetchone()
+    finally:
+        conn.close()
+
+    # sqlite3.Row allows both index and name access.
+    assert row["id"] == 1
+    assert row["name"] == "hello"
+
+
+# ---- transaction() ----
+
+
+def test_transaction_commits_on_success(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    with transaction(conn, "IMMEDIATE"):
+        conn.execute("INSERT INTO t VALUES (1)")
+    rows = conn.execute("SELECT id FROM t").fetchall()
+    conn.close()
+    assert [r["id"] for r in rows] == [1]
+
+
+def test_transaction_rollback_on_exception(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    conn.execute("CREATE TABLE t (id INTEGER)")
+    with pytest.raises(RuntimeError):
+        with transaction(conn):
+            conn.execute("INSERT INTO t VALUES (1)")
+            raise RuntimeError("boom")
+    rows = conn.execute("SELECT id FROM t").fetchall()
+    conn.close()
+    assert rows == []
+
+
+def test_transaction_rejects_unknown_mode(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    with pytest.raises(ValueError):
+        with transaction(conn, "BOGUS"):
+            pass
+    conn.close()
+
+
+# ---- init_db ----
+
+
+def test_init_db_applies_schema_and_removes_legacy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    # Seed a fake legacy DB to prove it gets removed.
+    legacy_dir = tmp_path / "legacy_home" / ".srunx"
+    legacy_dir.mkdir(parents=True)
+    legacy_db = legacy_dir / "history.db"
+    legacy_db.touch()
+    monkeypatch.setattr(conn_mod, "LEGACY_HISTORY_DB_PATH", legacy_db)
+
+    db_path = init_db()
+    assert db_path == tmp_path / "srunx" / "srunx.db"
+    assert db_path.exists()
+    assert not legacy_db.exists()
+
+    # Schema was applied — v1 migration row exists.
+    conn = sqlite3.connect(db_path)
+    try:
+        names = {
+            r[0] for r in conn.execute("SELECT name FROM schema_version").fetchall()
+        }
+    finally:
+        conn.close()
+    assert "v1_initial" in names
+
+
+def test_init_db_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(conn_mod, "LEGACY_HISTORY_DB_PATH", tmp_path / "nope.db")
+
+    init_db()
+    init_db()  # must not raise
+
+    conn = sqlite3.connect(tmp_path / "srunx" / "srunx.db")
+    try:
+        rows = conn.execute(
+            "SELECT COUNT(*) FROM schema_version WHERE name = 'v1_initial'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert rows[0] == 1

--- a/tests/db/test_migrations.py
+++ b/tests/db/test_migrations.py
@@ -1,0 +1,221 @@
+"""Tests for ``srunx.db.migrations``."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import (
+    apply_migrations,
+    bootstrap_from_config,
+)
+
+# ---- apply_migrations ----
+
+
+def test_apply_migrations_applies_v1_on_fresh_db(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        applied = apply_migrations(conn)
+    finally:
+        conn.close()
+    assert "v1_initial" in applied
+
+
+def test_apply_migrations_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        first = apply_migrations(conn)
+        second = apply_migrations(conn)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM schema_version WHERE name = 'v1_initial'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "v1_initial" in first
+    assert second == []
+    assert count == 1
+
+
+def test_apply_migrations_creates_all_tables(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+        tables = {r[0] for r in rows}
+    finally:
+        conn.close()
+
+    expected = {
+        "schema_version",
+        "workflow_runs",
+        "jobs",
+        "workflow_run_jobs",
+        "job_state_transitions",
+        "resource_snapshots",
+        "endpoints",
+        "watches",
+        "subscriptions",
+        "events",
+        "deliveries",
+    }
+    missing = expected - tables
+    assert not missing, f"missing tables: {missing}"
+
+
+def test_resource_snapshots_gpu_utilization_is_null_when_total_zero(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        conn.execute(
+            "INSERT INTO resource_snapshots "
+            "(observed_at, partition, gpus_total, gpus_available, gpus_in_use, "
+            "nodes_total, nodes_idle, nodes_down) "
+            "VALUES (?, NULL, 0, 0, 0, 1, 1, 0)",
+            ("2026-04-18T00:00:00Z",),
+        )
+        conn.execute(
+            "INSERT INTO resource_snapshots "
+            "(observed_at, partition, gpus_total, gpus_available, gpus_in_use, "
+            "nodes_total, nodes_idle, nodes_down) "
+            "VALUES (?, NULL, 8, 2, 6, 1, 0, 0)",
+            ("2026-04-18T00:05:00Z",),
+        )
+        conn.commit()
+        rows = conn.execute(
+            "SELECT gpus_total, gpu_utilization FROM resource_snapshots "
+            "ORDER BY observed_at"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert rows[0]["gpus_total"] == 0
+    assert rows[0]["gpu_utilization"] is None
+    assert rows[1]["gpus_total"] == 8
+    assert rows[1]["gpu_utilization"] == pytest.approx(0.75)
+
+
+# ---- bootstrap_from_config ----
+
+
+@dataclass
+class _FakeNotifications:
+    slack_webhook_url: str | None = None
+
+
+@dataclass
+class _FakeConfig:
+    notifications: _FakeNotifications
+
+
+def _open_migrated(db: Path):
+    conn = open_connection(db)
+    apply_migrations(conn)
+    return conn
+
+
+def test_bootstrap_no_webhook_records_guard_only(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = _open_migrated(db)
+    try:
+        inserted = bootstrap_from_config(
+            conn, _FakeConfig(_FakeNotifications(slack_webhook_url=None))
+        )
+        endpoint_count = conn.execute("SELECT COUNT(*) FROM endpoints").fetchone()[0]
+        guard_count = conn.execute(
+            "SELECT COUNT(*) FROM schema_version WHERE name = 'bootstrap_slack_webhook_url'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert inserted is False
+    assert endpoint_count == 0
+    assert guard_count == 1
+
+
+def test_bootstrap_inserts_endpoint_and_guard(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = _open_migrated(db)
+    try:
+        inserted = bootstrap_from_config(
+            conn,
+            _FakeConfig(
+                _FakeNotifications(
+                    slack_webhook_url="https://hooks.slack.com/services/A/B/C"
+                )
+            ),
+        )
+        rows = conn.execute("SELECT kind, name, config FROM endpoints").fetchall()
+        guard_count = conn.execute(
+            "SELECT COUNT(*) FROM schema_version WHERE name = 'bootstrap_slack_webhook_url'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert inserted is True
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "slack_webhook"
+    assert rows[0]["name"] == "default"
+    cfg = json.loads(rows[0]["config"])
+    assert cfg == {"webhook_url": "https://hooks.slack.com/services/A/B/C"}
+    assert guard_count == 1
+
+
+def test_bootstrap_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = _open_migrated(db)
+    try:
+        cfg = _FakeConfig(
+            _FakeNotifications(
+                slack_webhook_url="https://hooks.slack.com/services/A/B/C"
+            )
+        )
+        first = bootstrap_from_config(conn, cfg)
+        second = bootstrap_from_config(conn, cfg)
+        endpoint_count = conn.execute("SELECT COUNT(*) FROM endpoints").fetchone()[0]
+    finally:
+        conn.close()
+    assert first is True
+    assert second is False
+    assert endpoint_count == 1
+
+
+def test_bootstrap_rolls_back_guard_on_insert_failure(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = _open_migrated(db)
+    try:
+        # Pre-create an endpoint with the name 'default' to force UNIQUE violation.
+        conn.execute(
+            "INSERT INTO endpoints (kind, name, config, created_at) "
+            "VALUES ('slack_webhook', 'default', '{}', '2026-04-18T00:00:00Z')"
+        )
+        conn.commit()
+
+        inserted = bootstrap_from_config(
+            conn,
+            _FakeConfig(
+                _FakeNotifications(
+                    slack_webhook_url="https://hooks.slack.com/services/A/B/C"
+                )
+            ),
+        )
+        guard_count = conn.execute(
+            "SELECT COUNT(*) FROM schema_version WHERE name = 'bootstrap_slack_webhook_url'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert inserted is False
+    # Guard NOT recorded — so next startup can retry.
+    assert guard_count == 0

--- a/tests/test_client_protocol.py
+++ b/tests/test_client_protocol.py
@@ -1,0 +1,169 @@
+"""Tests for ``srunx.client_protocol`` and ``queue_by_ids`` implementations."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from srunx.client import Slurm
+from srunx.client_protocol import (
+    JobStatusInfo,
+    SlurmClientProtocol,
+    parse_slurm_datetime,
+    parse_slurm_duration,
+)
+
+# ---- parse helpers ----
+
+
+def test_parse_slurm_datetime_valid() -> None:
+    got = parse_slurm_datetime("2026-04-18T10:00:00")
+    assert got == datetime(2026, 4, 18, 10, 0, 0)
+
+
+def test_parse_slurm_datetime_unknown_values() -> None:
+    for v in ("", "   ", "N/A", "Unknown", "None", None):
+        assert parse_slurm_datetime(v) is None
+
+
+def test_parse_slurm_datetime_invalid() -> None:
+    assert parse_slurm_datetime("not-a-date") is None
+
+
+def test_parse_slurm_duration_hhmmss() -> None:
+    assert parse_slurm_duration("01:02:03") == 3723
+
+
+def test_parse_slurm_duration_mmss() -> None:
+    assert parse_slurm_duration("02:03") == 123
+
+
+def test_parse_slurm_duration_with_days() -> None:
+    assert parse_slurm_duration("2-01:00:00") == 2 * 86400 + 3600
+
+
+def test_parse_slurm_duration_invalid_values() -> None:
+    for v in (None, "", "N/A", "Unknown", "abc", "1:2:3:4"):
+        assert parse_slurm_duration(v) is None
+
+
+# ---- JobStatusInfo ----
+
+
+def test_job_status_info_defaults_optional() -> None:
+    info = JobStatusInfo(status="RUNNING")
+    assert info.status == "RUNNING"
+    assert info.started_at is None
+    assert info.completed_at is None
+    assert info.duration_secs is None
+    assert info.nodelist is None
+
+
+# ---- Slurm.queue_by_ids ----
+
+
+def _run_result(stdout: str = "", returncode: int = 0) -> MagicMock:
+    m = MagicMock(spec=subprocess.CompletedProcess)
+    m.stdout = stdout
+    m.stderr = ""
+    m.returncode = returncode
+    return m
+
+
+def test_queue_by_ids_empty_returns_empty_dict() -> None:
+    client = Slurm()
+    with patch("subprocess.run") as run_mock:
+        got = client.queue_by_ids([])
+    assert got == {}
+    run_mock.assert_not_called()
+
+
+def test_queue_by_ids_parses_squeue_output() -> None:
+    client = Slurm()
+    squeue_out = (
+        "12345|RUNNING|2026-04-18T10:00:00|00:05:23|node01\n"
+        "12346|PENDING|N/A|00:00:00|(Resources)\n"
+    )
+    with patch("subprocess.run") as run_mock:
+        run_mock.return_value = _run_result(squeue_out)
+        got = client.queue_by_ids([12345, 12346])
+
+    # Only squeue was called (all ids found there).
+    assert run_mock.call_count == 1
+    cmd = run_mock.call_args.args[0]
+    assert cmd[0] == "squeue"
+    assert "12345,12346" in cmd
+
+    assert got[12345].status == "RUNNING"
+    assert got[12345].started_at == datetime(2026, 4, 18, 10, 0, 0)
+    assert got[12345].duration_secs == 5 * 60 + 23
+    assert got[12345].nodelist == "node01"
+    assert got[12345].completed_at is None
+
+    assert got[12346].status == "PENDING"
+    assert got[12346].started_at is None
+    assert got[12346].duration_secs == 0
+
+
+def test_queue_by_ids_falls_back_to_sacct_for_terminal_jobs() -> None:
+    client = Slurm()
+    squeue_out = ""  # job no longer in queue
+    sacct_out = (
+        "12345|COMPLETED|2026-04-18T10:00:00|2026-04-18T11:00:00|01:00:00|node01\n"
+        "12345.batch|COMPLETED|2026-04-18T10:00:00|2026-04-18T11:00:00|01:00:00|node01\n"
+    )
+
+    def fake_run(cmd: list[str], *_, **__):
+        if cmd[0] == "squeue":
+            return _run_result(squeue_out)
+        if cmd[0] == "sacct":
+            return _run_result(sacct_out)
+        return _run_result("", returncode=1)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        got = client.queue_by_ids([12345])
+
+    assert got[12345].status == "COMPLETED"
+    assert got[12345].started_at == datetime(2026, 4, 18, 10, 0, 0)
+    assert got[12345].completed_at == datetime(2026, 4, 18, 11, 0, 0)
+    assert got[12345].duration_secs == 3600
+    assert got[12345].nodelist == "node01"
+
+
+def test_queue_by_ids_missing_jobs_are_omitted() -> None:
+    client = Slurm()
+
+    def fake_run(cmd: list[str], *_, **__):
+        # Neither squeue nor sacct know about the job.
+        return _run_result("")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        got = client.queue_by_ids([99999])
+
+    assert got == {}
+
+
+def test_queue_by_ids_cancelled_state_word_is_extracted() -> None:
+    client = Slurm()
+    squeue_out = ""
+    sacct_out = "12345|CANCELLED by 1000|2026-04-18T10:00:00|2026-04-18T10:05:00|00:05:00|node01\n"
+
+    def fake_run(cmd: list[str], *_, **__):
+        if cmd[0] == "squeue":
+            return _run_result(squeue_out)
+        return _run_result(sacct_out)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        got = client.queue_by_ids([12345])
+
+    assert got[12345].status == "CANCELLED"
+
+
+# ---- Protocol ----
+
+
+def test_slurm_satisfies_protocol() -> None:
+    client = Slurm()
+    # runtime_checkable — covers structural subtyping.
+    assert isinstance(client, SlurmClientProtocol)


### PR DESCRIPTION
## Summary

Adds the durable storage foundation for the notification + state persistence overhaul specified in `.claude/specs/notification-and-state-persistence/`.

This is **PR 1 of 3** in a stacked series:
- **PR 1 (this)** → DB + repositories + SlurmClientProtocol + spec docs
- PR 2 → notifications + pollers + lifespan wiring (stacked on PR 1)
- PR 3 → CRUD routers + submit flow + frontend + docs (stacked on PR 2)

## What's in this PR

- New `~/.config/srunx/srunx.db` with a 10-table schema (`workflow_runs`, `jobs`, `workflow_run_jobs`, `job_state_transitions`, `resource_snapshots`, `endpoints`, `watches`, `subscriptions`, `events`, `deliveries` + `schema_version`). Migration applied via `apply_migrations()` on first open; WAL + `busy_timeout` + `foreign_keys` enforced; file mode `0o600`.

- `SlurmClientProtocol`: unified `queue_by_ids(job_ids)` contract implemented by both `Slurm` (local subprocess) and `SlurmSSHAdapter` (remote SSH). Lets downstream consumers target either transparently.

- 10 repositories (`Endpoint`, `Watch`, `Subscription`, `Event`, `Delivery`, `WorkflowRun`, `WorkflowRunJob`, `JobStateTransition`, `ResourceSnapshot`, `Job`) with Pydantic v2 row models. `DeliveryRepository` implements the outbox claim pattern (SELECT + UPDATE in `BEGIN IMMEDIATE`, since stock Python sqlite3 lacks `UPDATE ... LIMIT RETURNING`) and `reclaim_expired_leases()` for crash recovery. `EventRepository` computes deterministic `payload_hash` for producer-side dedup.

- `conftest` adds file-backed `tmp_srunx_db` fixture (NOT `:memory:` so WAL + multi-connection tests work).

## Test plan

- [x] 186 unit tests covering schema, migrations, `bootstrap_from_config`, all repositories, `payload_hash` determinism, concurrent claim races, and lease recovery
- [x] `uv run pytest` passes
- [x] `uv run mypy .` clean
- [x] `uv run ruff check .` clean
- [ ] Verify schema migration against a freshly-deleted DB on reviewer's machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)