### PR TITLE
fix(notifications): P1-3 — reject digest preset on create

### DIFF
--- a/src/srunx/notifications/presets.py
+++ b/src/srunx/notifications/presets.py
@@ -44,9 +44,14 @@ def should_deliver(
         delivery for this event, ``False`` otherwise.
 
     Notes:
-        - ``'digest'`` is reserved for Phase 2; this function always
-          returns ``False`` for it so the flag may be stored without
-          producing immediate deliveries.
+        - ``'digest'`` batching is not yet implemented. This function
+          always returns ``False`` for it. The ``/api/subscriptions``
+          router refuses to create *new* rows with this preset (see
+          ``_ACCEPTED_PRESETS_FOR_CREATE`` in
+          ``srunx.web.routers.subscriptions``), so the only way to
+          reach this branch today is on rows that pre-date the
+          enforcement — they are read-through but produce zero
+          deliveries. (P1-3)
         - ``job.submitted``, ``resource.threshold_crossed`` and
           ``scheduled_report.due`` only deliver under preset ``'all'``.
     """

--- a/src/srunx/web/routers/subscriptions.py
+++ b/src/srunx/web/routers/subscriptions.py
@@ -15,6 +15,14 @@ router = APIRouter(prefix="/api/subscriptions", tags=["subscriptions"])
 
 _VALID_PRESETS = ("terminal", "running_and_terminal", "all", "digest")
 
+# Presets that are accepted for NEW subscriptions. The schema CHECK
+# still allows ``'digest'`` (keeping any prior rows readable), but the
+# service layer drops every delivery under that preset
+# (``should_deliver('digest', ...) → False``), so new subscribers who
+# picked it would silently receive zero notifications. Reject it at
+# the API until digest batching is actually implemented. (P1-3)
+_ACCEPTED_PRESETS_FOR_CREATE = ("terminal", "running_and_terminal", "all")
+
 
 class SubscriptionCreate(BaseModel):
     watch_id: int = Field(..., gt=0)
@@ -66,6 +74,17 @@ async def create_subscription(
         raise HTTPException(
             status_code=422,
             detail=f"Invalid preset '{body.preset}'. Allowed: {_VALID_PRESETS}",
+        )
+    if body.preset not in _ACCEPTED_PRESETS_FOR_CREATE:
+        # Digest batching isn't implemented yet; accepting new
+        # subscriptions under that preset would silently deliver zero
+        # notifications.
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Preset '{body.preset}' is not implemented yet. "
+                f"Accepted: {_ACCEPTED_PRESETS_FOR_CREATE}"
+            ),
         )
     repo = get_subscription_repo(conn)
     try:

--- a/tests/web/test_notification_routers.py
+++ b/tests/web/test_notification_routers.py
@@ -99,6 +99,31 @@ def test_subscriptions_rejects_invalid_preset(
     assert r.status_code == 422
 
 
+def test_subscriptions_rejects_digest_preset(
+    app_client_and_db: tuple[TestClient, Path],
+) -> None:
+    """P1-3: ``digest`` is schema-valid but not yet implemented.
+
+    Accepting a new subscription under ``preset='digest'`` would
+    silently deliver zero notifications because
+    ``should_deliver('digest', ...)`` returns False. Reject the create
+    with a 422 that explains the accepted presets.
+    """
+    client, db_path = app_client_and_db
+    endpoint_id, watch_id = _seed_endpoint_and_watch(db_path)
+
+    r = client.post(
+        "/api/subscriptions",
+        json={
+            "watch_id": watch_id,
+            "endpoint_id": endpoint_id,
+            "preset": "digest",
+        },
+    )
+    assert r.status_code == 422
+    assert "not implemented" in r.json()["detail"]
+
+
 # --- watches router ---
 
 


### PR DESCRIPTION
## Summary

**P1-3** from the post-Phase-1 triage. The ``digest`` preset is schema-valid (``subscriptions.preset CHECK`` allows it), the frontend Subscription type includes it, and users could POST ``{ preset: 'digest' }`` through ``/api/subscriptions`` — but ``should_deliver('digest', ...)`` always returns False because batching isn't implemented yet. A user picking digest would silently receive zero notifications with no hint why.

## The fix

``POST /api/subscriptions`` now refuses new rows under ``digest`` with **422** and a detail that names the accepted set (``terminal`` / ``running_and_terminal`` / ``all``). The schema ``CHECK`` stays open so any rows pre-dating this enforcement are still readable — the backend must not regress on existing data.

- Added ``_ACCEPTED_PRESETS_FOR_CREATE`` separate from ``_VALID_PRESETS`` (which still mirrors the schema). Two-stage validation distinguishes "unknown preset" (422, allowed set) from "not yet implemented" (422, accepted set).
- ``presets.py::should_deliver`` docstring now points at the router guard so future readers know why digest reads as ``False`` at this layer.

Frontend already excludes digest from its ``NOTIFICATION_PRESETS`` dropdown (``FileExplorer.tsx:43-47``) so no UI change needed. The TS ``NotificationPreset`` union keeps digest for list-view typing.

## Tests

- New ``test_subscriptions_rejects_digest_preset`` — asserts 422 + ``"not implemented"`` in the detail.

``uv run pytest`` → 1346 passed. mypy / ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)