### PR TITLE
fix(web): P1-1 — workflow_run starts 'pending', poller owns lifecycle

### DIFF
--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -1128,21 +1128,32 @@ async def run_workflow(
         await anyio.to_thread.run_sync(functools.partial(_fail, reason))
         raise
 
-    # Phase 5: Mark running + create workflow_run watch so the poller
-    # can aggregate child statuses into the workflow run going forward.
-    def _activate() -> None:
-        run_repo.update_status(run_id, "running")  # type: ignore[arg-type]
+    # Phase 5: open the workflow_run watch so the poller can drive
+    # status transitions going forward. We deliberately do NOT set
+    # ``workflow_runs.status='running'`` here: the run record stays
+    # ``pending`` (as created above) until ActiveWatchPoller observes a
+    # child job in RUNNING state.
+    #
+    # Rationale (R/Codex P1-1): the poller's aggregation rules say
+    # "any child RUNNING → running; otherwise pending". Pre-emptively
+    # writing ``running`` here meant the very first poll cycle — while
+    # all children are still PENDING in SLURM — would aggregate to
+    # ``pending`` and emit a spurious ``running → pending`` transition,
+    # complete with a ``workflow_run.status_changed`` event to every
+    # subscriber. Letting the poller own the lifecycle keeps transitions
+    # monotonic: ``pending → running → completed/failed/cancelled``.
+    def _open_watch() -> None:
         watch_repo.create(
             kind="workflow_run",
             target_ref=f"workflow_run:{run_id}",
         )
 
-    await anyio.to_thread.run_sync(_activate)
+    await anyio.to_thread.run_sync(_open_watch)
 
     def _load_final() -> dict[str, Any]:
         final_run = run_repo.get(run_id)  # type: ignore[arg-type]
         if final_run is None:
-            return {"id": str(run_id), "status": "running"}
+            return {"id": str(run_id), "status": "pending"}
         return _build_run_response(conn, final_run)
 
     return await anyio.to_thread.run_sync(_load_final)

--- a/tests/pollers/test_active_watch_poller.py
+++ b/tests/pollers/test_active_watch_poller.py
@@ -379,6 +379,52 @@ class TestWorkflowAggregation:
         assert watch is not None
         assert watch.closed_at is not None
 
+    def test_pending_run_with_all_pending_children_is_quiet(
+        self,
+        tmp_srunx_db: tuple[sqlite3.Connection, Path],
+    ) -> None:
+        """Regression: P1-1 (#E).
+
+        A just-submitted workflow run sits at ``status='pending'`` with
+        every child job at ``PENDING``. Rule 5 (Otherwise → pending) of
+        the aggregator should match the current status and emit
+        nothing. Pre-P1-1 the router wrote ``running`` eagerly here, so
+        this cycle emitted a spurious ``running → pending`` transition.
+        """
+        conn, db_path = tmp_srunx_db
+
+        run_id = WorkflowRunRepository(conn).create(
+            workflow_name="pipeline",
+            yaml_path=None,
+            args=None,
+            triggered_by="web",
+        )
+        # Leave the run at its default 'pending' — exactly what the
+        # fixed /run endpoint yields now.
+        _seed_job(conn, 601, status="PENDING")
+        _seed_job(conn, 602, status="PENDING")
+        WorkflowRunJobRepository(conn).create(
+            workflow_run_id=run_id, job_name="a", job_id=601
+        )
+        WorkflowRunJobRepository(conn).create(
+            workflow_run_id=run_id, job_name="b", job_id=602
+        )
+        WatchRepository(conn).create(
+            kind="workflow_run", target_ref=f"workflow_run:{run_id}"
+        )
+
+        _run_once(ActiveWatchPoller(StubSlurmClient({}), db_path=db_path))
+
+        run = WorkflowRunRepository(conn).get(run_id)
+        assert run is not None
+        assert run.status == "pending"
+        wf_events = [
+            e
+            for e in EventRepository(conn).list_recent()
+            if e.kind == "workflow_run.status_changed"
+        ]
+        assert wf_events == []
+
     def test_running_child_leaves_run_running_no_event(
         self,
         tmp_srunx_db: tuple[sqlite3.Connection, Path],

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -486,7 +486,11 @@ class TestWorkflowsRouter:
         assert resp.status_code == 202
         data = resp.json()
         assert data["workflow_name"] == "run-test"
-        assert data["status"] == "running"
+        # Status stays 'pending' until ActiveWatchPoller observes a child
+        # job in RUNNING state. Pre-emptively writing 'running' here
+        # caused a spurious 'running → pending' regression on the first
+        # poll cycle (see P1-1 in the Codex review triage).
+        assert data["status"] == "pending"
         assert "10001" in data["job_ids"].values()
         assert "10002" in data["job_ids"].values()
 
@@ -564,7 +568,9 @@ class TestWorkflowsRouter:
             run = WorkflowRunRepository(conn).get(run_id)
             assert run is not None
             assert run.workflow_name == "integration-run"
-            assert run.status == "running"
+            # P1-1: the run stays 'pending' until the poller observes a
+            # RUNNING child. See the phase-5 comment in workflows.py.
+            assert run.status == "pending"
             assert run.triggered_by == "web"
 
             memberships = WorkflowRunJobRepository(conn).list_by_run(run_id)
@@ -1589,7 +1595,9 @@ class TestWorkflowExecutionControl:
         )
         assert resp.status_code == 202
         data = resp.json()
-        assert data["status"] == "running"
+        # P1-1: newly-created runs start at 'pending' and the poller
+        # promotes them to 'running' on the first RUNNING child.
+        assert data["status"] == "pending"
         # All 3 jobs should be submitted
         assert mock_adapter.submit_job.call_count == 3
 


### PR DESCRIPTION
## Summary

**P1-1** from the Codex / code-explorer triage after Phase 1 landed. Fixes a spurious ``running → pending`` transition that the ``/api/workflows/{name}/run`` endpoint was triggering on every run.

## The bug

``workflows.py::_activate`` eagerly set ``workflow_runs.status='running'`` in phase 5 — while every child job was still ``PENDING`` in SLURM. The first ``ActiveWatchPoller`` cycle ran the aggregation rules:

> rule 4: any child RUNNING → running
> rule 5: otherwise → pending

No child was RUNNING yet, so rule 5 returned ``pending``. The poller then wrote a ``running → pending`` transition and fan-out'd a ``workflow_run.status_changed`` event to every subscriber.

## The fix

Don't flip the status in ``/run``. Leave it at its default ``pending`` (from ``WorkflowRunRepository.create``) and let the poller promote it to ``running`` when a child actually enters RUNNING. Lifecycle transitions now stay monotonic: ``pending → running → terminal``.

The ``workflow_run`` watch is still opened in phase 5 — that's the poller's entry point.

## Tests

- ``test_run_workflow_success`` / ``test_run_workflow_persists_all_db_rows`` / ``test_no_body_backward_compat`` now expect ``status='pending'`` on the ``/run`` response.
- New ``test_pending_run_with_all_pending_children_is_quiet`` in the poller suite — seeds a pending run with PENDING children and asserts the first ``run_cycle()`` emits no transition and no event.

``uv run pytest`` → 1346 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)