### PR TITLE
feat(web): C3 — Notifications observability dashboard page

### DIFF
--- a/src/srunx/db/migrations.py
+++ b/src/srunx/db/migrations.py
@@ -190,6 +190,19 @@ CREATE INDEX idx_deliveries_lease_active ON deliveries(leased_until) WHERE statu
 """
 
 
+# v2: non-schema index additions to support the NotificationsCenter
+# dashboard queries. ``list_recent`` does ``ORDER BY created_at DESC``
+# with an optional ``WHERE status = ?``; without these indexes the
+# 10-second dashboard poll degenerates into a full scan + sort on a
+# growing outbox.
+SCHEMA_V2_DASHBOARD_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_deliveries_created_at
+    ON deliveries(created_at);
+CREATE INDEX IF NOT EXISTS idx_deliveries_status_created_at
+    ON deliveries(status, created_at);
+"""
+
+
 # ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
@@ -204,6 +217,11 @@ class Migration:
 
 MIGRATIONS: list[Migration] = [
     Migration(version=1, name="v1_initial", sql=SCHEMA_V1),
+    Migration(
+        version=2,
+        name="v2_dashboard_indexes",
+        sql=SCHEMA_V2_DASHBOARD_INDEXES,
+    ),
 ]
 
 

--- a/src/srunx/db/repositories/deliveries.py
+++ b/src/srunx/db/repositories/deliveries.py
@@ -148,6 +148,35 @@ class DeliveryRepository(BaseRepository):
         rows: list[sqlite3.Row] = self.conn.execute(sql, params).fetchall()
         return [self._row_to_model(r, Delivery) for r in rows if r is not None]  # type: ignore[misc]
 
+    def list_recent(
+        self,
+        *,
+        status: str | None = None,
+        limit: int = 100,
+    ) -> list[Delivery]:
+        """Return the most recent deliveries across all subscriptions.
+
+        Powers the NotificationsCenter dashboard — a read-only
+        observability view of the outbox. Callers must bound ``limit``
+        to avoid pulling the full table during incidents.
+        """
+        if status is None:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM deliveries "
+                "ORDER BY created_at DESC LIMIT ?"
+            )
+            params: list[Any] = [limit]
+        else:
+            sql = (
+                f"SELECT {', '.join(self._COLUMNS)} FROM deliveries "
+                "WHERE status = ? "
+                "ORDER BY created_at DESC LIMIT ?"
+            )
+            params = [status, limit]
+
+        rows: list[sqlite3.Row] = self.conn.execute(sql, params).fetchall()
+        return [self._row_to_model(r, Delivery) for r in rows if r is not None]  # type: ignore[misc]
+
     # -- lease mechanics ---------------------------------------------------
 
     def reclaim_expired_leases(self) -> int:

--- a/src/srunx/db/repositories/subscriptions.py
+++ b/src/srunx/db/repositories/subscriptions.py
@@ -62,6 +62,20 @@ class SubscriptionRepository(BaseRepository):
         ).fetchall()
         return [self._row_to_model(r, Subscription) for r in rows if r is not None]  # type: ignore[misc]
 
+    def list_recent(self, limit: int = 200) -> list[Subscription]:
+        """Return every subscription, newest first, bounded by ``limit``.
+
+        Powers the NotificationsCenter dashboard. Scoped paths
+        (:meth:`list_by_watch` / :meth:`list_by_endpoint`) remain the
+        preferred call on the hot path.
+        """
+        rows = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM subscriptions "
+            "ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [self._row_to_model(r, Subscription) for r in rows if r is not None]  # type: ignore[misc]
+
     def delete(self, id: int) -> bool:
         cur = self.conn.execute("DELETE FROM subscriptions WHERE id = ?", (id,))
         return cur.rowcount > 0

--- a/src/srunx/web/frontend/src/App.tsx
+++ b/src/srunx/web/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { Templates } from "./pages/Templates.tsx";
 import { Resources } from "./pages/Resources.tsx";
 import { Settings } from "./pages/Settings.tsx";
 import { LogViewer } from "./pages/LogViewer.tsx";
