### PR TITLE
feat(config): P3-9 #G — honour XDG_CONFIG_HOME in get_config_paths

### DIFF
--- a/src/srunx/config.py
+++ b/src/srunx/config.py
@@ -93,6 +93,27 @@ class SrunxConfig(BaseModel):
     work_dir: str | None = Field(default=None, description="Default working directory")
 
 
+def _user_config_dir() -> Path:
+    """Return the XDG-compliant per-user srunx config directory.
+
+    Resolution order:
+
+    1. ``$XDG_CONFIG_HOME/srunx`` when the env var is set (POSIX spec).
+    2. ``~/.config/srunx`` on POSIX fallback.
+    3. ``~/AppData/Roaming/srunx`` on Windows.
+
+    Matches :func:`srunx.db.connection.get_config_dir` so that the
+    state DB and the JSON config land under the same root — flipping
+    ``XDG_CONFIG_HOME`` isolates both in one go (tests rely on this).
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "srunx"
+    if os.name == "posix":
+        return Path.home() / ".config" / "srunx"
+    return Path.home() / "AppData" / "Roaming" / "srunx"
+
+
 def get_config_paths() -> list[Path]:
     """Get configuration file paths in order of precedence (lowest to highest)."""
     paths = []
@@ -105,14 +126,8 @@ def get_config_paths() -> list[Path]:
     else:
         paths.append(Path("C:/ProgramData/srunx/config.json"))
 
-    # User-wide config
-    # On Unix: ~/.config/srunx/config.json
-    # On Windows: ~/AppData/Roaming/srunx/config.json
-    if os.name == "posix":
-        user_config_dir = Path.home() / ".config" / "srunx"
-    else:
-        user_config_dir = Path.home() / "AppData" / "Roaming" / "srunx"
-    paths.append(user_config_dir / "config.json")
+    # User-wide config (honours XDG_CONFIG_HOME on POSIX)
+    paths.append(_user_config_dir() / "config.json")
 
     # Project-wide config (current working directory)
     paths.append(Path.cwd() / "srunx.json")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -194,18 +194,43 @@ class TestConfigLoading:
 class TestConfigPaths:
     """Test configuration path functions."""
 
-    def test_get_config_paths(self):
+    def test_get_config_paths(self, monkeypatch):
         """Test getting configuration paths."""
+        # Drop XDG_CONFIG_HOME so the default POSIX/Windows branch runs
+        # — this test asserts shape, not the XDG override.
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         paths = get_config_paths()
         assert len(paths) == 3  # system, user, project (srunx.json)
         assert all(isinstance(path, Path) for path in paths)
 
     @patch("os.name", "posix")
-    def test_get_config_paths_posix(self):
+    def test_get_config_paths_posix(self, monkeypatch):
         """Test getting configuration paths on POSIX systems."""
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
         paths = get_config_paths()
         assert str(paths[0]).startswith("/etc/srunx/")
         assert ".config/srunx/" in str(paths[1])
+
+    def test_get_config_paths_honours_xdg_config_home(self, tmp_path, monkeypatch):
+        """``$XDG_CONFIG_HOME`` overrides the default user config dir.
+
+        Matches the XDG base-directory spec and the state DB's resolver
+        in ``srunx.db.connection.get_config_dir``. Without this, flipping
+        ``XDG_CONFIG_HOME`` for tests/containers/multi-tenant setups would
+        isolate the DB but silently land the JSON config in ``~/.config``.
+        """
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        paths = get_config_paths()
+        # User config now lives under the override dir.
+        assert paths[1] == tmp_path / "srunx" / "config.json"
+
+    def test_get_config_paths_falls_back_when_xdg_unset(self, monkeypatch):
+        """Empty env var is treated the same as unset (no override)."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", "")
+        paths = get_config_paths()
+        # Empty string is falsy → default path resolution.
+        if Path("/etc").exists():  # POSIX branch; Windows skipped
+            assert ".config/srunx/" in str(paths[1])
 
     # Skipping Windows test as it's complex to mock across platforms
 


### PR DESCRIPTION
## Summary

- ``get_config_paths`` now resolves the per-user ``config.json`` under ``\$XDG_CONFIG_HOME/srunx`` when the env var is set, matching the XDG base-directory spec and the state DB's resolver in ``srunx.db.connection.get_config_dir``.
- Empty env var is treated the same as unset (falsy check), preserving the legacy fallback path.
- Extracts ``_user_config_dir()`` so the XDG logic lives in one place; system-wide (``/etc/srunx``) and project-local (``./srunx.json``) paths are unchanged.

## Why this matters

Without this, flipping ``XDG_CONFIG_HOME`` for tests / containers / multi-tenant setups isolates the state DB but silently lands the JSON config in ``~/.config``, causing config/state divergence.

## Base branch

- ``main`` — independent of the current P1/P2 stacked chain (no code conflicts).

## Test plan

- [x] ``uv run pytest tests/test_config.py -v`` — 25 passed including 2 new XDG-specific cases
- [x] ``uv run pytest -q`` — 1320 passed, 2 skipped
- [x] ``uv run ruff check . && uv run mypy .`` — both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)