### PR TITLE
fix(db): cross-thread sqlite3 Connection handoff (hotfix)

### DIFF
--- a/src/srunx/db/connection.py
+++ b/src/srunx/db/connection.py
@@ -70,6 +70,14 @@ def open_connection(db_path: Path | None = None) -> sqlite3.Connection:
 
     On first creation, the DB file is chmod'd to ``0o600``. Caller owns the
     returned connection and must close it (or use a ``with`` block).
+
+    ``check_same_thread=False`` is set so the same connection can be
+    passed across the FastAPI request-handler thread ↔ anyio worker
+    thread boundary within a single request (``get_db_conn`` yields per
+    request; writes run inside ``anyio.to_thread.run_sync`` blocks).
+    srunx's access pattern serialises calls on any given connection —
+    one request owns it at a time — so the relaxed thread check is
+    safe. sqlite itself still serialises writers via the WAL lock.
     """
     path = db_path or get_db_path()
     created = not path.exists()
@@ -79,7 +87,7 @@ def open_connection(db_path: Path | None = None) -> sqlite3.Connection:
     # is required for the outbox claim pattern (BEGIN IMMEDIATE ... COMMIT)
     # because the default "deferred" mode auto-starts a transaction on
     # the first DML and then refuses BEGIN.
-    conn = sqlite3.connect(path, isolation_level=None)
+    conn = sqlite3.connect(path, isolation_level=None, check_same_thread=False)
     conn.row_factory = sqlite3.Row
     _apply_pragmas(conn)
     if created:

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -171,3 +171,43 @@ def test_init_db_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     finally:
         conn.close()
     assert rows[0] == 1
+
+
+def test_connection_usable_from_another_thread(tmp_path: Path) -> None:
+    """Regression: FastAPI routes pass the request-bound connection into
+    ``anyio.to_thread.run_sync`` worker threads. The stock ``sqlite3``
+    driver rejects cross-thread use unless ``check_same_thread=False``
+    was set at open time — which a real uvicorn run would hit on every
+    /api/endpoints, /api/deliveries, /api/subscriptions, /api/watches
+    call.
+
+    This test exercises the exact cross-thread pattern (connection
+    opened on thread A, read on thread B) to prevent the bug from
+    regressing.
+    """
+    import threading
+
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        conn.execute("CREATE TABLE t (id INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1)")
+
+        result: list[int] = []
+        error: list[BaseException] = []
+
+        def read_on_other_thread() -> None:
+            try:
+                row = conn.execute("SELECT id FROM t").fetchone()
+                result.append(row[0])
+            except BaseException as exc:  # noqa: BLE001
+                error.append(exc)
+
+        t = threading.Thread(target=read_on_other_thread)
+        t.start()
+        t.join(timeout=5)
+
+        assert not error, f"cross-thread read raised: {error[0]!r}"
+        assert result == [1]
+    finally:
+        conn.close()


### PR DESCRIPTION
## ⚠️ Critical hotfix

**Discovered during manual Playwright QA of C3 (#82).** Every
notification-domain route (``/api/endpoints``, ``/api/deliveries``,
``/api/subscriptions``, ``/api/watches``) plus the notify-path in
``/api/jobs`` returned **HTTP 500** under real uvicorn with this
traceback:

```
sqlite3.ProgrammingError: SQLite objects created in a thread can only
be used in that same thread. The object was created in thread id X
and this is thread id Y.
```

## Root cause

Routes open a request-bound ``sqlite3.Connection`` via
``Depends(get_db_conn)`` (thread A = handler) and then pass it into
``anyio.to_thread.run_sync`` blocks (thread B = worker). The stock
sqlite3 driver defaults to ``check_same_thread=True`` and rejects.

**Why tests passed:** ``fastapi.testclient.TestClient`` runs the app
synchronously in a single thread; the handoff is effectively elided.
No existing unit test exercised the real thread boundary.

## Fix

Open connections with ``check_same_thread=False``. Safe under our
invariants:

- each connection is request-scoped (``get_db_conn`` yields once per
  request, closed in ``finally``)
- srunx serialises all calls on any one connection — the handler-to-
  worker transition is awaited, never concurrent
- sqlite itself still serialises writers via the WAL lock +
  ``busy_timeout``

## Regression test

``tests/db/test_connection.py::test_connection_usable_from_another_thread``
walks a real ``threading.Thread`` to reproduce the exact pattern that
broke. Also 1328 existing tests still pass.

## Suggested merge order

Merge this **first**, before #80 / #81 / #82 / #83 / #84 / #85 / #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)