### PR TITLE
feat(web): notification CRUD routers + UI + submit flow rewrite (PR 3/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,19 +96,36 @@ uv run srunx resources --partition gpu
 src/srunx/
 ├── models.py          # Data models and validation
 ├── client.py          # SLURM client for job operations
+├── client_protocol.py # SlurmClientProtocol (unified queue_by_ids) + JobStatusInfo
 ├── runner.py          # Workflow execution engine
 ├── callbacks.py       # Callback system for job notifications
 ├── config.py          # Configuration management and defaults
 ├── exceptions.py      # Custom exceptions
 ├── logging.py         # Centralized logging configuration
 ├── utils.py           # Utility functions
+├── db/                # DB-backed state persistence (SQLite, ~/.config/srunx/srunx.db)
+│   ├── connection.py  # XDG path resolution, open_connection, init_db, transaction
+│   ├── migrations.py  # SCHEMA_V1 DDL + apply_migrations + bootstrap_from_config
+│   ├── models.py      # Pydantic row models (Endpoint/Watch/.../Delivery, WorkflowRun, Job...)
+│   └── repositories/  # Thin CRUD per table (JobRepository, DeliveryRepository, ...)
+├── notifications/     # Notification domain
+│   ├── sanitize.py    # sanitize_slack_text (shared with callbacks.SlackCallback)
+│   ├── presets.py     # should_deliver(preset, event_kind, to_status) filter
+│   ├── service.py     # NotificationService.fan_out (events → deliveries)
+│   └── adapters/      # DeliveryAdapter + SlackWebhookDeliveryAdapter + registry
+├── pollers/           # Long-running lifespan tasks
+│   ├── reload_guard.py      # is_reload_mode, should_start_pollers (pure functions)
+│   ├── supervisor.py        # PollerSupervisor (anyio task group + crash/grace)
+│   ├── active_watch_poller.py  # producer: SLURM → events → deliveries
+│   ├── delivery_poller.py   # consumer: claim → send → mark_delivered/retry
+│   └── resource_snapshotter.py # periodic ResourceSnapshot writes
 ├── cli/               # Command-line interfaces
 │   ├── main.py        # Main CLI commands (submit, status, list, cancel, resources)
 │   ├── monitor.py     # Monitor subcommands (jobs, resources, cluster)
 │   └── workflow.py    # Workflow CLI
 ├── monitor/           # Job and resource monitoring
 │   ├── base.py        # BaseMonitor abstract class
-│   ├── job_monitor.py # JobMonitor for job state tracking
+│   ├── job_monitor.py # JobMonitor for job state tracking (also writes to job_state_transitions for SSOT)
 │   ├── resource_monitor.py  # ResourceMonitor for GPU availability
 │   └── types.py       # MonitorConfig, ResourceSnapshot, WatchMode
 ├── ssh/               # SSH integration for remote SLURM
@@ -304,6 +321,37 @@ jobs:
 - **Resource Management**: Full SLURM resource specification
 - **Workflow Validation**: Dependency checking and cycle detection
 - **Inter-Job Communication**: Runtime variable passing between workflow jobs via shared outputs directory
+
+### Notification + State Persistence (new in 2026-Q2)
+
+srunx stores durable state in a SQLite DB at **`$XDG_CONFIG_HOME/srunx/srunx.db`** (or `~/.config/srunx/srunx.db` when the env var is unset). Schema lives in `src/srunx/db/migrations.py` (`SCHEMA_V1`).
+
+Tables (abbreviated):
+- `jobs` — every SLURM submission, annotated with `submission_source` (`cli` / `web` / `workflow`) and `workflow_run_id`.
+- `workflow_runs` + `workflow_run_jobs` — Web UI workflow runs, replacing the former in-memory `RunRegistry`.
+- `job_state_transitions` — single source of truth for observed state changes, fed by both `ActiveWatchPoller` (`source='poller'`) and `JobMonitor` (`source='cli_monitor'`).
+- `resource_snapshots` — periodic GPU/node stats; `gpu_utilization` is a STORED generated column (NULL when `gpus_total=0`).
+- `endpoints` + `watches` + `subscriptions` + `events` + `deliveries` — the notification 5-concept outbox. `events` has a UNIQUE `(kind, source_ref, payload_hash)` dedup index; `deliveries` has UNIQUE `(endpoint_id, idempotency_key)`. `deliveries` uses a SELECT-then-UPDATE claim pattern inside `BEGIN IMMEDIATE` (stock Python `sqlite3` lacks `UPDATE ... LIMIT RETURNING`).
+
+Background pollers (lifespan tasks managed by `PollerSupervisor`):
+- `ActiveWatchPoller` (producer) — polls SLURM every 15 s, writes `job_state_transitions`, `jobs` status, `events`, and fan-outs into `deliveries`.
+- `DeliveryPoller` (consumer) — claims `pending` deliveries every 10 s, sends via `SlackWebhookDeliveryAdapter` (or future channels), handles retry/abandon with exponential backoff (base 10 s, cap 1 h, max 5 attempts).
+- `ResourceSnapshotter` — every 5 min, writes one `resource_snapshots` row.
+
+All pollers are crash-resilient via a lease mechanism (`leased_until`, `worker_id`) and a `reclaim_expired_leases()` sweep at the start of every `DeliveryPoller` cycle.
+
+Legacy ``~/.srunx/history.db`` is preserved during Phase 1 rollout; a future cleanup will delete it.
+
+**Environment variables** that affect poller startup:
+- `SRUNX_DISABLE_POLLER=1` — disable ALL pollers (also applied automatically in `uvicorn --reload` dev mode).
+- `SRUNX_DISABLE_ACTIVE_WATCH_POLLER=1` — skip the SLURM → events producer.
+- `SRUNX_DISABLE_DELIVERY_POLLER=1` — skip the outbox consumer.
+- `SRUNX_DISABLE_RESOURCE_SNAPSHOTTER=1` — skip resource time-series capture.
+- `UVICORN_RELOAD` — anything truthy enables dev-mode reload detection in `pollers.reload_guard`.
+
+Notification settings UI lives in `Settings → Notifications`; Phase 1 supports endpoint CRUD for `slack_webhook` only. Webhook URL validation (both UI and backend): `^https://hooks\.slack\.com/services/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$`.
+
+See `.claude/specs/notification-and-state-persistence/` for full requirements, design, and task list.
 
 ## Dependencies
 - **Jinja2**: Template rendering

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -15,6 +15,8 @@ from srunx.logging import get_logger
 
 from .config import get_web_config
 from .deps import set_adapter
+from .routers import deliveries as deliveries_router
+from .routers import endpoints as endpoints_router
 from .routers import (
     files,
     history,
@@ -22,6 +24,8 @@ from .routers import (
     resources,
     workflows,
 )
+from .routers import subscriptions as subscriptions_router
+from .routers import watches as watches_router
 from .ssh_adapter import SlurmSSHAdapter
 
 _FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
@@ -338,6 +342,11 @@ def create_app() -> FastAPI:
     app.include_router(history.router)
     app.include_router(files.router)
     app.include_router(templates.router)
+    # New CRUD / observability routers for the notification + state overhaul
+    app.include_router(endpoints_router.router)
+    app.include_router(subscriptions_router.router)
+    app.include_router(watches_router.router)
+    app.include_router(deliveries_router.router)
 
     # Serve frontend static files (production) with SPA fallback
     if _FRONTEND_DIST.exists():

--- a/src/srunx/web/frontend/src/components/FileExplorer.tsx
+++ b/src/srunx/web/frontend/src/components/FileExplorer.tsx
@@ -30,8 +30,27 @@ import xml from "highlight.js/lib/languages/xml";
 import ini from "highlight.js/lib/languages/ini";
 import dockerfile from "highlight.js/lib/languages/dockerfile";
 import "highlight.js/styles/github-dark.css";
-import { config, files, jobs } from "../lib/api.ts";
-import type { Mount, FileEntry, FileEntryType } from "../lib/types.ts";
+import { config, endpoints as endpointsApi, files, jobs } from "../lib/api.ts";
+import type {
+  Endpoint,
+  FileEntry,
+  FileEntryType,
+  Mount,
+} from "../lib/types.ts";
+
+/* ── Notification presets ───────────────────── */
+
+const NOTIFICATION_PRESETS = [
+  { value: "terminal", label: "Terminal (completed / failed)" },
+  { value: "running_and_terminal", label: "Running + terminal" },
+  { value: "all", label: "All state changes" },
+] as const;
+
+type NotificationPresetValue = (typeof NOTIFICATION_PRESETS)[number]["value"];
+
+function isKnownPreset(value: string): value is NotificationPresetValue {
+  return NOTIFICATION_PRESETS.some((p) => p.value === value);
+}
 
 /* ── highlight.js setup ────────────────────── */
 
@@ -242,26 +261,67 @@ function SubmitDialog({
   const [result, setResult] = useState<{ job_id: number | null } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  // Slack notification toggle
-  const [notifySlack, setNotifySlack] = useState(false);
-  const [slackAvailable, setSlackAvailable] = useState(false);
+  // Notification controls
+  const [notify, setNotify] = useState(false);
+  const [endpointList, setEndpointList] = useState<Endpoint[]>([]);
+  const [selectedEndpointId, setSelectedEndpointId] = useState<number | null>(
+    null,
+  );
+  const [preset, setPreset] = useState<NotificationPresetValue>("terminal");
+  const [endpointsLoading, setEndpointsLoading] = useState(true);
 
   // Script preview
   const [preview, setPreview] = useState<string | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
 
-  // Check if Slack webhook is configured
+  // Fetch endpoints + notification defaults from config.
   useEffect(() => {
-    config
-      .get()
-      .then((c) => {
-        const hasWebhook = !!c.notifications?.slack_webhook_url;
-        setSlackAvailable(hasWebhook);
-        setNotifySlack(hasWebhook);
-      })
-      .catch(() => {});
+    let cancelled = false;
+    async function loadNotificationState() {
+      try {
+        setEndpointsLoading(true);
+        const [fetched, cfg] = await Promise.all([
+          endpointsApi.list(),
+          config.get().catch(() => null),
+        ]);
+        if (cancelled) return;
+        setEndpointList(fetched);
+
+        const defaultName = cfg?.notifications?.default_endpoint_name ?? null;
+        const defaultPreset = cfg?.notifications?.default_preset;
+        if (defaultPreset && isKnownPreset(defaultPreset)) {
+          setPreset(defaultPreset);
+        }
+
+        if (fetched.length > 0) {
+          const match = defaultName
+            ? fetched.find((e) => e.name === defaultName)
+            : undefined;
+          setSelectedEndpointId((match ?? fetched[0]).id);
+          setNotify(true);
+        } else {
+          setSelectedEndpointId(null);
+          setNotify(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setEndpointList([]);
+          setSelectedEndpointId(null);
+          setNotify(false);
+        }
+      } finally {
+        if (!cancelled) setEndpointsLoading(false);
+      }
+    }
+    loadNotificationState();
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  const hasEndpoints = endpointList.length > 0;
+  const notifyEnabled = notify && hasEndpoints && selectedEndpointId !== null;
 
   // Load script preview on toggle
   useEffect(() => {
@@ -282,7 +342,18 @@ function SubmitDialog({
       // Reuse cached preview if available, otherwise fetch
       const content =
         preview ?? (await files.read(mountName, filePath)).content;
-      const res = await jobs.submit(content, jobName, mountName, notifySlack);
+      const res = await jobs.submit(
+        content,
+        jobName,
+        mountName,
+        // DEPRECATED `notify_slack` flag, retained for backward compatibility.
+        notifyEnabled,
+        {
+          notify: notifyEnabled,
+          endpointId: notifyEnabled ? selectedEndpointId : null,
+          preset,
+        },
+      );
       setResult(res);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Submission failed");
@@ -480,12 +551,12 @@ function SubmitDialog({
             />
           </div>
 
-          {/* Slack notification toggle */}
+          {/* Notification controls */}
           <div
             style={{
               display: "flex",
-              alignItems: "center",
-              gap: 8,
+              flexDirection: "column",
+              gap: "var(--sp-2)",
             }}
           >
             <label
@@ -493,23 +564,25 @@ function SubmitDialog({
                 display: "flex",
                 alignItems: "center",
                 gap: 8,
-                cursor: slackAvailable ? "pointer" : "default",
-                opacity: slackAvailable ? 1 : 0.4,
+                cursor: hasEndpoints ? "pointer" : "default",
+                opacity: hasEndpoints ? 1 : 0.4,
               }}
               title={
-                slackAvailable
-                  ? "Send Slack notification on submission"
-                  : "Configure Slack webhook in Settings > Notifications"
+                hasEndpoints
+                  ? "Send a notification on job state changes"
+                  : "Add an endpoint in Settings → Notifications first."
               }
             >
               <input
                 type="checkbox"
-                checked={notifySlack}
-                onChange={(e) => setNotifySlack(e.target.checked)}
-                disabled={!slackAvailable || submitting || !!result}
+                checked={notify && hasEndpoints}
+                onChange={(e) => setNotify(e.target.checked)}
+                disabled={
+                  !hasEndpoints || endpointsLoading || submitting || !!result
+                }
                 style={{ accentColor: "var(--st-running)", margin: 0 }}
               />
-              {notifySlack ? (
+              {notify && hasEndpoints ? (
                 <Bell size={13} style={{ color: "var(--st-running)" }} />
               ) : (
                 <BellOff size={13} style={{ color: "var(--text-muted)" }} />
@@ -518,39 +591,128 @@ function SubmitDialog({
                 style={{
                   fontFamily: "var(--font-mono)",
                   fontSize: "0.75rem",
-                  color: slackAvailable
+                  color: hasEndpoints
                     ? "var(--text-secondary)"
                     : "var(--text-muted)",
                 }}
               >
-                Slack notification
+                Notify on state changes
               </span>
             </label>
-            {!slackAvailable && (
-              <a
-                href="/settings"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClose();
-                }}
+
+            {!endpointsLoading && !hasEndpoints && (
+              <div
                 style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--sp-2)",
+                  padding: "var(--sp-2) var(--sp-3)",
+                  background: "var(--bg-base)",
+                  border: "1px solid var(--border-subtle)",
+                  borderRadius: "var(--radius-md)",
                   fontFamily: "var(--font-mono)",
-                  fontSize: "0.65rem",
-                  color: "var(--st-running)",
-                  textDecoration: "none",
-                  opacity: 0.8,
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.textDecoration = "underline";
-                  e.currentTarget.style.opacity = "1";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.textDecoration = "none";
-                  e.currentTarget.style.opacity = "0.8";
+                  fontSize: "0.7rem",
+                  color: "var(--text-muted)",
                 }}
               >
-                Settings で設定
-              </a>
+                <AlertTriangle size={12} />
+                <span style={{ flex: 1 }}>
+                  Add an endpoint in Settings → Notifications first.
+                </span>
+                <a
+                  href="/settings"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClose();
+                  }}
+                  style={{
+                    color: "var(--st-running)",
+                    textDecoration: "none",
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.textDecoration = "underline";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.textDecoration = "none";
+                  }}
+                >
+                  Open Settings
+                </a>
+              </div>
+            )}
+
+            {hasEndpoints && notify && (
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gap: "var(--sp-2)",
+                }}
+              >
+                <div>
+                  <label
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.65rem",
+                      color: "var(--text-muted)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.06em",
+                      marginBottom: 4,
+                      display: "block",
+                    }}
+                  >
+                    Endpoint
+                  </label>
+                  <select
+                    className="input"
+                    style={{ width: "100%", fontSize: "0.75rem" }}
+                    value={selectedEndpointId ?? ""}
+                    onChange={(e) =>
+                      setSelectedEndpointId(
+                        e.target.value === "" ? null : Number(e.target.value),
+                      )
+                    }
+                    disabled={submitting || !!result}
+                  >
+                    {endpointList.map((ep) => (
+                      <option key={ep.id} value={ep.id}>
+                        {ep.name} ({ep.kind})
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label
+                    style={{
+                      fontFamily: "var(--font-mono)",
+                      fontSize: "0.65rem",
+                      color: "var(--text-muted)",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.06em",
+                      marginBottom: 4,
+                      display: "block",
+                    }}
+                  >
+                    Preset
+                  </label>
+                  <select
+                    className="input"
+                    style={{ width: "100%", fontSize: "0.75rem" }}
+                    value={preset}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (isKnownPreset(v)) setPreset(v);
+                    }}
+                    disabled={submitting || !!result}
+                  >
+                    {NOTIFICATION_PRESETS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
             )}
           </div>
 

--- a/src/srunx/web/frontend/src/lib/api.ts
+++ b/src/srunx/web/frontend/src/lib/api.ts
@@ -2,6 +2,8 @@ import type {
   BrowseResult,
   CommandJob,
   ConfigPathInfo,
+  Delivery,
+  Endpoint,
   EnvVarInfo,
   HistoryStats,
   LogData,
@@ -19,6 +21,7 @@ import type {
   SSHProfilesResponse,
   SSHTestResult,
   SrunxConfig,
+  Subscription,
   SyncResult,
   TemplateCreateRequest,
   TemplateDetail,
@@ -75,17 +78,32 @@ export const jobs = {
     jobName: string,
     mountName?: string,
     notifySlack?: boolean,
+    notifyOpts?: {
+      notify?: boolean;
+      endpointId?: number | null;
+      preset?: string;
+    },
   ): Promise<{ name: string; job_id: number | null; status: string }> => {
+    const body: Record<string, unknown> = {
+      name: jobName,
+      script_content: scriptContent,
+      job_name: jobName,
+      mount_name: mountName,
+      // DEPRECATED: retained for backward compatibility with the legacy
+      // slack-only notification path; new endpoint/subscription fields below
+      // supersede it when provided.
+      notify_slack: notifySlack ?? false,
+    };
+    if (notifyOpts) {
+      if (notifyOpts.notify !== undefined) body.notify = notifyOpts.notify;
+      if (notifyOpts.endpointId !== undefined && notifyOpts.endpointId !== null)
+        body.endpoint_id = notifyOpts.endpointId;
+      if (notifyOpts.preset !== undefined) body.preset = notifyOpts.preset;
+    }
     const res = await fetch("/api/jobs", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        name: jobName,
-        script_content: scriptContent,
-        job_name: jobName,
-        mount_name: mountName,
-        notify_slack: notifySlack ?? false,
-      }),
+      body: JSON.stringify(body),
     });
     if (!res.ok) {
       const err = await res.json();
@@ -633,5 +651,166 @@ export const templates = {
       const err = await res.json();
       throw new Error(extractDetail(err, "Failed to delete template"));
     }
+  },
+};
+
+/* ── Endpoints ──────────────────────────────── */
+
+export const endpoints = {
+  list: async (opts?: {
+    include_disabled?: boolean;
+  }): Promise<Endpoint[]> => {
+    const params = new URLSearchParams();
+    if (opts?.include_disabled) params.set("include_disabled", "true");
+    const qs = params.toString();
+    const res = await fetch(`/api/endpoints${qs ? `?${qs}` : ""}`);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to fetch endpoints"));
+    }
+    return res.json();
+  },
+
+  create: async (body: {
+    kind: string;
+    name: string;
+    config: object;
+  }): Promise<Endpoint> => {
+    const res = await fetch("/api/endpoints", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to create endpoint"));
+    }
+    return res.json();
+  },
+
+  update: async (
+    id: number,
+    body: { name?: string; config?: object },
+  ): Promise<Endpoint> => {
+    const res = await fetch(`/api/endpoints/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to update endpoint"));
+    }
+    return res.json();
+  },
+
+  disable: async (id: number): Promise<Endpoint> => {
+    const res = await fetch(`/api/endpoints/${id}/disable`, { method: "POST" });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to disable endpoint"));
+    }
+    return res.json();
+  },
+
+  enable: async (id: number): Promise<Endpoint> => {
+    const res = await fetch(`/api/endpoints/${id}/enable`, { method: "POST" });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to enable endpoint"));
+    }
+    return res.json();
+  },
+
+  delete: async (id: number): Promise<void> => {
+    const res = await fetch(`/api/endpoints/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to delete endpoint"));
+    }
+  },
+};
+
+/* ── Subscriptions ──────────────────────────── */
+
+export const subscriptions = {
+  list: async (opts: {
+    watch_id?: number;
+    endpoint_id?: number;
+  }): Promise<Subscription[]> => {
+    const params = new URLSearchParams();
+    if (opts.watch_id !== undefined)
+      params.set("watch_id", String(opts.watch_id));
+    if (opts.endpoint_id !== undefined)
+      params.set("endpoint_id", String(opts.endpoint_id));
+    const qs = params.toString();
+    const res = await fetch(`/api/subscriptions${qs ? `?${qs}` : ""}`);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to fetch subscriptions"));
+    }
+    return res.json();
+  },
+
+  create: async (body: {
+    watch_id: number;
+    endpoint_id: number;
+    preset: string;
+  }): Promise<Subscription> => {
+    const res = await fetch("/api/subscriptions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to create subscription"));
+    }
+    return res.json();
+  },
+
+  delete: async (id: number): Promise<void> => {
+    const res = await fetch(`/api/subscriptions/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to delete subscription"));
+    }
+  },
+};
+
+/* ── Deliveries ─────────────────────────────── */
+
+export const deliveries = {
+  listBySubscription: async (
+    subscriptionId: number,
+    status?: string,
+  ): Promise<Delivery[]> => {
+    const params = new URLSearchParams({
+      subscription_id: String(subscriptionId),
+    });
+    if (status) params.set("status", status);
+    const res = await fetch(`/api/deliveries?${params.toString()}`);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to fetch deliveries"));
+    }
+    return res.json();
+  },
+
+  countStuck: async (
+    olderThanSec?: number,
+  ): Promise<{ count: number; older_than_sec: number }> => {
+    const params = new URLSearchParams();
+    if (olderThanSec !== undefined)
+      params.set("older_than_sec", String(olderThanSec));
+    const qs = params.toString();
+    const res = await fetch(
+      `/api/deliveries/stuck-count${qs ? `?${qs}` : ""}`,
+    );
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to fetch stuck count"));
+    }
+    return res.json();
   },
 };

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -232,6 +232,57 @@ export type SrunxConfig = {
 
 export type NotificationConfig = {
   slack_webhook_url: string | null;
+  default_endpoint_name?: string | null;
+  default_preset?: string;
+};
+
+/* ── Notification endpoints / subscriptions / deliveries ─── */
+
+export type EndpointKind =
+  | "slack_webhook"
+  | "generic_webhook"
+  | "email"
+  | "slack_bot";
+
+export type Endpoint = {
+  id: number;
+  kind: EndpointKind;
+  name: string;
+  config: Record<string, unknown>;
+  created_at: string;
+  disabled_at: string | null;
+};
+
+export type NotificationPreset =
+  | "terminal"
+  | "running_and_terminal"
+  | "all"
+  | "digest";
+
+export type Subscription = {
+  id: number;
+  watch_id: number;
+  endpoint_id: number;
+  preset: NotificationPreset;
+  created_at: string;
+};
+
+export type DeliveryStatus = "pending" | "sending" | "delivered" | "abandoned";
+
+export type Delivery = {
+  id: number;
+  event_id: number;
+  subscription_id: number;
+  endpoint_id: number;
+  idempotency_key: string;
+  status: DeliveryStatus;
+  attempt_count: number;
+  next_attempt_at: string;
+  leased_until: string | null;
+  worker_id: string | null;
+  last_error: string | null;
+  delivered_at: string | null;
+  created_at: string;
 };
 
 export type ConfigPathInfo = {

--- a/src/srunx/web/frontend/src/pages/settings/NotificationsTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/NotificationsTab.tsx
@@ -1,29 +1,387 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { Bell, Save, Check, AlertTriangle } from "lucide-react";
+import {
+  AlertTriangle,
+  Bell,
+  BellOff,
+  Check,
+  Plus,
+  Power,
+  Trash2,
+  X,
+} from "lucide-react";
 import { ErrorBanner } from "../../components/ErrorBanner.tsx";
-import { config as configApi } from "../../lib/api.ts";
-import type { SrunxConfig } from "../../lib/types.ts";
+import { endpoints as endpointsApi } from "../../lib/api.ts";
+import type { Endpoint } from "../../lib/types.ts";
 
 const SLACK_WEBHOOK_PATTERN =
   /^https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+\/[A-Za-z0-9_-]+$/;
 
-export function NotificationsTab() {
-  const [cfg, setCfg] = useState<SrunxConfig | null>(null);
+function formatDate(value: string): string {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  return d.toLocaleString();
+}
+
+type AddFormProps = {
+  onCancel: () => void;
+  onCreated: (endpoint: Endpoint) => void;
+};
+
+function AddEndpointForm({ onCancel, onCreated }: AddFormProps) {
+  const [name, setName] = useState("");
   const [webhookUrl, setWebhookUrl] = useState("");
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const urlValid = SLACK_WEBHOOK_PATTERN.test(webhookUrl);
+  const canSubmit = name.trim().length > 0 && urlValid && !saving;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    try {
+      setSaving(true);
+      setError(null);
+      const created = await endpointsApi.create({
+        kind: "slack_webhook",
+        name: name.trim(),
+        config: { webhook_url: webhookUrl },
+      });
+      onCreated(created);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create endpoint");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -6 }}
+      animate={{ opacity: 1, y: 0 }}
+      style={{
+        padding: "var(--sp-4)",
+        background: "var(--bg-base)",
+        border: "1px solid var(--border-subtle)",
+        borderRadius: "var(--radius-md)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--sp-3)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "0.75rem",
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            color: "var(--text-secondary)",
+          }}
+        >
+          New Slack Endpoint
+        </span>
+        <button
+          onClick={onCancel}
+          style={{
+            background: "none",
+            border: "none",
+            color: "var(--text-muted)",
+            cursor: "pointer",
+            padding: 4,
+            borderRadius: "var(--radius-sm)",
+            display: "flex",
+          }}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div>
+        <label
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.65rem",
+            color: "var(--text-muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            marginBottom: 4,
+            display: "block",
+          }}
+        >
+          Name
+        </label>
+        <input
+          className="input"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. team-alerts"
+          style={{ width: "100%", fontSize: "0.8rem" }}
+        />
+      </div>
+
+      <div>
+        <label
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.65rem",
+            color: "var(--text-muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            marginBottom: 4,
+            display: "block",
+          }}
+        >
+          Kind
+        </label>
+        <input
+          className="input"
+          type="text"
+          value="slack_webhook"
+          disabled
+          style={{
+            width: "100%",
+            fontSize: "0.8rem",
+            fontFamily: "var(--font-mono)",
+            opacity: 0.6,
+          }}
+        />
+      </div>
+
+      <div>
+        <label
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.65rem",
+            color: "var(--text-muted)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            marginBottom: 4,
+            display: "block",
+          }}
+        >
+          Webhook URL
+        </label>
+        <input
+          className="input"
+          type="url"
+          value={webhookUrl}
+          onChange={(e) => setWebhookUrl(e.target.value)}
+          placeholder="https://hooks.slack.com/services/..."
+          style={{
+            width: "100%",
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.8rem",
+            borderColor:
+              webhookUrl && !urlValid ? "var(--st-failed)" : undefined,
+          }}
+        />
+        {webhookUrl && !urlValid && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--sp-1)",
+              marginTop: "var(--sp-2)",
+              color: "var(--st-failed)",
+              fontSize: "0.75rem",
+            }}
+          >
+            <AlertTriangle size={12} />
+            Must be a valid Slack webhook URL
+            (https://hooks.slack.com/services/...)
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--sp-1)",
+            color: "var(--st-failed)",
+            fontSize: "0.75rem",
+          }}
+        >
+          <AlertTriangle size={12} />
+          {error}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          gap: "var(--sp-2)",
+        }}
+      >
+        <button className="btn btn-ghost" onClick={onCancel} disabled={saving}>
+          Cancel
+        </button>
+        <button
+          className="btn btn-primary"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        >
+          <Plus size={13} />
+          {saving ? "Creating..." : "Create"}
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
+type EndpointRowProps = {
+  endpoint: Endpoint;
+  busy: boolean;
+  onToggle: () => void;
+  onDelete: () => void;
+};
+
+function EndpointRow({ endpoint, busy, onToggle, onDelete }: EndpointRowProps) {
+  const disabled = endpoint.disabled_at !== null;
+
+  return (
+    <tr>
+      <td
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.75rem",
+          color: "var(--text-secondary)",
+          borderBottom: "1px solid var(--border-ghost)",
+        }}
+      >
+        {endpoint.kind}
+      </td>
+      <td
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          fontSize: "0.8rem",
+          color: "var(--text-primary)",
+          borderBottom: "1px solid var(--border-ghost)",
+        }}
+      >
+        {endpoint.name}
+      </td>
+      <td
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          borderBottom: "1px solid var(--border-ghost)",
+        }}
+      >
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            fontFamily: "var(--font-mono)",
+            fontSize: "0.7rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: disabled ? "var(--text-muted)" : "var(--st-completed)",
+          }}
+        >
+          {disabled ? <BellOff size={11} /> : <Bell size={11} />}
+          {disabled ? "Disabled" : "Enabled"}
+        </span>
+      </td>
+      <td
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          fontFamily: "var(--font-mono)",
+          fontSize: "0.7rem",
+          color: "var(--text-muted)",
+          borderBottom: "1px solid var(--border-ghost)",
+        }}
+      >
+        {formatDate(endpoint.created_at)}
+      </td>
+      <td
+        style={{
+          padding: "var(--sp-2) var(--sp-3)",
+          borderBottom: "1px solid var(--border-ghost)",
+          textAlign: "right",
+        }}
+      >
+        <div
+          style={{
+            display: "inline-flex",
+            gap: "var(--sp-2)",
+          }}
+        >
+          <button
+            onClick={onToggle}
+            disabled={busy}
+            title={disabled ? "Enable" : "Disable"}
+            style={{
+              background: "none",
+              border: "1px solid var(--border-subtle)",
+              color: disabled ? "var(--st-completed)" : "var(--text-muted)",
+              cursor: busy ? "not-allowed" : "pointer",
+              padding: "4px 8px",
+              borderRadius: "var(--radius-sm)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              fontSize: "0.7rem",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            <Power size={11} />
+            {disabled ? "Enable" : "Disable"}
+          </button>
+          <button
+            onClick={onDelete}
+            disabled={busy}
+            title="Delete"
+            style={{
+              background: "none",
+              border: "1px solid var(--border-subtle)",
+              color: "var(--st-failed)",
+              cursor: busy ? "not-allowed" : "pointer",
+              padding: "4px 8px",
+              borderRadius: "var(--radius-sm)",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              fontSize: "0.7rem",
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            <Trash2 size={11} />
+            Delete
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export function NotificationsTab() {
+  const [endpointList, setEndpointList] = useState<Endpoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const [busyId, setBusyId] = useState<number | null>(null);
 
   const load = useCallback(async () => {
     try {
       setLoading(true);
-      const c = await configApi.get();
-      setCfg(c);
-      setWebhookUrl(c.notifications?.slack_webhook_url ?? "");
+      const list = await endpointsApi.list({ include_disabled: true });
+      setEndpointList(list);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load config");
+      setError(e instanceof Error ? e.message : "Failed to load endpoints");
     } finally {
       setLoading(false);
     }
@@ -40,25 +398,53 @@ export function NotificationsTab() {
     }
   }, [success]);
 
-  const isValid = !webhookUrl || SLACK_WEBHOOK_PATTERN.test(webhookUrl);
+  const handleCreated = (created: Endpoint) => {
+    setEndpointList((prev) => [...prev, created]);
+    setShowAdd(false);
+    setSuccess(`Endpoint "${created.name}" created`);
+  };
 
-  const handleSave = async () => {
-    if (!cfg || !isValid) return;
+  const handleToggle = async (ep: Endpoint) => {
     try {
-      setSaving(true);
+      setBusyId(ep.id);
       setError(null);
-      const updated = await configApi.update({
-        ...cfg,
-        notifications: {
-          slack_webhook_url: webhookUrl || null,
-        },
-      });
-      setCfg(updated);
-      setSuccess("Notification settings saved");
+      const updated =
+        ep.disabled_at === null
+          ? await endpointsApi.disable(ep.id)
+          : await endpointsApi.enable(ep.id);
+      setEndpointList((prev) =>
+        prev.map((e) => (e.id === updated.id ? updated : e)),
+      );
+      setSuccess(
+        updated.disabled_at === null
+          ? `Endpoint "${updated.name}" enabled`
+          : `Endpoint "${updated.name}" disabled`,
+      );
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save");
+      setError(e instanceof Error ? e.message : "Failed to update endpoint");
     } finally {
-      setSaving(false);
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (ep: Endpoint) => {
+    if (
+      !window.confirm(
+        `Delete endpoint "${ep.name}"? Existing subscriptions referencing it may be affected.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      setBusyId(ep.id);
+      setError(null);
+      await endpointsApi.delete(ep.id);
+      setEndpointList((prev) => prev.filter((e) => e.id !== ep.id));
+      setSuccess(`Endpoint "${ep.name}" deleted`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete endpoint");
+    } finally {
+      setBusyId(null);
     }
   };
 
@@ -91,77 +477,108 @@ export function NotificationsTab() {
       )}
 
       <div className="panel">
-        <div className="panel-header">
+        <div
+          className="panel-header"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
           <h3>
             <Bell size={14} style={{ marginRight: 8, verticalAlign: -2 }} />
-            Slack
+            Notification Endpoints
           </h3>
-        </div>
-        <div className="panel-body">
-          <div style={{ marginBottom: "var(--sp-3)" }}>
-            <label
-              style={{
-                fontSize: "0.85rem",
-                fontWeight: 500,
-                color: "var(--text-primary)",
-                display: "block",
-                marginBottom: 4,
-              }}
-            >
-              Webhook URL
-            </label>
-            <p
-              style={{
-                fontSize: "0.75rem",
-                color: "var(--text-muted)",
-                marginBottom: "var(--sp-3)",
-              }}
-            >
-              Used for job completion/failure notifications and scheduled
-              reports.
-            </p>
-            <input
-              className="input"
-              type="url"
-              value={webhookUrl}
-              onChange={(e) => setWebhookUrl(e.target.value)}
-              placeholder="https://hooks.slack.com/services/..."
-              style={{
-                width: "100%",
-                fontFamily: "var(--font-mono)",
-                fontSize: "0.8rem",
-                borderColor:
-                  webhookUrl && !isValid ? "var(--st-failed)" : undefined,
-              }}
-            />
-            {webhookUrl && !isValid && (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "var(--sp-1)",
-                  marginTop: "var(--sp-2)",
-                  color: "var(--st-failed)",
-                  fontSize: "0.75rem",
-                }}
-              >
-                <AlertTriangle size={12} />
-                Must be a valid Slack webhook URL
-                (https://hooks.slack.com/services/...)
-              </div>
-            )}
-          </div>
-
-          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          {!showAdd && (
             <button
               className="btn btn-primary"
-              onClick={handleSave}
-              disabled={saving || !isValid}
+              onClick={() => setShowAdd(true)}
             >
-              <Save size={14} />
-              {saving ? "Saving..." : "Save"}
+              <Plus size={13} />
+              Add endpoint
             </button>
-          </div>
+          )}
+        </div>
+        <div className="panel-body">
+          <p
+            style={{
+              fontSize: "0.75rem",
+              color: "var(--text-muted)",
+              marginBottom: "var(--sp-3)",
+            }}
+          >
+            Configure delivery targets for job state notifications. Jobs can
+            subscribe to individual endpoints at submit time.
+          </p>
+
+          {showAdd && (
+            <div style={{ marginBottom: "var(--sp-4)" }}>
+              <AddEndpointForm
+                onCancel={() => setShowAdd(false)}
+                onCreated={handleCreated}
+              />
+            </div>
+          )}
+
+          {endpointList.length === 0 ? (
+            <div
+              style={{
+                padding: "var(--sp-4)",
+                textAlign: "center",
+                fontSize: "0.8rem",
+                color: "var(--text-muted)",
+                fontStyle: "italic",
+                border: "1px dashed var(--border-subtle)",
+                borderRadius: "var(--radius-md)",
+              }}
+            >
+              No endpoints configured yet. Click "Add endpoint" to create one.
+            </div>
+          ) : (
+            <div style={{ overflowX: "auto" }}>
+              <table
+                style={{
+                  width: "100%",
+                  borderCollapse: "collapse",
+                  fontSize: "0.8rem",
+                }}
+              >
+                <thead>
+                  <tr>
+                    {["Kind", "Name", "Status", "Created", ""].map((h, i) => (
+                      <th
+                        key={h || `col-${i}`}
+                        style={{
+                          padding: "var(--sp-2) var(--sp-3)",
+                          textAlign: i === 4 ? "right" : "left",
+                          fontFamily: "var(--font-display)",
+                          fontSize: "0.65rem",
+                          fontWeight: 600,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.08em",
+                          color: "var(--text-muted)",
+                          borderBottom: "1px solid var(--border-default)",
+                        }}
+                      >
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {endpointList.map((ep) => (
+                    <EndpointRow
+                      key={ep.id}
+                      endpoint={ep}
+                      busy={busyId === ep.id}
+                      onToggle={() => handleToggle(ep)}
+                      onDelete={() => handleDelete(ep)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/srunx/web/routers/deliveries.py
+++ b/src/srunx/web/routers/deliveries.py
@@ -1,0 +1,69 @@
+"""Deliveries observability: ``/api/deliveries/*``.
+
+Read-only routes for surfacing outbox state. No direct delivery-send
+endpoint here — delivery is the ``DeliveryPoller``'s job.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import anyio
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..deps import get_db_conn, get_delivery_repo
+
+router = APIRouter(prefix="/api/deliveries", tags=["deliveries"])
+
+
+def _serialize(delivery: Any) -> dict[str, Any]:
+    d = delivery.model_dump()
+    for field in ("created_at", "delivered_at", "leased_until", "next_attempt_at"):
+        val = d.get(field)
+        if val is not None and hasattr(val, "isoformat"):
+            d[field] = val.isoformat().replace("+00:00", "Z")
+    return d
+
+
+@router.get("")
+async def list_deliveries(
+    subscription_id: int | None = Query(default=None),
+    status: str | None = Query(default=None),
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> list[dict[str, Any]]:
+    repo = get_delivery_repo(conn)
+    if subscription_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="subscription_id query parameter required (global listings are disabled)",
+        )
+    rows = await anyio.to_thread.run_sync(
+        lambda: repo.list_by_subscription(subscription_id, status=status)
+    )
+    return [_serialize(r) for r in rows]
+
+
+@router.get("/stuck")
+async def count_stuck(
+    older_than_sec: int = Query(default=300, ge=0),
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, int]:
+    """Return the count of deliveries ``pending`` past ``older_than_sec``."""
+    repo = get_delivery_repo(conn)
+    count = await anyio.to_thread.run_sync(
+        lambda: repo.count_stuck_pending(older_than_sec=older_than_sec)
+    )
+    return {"count": int(count), "older_than_sec": older_than_sec}
+
+
+@router.get("/{delivery_id}")
+async def get_delivery(
+    delivery_id: int,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, Any]:
+    repo = get_delivery_repo(conn)
+    d = await anyio.to_thread.run_sync(lambda: repo.get(delivery_id))
+    if d is None:
+        raise HTTPException(status_code=404, detail="delivery not found")
+    return _serialize(d)

--- a/src/srunx/web/routers/endpoints.py
+++ b/src/srunx/web/routers/endpoints.py
@@ -1,0 +1,170 @@
+"""Notification endpoints CRUD: ``/api/endpoints/*``."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from typing import Any
+
+import anyio
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..deps import get_db_conn, get_endpoint_repo
+
+router = APIRouter(prefix="/api/endpoints", tags=["endpoints"])
+
+_SLACK_WEBHOOK_RE = re.compile(
+    r"^https://hooks\.slack\.com/services/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$"
+)
+_ALLOWED_KINDS = ("slack_webhook",)  # Phase 1: Slack only
+
+
+class EndpointCreate(BaseModel):
+    kind: str = Field(
+        ..., description="Endpoint kind; Phase 1 allows 'slack_webhook' only."
+    )
+    name: str = Field(..., min_length=1, max_length=80)
+    config: dict[str, Any] = Field(
+        ...,
+        description=(
+            "Kind-specific config. For slack_webhook: {'webhook_url': "
+            "'https://hooks.slack.com/services/.../.../..'}"
+        ),
+    )
+
+
+class EndpointUpdate(BaseModel):
+    name: str | None = None
+    config: dict[str, Any] | None = None
+
+
+def _validate(kind: str, config: dict[str, Any]) -> None:
+    if kind not in _ALLOWED_KINDS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Endpoint kind '{kind}' is not enabled in Phase 1. "
+                f"Allowed: {_ALLOWED_KINDS}"
+            ),
+        )
+    if kind == "slack_webhook":
+        url = config.get("webhook_url")
+        if not isinstance(url, str) or not _SLACK_WEBHOOK_RE.match(url):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "slack_webhook endpoint requires 'webhook_url' matching "
+                    "https://hooks.slack.com/services/WORKSPACE/CHANNEL/TOKEN"
+                ),
+            )
+
+
+def _serialize(endpoint: Any) -> dict[str, Any]:
+    d = endpoint.model_dump()
+    # Emit ISO strings for timestamps so frontend/json round-trip is stable.
+    for field in ("created_at", "disabled_at"):
+        val = d.get(field)
+        if val is not None:
+            d[field] = (
+                val.isoformat().replace("+00:00", "Z")
+                if hasattr(val, "isoformat")
+                else str(val)
+            )
+    return d
+
+
+@router.get("")
+async def list_endpoints(
+    conn: sqlite3.Connection = Depends(get_db_conn),
+    include_disabled: bool = True,
+) -> list[dict[str, Any]]:
+    repo = get_endpoint_repo(conn)
+    rows = await anyio.to_thread.run_sync(
+        lambda: repo.list(include_disabled=include_disabled)
+    )
+    return [_serialize(r) for r in rows]
+
+
+@router.post("", status_code=201)
+async def create_endpoint(
+    body: EndpointCreate,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, Any]:
+    _validate(body.kind, body.config)
+    repo = get_endpoint_repo(conn)
+    try:
+        new_id = await anyio.to_thread.run_sync(
+            lambda: repo.create(body.kind, body.name, body.config)
+        )
+    except sqlite3.IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Endpoint (kind={body.kind}, name={body.name}) already exists",
+        ) from exc
+    created = await anyio.to_thread.run_sync(lambda: repo.get(new_id))
+    if created is None:
+        raise HTTPException(status_code=500, detail="endpoint vanished after create")
+    return _serialize(created)
+
+
+@router.patch("/{endpoint_id}")
+async def update_endpoint(
+    endpoint_id: int,
+    body: EndpointUpdate,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, Any]:
+    repo = get_endpoint_repo(conn)
+    current = await anyio.to_thread.run_sync(lambda: repo.get(endpoint_id))
+    if current is None:
+        raise HTTPException(status_code=404, detail="endpoint not found")
+    # If config is changing, re-validate with the (possibly new) kind.
+    if body.config is not None:
+        _validate(current.kind, body.config)
+    changed = await anyio.to_thread.run_sync(
+        lambda: repo.update(endpoint_id, name=body.name, config=body.config)
+    )
+    if not changed:
+        # Nothing to update OR not found — return current state unchanged.
+        pass
+    updated = await anyio.to_thread.run_sync(lambda: repo.get(endpoint_id))
+    if updated is None:
+        raise HTTPException(status_code=404, detail="endpoint not found")
+    return _serialize(updated)
+
+
+@router.post("/{endpoint_id}/disable")
+async def disable_endpoint(
+    endpoint_id: int,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, Any]:
+    repo = get_endpoint_repo(conn)
+    ok = await anyio.to_thread.run_sync(lambda: repo.disable(endpoint_id))
+    if not ok:
+        raise HTTPException(status_code=404, detail="endpoint not found")
+    updated = await anyio.to_thread.run_sync(lambda: repo.get(endpoint_id))
+    return _serialize(updated) if updated else {}
+
+
+@router.post("/{endpoint_id}/enable")
+async def enable_endpoint(
+    endpoint_id: int,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, Any]:
+    repo = get_endpoint_repo(conn)
+    ok = await anyio.to_thread.run_sync(lambda: repo.enable(endpoint_id))
+    if not ok:
+        raise HTTPException(status_code=404, detail="endpoint not found")
+    updated = await anyio.to_thread.run_sync(lambda: repo.get(endpoint_id))
+    return _serialize(updated) if updated else {}
+
+
+@router.delete("/{endpoint_id}", status_code=204)
+async def delete_endpoint(
+    endpoint_id: int,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> None:
+    repo = get_endpoint_repo(conn)
+    ok = await anyio.to_thread.run_sync(lambda: repo.delete(endpoint_id))
+    if not ok:
+        raise HTTPException(status_code=404, detail="endpoint not found")

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
+import sqlite3
 from typing import Any
 
 import anyio
 from fastapi import APIRouter, Depends, HTTPException, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 
+from srunx.db.repositories.deliveries import DeliveryRepository
+from srunx.db.repositories.endpoints import EndpointRepository
+from srunx.db.repositories.events import EventRepository
+from srunx.db.repositories.job_state_transitions import (
+    JobStateTransitionRepository,
+)
+from srunx.db.repositories.jobs import JobRepository
+from srunx.db.repositories.subscriptions import SubscriptionRepository
+from srunx.db.repositories.watches import WatchRepository
 from srunx.logging import get_logger
+from srunx.notifications.service import NotificationService
 
-from ..deps import get_adapter
+from ..deps import get_adapter, get_db_conn
 from ..ssh_adapter import SlurmSSHAdapter
 
 router = APIRouter(prefix="/api/jobs", tags=["jobs"])
@@ -71,23 +82,142 @@ async def preview_script(req: ScriptPreviewRequest) -> ScriptPreviewResponse:
 
 
 class JobSubmitRequest(BaseModel):
+    """Request body for submitting a job via the Web UI.
+
+    ``notify_slack`` (DEPRECATED) is retained for backward compatibility with
+    older frontend builds but has no effect beyond logging a warning. Prefer
+    the ``notify`` + ``endpoint_id`` + ``preset`` triplet.
+    """
+
     name: str
     script_content: str
     job_name: str | None = None
     mount_name: str | None = None
+
+    # DEPRECATED: keep for API backward-compat but behaviour is a no-op.
     notify_slack: bool = False
+
+    # New notification-watch fields (optional; all three must be present
+    # together for a watch to be created on submit).
+    notify: bool = False
+    endpoint_id: int | None = Field(default=None, gt=0)
+    preset: str = "terminal"
+
+    @model_validator(mode="after")
+    def _check_notify(self) -> JobSubmitRequest:
+        if self.notify and self.endpoint_id is None:
+            raise ValueError("notify=true requires endpoint_id")
+        return self
+
+
+def _validate_notify_endpoint(conn: sqlite3.Connection, req: JobSubmitRequest) -> None:
+    """Validate the notification endpoint BEFORE SLURM submission.
+
+    Called on the request path so that a bad ``endpoint_id`` fails the
+    request without leaking a SLURM job.
+    """
+    if not req.notify or req.endpoint_id is None:
+        return
+    endpoint = EndpointRepository(conn).get(req.endpoint_id)
+    if endpoint is None:
+        raise HTTPException(
+            status_code=404, detail=f"endpoint {req.endpoint_id} not found"
+        )
+    if endpoint.disabled_at is not None:
+        raise HTTPException(
+            status_code=422, detail=f"endpoint {req.endpoint_id} is disabled"
+        )
+
+
+def _record_and_watch(
+    conn: sqlite3.Connection,
+    *,
+    job_id: int,
+    job_name: str,
+    req: JobSubmitRequest,
+) -> None:
+    """Persist the submission record and (optionally) create a notification watch.
+
+    Executes inside a single IMMEDIATE transaction so the ``jobs`` insert,
+    watch/subscription rows, initial ``job_state_transitions`` seed, and
+    ``job.submitted`` event (plus fan-out) appear atomically.
+
+    Endpoint validation is done BEFORE this function is called (in the
+    request path, pre-sbatch) so that a 4xx never strands a SLURM job.
+    """
+    job_repo = JobRepository(conn)
+    watch_repo = WatchRepository(conn)
+    sub_repo = SubscriptionRepository(conn)
+    event_repo = EventRepository(conn)
+    transition_repo = JobStateTransitionRepository(conn)
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        # R5.1 bug fix: web-submitted jobs now hit the history.
+        job_repo.record_submission(
+            job_id=job_id,
+            name=job_name,
+            status="PENDING",
+            submission_source="web",
+        )
+        # Seed baseline transition so ActiveWatchPoller's first observation
+        # produces a real transition (from_status='PENDING') rather than
+        # being skipped as a "first observation". (Codex-flagged critical.)
+        transition_repo.insert(
+            job_id=job_id,
+            from_status=None,
+            to_status="PENDING",
+            source="webhook",
+        )
+        if req.notify and req.endpoint_id is not None:
+            watch_id = watch_repo.create(kind="job", target_ref=f"job:{job_id}")
+            sub_repo.create(watch_id, req.endpoint_id, req.preset)
+            event_id = event_repo.insert(
+                kind="job.submitted",
+                source_ref=f"job:{job_id}",
+                payload={"job_id": job_id, "job_name": job_name},
+            )
+            # Fan out the job.submitted event so ``preset='all'`` subscribers
+            # receive the notification.
+            if event_id is not None:
+                event = event_repo.get(event_id)
+                if event is not None:
+                    NotificationService(
+                        watch_repo=watch_repo,
+                        subscription_repo=sub_repo,
+                        event_repo=event_repo,
+                        delivery_repo=DeliveryRepository(conn),
+                        endpoint_repo=EndpointRepository(conn),
+                    ).fan_out(event, conn)
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
 
 
 @router.post("", status_code=201)
 async def submit_job(
     req: JobSubmitRequest,
     adapter: SlurmSSHAdapter = Depends(get_adapter),
+    conn: sqlite3.Connection = Depends(get_db_conn),
 ) -> dict[str, Any]:
     """Submit a new job to SLURM via SSH.
 
     If *mount_name* is provided, the corresponding mount is synced
     via rsync before submission.
     """
+    # Legacy-flag diagnostic: surface a soft warning if the frontend still
+    # ships ``notify_slack`` without the new trio.
+    if req.notify_slack and not req.notify:
+        logger.warning(
+            "Request sent deprecated `notify_slack=True`; field has no effect. "
+            "Use notify/endpoint_id/preset instead."
+        )
+
+    # Validate the notification endpoint BEFORE sbatch so a bad ID never
+    # results in a leaked SLURM job. (Codex-flagged.)
+    _validate_notify_endpoint(conn, req)
+
     # Sync mount before submission if requested
     if req.mount_name:
         from ..sync_utils import get_current_profile, sync_mount_by_name
@@ -122,25 +252,26 @@ async def submit_job(
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"sbatch failed: {e}") from e
 
-    # Send Slack notification if requested
-    if req.notify_slack and result.get("job_id"):
+    # Persist the submission + (optionally) create a notification watch.
+    job_id = result.get("job_id")
+    if job_id:
         try:
-            from srunx.callbacks import SlackCallback
-            from srunx.config import get_config
-            from srunx.models import Job
-
-            cfg = get_config()
-            webhook_url = cfg.notifications.slack_webhook_url
-            if webhook_url:
-                job = Job(
-                    name=req.job_name or req.name,
-                    job_id=result["job_id"],
-                    command=[],
+            await anyio.to_thread.run_sync(
+                lambda: _record_and_watch(
+                    conn,
+                    job_id=int(job_id),
+                    job_name=req.job_name or req.name,
+                    req=req,
                 )
-                slack = SlackCallback(webhook_url=webhook_url)
-                await anyio.to_thread.run_sync(lambda: slack.on_job_submitted(job))
+            )
+        except HTTPException:
+            raise
         except Exception:
-            logger.warning("Failed to send Slack notification", exc_info=True)
+            logger.warning(
+                "Failed to record submission / create watch for job %s",
+                job_id,
+                exc_info=True,
+            )
 
     return result
 

--- a/src/srunx/web/routers/subscriptions.py
+++ b/src/srunx/web/routers/subscriptions.py
@@ -1,0 +1,91 @@
+"""Notification subscriptions CRUD: ``/api/subscriptions/*``."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import anyio
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ..deps import get_db_conn, get_subscription_repo
+
+router = APIRouter(prefix="/api/subscriptions", tags=["subscriptions"])
+
+_VALID_PRESETS = ("terminal", "running_and_terminal", "all", "digest")
+
+
+class SubscriptionCreate(BaseModel):
+    watch_id: int = Field(..., gt=0)
+    endpoint_id: int = Field(..., gt=0)
+    preset: str = Field(default="terminal")
+
+
+def _serialize(sub: Any) -> dict[str, Any]:
+    d = sub.model_dump()
+    for field in ("created_at",):
+        val = d.get(field)
+        if val is not None and hasattr(val, "isoformat"):
+            d[field] = val.isoformat().replace("+00:00", "Z")
+    return d
+
+
+@router.get("")
+async def list_subscriptions(
+    watch_id: int | None = Query(default=None),
+    endpoint_id: int | None = Query(default=None),
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> list[dict[str, Any]]:
+    repo = get_subscription_repo(conn)
+    if watch_id is not None:
+        rows = await anyio.to_thread.run_sync(lambda: repo.list_by_watch(watch_id))
+    elif endpoint_id is not None:
+        rows = await anyio.to_thread.run_sync(
+            lambda: repo.list_by_endpoint(endpoint_id)
+        )
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="watch_id or endpoint_id query parameter required",
+        )
+    return [_serialize(r) for r in rows]
+
+
+@router.post("", status_code=201)
+async def create_subscription(
+    body: SubscriptionCreate,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, Any]:
+    if body.preset not in _VALID_PRESETS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid preset '{body.preset}'. Allowed: {_VALID_PRESETS}",
+        )
+    repo = get_subscription_repo(conn)
+    try:
+        new_id = await anyio.to_thread.run_sync(
+            lambda: repo.create(body.watch_id, body.endpoint_id, body.preset)
+        )
+    except sqlite3.IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="subscription for this (watch, endpoint) already exists",
+        ) from exc
+    created = await anyio.to_thread.run_sync(lambda: repo.get(new_id))
+    if created is None:
+        raise HTTPException(
+            status_code=500, detail="subscription vanished after create"
+        )
+    return _serialize(created)
+
+
+@router.delete("/{subscription_id}", status_code=204)
+async def delete_subscription(
+    subscription_id: int,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> None:
+    repo = get_subscription_repo(conn)
+    ok = await anyio.to_thread.run_sync(lambda: repo.delete(subscription_id))
+    if not ok:
+        raise HTTPException(status_code=404, detail="subscription not found")

--- a/src/srunx/web/routers/watches.py
+++ b/src/srunx/web/routers/watches.py
@@ -1,0 +1,57 @@
+"""Watches (read-only observability): ``/api/watches/*``."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import anyio
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from ..deps import get_db_conn, get_watch_repo
+
+router = APIRouter(prefix="/api/watches", tags=["watches"])
+
+
+def _serialize(watch: Any) -> dict[str, Any]:
+    d = watch.model_dump()
+    for field in ("created_at", "closed_at"):
+        val = d.get(field)
+        if val is not None and hasattr(val, "isoformat"):
+            d[field] = val.isoformat().replace("+00:00", "Z")
+    return d
+
+
+@router.get("")
+async def list_watches(
+    open_only: bool = Query(default=True, alias="open"),
+    kind: str | None = Query(default=None),
+    target_ref: str | None = Query(default=None),
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> list[dict[str, Any]]:
+    repo = get_watch_repo(conn)
+
+    if kind is not None and target_ref is not None:
+        rows = await anyio.to_thread.run_sync(
+            lambda: repo.list_by_target(kind, target_ref, only_open=open_only)
+        )
+    elif open_only:
+        rows = await anyio.to_thread.run_sync(lambda: repo.list_open())
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="Unfiltered listing disabled. Provide kind+target_ref or open=true.",
+        )
+    return [_serialize(r) for r in rows]
+
+
+@router.get("/{watch_id}")
+async def get_watch(
+    watch_id: int,
+    conn: sqlite3.Connection = Depends(get_db_conn),
+) -> dict[str, Any]:
+    repo = get_watch_repo(conn)
+    w = await anyio.to_thread.run_sync(lambda: repo.get(watch_id))
+    if w is None:
+        raise HTTPException(status_code=404, detail="watch not found")
+    return _serialize(w)

--- a/tests/web/test_endpoints_router.py
+++ b/tests/web/test_endpoints_router.py
@@ -1,0 +1,141 @@
+"""Integration tests for the new notification CRUD routers.
+
+Uses the FastAPI ``TestClient`` against an app whose DB is pointed at a
+file-backed tmp SQLite (via the ``tmp_srunx_db`` fixture + ``XDG_CONFIG_HOME``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from srunx.db.connection import init_db
+
+
+@pytest.fixture
+def app_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """A fresh app instance with an isolated tmp DB."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    # Pre-initialize the DB so the first API call doesn't race on schema creation.
+    init_db(delete_legacy=False)
+
+    from srunx.web.app import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+# --- endpoints CRUD ---
+
+
+def test_list_endpoints_empty(app_client: TestClient) -> None:
+    r = app_client.get("/api/endpoints")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_create_endpoint_happy_path(app_client: TestClient) -> None:
+    r = app_client.post(
+        "/api/endpoints",
+        json={
+            "kind": "slack_webhook",
+            "name": "default",
+            "config": {"webhook_url": "https://hooks.slack.com/services/A/B/C"},
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["kind"] == "slack_webhook"
+    assert body["name"] == "default"
+    assert body["disabled_at"] is None
+    assert isinstance(body["id"], int)
+
+
+def test_create_endpoint_invalid_kind(app_client: TestClient) -> None:
+    r = app_client.post(
+        "/api/endpoints",
+        json={"kind": "email", "name": "x", "config": {}},
+    )
+    assert r.status_code == 422
+
+
+def test_create_endpoint_invalid_webhook_url(app_client: TestClient) -> None:
+    r = app_client.post(
+        "/api/endpoints",
+        json={
+            "kind": "slack_webhook",
+            "name": "x",
+            "config": {"webhook_url": "https://example.com/hook"},
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_disable_then_enable_endpoint(app_client: TestClient) -> None:
+    created = app_client.post(
+        "/api/endpoints",
+        json={
+            "kind": "slack_webhook",
+            "name": "d",
+            "config": {"webhook_url": "https://hooks.slack.com/services/A/B/C"},
+        },
+    ).json()
+    eid = created["id"]
+
+    r = app_client.post(f"/api/endpoints/{eid}/disable")
+    assert r.status_code == 200
+    assert r.json()["disabled_at"] is not None
+
+    r = app_client.post(f"/api/endpoints/{eid}/enable")
+    assert r.status_code == 200
+    assert r.json()["disabled_at"] is None
+
+
+def test_delete_endpoint(app_client: TestClient) -> None:
+    created = app_client.post(
+        "/api/endpoints",
+        json={
+            "kind": "slack_webhook",
+            "name": "d2",
+            "config": {"webhook_url": "https://hooks.slack.com/services/A/B/C"},
+        },
+    ).json()
+    r = app_client.delete(f"/api/endpoints/{created['id']}")
+    assert r.status_code == 204
+    r = app_client.get("/api/endpoints")
+    assert r.json() == []
+
+
+# --- subscriptions CRUD (requires endpoint + watch) ---
+
+
+def test_subscription_requires_filter(app_client: TestClient) -> None:
+    r = app_client.get("/api/subscriptions")
+    assert r.status_code == 400
+
+
+# --- deliveries observability ---
+
+
+def test_deliveries_stuck_count(app_client: TestClient) -> None:
+    r = app_client.get("/api/deliveries/stuck")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["count"] == 0
+    assert "older_than_sec" in body
+
+
+def test_deliveries_list_requires_subscription_id(app_client: TestClient) -> None:
+    r = app_client.get("/api/deliveries")
+    assert r.status_code == 400
+
+
+# --- watches observability ---
+
+
+def test_watches_list_open(app_client: TestClient) -> None:
+    r = app_client.get("/api/watches?open=true")
+    assert r.status_code == 200
+    assert r.json() == []

--- a/tests/web/test_notification_routers.py
+++ b/tests/web/test_notification_routers.py
@@ -1,0 +1,210 @@
+"""Coverage for subscription / watch / delivery CRUD routers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from srunx.db.connection import init_db, open_connection
+from srunx.db.repositories.endpoints import EndpointRepository
+from srunx.db.repositories.watches import WatchRepository
+
+
+@pytest.fixture
+def app_client_and_db(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[TestClient, Path]:
+    """Fresh app instance + DB path."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    db_path = init_db(delete_legacy=False)
+
+    from srunx.web.app import create_app
+
+    return TestClient(create_app()), db_path
+
+
+def _seed_endpoint_and_watch(db_path: Path) -> tuple[int, int]:
+    conn = open_connection(db_path)
+    try:
+        endpoint_id = EndpointRepository(conn).create(
+            kind="slack_webhook",
+            name="test",
+            config={"webhook_url": "https://hooks.slack.com/services/A/B/C"},
+        )
+        watch_id = WatchRepository(conn).create(kind="job", target_ref="job:1001")
+    finally:
+        conn.close()
+    return endpoint_id, watch_id
+
+
+# --- subscriptions router ---
+
+
+def test_subscriptions_crud_full_flow(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, db_path = app_client_and_db
+    endpoint_id, watch_id = _seed_endpoint_and_watch(db_path)
+
+    # POST
+    r = client.post(
+        "/api/subscriptions",
+        json={"watch_id": watch_id, "endpoint_id": endpoint_id, "preset": "terminal"},
+    )
+    assert r.status_code == 201, r.text
+    sub_id = r.json()["id"]
+
+    # List by watch_id
+    r = client.get(f"/api/subscriptions?watch_id={watch_id}")
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+
+    # List by endpoint_id
+    r = client.get(f"/api/subscriptions?endpoint_id={endpoint_id}")
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+
+    # Duplicate insert returns 409
+    r = client.post(
+        "/api/subscriptions",
+        json={"watch_id": watch_id, "endpoint_id": endpoint_id, "preset": "all"},
+    )
+    assert r.status_code == 409
+
+    # Delete
+    r = client.delete(f"/api/subscriptions/{sub_id}")
+    assert r.status_code == 204
+
+    # List empty
+    r = client.get(f"/api/subscriptions?watch_id={watch_id}")
+    assert r.json() == []
+
+    # Delete missing → 404
+    r = client.delete(f"/api/subscriptions/{sub_id}")
+    assert r.status_code == 404
+
+
+def test_subscriptions_rejects_invalid_preset(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, db_path = app_client_and_db
+    endpoint_id, watch_id = _seed_endpoint_and_watch(db_path)
+
+    r = client.post(
+        "/api/subscriptions",
+        json={"watch_id": watch_id, "endpoint_id": endpoint_id, "preset": "bogus"},
+    )
+    assert r.status_code == 422
+
+
+# --- watches router ---
+
+
+def test_watches_list_by_target(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, db_path = app_client_and_db
+    _, watch_id = _seed_endpoint_and_watch(db_path)
+
+    r = client.get("/api/watches?kind=job&target_ref=job:1001")
+    assert r.status_code == 200
+    rows = r.json()
+    assert len(rows) == 1
+    assert rows[0]["id"] == watch_id
+
+
+def test_watches_unfiltered_closed_listing_rejected(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, _ = app_client_and_db
+    r = client.get("/api/watches?open=false")
+    assert r.status_code == 400
+
+
+def test_watches_get_by_id(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, db_path = app_client_and_db
+    _, watch_id = _seed_endpoint_and_watch(db_path)
+
+    r = client.get(f"/api/watches/{watch_id}")
+    assert r.status_code == 200
+    assert r.json()["target_ref"] == "job:1001"
+
+    r = client.get("/api/watches/999999")
+    assert r.status_code == 404
+
+
+# --- deliveries router ---
+
+
+def test_deliveries_list_by_subscription_empty(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, db_path = app_client_and_db
+    endpoint_id, watch_id = _seed_endpoint_and_watch(db_path)
+    sub = client.post(
+        "/api/subscriptions",
+        json={"watch_id": watch_id, "endpoint_id": endpoint_id, "preset": "terminal"},
+    ).json()
+    r = client.get(f"/api/deliveries?subscription_id={sub['id']}")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_deliveries_get_missing_returns_404(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, _ = app_client_and_db
+    r = client.get("/api/deliveries/999999")
+    assert r.status_code == 404
+
+
+# --- endpoints router extra coverage ---
+
+
+def test_endpoints_patch_updates_name_and_config(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, _ = app_client_and_db
+    created = client.post(
+        "/api/endpoints",
+        json={
+            "kind": "slack_webhook",
+            "name": "orig",
+            "config": {"webhook_url": "https://hooks.slack.com/services/A/B/C"},
+        },
+    ).json()
+    eid = created["id"]
+
+    r = client.patch(
+        f"/api/endpoints/{eid}",
+        json={"name": "renamed"},
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == "renamed"
+
+    # Invalid config rejected
+    r = client.patch(
+        f"/api/endpoints/{eid}",
+        json={"config": {"webhook_url": "not-a-url"}},
+    )
+    assert r.status_code == 422
+
+
+def test_endpoints_patch_404_when_missing(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, _ = app_client_and_db
+    r = client.patch("/api/endpoints/99999", json={"name": "x"})
+    assert r.status_code == 404
+
+
+def test_endpoints_disable_missing_returns_404(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    client, _ = app_client_and_db
+    r = client.post("/api/endpoints/99999/disable")
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

Wires the notification domain into the Web UI, closes the R5.1 bug (web submits never reaching the history DB), and ships the minimum frontend so users can actually add, disable, and delete endpoints.

This is **PR 3 of 3** in a stacked series:
- PR 1 → DB + repositories + SlurmClientProtocol + spec docs (#77)
- PR 2 → notifications + pollers + lifespan wiring (#78)
- **PR 3 (this)** → CRUD routers + submit flow + frontend + docs

⚠️ **Base**: this PR is based on \`pr2/notifications-pollers\` — please merge #77 and #78 first.

## What's in this PR

- 4 new FastAPI routers:
  - \`/api/endpoints\` (CRUD + disable/enable, webhook URL regex re-validated server-side)
  - \`/api/subscriptions\` (CRUD, UNIQUE \`(watch_id, endpoint_id)\` maps to 409)
  - \`/api/watches\` (read-only listing, open-only or by target)
  - \`/api/deliveries\` (observability: list by subscription, count stuck pending)

- \`routers/jobs.py\` submit flow — R5.1 bug fix + notification integration:
  - New request fields: \`notify\` / \`endpoint_id\` / \`preset\`. \`notify_slack\` kept for backward compat but is a soft-deprecated no-op.
  - \`_validate_notify_endpoint\` runs BEFORE \`sbatch\` so a bad endpoint never leaves a stranded SLURM job.
  - \`_record_and_watch\` runs inside a single IMMEDIATE transaction that: (1) inserts the jobs row (the historic R5.1 fix — web-submitted jobs now hit history); (2) seeds a \`PENDING\` \`job_state_transitions\` row so \`ActiveWatchPoller\`'s first observation produces a real transition rather than skipping as a \"first observation\"; (3) creates the watch + subscription; and (4) inserts the \`job.submitted\` event + fan-outs via \`NotificationService\` so \`preset=all\` subscribers receive it.

- Frontend:
  - \`lib/types.ts\`: adds \`Endpoint\` / \`Subscription\` / \`Delivery\` types + unions
  - \`lib/api.ts\`: new endpoints/subscriptions/deliveries modules; \`jobs.submit\` extended with \`notify\`/\`endpoint_id\`/\`preset\`
  - \`pages/settings/NotificationsTab.tsx\`: full rewrite. Replaces the single-webhook input with an endpoints table + inline Add Endpoint form (Slack-URL regex client-side), per-row disable/enable/delete with \`window.confirm\` guard.
  - \`components/FileExplorer.tsx\`: submit dialog now renders notify toggle + endpoint select (disabled with guidance when no endpoints exist) + preset select; reads defaults from \`SrunxConfig\`.

- \`CLAUDE.md\`: documents the new \`~/.config/srunx/srunx.db\` location, 10-table schema summary, 3-poller lifecycle, env var toggles, and the 5-concept notification model.

## Deferred to follow-up

- \`workflows.py\` \`_monitor_run\` / \`run_registry\` removal (C1)
- \`NotificationsCenter.tsx\` dashboard page (C3)
- Playwright E2E suite (C4)
- Full \`history.py\` call-site migration (C2)

## Test plan

- [x] 20 new integration tests against TestClient-driven FastAPI app with isolated tmp SQLite DB (endpoints CRUD, subscription 409 on duplicate, watches by-target, deliveries stuck count, error paths)
- [x] \`uv run pytest\` passes
- [x] \`uv run mypy .\` clean
- [x] \`uv run ruff check .\` clean
- [x] Playwright MCP manual E2E: endpoint CRUD flow in real browser
- [x] Local HTTPServer smoke: real webhook POST round-trip verified
- [ ] Verify submit dialog default endpoint preselection in staging
- [ ] Verify R5.1 bug fix: web-submitted job shows up in \`jobs\` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)