### PR TITLE
feat(ui): P3-8 #F — require explicit config opt-in for submit-dialog notify toggle

### DIFF
--- a/src/srunx/web/frontend/src/components/FileExplorer.tsx
+++ b/src/srunx/web/frontend/src/components/FileExplorer.tsx
@@ -295,11 +295,23 @@ function SubmitDialog({
         }
 
         if (fetched.length > 0) {
+          // Pre-select the endpoint the user will most likely pick —
+          // their configured default, or the first available — so the
+          // dropdown is not empty the moment they tick the box.
           const match = defaultName
             ? fetched.find((e) => e.name === defaultName)
             : undefined;
           setSelectedEndpointId((match ?? fetched[0]).id);
-          setNotify(true);
+          // Auto-opt-in only when the user has *explicitly* wired up
+          // a ``default_endpoint_name`` in config. Merely having an
+          // endpoint row in the DB (e.g. from a teammate) is not a
+          // signal that this user wants every submit to notify — we
+          // used to turn the toggle on in that case, which surprised
+          // users who didn't realise their runs were firing Slack.
+          // The checkbox still defaults to ON when the opt-in is
+          // explicit via config, so configured users see no behaviour
+          // change.
+          setNotify(match !== undefined);
         } else {
           setSelectedEndpointId(null);
           setNotify(false);


### PR DESCRIPTION
## Summary

The submit dialog used to flip the "notify" checkbox ON whenever the endpoints list was non-empty, regardless of whether this specific user had opted in. In multi-user deployments — or after the P1 seeding fix surfaced pre-existing endpoints — every submit silently fired Slack until someone noticed and unchecked the box.

Auto-opt-in now requires ``notifications.default_endpoint_name`` in ``config.json`` **and** for that name to resolve to an actual endpoint row. Endpoint pre-selection still runs so toggling the checkbox ON lands on a sensible endpoint without a second click; the submit payload shape is unchanged.

## Why this matters

Users who had wired ``default_endpoint_name`` explicitly see zero behaviour change. Everyone else stops receiving surprise notifications on every run.

## Base branch

- ``main`` — UI-only, independent of the open P1/P2 backend stack.

## Test plan

- [x] ``cd src/srunx/web/frontend && npx tsc --noEmit`` — clean
- [x] No Playwright tests assert the auto-opt-in behaviour; all existing locators intact.
- [ ] Manual: (a) without ``default_endpoint_name`` set → checkbox defaults OFF, endpoint list populated; (b) with a valid ``default_endpoint_name`` → checkbox defaults ON, that endpoint pre-selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)