### PR TITLE
fix(db): P1-2 — record_submission uses INSERT OR IGNORE

### DIFF
--- a/src/srunx/db/repositories/jobs.py
+++ b/src/srunx/db/repositories/jobs.py
@@ -71,13 +71,29 @@ class JobRepository(BaseRepository):
     ) -> int:
         """Insert a new row for a just-submitted job.
 
-        Uses ``INSERT OR REPLACE`` on ``job_id``: a resubmission under the
-        same SLURM ID replaces the prior record. Returns the row's ``id``.
+        Uses ``INSERT OR IGNORE`` on the ``job_id`` UNIQUE constraint:
+        if a row with this SLURM id already exists, the call is a
+        no-op and returns ``0``. Callers that want to mutate an
+        existing row should use :meth:`update_status` /
+        :meth:`update_completion` explicitly.
+
+        Rationale for **not** using ``INSERT OR REPLACE`` here
+        (P1-2 in the Codex review triage): ``REPLACE`` executes
+        ``DELETE`` + ``INSERT``, which triggers
+        ``ON DELETE SET NULL`` on the FK references in
+        ``workflow_run_jobs.job_id`` and ``job_state_transitions.job_id``.
+        A re-submission path (or a bug-induced double call) would
+        silently orphan every prior transition and membership, which
+        corrupts the poller's dedup / aggregation invariants. It would
+        also reset a poller-advanced ``status='RUNNING'`` row back to
+        ``'PENDING'`` + rewrite ``submitted_at``. With ``IGNORE`` the
+        first call wins; subsequent callers observe ``lastrowid=0``
+        and must decide explicitly what to do.
         """
         submitted_at = submitted_at or now_iso()
         cur = self.conn.execute(
             """
-            INSERT OR REPLACE INTO jobs (
+            INSERT OR IGNORE INTO jobs (
                 job_id, name, command, status,
                 nodes, gpus_per_node, memory_per_node, time_limit,
                 partition, nodelist,
@@ -109,6 +125,12 @@ class JobRepository(BaseRepository):
                 self._encode_json(metadata),
             ),
         )
+        # ``lastrowid`` is only meaningful when rowcount > 0. SQLite (and
+        # the Python driver) preserve the prior successful rowid from the
+        # same connection across an IGNORE no-op, so relying on it would
+        # make duplicates look like fresh inserts. Gate on rowcount.
+        if cur.rowcount == 0:
+            return 0
         return int(cur.lastrowid or 0)
 
     def update_status(

--- a/tests/db/repositories/test_jobs.py
+++ b/tests/db/repositories/test_jobs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sqlite3
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -12,9 +14,17 @@ from srunx.db.repositories.jobs import JobRepository
 
 
 @pytest.fixture
-def repo(tmp_path: Path) -> JobRepository:
-    conn = open_connection(tmp_path / "t.db")
-    apply_migrations(conn)
+def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    connection = open_connection(tmp_path / "t.db")
+    apply_migrations(connection)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def repo(conn: sqlite3.Connection) -> JobRepository:
     return JobRepository(conn)
 
 
@@ -49,19 +59,71 @@ def test_record_submission_roundtrip(repo: JobRepository) -> None:
     assert job.metadata == {"run_id": "abc"}
 
 
-def test_record_submission_is_idempotent_on_same_job_id(
+def test_record_submission_duplicate_job_id_is_noop(
     repo: JobRepository,
 ) -> None:
-    repo.record_submission(
+    """P1-2: duplicate record_submission must NOT overwrite.
+
+    ``INSERT OR REPLACE`` would ``DELETE`` the existing row (cascading
+    ``ON DELETE SET NULL`` to ``workflow_run_jobs.job_id`` and
+    ``job_state_transitions.job_id``) before inserting the new one —
+    silently orphaning every prior transition and membership. With
+    ``INSERT OR IGNORE`` the first call wins, subsequent callers get
+    ``lastrowid=0`` and can decide explicitly what to do.
+    """
+    first_row_id = repo.record_submission(
         job_id=202, name="first", status="PENDING", submission_source="web"
     )
-    # Re-submission replaces the record via INSERT OR REPLACE.
-    repo.record_submission(
-        job_id=202, name="second", status="PENDING", submission_source="web"
+    assert first_row_id > 0
+
+    second_row_id = repo.record_submission(
+        job_id=202,
+        name="second",
+        status="RUNNING",
+        submission_source="workflow",
     )
+    assert second_row_id == 0  # INSERT OR IGNORE → no row inserted
+
     job = repo.get(202)
     assert job is not None
-    assert job.name == "second"
+    # Original fields preserved — not clobbered to "second" / RUNNING.
+    assert job.name == "first"
+    assert job.status == "PENDING"
+    assert job.submission_source == "web"
+
+
+def test_record_submission_ignore_preserves_fk_references(
+    repo: JobRepository, conn: sqlite3.Connection
+) -> None:
+    """P1-2: ensure the FK references survive a duplicate call.
+
+    ``INSERT OR REPLACE`` would have cascaded a ``SET NULL`` through the
+    ``job_state_transitions.job_id`` FK; ``INSERT OR IGNORE`` preserves.
+    """
+    repo.record_submission(
+        job_id=210, name="fk-test", status="PENDING", submission_source="web"
+    )
+    # Simulate a prior transition observed by the poller.
+    conn.execute(
+        "INSERT INTO job_state_transitions (job_id, to_status, observed_at, source) "
+        "VALUES (?, 'RUNNING', '2026-04-19T00:00:00Z', 'poller')",
+        (210,),
+    )
+    conn.commit()
+
+    # A second (spurious) record_submission for the same job_id.
+    repo.record_submission(
+        job_id=210,
+        name="fk-test",
+        status="PENDING",
+        submission_source="web",
+    )
+
+    # The prior transition still references the jobs row — not SET NULL.
+    rows = conn.execute(
+        "SELECT job_id FROM job_state_transitions WHERE to_status='RUNNING'"
+    ).fetchall()
+    assert [r[0] for r in rows] == [210]
 
 
 def test_update_status_fills_optional_fields(repo: JobRepository) -> None:


### PR DESCRIPTION
## Summary

**P1-2** from the post-Phase-1 triage. ``JobRepository.record_submission`` used ``INSERT OR REPLACE``, which SQLite implements as ``DELETE`` + ``INSERT``. Any duplicate call — a spurious dual-write, a future retry path, or a cross-process race — therefore cascades ``ON DELETE SET NULL`` through the FK references on ``workflow_run_jobs.job_id`` and ``job_state_transitions.job_id``. Every prior transition / membership for that SLURM id would be silently orphaned, breaking the poller's dedup and aggregation invariants, and a poller-advanced ``status='RUNNING'`` row would be reset to ``'PENDING'``.

## The fix

Switch to ``INSERT OR IGNORE``. First caller wins; subsequent callers observe ``rowcount=0`` and receive ``0`` as the returned row_id. Every current caller treats the row_id as advisory so no call site needs to change.

Also gate the return value on ``cursor.rowcount`` instead of ``cursor.lastrowid``. SQLite preserves the prior successful rowid across an ``IGNORE`` no-op, which would otherwise make duplicates look like fresh inserts.

## Tests

- Renamed ``test_record_submission_is_idempotent_on_same_job_id`` to ``test_record_submission_duplicate_job_id_is_noop`` — asserts the second call returns 0 and the original fields (name, status, submission_source) survive unchanged.
- New ``test_record_submission_ignore_preserves_fk_references`` — inserts a job + an FK-referring ``job_state_transitions`` row via the poller path, calls ``record_submission`` again with the same job_id, asserts the transition's ``job_id`` is still the original value (no ``SET NULL`` cascade).

``uv run pytest`` → 1346 passed. mypy / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)