### PR TITLE
feat: P3-7 #H — expose workflow_run notification subscription in run dialog

### DIFF
--- a/src/srunx/web/frontend/src/components/WorkflowRunDialog.tsx
+++ b/src/srunx/web/frontend/src/components/WorkflowRunDialog.tsx
@@ -1,9 +1,26 @@
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { Play, Eye, Loader2, X, ChevronDown, ChevronUp } from "lucide-react";
-import { workflows as workflowsApi } from "../lib/api.ts";
+import {
+  Play,
+  Eye,
+  Loader2,
+  X,
+  ChevronDown,
+  ChevronUp,
+  Bell,
+  BellOff,
+} from "lucide-react";
+import {
+  config as configApi,
+  endpoints as endpointsApi,
+  workflows as workflowsApi,
+} from "../lib/api.ts";
 import { ErrorBanner } from "./ErrorBanner.tsx";
-import type { WorkflowRunOptions, DryRunJobInfo } from "../lib/types.ts";
+import type {
+  DryRunJobInfo,
+  Endpoint,
+  WorkflowRunOptions,
+} from "../lib/types.ts";
 
 type WorkflowRunDialogProps = {
   workflowName: string;
@@ -14,6 +31,18 @@ type WorkflowRunDialogProps = {
 };
 
 type ExecutionMode = "full" | "from" | "to" | "range" | "single";
+
+const NOTIFICATION_PRESETS = [
+  { value: "terminal", label: "Terminal (completed / failed)" },
+  { value: "running_and_terminal", label: "Running + terminal" },
+  { value: "all", label: "All state changes" },
+] as const;
+
+type PresetValue = (typeof NOTIFICATION_PRESETS)[number]["value"];
+
+function isKnownPreset(value: string): value is PresetValue {
+  return NOTIFICATION_PRESETS.some((p) => p.value === value);
+}
 
 export function WorkflowRunDialog({
   workflowName,
@@ -34,6 +63,18 @@ export function WorkflowRunDialog({
   );
   const [expandedScript, setExpandedScript] = useState<string | null>(null);
 
+  // Notification controls — mirror the submit-dialog pattern.
+  // Auto-opt-in requires both (a) a configured ``default_endpoint_name``
+  // and (b) that name matching an endpoint row; just having endpoints
+  // in the DB is not a signal of user intent. (Matches P3-8.)
+  const [notify, setNotify] = useState(false);
+  const [endpointList, setEndpointList] = useState<Endpoint[]>([]);
+  const [selectedEndpointId, setSelectedEndpointId] = useState<number | null>(
+    null,
+  );
+  const [preset, setPreset] = useState<PresetValue>("terminal");
+  const [endpointsLoading, setEndpointsLoading] = useState(true);
+
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -41,6 +82,53 @@ export function WorkflowRunDialog({
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [onClose]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadNotificationState() {
+      try {
+        setEndpointsLoading(true);
+        const [fetched, cfg] = await Promise.all([
+          endpointsApi.list(),
+          configApi.get().catch(() => null),
+        ]);
+        if (cancelled) return;
+        setEndpointList(fetched);
+
+        const defaultName = cfg?.notifications?.default_endpoint_name ?? null;
+        const defaultPreset = cfg?.notifications?.default_preset;
+        if (defaultPreset && isKnownPreset(defaultPreset)) {
+          setPreset(defaultPreset);
+        }
+
+        if (fetched.length > 0) {
+          const match = defaultName
+            ? fetched.find((e) => e.name === defaultName)
+            : undefined;
+          setSelectedEndpointId((match ?? fetched[0]).id);
+          setNotify(match !== undefined);
+        } else {
+          setSelectedEndpointId(null);
+          setNotify(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setEndpointList([]);
+          setSelectedEndpointId(null);
+          setNotify(false);
+        }
+      } finally {
+        if (!cancelled) setEndpointsLoading(false);
+      }
+    }
+    loadNotificationState();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasEndpoints = endpointList.length > 0;
+  const notifyEnabled = notify && hasEndpoints && selectedEndpointId !== null;
 
   const buildOptions = (): WorkflowRunOptions => {
     const opts: WorkflowRunOptions = {};
@@ -60,6 +148,11 @@ export function WorkflowRunDialog({
         break;
     }
     if (dryRun) opts.dry_run = true;
+    if (notifyEnabled) {
+      opts.notify = true;
+      opts.endpoint_id = selectedEndpointId;
+      opts.preset = preset;
+    }
     return opts;
   };
 
@@ -294,6 +387,117 @@ export function WorkflowRunDialog({
             />
             Dry run (preview scripts without submitting)
           </label>
+
+          {/* Notification controls */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--sp-2)",
+              paddingTop: "var(--sp-3)",
+              borderTop: "1px solid var(--border-ghost)",
+            }}
+          >
+            <label
+              title={
+                hasEndpoints
+                  ? "Notify via the notification pipeline when the run finishes"
+                  : "Add an endpoint in Settings → Notifications first."
+              }
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--sp-2)",
+                fontSize: "0.8rem",
+                cursor: hasEndpoints ? "pointer" : "not-allowed",
+                color: hasEndpoints
+                  ? "var(--text-primary)"
+                  : "var(--text-muted)",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={notify && hasEndpoints}
+                onChange={(e) => setNotify(e.target.checked)}
+                disabled={!hasEndpoints || endpointsLoading || loading}
+              />
+              {notify && hasEndpoints ? (
+                <Bell size={13} aria-hidden="true" />
+              ) : (
+                <BellOff size={13} aria-hidden="true" />
+              )}
+              Notify on workflow completion
+            </label>
+            {!endpointsLoading && !hasEndpoints && (
+              <div
+                style={{
+                  fontSize: "0.72rem",
+                  color: "var(--text-muted)",
+                  paddingLeft: 24,
+                }}
+              >
+                Add an endpoint in Settings → Notifications first.
+              </div>
+            )}
+            {hasEndpoints && notify && (
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1fr 1fr",
+                  gap: "var(--sp-2)",
+                  paddingLeft: 24,
+                }}
+              >
+                <select
+                  value={selectedEndpointId ?? ""}
+                  onChange={(e) =>
+                    setSelectedEndpointId(
+                      e.target.value ? Number(e.target.value) : null,
+                    )
+                  }
+                  aria-label="Notification endpoint"
+                  style={{
+                    padding: "var(--sp-2)",
+                    background: "var(--bg-base)",
+                    border: "1px solid var(--border-subtle)",
+                    borderRadius: "var(--radius-md)",
+                    color: "var(--text-primary)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.8rem",
+                  }}
+                >
+                  {endpointList.map((ep) => (
+                    <option key={ep.id} value={ep.id}>
+                      {ep.kind}:{ep.name}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={preset}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    if (isKnownPreset(v)) setPreset(v);
+                  }}
+                  aria-label="Notification preset"
+                  style={{
+                    padding: "var(--sp-2)",
+                    background: "var(--bg-base)",
+                    border: "1px solid var(--border-subtle)",
+                    borderRadius: "var(--radius-md)",
+                    color: "var(--text-primary)",
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "0.8rem",
+                  }}
+                >
+                  {NOTIFICATION_PRESETS.map((p) => (
+                    <option key={p.value} value={p.value}>
+                      {p.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
 
           <ErrorBanner error={error} />
 

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -385,6 +385,12 @@ export type WorkflowRunOptions = {
   to_job?: string;
   single_job?: string;
   dry_run?: boolean;
+  // Notification subscription wiring (P3-7). When ``notify`` is true
+  // and ``endpoint_id`` resolves to an enabled endpoint, the workflow
+  // run's auto-created watch is paired with a subscription.
+  notify?: boolean;
+  endpoint_id?: number | null;
+  preset?: string;
 };
 
 export type DryRunJobInfo = {

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -627,6 +627,18 @@ class WorkflowRunRequest(BaseModel):
     to_job: str | None = None
     single_job: str | None = None
     dry_run: bool = False
+    # Notification subscription wiring. When ``notify`` is true and
+    # ``endpoint_id`` resolves to an enabled endpoint row, the run's
+    # auto-created ``kind='workflow_run'`` watch is paired with a
+    # subscription so the delivery poller fans status-transition
+    # events out to that endpoint. Matches the shape accepted by
+    # ``/api/jobs`` submit (R6 in design.md §Request models).
+    notify: bool = False
+    endpoint_id: int | None = Field(default=None, gt=0)
+    preset: str = "terminal"
+
+
+_WORKFLOW_RUN_PRESETS = ("terminal", "running_and_terminal", "all")
 
 
 def _filter_workflow_jobs(
@@ -1132,20 +1144,51 @@ async def run_workflow(
     # status transitions going forward. We deliberately do NOT set
     # ``workflow_runs.status='running'`` here: the run record stays
     # ``pending`` (as created above) until ActiveWatchPoller observes a
-    # child job in RUNNING state.
+    # child job in RUNNING state (P1-1).
     #
-    # Rationale (R/Codex P1-1): the poller's aggregation rules say
-    # "any child RUNNING → running; otherwise pending". Pre-emptively
-    # writing ``running`` here meant the very first poll cycle — while
-    # all children are still PENDING in SLURM — would aggregate to
-    # ``pending`` and emit a spurious ``running → pending`` transition,
-    # complete with a ``workflow_run.status_changed`` event to every
-    # subscriber. Letting the poller own the lifecycle keeps transitions
-    # monotonic: ``pending → running → completed/failed/cancelled``.
-    def _open_watch() -> None:
-        watch_repo.create(
+    # When ``notify`` is requested, also pair the watch with a
+    # subscription for the chosen endpoint; the delivery poller then
+    # fans ``workflow_run.status_changed`` events out to Slack/etc.
+    def _open_watch() -> int | None:
+        new_watch_id = watch_repo.create(
             kind="workflow_run",
             target_ref=f"workflow_run:{run_id}",
+        )
+        if run_opts.notify and run_opts.endpoint_id is not None:
+            from srunx.db.repositories.endpoints import EndpointRepository
+            from srunx.db.repositories.subscriptions import SubscriptionRepository
+
+            endpoint = EndpointRepository(conn).get(run_opts.endpoint_id)
+            if endpoint is None or endpoint.disabled_at is not None:
+                # Non-fatal: the watch still exists, the run is running,
+                # the user just won't get external notifications. We log
+                # a warning instead of 4xx'ing because the run already
+                # submitted jobs — returning a failure now would be
+                # misleading.
+                logger.warning(
+                    "workflow_run %s: requested endpoint_id=%s not usable "
+                    "(missing or disabled); skipping subscription",
+                    run_id,
+                    run_opts.endpoint_id,
+                )
+                return new_watch_id
+            SubscriptionRepository(conn).create(
+                watch_id=new_watch_id,
+                endpoint_id=run_opts.endpoint_id,
+                preset=run_opts.preset,
+            )
+        return new_watch_id
+
+    # Validate preset up-front so a bogus value aborts before we mark
+    # the run running (we can still refuse here without orphaning jobs
+    # — Phase 4 already submitted them, but the watch/subscription step
+    # is still cheap to reject). Mirrors the guard in subscriptions router.
+    if run_opts.notify and run_opts.preset not in _WORKFLOW_RUN_PRESETS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid preset '{run_opts.preset}'. Allowed: {_WORKFLOW_RUN_PRESETS}"
+            ),
         )
 
     await anyio.to_thread.run_sync(_open_watch)

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -1019,6 +1019,21 @@ async def run_workflow(
         raise HTTPException(status_code=422, detail="mount query parameter is required")
 
     run_opts = body or WorkflowRunRequest()
+
+    # Validate preset up-front — before mounting, rendering, and
+    # ``sbatch``ing. Deferring this check until Phase 5 (post-submit)
+    # means a bogus preset returns 422 with jobs already queued on
+    # the cluster, leaving orphans behind. The implementation set
+    # matches ``SubscriptionRepository`` + the subscriptions router
+    # guard (P1-3) — ``digest`` has no delivery pipeline yet.
+    if run_opts.notify and run_opts.preset not in _WORKFLOW_RUN_PRESETS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid preset '{run_opts.preset}'. Allowed: {_WORKFLOW_RUN_PRESETS}"
+            ),
+        )
+
     yaml_path = _find_yaml(name, mount)
 
     # Load and optionally filter workflow
@@ -1141,10 +1156,14 @@ async def run_workflow(
         raise
 
     # Phase 5: open the workflow_run watch so the poller can drive
-    # status transitions going forward. We deliberately do NOT set
-    # ``workflow_runs.status='running'`` here: the run record stays
-    # ``pending`` (as created above) until ActiveWatchPoller observes a
-    # child job in RUNNING state (P1-1).
+    # status transitions going forward. ``workflow_runs.status='running'``
+    # is deliberately NOT written here — the run record stays ``pending``
+    # (as created above) until ``ActiveWatchPoller`` observes a child
+    # job in RUNNING state (P1-1). Writing ``running`` eagerly would
+    # race the poller's "otherwise→pending" rule and emit a spurious
+    # ``running → pending`` transition (+ a
+    # ``workflow_run.status_changed`` event to every subscriber) on the
+    # very first cycle, while all children are still PENDING in SLURM.
     #
     # When ``notify`` is requested, also pair the watch with a
     # subscription for the chosen endpoint; the delivery poller then
@@ -1160,11 +1179,10 @@ async def run_workflow(
 
             endpoint = EndpointRepository(conn).get(run_opts.endpoint_id)
             if endpoint is None or endpoint.disabled_at is not None:
-                # Non-fatal: the watch still exists, the run is running,
-                # the user just won't get external notifications. We log
-                # a warning instead of 4xx'ing because the run already
-                # submitted jobs — returning a failure now would be
-                # misleading.
+                # Non-fatal: the watch still exists, the run is open,
+                # the user just won't get external notifications. Jobs
+                # are already queued on the cluster — 4xx'ing here
+                # would be misleading.
                 logger.warning(
                     "workflow_run %s: requested endpoint_id=%s not usable "
                     "(missing or disabled); skipping subscription",
@@ -1178,18 +1196,6 @@ async def run_workflow(
                 preset=run_opts.preset,
             )
         return new_watch_id
-
-    # Validate preset up-front so a bogus value aborts before we mark
-    # the run running (we can still refuse here without orphaning jobs
-    # — Phase 4 already submitted them, but the watch/subscription step
-    # is still cheap to reject). Mirrors the guard in subscriptions router.
-    if run_opts.notify and run_opts.preset not in _WORKFLOW_RUN_PRESETS:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"Invalid preset '{run_opts.preset}'. Allowed: {_WORKFLOW_RUN_PRESETS}"
-            ),
-        )
 
     await anyio.to_thread.run_sync(_open_watch)
 

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -605,6 +605,156 @@ class TestWorkflowsRouter:
         finally:
             conn.close()
 
+    def test_run_workflow_with_notify_creates_subscription(
+        self, client: TestClient, mock_adapter: MagicMock
+    ) -> None:
+        """``notify=True`` + valid endpoint_id → one subscription on the run watch.
+
+        P3-7 #H wires the workflow-run dialog's notification toggle
+        through the API: the auto-created ``kind='workflow_run'`` watch
+        must be paired with a subscription when the caller opts in, so
+        the delivery poller fans ``workflow_run.status_changed`` events
+        out to Slack/etc.
+        """
+        from srunx.db.connection import open_connection
+        from srunx.db.repositories.endpoints import EndpointRepository
+        from srunx.db.repositories.subscriptions import SubscriptionRepository
+        from srunx.db.repositories.watches import WatchRepository
+
+        # Seed an endpoint row — real FK target.
+        conn = open_connection()
+        try:
+            endpoint_id = EndpointRepository(conn).create(
+                kind="slack_webhook",
+                name="ops",
+                config={"webhook_url": "https://hooks.slack.com/services/T/B/X"},
+            )
+        finally:
+            conn.close()
+
+        resp = client.post(
+            "/api/workflows/create",
+            json={
+                "name": "notify-run",
+                "default_project": MOUNT,
+                "jobs": [{"name": "a", "command": ["echo", "a"]}],
+            },
+        )
+        assert resp.status_code == 200
+
+        mock_adapter.submit_job.return_value = {
+            "name": "a",
+            "job_id": 30000,
+            "status": "PENDING",
+            "depends_on": [],
+            "command": [],
+            "resources": {},
+        }
+
+        resp = client.post(
+            "/api/workflows/notify-run/run",
+            params={"mount": MOUNT},
+            json={
+                "notify": True,
+                "endpoint_id": endpoint_id,
+                "preset": "all",
+            },
+        )
+        assert resp.status_code == 202
+        run_id = int(resp.json()["id"])
+
+        conn = open_connection()
+        try:
+            watch = next(
+                w
+                for w in WatchRepository(conn).list_open()
+                if w.target_ref == f"workflow_run:{run_id}"
+            )
+            assert watch.id is not None
+            subs = SubscriptionRepository(conn).list_by_watch(watch.id)
+            assert len(subs) == 1
+            assert subs[0].endpoint_id == endpoint_id
+            assert subs[0].preset == "all"
+        finally:
+            conn.close()
+
+    def test_run_workflow_without_notify_creates_no_subscription(
+        self, client: TestClient, mock_adapter: MagicMock
+    ) -> None:
+        """Default path — watch is created, but no subscription."""
+        from srunx.db.connection import open_connection
+        from srunx.db.repositories.subscriptions import SubscriptionRepository
+        from srunx.db.repositories.watches import WatchRepository
+
+        resp = client.post(
+            "/api/workflows/create",
+            json={
+                "name": "no-notify-run",
+                "default_project": MOUNT,
+                "jobs": [{"name": "a", "command": ["echo", "a"]}],
+            },
+        )
+        assert resp.status_code == 200
+
+        mock_adapter.submit_job.return_value = {
+            "name": "a",
+            "job_id": 30100,
+            "status": "PENDING",
+            "depends_on": [],
+            "command": [],
+            "resources": {},
+        }
+
+        resp = client.post(
+            "/api/workflows/no-notify-run/run",
+            params={"mount": MOUNT},
+        )
+        assert resp.status_code == 202
+        run_id = int(resp.json()["id"])
+
+        conn = open_connection()
+        try:
+            watch = next(
+                w
+                for w in WatchRepository(conn).list_open()
+                if w.target_ref == f"workflow_run:{run_id}"
+            )
+            assert watch.id is not None
+            assert SubscriptionRepository(conn).list_by_watch(watch.id) == []
+        finally:
+            conn.close()
+
+    def test_run_workflow_invalid_preset_is_rejected(
+        self, client: TestClient, mock_adapter: MagicMock
+    ) -> None:
+        """Bogus preset → 422, before we touch the watch/subscription step."""
+        resp = client.post(
+            "/api/workflows/create",
+            json={
+                "name": "bad-preset-run",
+                "default_project": MOUNT,
+                "jobs": [{"name": "a", "command": ["echo", "a"]}],
+            },
+        )
+        assert resp.status_code == 200
+
+        mock_adapter.submit_job.return_value = {
+            "name": "a",
+            "job_id": 30200,
+            "status": "PENDING",
+            "depends_on": [],
+            "command": [],
+            "resources": {},
+        }
+
+        resp = client.post(
+            "/api/workflows/bad-preset-run/run",
+            params={"mount": MOUNT},
+            json={"notify": True, "endpoint_id": 1, "preset": "digest"},
+        )
+        assert resp.status_code == 422
+        assert "preset" in resp.json()["detail"].lower()
+
     def test_run_workflow_not_found(self, client: TestClient) -> None:
         resp = client.post("/api/workflows/nonexistent-wf/run", params={"mount": MOUNT})
         assert resp.status_code == 404

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -486,10 +486,10 @@ class TestWorkflowsRouter:
         assert resp.status_code == 202
         data = resp.json()
         assert data["workflow_name"] == "run-test"
-        # Status stays 'pending' until ActiveWatchPoller observes a child
-        # job in RUNNING state. Pre-emptively writing 'running' here
-        # caused a spurious 'running → pending' regression on the first
-        # poll cycle (see P1-1 in the Codex review triage).
+        # Status stays ``pending`` until ``ActiveWatchPoller`` observes
+        # the first child transition (P1-1). Pre-emptively writing
+        # ``running`` here caused a spurious ``running → pending``
+        # transition on the first poll cycle.
         assert data["status"] == "pending"
         assert "10001" in data["job_ids"].values()
         assert "10002" in data["job_ids"].values()
@@ -568,8 +568,8 @@ class TestWorkflowsRouter:
             run = WorkflowRunRepository(conn).get(run_id)
             assert run is not None
             assert run.workflow_name == "integration-run"
-            # P1-1: the run stays 'pending' until the poller observes a
-            # RUNNING child. See the phase-5 comment in workflows.py.
+            # P1-1: the run stays ``pending`` until the poller observes
+            # a RUNNING child. See the phase-5 comment in workflows.py.
             assert run.status == "pending"
             assert run.triggered_by == "web"
 
@@ -727,7 +727,13 @@ class TestWorkflowsRouter:
     def test_run_workflow_invalid_preset_is_rejected(
         self, client: TestClient, mock_adapter: MagicMock
     ) -> None:
-        """Bogus preset → 422, before we touch the watch/subscription step."""
+        """Bogus preset → 422, **before** any sbatch submission.
+
+        Guards against the "422 with orphan jobs" shape: validating
+        preset after ``_submit_jobs_bfs`` would leave already-queued
+        SLURM jobs running on the cluster with no accompanying
+        workflow_run record and no way for the user to find them.
+        """
         resp = client.post(
             "/api/workflows/create",
             json={
@@ -754,6 +760,19 @@ class TestWorkflowsRouter:
         )
         assert resp.status_code == 422
         assert "preset" in resp.json()["detail"].lower()
+
+        # The early reject must short-circuit BEFORE phase 4: no sbatch
+        # calls, and no ``workflow_runs`` row for the aborted run.
+        mock_adapter.submit_job.assert_not_called()
+        from srunx.db.connection import open_connection
+        from srunx.db.repositories.workflow_runs import WorkflowRunRepository
+
+        conn = open_connection()
+        try:
+            all_runs = WorkflowRunRepository(conn).list_all()
+            assert not any(r.workflow_name == "bad-preset-run" for r in all_runs)
+        finally:
+            conn.close()
 
     def test_run_workflow_not_found(self, client: TestClient) -> None:
         resp = client.post("/api/workflows/nonexistent-wf/run", params={"mount": MOUNT})
@@ -1745,8 +1764,8 @@ class TestWorkflowExecutionControl:
         )
         assert resp.status_code == 202
         data = resp.json()
-        # P1-1: newly-created runs start at 'pending' and the poller
-        # promotes them to 'running' on the first RUNNING child.
+        # P1-1: newly-created runs start at ``pending`` and the poller
+        # promotes them to ``running`` on the first RUNNING child.
         assert data["status"] == "pending"
         # All 3 jobs should be submitted
         assert mock_adapter.submit_job.call_count == 3


### PR DESCRIPTION
## Summary

The ``kind='workflow_run'`` watch that every run auto-creates was never paired with a subscription, so the plumbing existed but the feature wasn't reachable. This PR wires end-to-end support:

**Backend** (``src/srunx/web/routers/workflows.py``)
- ``WorkflowRunRequest`` gains optional ``notify``, ``endpoint_id``, ``preset``.
- ``_activate()`` creates a subscription paired with the workflow_run watch when the caller opts in. Non-fatal when the endpoint is missing/disabled (jobs already submitted; we log a warning rather than 4xx and orphan them).
- Preset validated against ``terminal`` / ``running_and_terminal`` / ``all``; ``digest`` excluded until the digest pipeline ships.

**Frontend** (``WorkflowRunDialog.tsx``)
- New notification controls block mirroring the submit dialog (Bell/BellOff icons, endpoint + preset selectors).
- Auto-opt-in requires ``notifications.default_endpoint_name`` to resolve to an actual endpoint row (matches P3-8).
- ``WorkflowRunOptions`` type extended with ``notify``/``endpoint_id``/``preset``.

## Base branch

- ``main`` — independent of the open P1/P2 chain (no conflicts expected).

## Test plan

- [x] ``uv run pytest tests/web/test_routers.py -v -k 'workflow_with_notify or workflow_without_notify or workflow_invalid_preset'`` — 3 passed
- [x] ``uv run pytest -q`` — 1348 passed, 2 skipped
- [x] ``uv run ruff check . && uv run mypy .`` — clean
- [x] ``cd src/srunx/web/frontend && npx tsc --noEmit`` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)