### PR TITLE
refactor(cli): P2-5 #B — CLI notification convergence (re-open)

### DIFF
--- a/src/srunx/callbacks.py
+++ b/src/srunx/callbacks.py
@@ -6,12 +6,15 @@ from typing import TYPE_CHECKING
 from slack_sdk import WebhookClient
 
 from srunx.formatters import SlackNotificationFormatter
+from srunx.logging import get_logger
 from srunx.models import JobType, Workflow
 from srunx.utils import job_status_msg
 
 if TYPE_CHECKING:
     from srunx.monitor.report_types import Report
     from srunx.monitor.types import ResourceSnapshot
+
+_logger = get_logger(__name__)
 
 
 class Callback:
@@ -314,3 +317,47 @@ class SlackCallback(Callback):
                 }
             ],
         )
+
+
+class NotificationWatchCallback(Callback):
+    """Attach a durable notification watch every time a job is submitted.
+
+    This is the endpoint-watch bridge for CLI code paths that still
+    drive submission through :class:`~srunx.client.Slurm` + the
+    :class:`Callback` fan-out. On each ``on_job_submitted``, it calls
+    :func:`srunx.cli.notification_setup.attach_notification_watch` so
+    the poller pipeline takes over delivery — no in-process Slack send.
+
+    Failures are swallowed with a warning: a missing/disabled endpoint
+    must never break the submit (matches ``attach_notification_watch``'s
+    own best-effort contract).
+    """
+
+    def __init__(
+        self,
+        endpoint_name: str,
+        preset: str = "terminal",
+        endpoint_kind: str = "slack_webhook",
+    ) -> None:
+        self.endpoint_name = endpoint_name
+        self.preset = preset
+        self.endpoint_kind = endpoint_kind
+
+    def on_job_submitted(self, job: JobType) -> None:
+        if job.job_id is None:
+            return
+        from srunx.cli.notification_setup import attach_notification_watch
+
+        try:
+            attach_notification_watch(
+                job_id=int(job.job_id),
+                endpoint_name=self.endpoint_name,
+                preset=self.preset,
+                endpoint_kind=self.endpoint_kind,
+            )
+        except Exception as exc:
+            _logger.warning(
+                "NotificationWatchCallback: failed to attach watch for job %s: %s",
+                job.job_id,
+                exc,
+            )

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -13,7 +13,7 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.table import Table
 