+import { NotificationsCenter } from "./pages/NotificationsCenter.tsx";
 
 export function App() {
   return (
@@ -25,6 +26,7 @@ export function App() {
           <Route path="workflows/:name" element={<WorkflowDetail />} />
           <Route path="templates" element={<Templates />} />
           <Route path="resources" element={<Resources />} />
+          <Route path="notifications" element={<NotificationsCenter />} />
           <Route path="settings" element={<Settings />} />
         </Route>
       </Routes>

--- a/src/srunx/web/frontend/src/components/Sidebar.tsx
+++ b/src/srunx/web/frontend/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   GitFork,
   FileCode2,
   Cpu,
+  Bell,
   Settings,
   Terminal,
   ChevronLeft,
@@ -31,6 +32,7 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/workflows", icon: <GitFork size={18} />, label: "Workflows" },
   { to: "/templates", icon: <FileCode2 size={18} />, label: "Templates" },
   { to: "/resources", icon: <Cpu size={18} />, label: "Resources" },
+  { to: "/notifications", icon: <Bell size={18} />, label: "Notifications" },
   { to: "/settings", icon: <Settings size={18} />, label: "Settings" },
 ];
 

--- a/src/srunx/web/frontend/src/hooks/use-api.ts
+++ b/src/srunx/web/frontend/src/hooks/use-api.ts
@@ -10,6 +10,13 @@ interface UseApiResult<T> {
 /**
  * Fetch data from an async function. Automatically refetches
  * when deps change. Supports polling via interval.
+ *
+ * Request sequencing: every invocation carries a monotonically
+ * increasing generation id. When a fetch resolves, we only commit its
+ * result to state if the generation still matches the latest one the
+ * hook kicked off. Without this, rapid dep changes (e.g. a status
+ * filter in the NotificationsCenter page) could let an older fetch
+ * arrive last and stomp on a newer one, showing stale rows.
  */
 export function useApi<T>(
   fetcher: () => Promise<T>,
@@ -21,22 +28,22 @@ export function useApi<T>(
   const [error, setError] = useState<string | null>(null);
   const mountedRef = useRef(true);
   const dataRef = useRef<T | null>(null);
+  const fetchGenRef = useRef(0);
 
   const fetchData = useCallback(async () => {
+    const gen = ++fetchGenRef.current;
     try {
       setLoading((prev) => (dataRef.current === null ? true : prev));
       const result = await fetcher();
-      if (mountedRef.current) {
-        dataRef.current = result;
-        setData(result);
-        setError(null);
-      }
+      if (!mountedRef.current || gen !== fetchGenRef.current) return;
+      dataRef.current = result;
+      setData(result);
+      setError(null);
     } catch (err) {
-      if (mountedRef.current) {
-        setError(err instanceof Error ? err.message : String(err));
-      }
+      if (!mountedRef.current || gen !== fetchGenRef.current) return;
+      setError(err instanceof Error ? err.message : String(err));
     } finally {
-      if (mountedRef.current) setLoading(false);
+      if (mountedRef.current && gen === fetchGenRef.current) setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);

--- a/src/srunx/web/frontend/src/lib/api.ts
+++ b/src/srunx/web/frontend/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   SrunxConfig,
   Subscription,
   SyncResult,
+  Watch,
   TemplateCreateRequest,
   TemplateDetail,
   TemplateListItem,
@@ -778,6 +779,28 @@ export const subscriptions = {
   },
 };
 
+/* ── Watches ────────────────────────────────── */
+
+export const watches = {
+  list: async (opts?: {
+    open?: boolean;
+    kind?: string;
+    target_ref?: string;
+  }): Promise<Watch[]> => {
+    const params = new URLSearchParams();
+    if (opts?.open !== undefined) params.set("open", String(opts.open));
+    if (opts?.kind) params.set("kind", opts.kind);
+    if (opts?.target_ref) params.set("target_ref", opts.target_ref);
+    const qs = params.toString();
+    const res = await fetch(`/api/watches${qs ? `?${qs}` : ""}`);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to fetch watches"));
+    }
+    return res.json();
+  },
+};
+
 /* ── Deliveries ─────────────────────────────── */
 
 export const deliveries = {
@@ -797,6 +820,22 @@ export const deliveries = {
     return res.json();
   },
 
+  listRecent: async (opts?: {
+    status?: string;
+    limit?: number;
+  }): Promise<Delivery[]> => {
+    const params = new URLSearchParams();
+    if (opts?.status) params.set("status", opts.status);
+    if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+    const qs = params.toString();
+    const res = await fetch(`/api/deliveries${qs ? `?${qs}` : ""}`);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(extractDetail(err, "Failed to fetch deliveries"));
+    }
+    return res.json();
+  },
+
   countStuck: async (
     olderThanSec?: number,
   ): Promise<{ count: number; older_than_sec: number }> => {
@@ -804,9 +843,7 @@ export const deliveries = {
     if (olderThanSec !== undefined)
       params.set("older_than_sec", String(olderThanSec));
     const qs = params.toString();
-    const res = await fetch(
-      `/api/deliveries/stuck-count${qs ? `?${qs}` : ""}`,
-    );
+    const res = await fetch(`/api/deliveries/stuck${qs ? `?${qs}` : ""}`);
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       throw new Error(extractDetail(err, "Failed to fetch stuck count"));

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -267,6 +267,21 @@ export type Subscription = {
   created_at: string;
 };
 
+export type WatchKind =
+  | "job"
+  | "workflow_run"
+  | "resource_threshold"
+  | "scheduled_report";
+
+export type Watch = {
+  id: number;
+  kind: WatchKind;
+  target_ref: string;
+  filter: Record<string, unknown> | null;
+  created_at: string;
+  closed_at: string | null;
+};
+
 export type DeliveryStatus = "pending" | "sending" | "delivered" | "abandoned";
 
 export type Delivery = {

--- a/src/srunx/web/frontend/src/pages/NotificationsCenter.tsx
+++ b/src/srunx/web/frontend/src/pages/NotificationsCenter.tsx
@@ -1,0 +1,545 @@
+import { motion } from "framer-motion";
+import {
+  Bell,
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  Clock,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { useApi } from "../hooks/use-api.ts";
+import {
+  deliveries as deliveriesApi,
+  endpoints as endpointsApi,
+  subscriptions as subscriptionsApi,
+  watches as watchesApi,
+} from "../lib/api.ts";
+import type {
+  Delivery,
+  DeliveryStatus,
+  Endpoint,
+  Subscription,
+  Watch,
+} from "../lib/types.ts";
+import { ErrorBanner } from "../components/ErrorBanner.tsx";
+
+const EASE = [0.16, 1, 0.3, 1] as [number, number, number, number];
+
+const stagger = (i: number) => ({
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0 },
+  transition: { delay: i * 0.06, duration: 0.4, ease: EASE },
+});
+
+const STATUS_FILTERS: (DeliveryStatus | "all")[] = [
+  "all",
+  "pending",
+  "sending",
+  "delivered",
+  "abandoned",
+];
+
+const STATUS_COLOR: Record<DeliveryStatus, string> = {
+  pending: "var(--st-pending)",
+  sending: "var(--st-running)",
+  delivered: "var(--st-completed)",
+  abandoned: "var(--st-failed)",
+};
+
+const STATUS_ICON: Record<DeliveryStatus, React.ReactNode> = {
+  pending: <Clock size={12} />,
+  sending: <Clock size={12} />,
+  delivered: <CheckCircle2 size={12} />,
+  abandoned: <XCircle size={12} />,
+};
+
+function formatIso(iso: string | null): string {
+  if (!iso) return "—";
+  const dt = new Date(iso);
+  if (Number.isNaN(dt.getTime())) return iso;
+  return dt.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function NotificationsCenter() {
+  const [statusFilter, setStatusFilter] = useState<DeliveryStatus | "all">(
+    "all",
+  );
+
+  const { data: deliveries, error: deliveriesError } = useApi<Delivery[]>(
+    () =>
+      deliveriesApi.listRecent({
+        status: statusFilter === "all" ? undefined : statusFilter,
+        limit: 100,
+      }),
+    [statusFilter],
+    { pollInterval: 10000 },
+  );
+
+  const { data: stuck } = useApi(() => deliveriesApi.countStuck(), [], {
+    pollInterval: 10000,
+  });
+
+  const { data: watches, error: watchesError } = useApi<Watch[]>(
+    () => watchesApi.list({ open: true }),
+    [],
+    { pollInterval: 15000 },
+  );
+
+  const { data: endpoints } = useApi<Endpoint[]>(
+    () => endpointsApi.list(),
+    [],
+    {},
+  );
+
+  const { data: subscriptions, error: subscriptionsError } = useApi<
+    Subscription[]
+  >(() => subscriptionsApi.list({}), [], { pollInterval: 30000 });
+
+  const endpointById = useMemo(() => {
+    const m = new Map<number, Endpoint>();
+    for (const e of endpoints ?? []) m.set(e.id, e);
+    return m;
+  }, [endpoints]);
+
+  const watchById = useMemo(() => {
+    const m = new Map<number, Watch>();
+    for (const w of watches ?? []) m.set(w.id, w);
+    return m;
+  }, [watches]);
+
+  const anyError = deliveriesError || watchesError || subscriptionsError;
+
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: "var(--sp-6)" }}
+    >
+      <motion.div {...stagger(0)}>
+        <h1 style={{ marginBottom: 4 }}>
+          <Bell size={20} style={{ verticalAlign: -3, marginRight: 8 }} />
+          Notifications
+        </h1>
+        <p style={{ color: "var(--text-muted)", fontSize: "0.85rem" }}>
+          Real-time view of the notification outbox, open watches, and
+          subscription fan-out.
+        </p>
+      </motion.div>
+
+      <ErrorBanner error={anyError ?? null} />
+
+      {/* Top stats row */}
+      <motion.div
+        {...stagger(1)}
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+          gap: "var(--sp-4)",
+        }}
+      >
+        <StatCard
+          label="Open watches"
+          value={watches?.length ?? "—"}
+          icon={<Bell size={16} />}
+        />
+        <StatCard
+          label="Active subscriptions"
+          value={subscriptions?.length ?? "—"}
+          icon={<Bell size={16} />}
+        />
+        <StatCard
+          label="Stuck pending (>5 min)"
+          value={stuck?.count ?? "—"}
+          icon={<AlertTriangle size={16} />}
+          accent={
+            stuck && stuck.count > 0 ? "var(--st-failed)" : "var(--text-muted)"
+          }
+        />
+      </motion.div>
+
+      {/* Recent deliveries */}
+      <motion.section {...stagger(2)} className="panel">
+        <div
+          className="panel-header"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <h3>Recent deliveries</h3>
+          <div style={{ display: "flex", gap: 6 }}>
+            {STATUS_FILTERS.map((s) => {
+              const active = s === statusFilter;
+              return (
+                <button
+                  key={s}
+                  onClick={() => setStatusFilter(s)}
+                  style={{
+                    padding: "4px 10px",
+                    borderRadius: 4,
+                    fontSize: "0.72rem",
+                    fontFamily: "var(--font-mono)",
+                    border: `1px solid ${active ? "var(--accent)" : "var(--border-subtle)"}`,
+                    background: active ? "var(--accent-dim)" : "transparent",
+                    color: active ? "var(--accent)" : "var(--text-secondary)",
+                    cursor: "pointer",
+                    textTransform: "lowercase",
+                  }}
+                >
+                  {s}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <DeliveriesTable
+          deliveries={deliveries ?? []}
+          endpointById={endpointById}
+        />
+      </motion.section>
+
+      {/* Open watches */}
+      <motion.section {...stagger(3)} className="panel">
+        <div className="panel-header">
+          <h3>Open watches ({watches?.length ?? 0})</h3>
+        </div>
+        <WatchesTable watches={watches ?? []} />
+      </motion.section>
+
+      {/* Subscriptions */}
+      <motion.section {...stagger(4)} className="panel">
+        <div className="panel-header">
+          <h3>Subscriptions ({subscriptions?.length ?? 0})</h3>
+        </div>
+        <SubscriptionsTable
+          subscriptions={subscriptions ?? []}
+          endpointById={endpointById}
+          watchById={watchById}
+        />
+      </motion.section>
+    </div>
+  );
+}
+
+type StatCardProps = {
+  label: string;
+  value: number | string;
+  icon: React.ReactNode;
+  accent?: string;
+};
+
+function StatCard({ label, value, icon, accent }: StatCardProps) {
+  return (
+    <div
+      className="panel"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        padding: "var(--sp-4)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          color: accent ?? "var(--text-muted)",
+          fontSize: "0.72rem",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+        }}
+      >
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div
+        style={{
+          fontFamily: "var(--font-display)",
+          fontSize: "1.6rem",
+          color: accent ?? "var(--text-primary)",
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+type DeliveriesTableProps = {
+  deliveries: Delivery[];
+  endpointById: Map<number, Endpoint>;
+};
+
+function DeliveriesTable({ deliveries, endpointById }: DeliveriesTableProps) {
+  if (deliveries.length === 0) {
+    return <EmptyState message="No deliveries yet." />;
+  }
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: "0.8rem",
+        }}
+      >
+        <thead>
+          <tr style={{ color: "var(--text-muted)", textAlign: "left" }}>
+            <Th>Status</Th>
+            <Th>Endpoint</Th>
+            <Th>Attempts</Th>
+            <Th>Created</Th>
+            <Th>Delivered / next try</Th>
+            <Th>Last error</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {deliveries.map((d) => {
+            const endpoint = endpointById.get(d.endpoint_id);
+            return (
+              <tr
+                key={d.id}
+                style={{ borderTop: "1px solid var(--border-ghost)" }}
+              >
+                <Td>
+                  <StatusChip status={d.status} />
+                </Td>
+                <Td>
+                  <span style={{ fontFamily: "var(--font-mono)" }}>
+                    {endpoint
+                      ? `${endpoint.kind}:${endpoint.name}`
+                      : `#${d.endpoint_id}`}
+                  </span>
+                </Td>
+                <Td>{d.attempt_count}</Td>
+                <Td>{formatIso(d.created_at)}</Td>
+                <Td>
+                  {d.delivered_at
+                    ? formatIso(d.delivered_at)
+                    : formatIso(d.next_attempt_at)}
+                </Td>
+                <Td>
+                  <span
+                    title={d.last_error ?? ""}
+                    style={{
+                      color: d.last_error
+                        ? "var(--st-failed)"
+                        : "var(--text-muted)",
+                      maxWidth: 320,
+                      display: "inline-block",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {d.last_error ?? "—"}
+                  </span>
+                </Td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type WatchesTableProps = { watches: Watch[] };
+
+function WatchesTable({ watches }: WatchesTableProps) {
+  if (watches.length === 0) {
+    return <EmptyState message="No open watches." />;
+  }
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: "0.8rem",
+        }}
+      >
+        <thead>
+          <tr style={{ color: "var(--text-muted)", textAlign: "left" }}>
+            <Th>Kind</Th>
+            <Th>Target</Th>
+            <Th>Created</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {watches.map((w) => (
+            <tr
+              key={w.id}
+              style={{ borderTop: "1px solid var(--border-ghost)" }}
+            >
+              <Td>
+                <span style={{ fontFamily: "var(--font-mono)" }}>{w.kind}</span>
+              </Td>
+              <Td>
+                <span style={{ fontFamily: "var(--font-mono)" }}>
+                  {w.target_ref}
+                </span>
+              </Td>
+              <Td>{formatIso(w.created_at)}</Td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+type SubscriptionsTableProps = {
+  subscriptions: Subscription[];
+  endpointById: Map<number, Endpoint>;
+  watchById: Map<number, Watch>;
+};
+
+function SubscriptionsTable({
+  subscriptions,
+  endpointById,
+  watchById,
+}: SubscriptionsTableProps) {
+  if (subscriptions.length === 0) {
+    return <EmptyState message="No subscriptions configured." />;
+  }
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table
+        style={{
+          width: "100%",
+          borderCollapse: "collapse",
+          fontSize: "0.8rem",
+        }}
+      >
+        <thead>
+          <tr style={{ color: "var(--text-muted)", textAlign: "left" }}>
+            <Th>Watch</Th>
+            <Th>Target</Th>
+            <Th>Endpoint</Th>
+            <Th>Preset</Th>
+            <Th>Created</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {subscriptions.map((s) => {
+            const endpoint = endpointById.get(s.endpoint_id);
+            const watch = watchById.get(s.watch_id);
+            return (
+              <tr
+                key={s.id}
+                style={{ borderTop: "1px solid var(--border-ghost)" }}
+              >
+                <Td>
+                  <span style={{ fontFamily: "var(--font-mono)" }}>
+                    {watch ? watch.kind : `#${s.watch_id}`}
+                  </span>
+                </Td>
+                <Td>
+                  <span style={{ fontFamily: "var(--font-mono)" }}>
+                    {watch ? watch.target_ref : "—"}
+                  </span>
+                </Td>
+                <Td>
+                  <span style={{ fontFamily: "var(--font-mono)" }}>
+                    {endpoint
+                      ? `${endpoint.kind}:${endpoint.name}`
+                      : `#${s.endpoint_id}`}
+                  </span>
+                </Td>
+                <Td>
+                  <span
+                    style={{
+                      padding: "2px 8px",
+                      borderRadius: 4,
+                      fontSize: "0.7rem",
+                      fontFamily: "var(--font-mono)",
+                      background: "var(--bg-base)",
+                      border: "1px solid var(--border-subtle)",
+                    }}
+                  >
+                    {s.preset}
+                  </span>
+                </Td>
+                <Td>{formatIso(s.created_at)}</Td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StatusChip({ status }: { status: DeliveryStatus }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "2px 8px",
+        borderRadius: 4,
+        fontSize: "0.72rem",
+        fontFamily: "var(--font-mono)",
+        color: STATUS_COLOR[status],
+        background: "var(--bg-base)",
+        border: `1px solid ${STATUS_COLOR[status]}`,
+      }}
+    >
+      {STATUS_ICON[status]}
+      {status}
+    </span>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return (
+    <th
+      style={{
+        padding: "8px 10px",
+        fontWeight: 500,
+        fontSize: "0.72rem",
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+      }}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return (
+    <td
+      style={{
+        padding: "8px 10px",
+        color: "var(--text-secondary)",
+      }}
+    >
+      {children}
+    </td>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        padding: "var(--sp-6)",
+        textAlign: "center",
+        color: "var(--text-muted)",
+        fontSize: "0.85rem",
+      }}
+    >
+      {message}
+    </div>
+  );
+}

--- a/src/srunx/web/frontend/src/pages/NotificationsCenter.tsx
+++ b/src/srunx/web/frontend/src/pages/NotificationsCenter.tsx
@@ -113,6 +113,24 @@ export function NotificationsCenter() {
     return m;
   }, [watches]);
 
+  // "Active" subscriptions = those whose watch is still open. The
+  // underlying API returns recent-first bounded by limit=200 and
+  // includes closed-watch rows; a naive count would double-report
+  // inactive subscriptions AND silently truncate at 200. Filter
+  // client-side so the headline reflects reality for the typical
+  // single-user outbox; large installs should call the scoped
+  // endpoints instead.
+  const activeSubscriptions = useMemo(() => {
+    if (!subscriptions) return null;
+    return subscriptions.filter((s) => watchById.has(s.watch_id));
+  }, [subscriptions, watchById]);
+  const activeSubsCount: number | string =
+    activeSubscriptions === null
+      ? "—"
+      : subscriptions && subscriptions.length >= 200
+        ? `${activeSubscriptions.length}+`
+        : activeSubscriptions.length;
+
   const anyError = deliveriesError || watchesError || subscriptionsError;
 
   return (
@@ -148,7 +166,7 @@ export function NotificationsCenter() {
         />
         <StatCard
           label="Active subscriptions"
-          value={subscriptions?.length ?? "—"}
+          value={activeSubsCount}
           icon={<Bell size={16} />}
         />
         <StatCard

--- a/src/srunx/web/routers/deliveries.py
+++ b/src/srunx/web/routers/deliveries.py
@@ -30,17 +30,25 @@ def _serialize(delivery: Any) -> dict[str, Any]:
 async def list_deliveries(
     subscription_id: int | None = Query(default=None),
     status: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
     conn: sqlite3.Connection = Depends(get_db_conn),
 ) -> list[dict[str, Any]]:
+    """List deliveries — scoped to a subscription, or recent across all.
+
+    - ``subscription_id`` + optional ``status`` → per-subscription view.
+    - ``subscription_id`` omitted → most recent deliveries across every
+      subscription (bounded by ``limit``, max 500). Used by the
+      NotificationsCenter dashboard.
+    """
     repo = get_delivery_repo(conn)
     if subscription_id is None:
-        raise HTTPException(
-            status_code=400,
-            detail="subscription_id query parameter required (global listings are disabled)",
+        rows = await anyio.to_thread.run_sync(
+            lambda: repo.list_recent(status=status, limit=limit)
         )
-    rows = await anyio.to_thread.run_sync(
-        lambda: repo.list_by_subscription(subscription_id, status=status)
-    )
+    else:
+        rows = await anyio.to_thread.run_sync(
+            lambda: repo.list_by_subscription(subscription_id, status=status)
+        )
     return [_serialize(r) for r in rows]
 
 

--- a/src/srunx/web/routers/subscriptions.py
+++ b/src/srunx/web/routers/subscriptions.py
@@ -35,8 +35,16 @@ def _serialize(sub: Any) -> dict[str, Any]:
 async def list_subscriptions(
     watch_id: int | None = Query(default=None),
     endpoint_id: int | None = Query(default=None),
+    limit: int = Query(default=200, ge=1, le=500),
     conn: sqlite3.Connection = Depends(get_db_conn),
 ) -> list[dict[str, Any]]:
+    """List subscriptions.
+
+    - With ``watch_id`` or ``endpoint_id`` → scoped listing (newest first).
+    - Without either → recent subscriptions across all watches/endpoints,
+      bounded by ``limit`` (default 200, max 500). Used by the
+      NotificationsCenter dashboard.
+    """
     repo = get_subscription_repo(conn)
     if watch_id is not None:
         rows = await anyio.to_thread.run_sync(lambda: repo.list_by_watch(watch_id))
@@ -45,10 +53,7 @@ async def list_subscriptions(
             lambda: repo.list_by_endpoint(endpoint_id)
         )
     else:
-        raise HTTPException(
-            status_code=400,
-            detail="watch_id or endpoint_id query parameter required",
-        )
+        rows = await anyio.to_thread.run_sync(lambda: repo.list_recent(limit=limit))
     return [_serialize(r) for r in rows]
 
 

--- a/tests/db/repositories/test_deliveries.py
+++ b/tests/db/repositories/test_deliveries.py
@@ -275,6 +275,46 @@ def test_list_by_subscription_filters_and_orders(
     assert delivered_rows == []
 
 
+def test_list_recent_returns_all_subscriptions(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+    conn: sqlite3.Connection,
+) -> None:
+    """``list_recent`` returns deliveries across subscriptions, newest first."""
+    repo.insert(
+        setup_fks["event_id"],
+        setup_fks["subscription_id"],
+        setup_fks["endpoint_id"],
+        "k1",
+    )
+    time.sleep(0.02)
+    other_event = _seed_event(conn, source_ref="job:99", payload_hash="hash-99")
+    other_watch = _seed_watch(conn, target_ref="job:99")
+    other_sub = _seed_subscription(conn, other_watch, setup_fks["endpoint_id"])
+    repo.insert(other_event, other_sub, setup_fks["endpoint_id"], "k2")
+
+    rows = repo.list_recent()
+    assert len(rows) == 2
+    assert rows[0].idempotency_key == "k2"  # newest first
+    assert rows[1].idempotency_key == "k1"
+
+
+def test_list_recent_respects_status_and_limit(
+    repo: DeliveryRepository,
+    setup_fks: dict[str, int],
+) -> None:
+    for i in range(5):
+        repo.insert(
+            setup_fks["event_id"],
+            setup_fks["subscription_id"],
+            setup_fks["endpoint_id"],
+            f"key-{i}",
+        )
+    assert len(repo.list_recent(limit=3)) == 3
+    assert repo.list_recent(status="delivered") == []
+    assert len(repo.list_recent(status="pending")) == 5
+
+
 # ---------------------------------------------------------------------------
 # claim_one
 # ---------------------------------------------------------------------------

--- a/tests/web/test_endpoints_router.py
+++ b/tests/web/test_endpoints_router.py
@@ -127,9 +127,19 @@ def test_deliveries_stuck_count(app_client: TestClient) -> None:
     assert "older_than_sec" in body
 
 
-def test_deliveries_list_requires_subscription_id(app_client: TestClient) -> None:
+def test_deliveries_list_recent_empty(app_client: TestClient) -> None:
+    """Without ``subscription_id`` the endpoint returns recent deliveries globally."""
     r = app_client.get("/api/deliveries")
-    assert r.status_code == 400
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_deliveries_list_recent_limit_validated(app_client: TestClient) -> None:
+    """``limit`` must stay within [1, 500]."""
+    r = app_client.get("/api/deliveries?limit=0")
+    assert r.status_code == 422
+    r = app_client.get("/api/deliveries?limit=501")
+    assert r.status_code == 422
 
 
 # --- watches observability ---

--- a/tests/web/test_endpoints_router.py
+++ b/tests/web/test_endpoints_router.py
@@ -111,9 +111,18 @@ def test_delete_endpoint(app_client: TestClient) -> None:
 # --- subscriptions CRUD (requires endpoint + watch) ---
 
 
-def test_subscription_requires_filter(app_client: TestClient) -> None:
+def test_subscription_list_recent_empty(app_client: TestClient) -> None:
+    """Without ``watch_id`` / ``endpoint_id`` the endpoint returns recent subs globally."""
     r = app_client.get("/api/subscriptions")
-    assert r.status_code == 400
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_subscription_list_recent_limit_validated(app_client: TestClient) -> None:
+    r = app_client.get("/api/subscriptions?limit=0")
+    assert r.status_code == 422
+    r = app_client.get("/api/subscriptions?limit=501")
+    assert r.status_code == 422
 
 
 # --- deliveries observability ---


### PR DESCRIPTION
## Summary

Adds a new top-level **Notifications** page that surfaces the outbox state previously only reachable via raw API calls. Summary cards show open watches / active subscriptions / stuck-pending count; three tables show recent deliveries (status-filterable), open watches, and subscriptions. Auto-refreshes every 10-30 s.

## What changes

### Backend

- ``DeliveryRepository.list_recent(status, limit)`` — global recent-first listing with a bounded limit (default 100, hard cap 500).
- ``GET /api/deliveries`` with no ``subscription_id`` now returns ``list_recent(...)`` instead of 400; subscription-scoped listings unchanged.
- ``GET /api/deliveries?limit=`` validated to [1, 500] via FastAPI Query.

### Frontend

- New ``/notifications`` route + sidebar nav entry (🔔 icon).
- Fixes ``/api/deliveries/stuck`` path (previously pointed at wrong endpoint).
- Adds ``listRecent()`` + a watches client.
- New ``Watch`` / ``WatchKind`` types.

## Test plan

- [x] Repo: ``list_recent`` returns newest-first across subscriptions + respects status/limit.
- [x] Router: new global list returns [] when empty; limit validation (422 for 0 or 501).
- [x] ``uv run pytest`` passes; ``mypy`` + ``ruff`` clean; ``tsc --noEmit`` clean.
- [ ] Playwright E2E — see stacked #$(gh pr view test/playwright-notifications-e2e-on-c3 --json number -q .number 2>/dev/null || echo TBD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)