### PR TITLE
test(e2e): P3-10 #J — Playwright coverage for Settings → Notifications endpoint CRUD

### DIFF
--- a/src/srunx/web/frontend/e2e/fixtures/mock-routes.ts
+++ b/src/srunx/web/frontend/e2e/fixtures/mock-routes.ts
@@ -225,6 +225,62 @@ export async function setupMockRoutes(page: Page) {
 
   /* ── Notifications (endpoints / watches / subscriptions / deliveries) ── */
   await setupNotificationMocks(page);
+
+  /* ── Config (needed for Settings page + submit-dialog notify logic) ── */
+  // P3-10: Settings.tsx and FileExplorer both hit ``/api/config`` and
+  // ``/api/config/paths`` on mount. Without these mocks the Settings
+  // page stays in its loading skeleton forever and no tab buttons
+  // appear. Individual tests can still override these routes with
+  // their own handlers if they need richer behaviour.
+  await page.route("**/api/config", (route) => {
+    if (route.request().method() === "PATCH") {
+      return route.fulfill({ status: 200, json: { ok: true } });
+    }
+    return route.fulfill({
+      json: {
+        resources: {
+          nodes: 1,
+          gpus_per_node: 0,
+          ntasks_per_node: 1,
+          cpus_per_task: 1,
+          memory_per_node: null,
+          time_limit: null,
+          nodelist: null,
+          partition: null,
+        },
+        environment: {
+          conda: null,
+          venv: null,
+          container: null,
+          env_vars: {},
+        },
+        notifications: {
+          slack_webhook_url: null,
+          default_endpoint_name: null,
+          default_preset: "terminal",
+        },
+        log_dir: "logs",
+        work_dir: null,
+      },
+    });
+  });
+  await page.route("**/api/config/paths", (route) => {
+    return route.fulfill({ json: [] });
+  });
+  await page.route("**/api/config/env", (route) => {
+    return route.fulfill({ json: { items: [] } });
+  });
+  await page.route("**/api/config/projects", (route) => {
+    return route.fulfill({ json: [] });
+  });
+  await page.route("**/api/config/ssh/status*", (route) => {
+    return route.fulfill({
+      json: { available: false, profile: null, hostname: null },
+    });
+  });
+  await page.route("**/api/config/ssh/profiles*", (route) => {
+    return route.fulfill({ json: { profiles: {}, current: null } });
+  });
 }
 
 /**
@@ -301,6 +357,16 @@ export async function setupNotificationMocks(page: Page) {
     ],
   };
 
+  // Matches both ``/api/endpoints`` (POST) and ``/api/endpoints?include_disabled=true``
+  // (GET with query string). ``/api/endpoints/123`` is handled by the
+  // next route below because ``*`` in Playwright globs doesn't cross
+  // path separators.
+  await page.route("**/api/endpoints?*", (route) => {
+    if (route.request().method() === "GET") {
+      return route.fulfill({ json: state.endpoints });
+    }
+    return route.continue();
+  });
   await page.route("**/api/endpoints", (route) => {
     if (route.request().method() === "GET") {
       return route.fulfill({ json: state.endpoints });
@@ -321,7 +387,10 @@ export async function setupNotificationMocks(page: Page) {
     return route.continue();
   });
 
-  await page.route("**/api/endpoints/*", (route) => {
+  // Also matches ``/api/endpoints/<id>/disable`` and ``/enable`` — the
+  // single-segment ``*`` doesn't cross ``/``, so we need ``**`` to
+  // cover both ``/api/endpoints/1`` and ``/api/endpoints/1/enable``.
+  await page.route("**/api/endpoints/**", (route) => {
     const method = route.request().method();
     const url = route.request().url();
     const idMatch = url.match(/\/api\/endpoints\/(\d+)/);

--- a/src/srunx/web/frontend/e2e/notifications-settings.spec.ts
+++ b/src/srunx/web/frontend/e2e/notifications-settings.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * E2E coverage for Settings → Notifications endpoint CRUD (P3-10 #J).
+ *
+ * The existing ``notifications.spec.ts`` covers the
+ * ``NotificationsCenter`` *dashboard* — read-only view of the outbox,
+ * open watches, subscriptions, and the deliveries filter.
+ *
+ * This spec exercises the *writable* surface on the Settings tab:
+ *
+ * 1. Initial render — existing endpoint row visible.
+ * 2. Add-endpoint form — validation + happy-path create.
+ * 3. Toggle disable/enable — button text + visible status flip.
+ * 4. Delete endpoint — row disappears after the confirm dialog.
+ *
+ * Mocks are in-memory via ``setupMockRoutes``; each test gets a
+ * fresh copy of the fixture state.
+ */
+
+import { test, expect } from "@playwright/test";
+import { setupMockRoutes } from "./fixtures/mock-routes.ts";
+
+async function openNotificationsTab(page: import("@playwright/test").Page) {
+  await page.goto("/settings");
+  // Settings tabs render as buttons with the label text.
+  await page.getByRole("button", { name: /Notifications/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /Notification Endpoints/i }),
+  ).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await setupMockRoutes(page);
+});
+
+test.describe("Settings → Notifications", () => {
+  test("existing endpoint is listed", async ({ page }) => {
+    await openNotificationsTab(page);
+
+    // Fixture seeds a ``primary`` slack_webhook endpoint.
+    await expect(page.getByText("primary")).toBeVisible();
+    await expect(page.getByText("slack_webhook").first()).toBeVisible();
+    await expect(page.getByText("Enabled")).toBeVisible();
+  });
+
+  test("webhook URL validation gates the Create button", async ({ page }) => {
+    await openNotificationsTab(page);
+    await page.getByRole("button", { name: /Add endpoint/i }).click();
+
+    // Name alone isn't enough — URL must match the Slack pattern.
+    const nameInput = page.locator("input[placeholder='e.g. team-alerts']");
+    const urlInput = page.locator(
+      "input[placeholder='https://hooks.slack.com/services/...']",
+    );
+    await nameInput.fill("team-alerts");
+    await urlInput.fill("not-a-slack-url");
+    await expect(page.getByRole("button", { name: /^Create$/ })).toBeDisabled();
+
+    // Inline validation message surfaces.
+    await expect(
+      page.getByText(/Must be a valid Slack webhook URL/i),
+    ).toBeVisible();
+
+    // Valid URL unlocks the button.
+    await urlInput.fill("https://hooks.slack.com/services/T00/B00/XYZ123");
+    await expect(page.getByRole("button", { name: /^Create$/ })).toBeEnabled();
+  });
+
+  test("creates an endpoint and shows the success banner", async ({ page }) => {
+    await openNotificationsTab(page);
+    await page.getByRole("button", { name: /Add endpoint/i }).click();
+
+    const nameInput = page.locator("input[placeholder='e.g. team-alerts']");
+    const urlInput = page.locator(
+      "input[placeholder='https://hooks.slack.com/services/...']",
+    );
+    await nameInput.fill("team-alerts");
+    await urlInput.fill("https://hooks.slack.com/services/T00/B00/XYZ123");
+    await page.getByRole("button", { name: /^Create$/ }).click();
+
+    // New row appears in the table + success banner fires with the name.
+    // The name text appears in two places (success banner + table cell),
+    // so scope each assertion to its specific landmark to avoid strict-
+    // mode locator collisions.
+    await expect(page.getByRole("cell", { name: "team-alerts" })).toBeVisible();
+    await expect(
+      page.getByText(/Endpoint "team-alerts" created/i),
+    ).toBeVisible();
+  });
+
+  test("toggle flips the endpoint status", async ({ page }) => {
+    await openNotificationsTab(page);
+
+    // Baseline: seeded endpoint is enabled — "Disable" button is shown.
+    await expect(page.getByRole("button", { name: "Disable" })).toBeVisible();
+    await page.getByRole("button", { name: "Disable" }).click();
+
+    // After click: button label swaps to Enable, status chip says Disabled.
+    // ``Disabled`` text appears in both the success banner and the status
+    // chip, so scope to the chip's exact match.
+    await expect(page.getByRole("button", { name: "Enable" })).toBeVisible();
+    await expect(page.getByText("Disabled", { exact: true })).toBeVisible();
+    await expect(page.getByText(/Endpoint "primary" disabled/i)).toBeVisible();
+  });
+
+  test("deletes an endpoint after confirm", async ({ page }) => {
+    await openNotificationsTab(page);
+
+    // Auto-accept the window.confirm prompt the row fires.
+    page.on("dialog", (d) => d.accept());
+
+    await page.getByRole("button", { name: "Delete" }).click();
+
+    // Row disappears + empty-state banner shows; success banner fires.
+    await expect(
+      page.getByText("No endpoints configured yet.", { exact: false }),
+    ).toBeVisible();
+    await expect(page.getByText(/primary.*deleted/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Covers the writable side of the notification UI — endpoint CRUD via Settings → Notifications — which previously had zero E2E coverage even though that's where users create the endpoints any notify toggle depends on.

**New spec** ``notifications-settings.spec.ts`` — 5 tests
1. **Initial render** — seeded row visible.
2. **URL validation gate** — Create button disabled on non-Slack URLs; inline validation message surfaces.
3. **Create** — new row lands in the table + success banner.
4. **Toggle disable/enable** — button label + status chip flip.
5. **Delete** — confirm dialog accepted, row replaced by empty state.

**Mock plumbing**
- Added ``/api/config`` family mocks (``config``, ``paths``, ``env``, ``projects``, ``ssh/status``, ``ssh/profiles``) in ``setupMockRoutes``; without them the Settings page stalled on the loading skeleton.
- Split ``/api/endpoints`` route globs so Playwright's single-segment ``*`` (list + query) vs multi-segment ``**`` (``/<id>/disable``, ``/<id>/enable``) semantics line up with the three URL shapes the UI actually hits.

## Base branch

- ``main`` — E2E-only, independent of the open P1/P2/P3 chain. Intentionally uses visible-text locators so the spec doesn't depend on the a11y attributes added in PR #97 (P3-11); it'll still work once that merges.

## Test plan

- [x] ``npx playwright test notifications-settings`` — 5 / 5 passed
- [x] ``npx playwright test notifications`` — 11 / 11 passed (existing + new)
- [x] ``npx playwright test`` — 83 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)