-from srunx.callbacks import Callback, SlackCallback
+from srunx.callbacks import Callback, NotificationWatchCallback, SlackCallback
 from srunx.cli.monitor import monitor_app
 from srunx.client import Slurm
 from srunx.config import (
@@ -791,6 +791,27 @@ def flow_run(
     slack: Annotated[
         bool, typer.Option("--slack", help="Send notifications to Slack")
     ] = False,
+    endpoint: Annotated[
+        str | None,
+        typer.Option(
+            "--endpoint",
+            help=(
+                "Name of a configured notification endpoint (see "
+                "`/api/endpoints` / Settings UI). Attaches a watch per "
+                "submitted job via the poller pipeline."
+            ),
+        ),
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset",
+            help=(
+                "Subscription preset for --endpoint: terminal (default), "
+                "running_and_terminal, or all."
+            ),
+        ),
+    ] = None,
     debug: Annotated[
         bool, typer.Option("--debug", help="Show rendered SLURM scripts for each job")
     ] = False,
@@ -824,11 +845,30 @@ def flow_run(
         sys.exit(1)
 
     try:
-        # Setup callbacks
+        # Setup callbacks.
+        #
+        # Resolution order mirrors ``srunx submit``:
+        #   --endpoint → durable watch per submitted job (poller pipeline)
+        #   --slack    → in-process SlackCallback fallback (deprecated)
+        # Both may be set; keeping the deprecated path firing guards
+        # against endpoint attach failures silently dropping notifications
+        # the user explicitly opted into.
         callbacks: list[Callback] = []
         if debug:
             callbacks.append(DebugCallback())
+        effective_preset = preset or get_config().notifications.default_preset
+        if endpoint:
+            callbacks.append(
+                NotificationWatchCallback(
+                    endpoint_name=endpoint,
+                    preset=effective_preset,
+                )
+            )
         if slack:
+            logger.warning(
+                "`--slack` is deprecated; configure an endpoint via "
+                "Settings → Notifications and pass `--endpoint <name>`."
+            )
             webhook_url = os.getenv("SLACK_WEBHOOK_URL")
             if webhook_url:
                 callbacks.append(SlackCallback(webhook_url=webhook_url))
@@ -1129,6 +1169,27 @@ def template_apply(
     slack: Annotated[
         bool, typer.Option("--slack", help="Send notifications to Slack")
     ] = False,
+    endpoint: Annotated[
+        str | None,
+        typer.Option(
+            "--endpoint",
+            help=(
+                "Name of a configured notification endpoint (see "
+                "`/api/endpoints` / Settings UI). Attaches a durable "
+                "watch via the poller pipeline."
+            ),
+        ),
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset",
+            help=(
+                "Subscription preset for --endpoint: terminal (default), "
+                "running_and_terminal, or all."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Apply a template and submit a job."""
     try:
@@ -1190,9 +1251,27 @@ def template_apply(
             environment=environment,
         )
 
-        # Setup callbacks
+        # Setup callbacks.
+        #
+        # Resolution order mirrors ``srunx submit``:
+        #   --endpoint → durable watch attached via the poller pipeline
+        #   --slack    → in-process SlackCallback fallback (deprecated)
+        # Both may be set — keep the deprecated path firing so endpoint
+        # lookup failures don't silently drop the user's opt-in.
         callbacks: list[Callback] = []
+        effective_preset = preset or get_config().notifications.default_preset
+        if endpoint:
+            callbacks.append(
+                NotificationWatchCallback(
+                    endpoint_name=endpoint,
+                    preset=effective_preset,
+                )
+            )
         if slack:
+            logger.warning(
+                "`--slack` is deprecated; configure an endpoint via "
+                "Settings → Notifications and pass `--endpoint <name>`."
+            )
             webhook_url = os.getenv("SLACK_WEBHOOK_URL")
             if not webhook_url:
                 raise ValueError("SLACK_WEBHOOK_URL is not set")

--- a/src/srunx/cli/monitor.py
+++ b/src/srunx/cli/monitor.py
@@ -52,6 +52,27 @@ def monitor_jobs(
         str | None,
         typer.Option("--notify", "-n", help="Slack webhook URL for notifications"),
     ] = None,
+    endpoint: Annotated[
+        str | None,
+        typer.Option(
+            "--endpoint",
+            help=(
+                "Name of a configured notification endpoint (see "
+                "`/api/endpoints` / Settings UI). Attaches a durable "
+                "watch per monitored job via the poller pipeline."
+            ),
+        ),
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset",
+            help=(
+                "Subscription preset for --endpoint: terminal (default), "
+                "running_and_terminal, or all."
+            ),
+        ),
+    ] = None,
     continuous: Annotated[
         bool,
         typer.Option(
@@ -103,9 +124,34 @@ def monitor_jobs(
             sys.exit(0)
         console.print(f"📋 Monitoring {len(job_ids)} jobs for current user")
 
-    # Setup callbacks
+    # Setup callbacks.
+    #
+    # Resolution order:
+    #   --endpoint → attach a durable watch per monitored job (poller
+    #                pipeline takes over delivery)
+    #   --notify   → in-process SlackCallback fallback (deprecated; kept
+    #                so endpoint-attach failures don't silently drop
+    #                notifications the user asked for)
     callbacks: list[Callback] = []
+    if endpoint:
+        from srunx.cli.notification_setup import attach_notification_watch
+        from srunx.config import get_config
+
+        effective_preset = preset or get_config().notifications.default_preset
+        # Attach per-job watches upfront: monitor_jobs does not resubmit
+        # jobs, so the one-shot attach here is the equivalent of the
+        # Callback.on_job_submitted hook used by submit flows.
+        assert job_ids is not None
+        for _jid in job_ids:
+            attach_notification_watch(
+                job_id=int(_jid),
+                endpoint_name=endpoint,
+                preset=effective_preset,
+            )
     if notify:
+        console.print(
+            "[yellow]⚠️  --notify is deprecated; use --endpoint instead.[/yellow]"
+        )
         try:
             callbacks.append(SlackCallback(notify))
         except ValueError as e:
@@ -117,7 +163,7 @@ def monitor_jobs(
         poll_interval=interval,
         timeout=timeout if not continuous else None,
         mode=WatchMode.CONTINUOUS if continuous else WatchMode.UNTIL_CONDITION,
-        notify_on_change=continuous or bool(notify),
+        notify_on_change=continuous or bool(notify) or bool(endpoint),
     )
 
     # Create and run monitor

--- a/src/srunx/cli/notification_setup.py
+++ b/src/srunx/cli/notification_setup.py
@@ -30,6 +30,13 @@ logger = get_logger(__name__)
 # ambiguity.
 DEFAULT_ENDPOINT_KIND = "slack_webhook"
 
+# Presets that actually produce deliveries today. ``digest`` is a
+# documented schema value but no delivery-time aggregator exists yet —
+# letting it through here reproduces the footgun the POST subscriptions
+# router closes (P1-3 #D): a subscription with ``preset='digest'`` is
+# created silently and nothing ever ships.
+_IMPLEMENTED_PRESETS = ("terminal", "running_and_terminal", "all")
+
 
 def attach_notification_watch(
     *,
@@ -57,6 +64,22 @@ def attach_notification_watch(
         failure (endpoint missing / disabled / DB error). All failure
         paths log a warning so ``srunx submit`` never aborts.
     """
+    # Reject presets that don't have a delivery implementation today.
+    # Silently accepting ``digest`` here would write a subscription the
+    # delivery poller never fans out — the same footgun P1-3 closes at
+    # the POST ``/api/subscriptions`` endpoint. Keep the guard narrow:
+    # we still accept anything else in case a test config or future
+    # preset lands ahead of the lookup constant.
+    if preset not in _IMPLEMENTED_PRESETS:
+        logger.warning(
+            "Preset %r is not implemented for delivery; skipping watch "
+            "creation for job %s. Use one of: %s.",
+            preset,
+            job_id,
+            ", ".join(_IMPLEMENTED_PRESETS),
+        )
+        return None
+
     try:
         from srunx.db.connection import init_db, open_connection
         from srunx.db.repositories.endpoints import EndpointRepository
@@ -96,6 +119,34 @@ def attach_notification_watch(
             watch_repo = WatchRepository(conn)
             sub_repo = SubscriptionRepository(conn)
             transition_repo = JobStateTransitionRepository(conn)
+
+            # Dedup: ``WatchRepository`` has no ``(kind, target_ref)``
+            # uniqueness constraint, so a second ``srunx monitor jobs
+            # 123 --endpoint foo`` would otherwise spawn a duplicate
+            # watch + subscription for the same (job, endpoint, preset)
+            # triple. Deliveries stay idempotent via their own
+            # ``idempotency_key`` uniqueness, but the DB would still
+            # accumulate zombie rows. Reuse an existing open watch +
+            # subscription when one already exists.
+            existing = watch_repo.list_by_target(
+                kind="job",
+                target_ref=f"job:{job_id}",
+                only_open=True,
+            )
+            for w in existing:
+                if w.id is None:
+                    continue
+                for sub in sub_repo.list_by_watch(w.id):
+                    if sub.endpoint_id == endpoint.id and sub.preset == preset:
+                        logger.debug(
+                            "Existing watch+subscription for job %s on "
+                            "%s:%s (preset=%s); skipping.",
+                            job_id,
+                            endpoint_kind,
+                            endpoint_name,
+                            preset,
+                        )
+                        return sub.id
 
             watch_id = watch_repo.create(kind="job", target_ref=f"job:{job_id}")
             subscription_id = sub_repo.create(

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -8,7 +8,8 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
-from srunx.callbacks import SlackCallback
+from srunx.callbacks import Callback, NotificationWatchCallback, SlackCallback
+from srunx.config import get_config
 from srunx.logging import configure_workflow_logging, get_logger
 from srunx.models import Job, ShellJob
 from srunx.runner import WorkflowRunner
@@ -83,6 +84,27 @@ def execute_yaml(
     slack: Annotated[
         bool, typer.Option("--slack", help="Send notifications to Slack")
     ] = False,
+    endpoint: Annotated[
+        str | None,
+        typer.Option(
+            "--endpoint",
+            help=(
+                "Name of a configured notification endpoint (see "
+                "`/api/endpoints` / Settings UI). Attaches a watch per "
+                "submitted job via the poller pipeline."
+            ),
+        ),
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset",
+            help=(
+                "Subscription preset for --endpoint: terminal (default), "
+                "running_and_terminal, or all."
+            ),
+        ),
+    ] = None,
     from_job: Annotated[
         str | None,
         typer.Option(
@@ -118,6 +140,8 @@ def execute_yaml(
         dry_run=dry_run,
         log_level=log_level,
         slack=slack,
+        endpoint=endpoint,
+        preset=preset,
         from_job=from_job,
         to_job=to_job,
         job=job,
@@ -130,6 +154,8 @@ def _execute_workflow(
     dry_run: bool = False,
     log_level: str = "INFO",
     slack: bool = False,
+    endpoint: str | None = None,
+    preset: str | None = None,
     from_job: str | None = None,
     to_job: str | None = None,
     job: str | None = None,
@@ -149,9 +175,28 @@ def _execute_workflow(
             logger.error(f"Workflow file not found: {yaml_file}")
             sys.exit(1)
 
-        # Setup callbacks if requested
-        callbacks = []
+        # Setup callbacks if requested.
+        #
+        # Resolution order mirrors ``srunx submit``:
+        #   --endpoint → durable watch per submitted job (poller pipeline)
+        #   --slack    → in-process SlackCallback fallback (deprecated)
+        # Both may be set; the deprecated path keeps firing so users who
+        # opt in always get *some* notification even if the endpoint
+        # lookup fails.
+        callbacks: list[Callback] = []
+        effective_preset = preset or get_config().notifications.default_preset
+        if endpoint:
+            callbacks.append(
+                NotificationWatchCallback(
+                    endpoint_name=endpoint,
+                    preset=effective_preset,
+                )
+            )
         if slack:
+            logger.warning(
+                "`--slack` is deprecated; configure an endpoint via "
+                "Settings → Notifications and pass `--endpoint <name>`."
+            )
             webhook_url = os.getenv("SLACK_WEBHOOK_URL")
             if not webhook_url:
                 raise ValueError("SLACK_WEBHOOK_URL environment variable is not set")
@@ -269,6 +314,27 @@ def run_command(
     slack: Annotated[
         bool, typer.Option("--slack", help="Send notifications to Slack")
     ] = False,
+    endpoint: Annotated[
+        str | None,
+        typer.Option(
+            "--endpoint",
+            help=(
+                "Name of a configured notification endpoint (see "
+                "`/api/endpoints` / Settings UI). Attaches a watch per "
+                "submitted job via the poller pipeline."
+            ),
+        ),
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset",
+            help=(
+                "Subscription preset for --endpoint: terminal (default), "
+                "running_and_terminal, or all."
+            ),
+        ),
+    ] = None,
     from_job: Annotated[
         str | None,
         typer.Option(
@@ -288,7 +354,16 @@ def run_command(
 ) -> None:
     """Execute workflow from YAML file."""
     _execute_workflow(
-        yaml_file, validate, dry_run, log_level, slack, from_job, to_job, job
+        yaml_file=yaml_file,
+        validate=validate,
+        dry_run=dry_run,
+        log_level=log_level,
+        slack=slack,
+        endpoint=endpoint,
+        preset=preset,
+        from_job=from_job,
+        to_job=to_job,
+        job=job,
     )
 
 

--- a/tests/cli/test_notification_setup.py
+++ b/tests/cli/test_notification_setup.py
@@ -262,3 +262,84 @@ def test_cli_submit_with_unknown_endpoint_still_succeeds(
         assert WatchRepository(conn).list_open() == []
     finally:
         conn.close()
+
+
+def test_rejects_unimplemented_preset(isolated_db: Path) -> None:
+    """``digest`` is schema-valid but has no delivery implementation yet.
+
+    Silently accepting it would write a subscription the delivery
+    poller never fans out — the same footgun P1-3 closes at the
+    POST ``/api/subscriptions`` router. Guard the CLI path too.
+    """
+    endpoint_id, job_id = _seed_endpoint_and_job(endpoint_name="primary")
+
+    subscription_id = attach_notification_watch(
+        job_id=job_id, endpoint_name="primary", preset="digest"
+    )
+
+    assert subscription_id is None
+
+    from srunx.db.connection import open_connection
+    from srunx.db.repositories.watches import WatchRepository
+
+    conn = open_connection()
+    try:
+        # Nothing got written — no watch, no subscription.
+        assert WatchRepository(conn).list_open() == []
+    finally:
+        conn.close()
+
+
+def test_dedups_existing_watch_subscription(isolated_db: Path) -> None:
+    """Attaching twice for the same (job, endpoint, preset) reuses the row.
+
+    Before the dedup guard, running ``srunx monitor jobs 123 --endpoint
+    foo`` twice would spawn a second watch + subscription targeting the
+    same job. Deliveries stay idempotent via ``idempotency_key``, but
+    the DB would accumulate zombie rows.
+    """
+    endpoint_id, job_id = _seed_endpoint_and_job(endpoint_name="primary")
+
+    first = attach_notification_watch(
+        job_id=job_id, endpoint_name="primary", preset="terminal"
+    )
+    second = attach_notification_watch(
+        job_id=job_id, endpoint_name="primary", preset="terminal"
+    )
+
+    assert first is not None
+    # Second call returns the existing subscription id rather than
+    # creating a new one.
+    assert second == first
+
+    from srunx.db.connection import open_connection
+    from srunx.db.repositories.subscriptions import SubscriptionRepository
+    from srunx.db.repositories.watches import WatchRepository
+
+    conn = open_connection()
+    try:
+        open_watches = WatchRepository(conn).list_open()
+        # Exactly one watch, one subscription for the (job, endpoint, preset) triple.
+        assert len(open_watches) == 1
+        assert open_watches[0].id is not None
+        subs = SubscriptionRepository(conn).list_by_watch(open_watches[0].id)
+        assert len(subs) == 1
+    finally:
+        conn.close()
+
+
+def test_dedup_scoped_by_preset(isolated_db: Path) -> None:
+    """Different preset = different subscription (reasonable user intent)."""
+    endpoint_id, job_id = _seed_endpoint_and_job(endpoint_name="primary")
+
+    first = attach_notification_watch(
+        job_id=job_id, endpoint_name="primary", preset="terminal"
+    )
+    second = attach_notification_watch(
+        job_id=job_id, endpoint_name="primary", preset="all"
+    )
+
+    assert first is not None
+    assert second is not None
+    # Different presets create distinct subscription rows.
+    assert first != second

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,8 +4,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from srunx.callbacks import Callback, SlackCallback
-from srunx.models import BaseJob, Job, JobEnvironment, JobStatus
+from srunx.callbacks import Callback, NotificationWatchCallback, SlackCallback
+from srunx.models import BaseJob, Job, JobEnvironment, JobStatus  # noqa: F401
 
 
 class TestCallback:
@@ -475,3 +475,71 @@ class TestSlackCallbackSecurity:
         assert "\\_" in sanitized  # Markdown italic escaped
         assert "\\[" in sanitized  # Markdown link brackets escaped
         assert "\\]" in sanitized  # Markdown link brackets escaped
+
+
+class TestNotificationWatchCallback:
+    """Test NotificationWatchCallback — the endpoint-watch bridge.
+
+    Invariants:
+
+    - ``on_job_submitted`` calls ``attach_notification_watch`` with the
+      configured endpoint_name / preset / endpoint_kind.
+    - A job with ``job_id=None`` is a no-op (nothing to attach to).
+    - An exception from ``attach_notification_watch`` is swallowed so
+      the callback chain keeps firing for sibling callbacks.
+    """
+
+    def test_on_job_submitted_attaches_watch(self):
+        job = BaseJob(name="test_job", job_id=12345)
+        cb = NotificationWatchCallback(endpoint_name="my-slack", preset="terminal")
+
+        with patch(
+            "srunx.cli.notification_setup.attach_notification_watch"
+        ) as mock_attach:
+            cb.on_job_submitted(job)
+            mock_attach.assert_called_once_with(
+                job_id=12345,
+                endpoint_name="my-slack",
+                preset="terminal",
+                endpoint_kind="slack_webhook",
+            )
+
+    def test_on_job_submitted_without_job_id_is_noop(self):
+        job = BaseJob(name="test_job")  # job_id=None
+        cb = NotificationWatchCallback(endpoint_name="my-slack")
+
+        with patch(
+            "srunx.cli.notification_setup.attach_notification_watch"
+        ) as mock_attach:
+            cb.on_job_submitted(job)
+            mock_attach.assert_not_called()
+
+    def test_on_job_submitted_swallows_attach_errors(self):
+        job = BaseJob(name="test_job", job_id=42)
+        cb = NotificationWatchCallback(endpoint_name="my-slack")
+
+        with patch(
+            "srunx.cli.notification_setup.attach_notification_watch",
+            side_effect=RuntimeError("DB error"),
+        ):
+            # Must not raise — downstream callbacks depend on this
+            cb.on_job_submitted(job)
+
+    def test_custom_preset_and_kind_flow_through(self):
+        job = BaseJob(name="test_job", job_id=7)
+        cb = NotificationWatchCallback(
+            endpoint_name="ops",
+            preset="all",
+            endpoint_kind="slack_webhook",
+        )
+
+        with patch(
+            "srunx.cli.notification_setup.attach_notification_watch"
+        ) as mock_attach:
+            cb.on_job_submitted(job)
+            mock_attach.assert_called_once_with(
+                job_id=7,
+                endpoint_name="ops",
+                preset="all",
+                endpoint_kind="slack_webhook",
+            )


### PR DESCRIPTION
Re-opens #94 (auto-closed when the stacked base branch was merged).

## Summary

- Replaces 4 remaining in-process ``SlackCallback`` wirings with the durable endpoint-watch pipeline (``flow_run``, ``flow execute_yaml``/``run``, ``template apply``, ``monitor jobs``).
- New ``NotificationWatchCallback`` bridges ``Callback.on_job_submitted`` → ``attach_notification_watch``.
- ``--slack`` stays as deprecation-logged fallback; ``digest`` preset rejected at the CLI (matches the subscriptions router guard from #91).
- Dedup: repeated ``srunx monitor jobs <id> --endpoint foo`` now reuses the existing ``(job, endpoint, preset)`` subscription rather than accumulating zombie watch rows.

## Test plan

- [x] 1323 pytest passed on rebased branch (ubuntu/mac/mypy/ruff all clean locally)
- [x] Live pyxis run confirmed digest rejection + submit happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)