### PR TITLE
refactor(monitor): P2-6 #C - prefer state DB over sacct for history counts

### DIFF
--- a/src/srunx/db/repositories/jobs.py
+++ b/src/srunx/db/repositories/jobs.py
@@ -225,30 +225,49 @@ class JobRepository(BaseRepository):
         rows = self.conn.execute(sql, params).fetchall()
         return [self._row_to_model(r, Job) for r in rows if r is not None]  # type: ignore[misc]
 
+    _ALLOWED_RANGE_FIELDS = ("submitted_at", "started_at", "completed_at")
+
     def count_by_status_in_range(
         self,
         from_at: str,
         to_at: str,
         statuses: list[str] | None = None,
+        *,
+        timestamp_field: str = "submitted_at",
     ) -> dict[str, int]:
-        """Return per-status counts for jobs submitted in ``[from_at, to_at)``.
+        """Return per-status counts for jobs whose chosen timestamp is in ``[from_at, to_at)``.
 
-        Provided for the future ``ScheduledReporter`` replacement
-        (design.md § "Phase 1 で変更しない領域"). ``statuses=None`` counts
-        every distinct status.
+        ``timestamp_field`` picks the lifecycle column the range filters on.
+        ``submitted_at`` (default) matches "jobs queued in this window".
+        ``completed_at`` matches ``sacct --starttime`` + terminal-state
+        semantics more closely — used by
+        :class:`srunx.monitor.scheduler.ScheduledReporter` so a 24h
+        report counts what *finished* in the window, not what was merely
+        submitted.
+
+        Raises ``ValueError`` for an unsupported field rather than
+        injecting it into the SQL (this parameter is interpolated into
+        the query because sqlite can't bind column names).
         """
+        if timestamp_field not in self._ALLOWED_RANGE_FIELDS:
+            raise ValueError(
+                f"timestamp_field must be one of {self._ALLOWED_RANGE_FIELDS}; "
+                f"got {timestamp_field!r}"
+            )
+
         if statuses:
             placeholders = ",".join(["?"] * len(statuses))
             sql = (
                 "SELECT status, COUNT(*) AS c FROM jobs "
-                f"WHERE submitted_at >= ? AND submitted_at < ? AND status IN ({placeholders}) "
+                f"WHERE {timestamp_field} >= ? AND {timestamp_field} < ? "
+                f"AND status IN ({placeholders}) "
                 "GROUP BY status"
             )
             params: list[Any] = [from_at, to_at, *statuses]
         else:
             sql = (
                 "SELECT status, COUNT(*) AS c FROM jobs "
-                "WHERE submitted_at >= ? AND submitted_at < ? "
+                f"WHERE {timestamp_field} >= ? AND {timestamp_field} < ? "
                 "GROUP BY status"
             )
             params = [from_at, to_at]

--- a/src/srunx/monitor/scheduler.py
+++ b/src/srunx/monitor/scheduler.py
@@ -4,7 +4,7 @@ import os
 import re
 import signal
 import sys
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from apscheduler.schedulers.blocking import BlockingScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -255,14 +255,34 @@ class ScheduledReporter:
         )
 
     def _get_historical_counts(self, user: str | None = None) -> tuple[int, int, int]:
-        """Query sacct for completed/failed/cancelled job counts within timeframe.
+        """Return (completed, failed, cancelled) job counts within timeframe.
+
+        Resolution order:
+
+        1. **State DB** (``JobRepository.count_by_status_in_range``). Preferred
+           because it works on every platform — including remote SSH submit
+           flows that never have a local ``sacct`` — and avoids a 15-second
+           subprocess timeout on the schedule's critical path. Covers only
+           srunx-recorded submissions, which in single-user deployments
+           matches ``sacct`` closely. Skipped when ``user`` is specified
+           (the state DB has no ``user`` column; see migrations.py
+           ``CREATE TABLE jobs``).
+        2. **sacct fallback**. Used when ``user`` is set, or when the DB
+           query fails for any reason (missing DB, schema mismatch, etc.).
 
         Args:
-            user: Optional username to filter results.
+            user: Optional username to filter results. Forces the sacct path.
 
         Returns:
             Tuple of (completed, failed, cancelled) counts.
         """
+        if user is None:
+            db_counts = self._db_historical_counts()
+            if db_counts is not None:
+                return db_counts
+            # Fall through to sacct on DB miss so a missing/broken
+            # state DB never silently zeroes the report.
+
         import subprocess
 
         try:
@@ -301,6 +321,63 @@ class ScheduledReporter:
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             logger.debug("sacct not available for historical job counts")
             return 0, 0, 0
+
+    def _db_historical_counts(self) -> tuple[int, int, int] | None:
+        """Count terminal jobs submitted in timeframe via JobRepository.
+
+        ``submitted_at`` is used (not ``completed_at``) because that's
+        what ``count_by_status_in_range`` supports; for short reporter
+        timeframes (1h / 24h) the overlap with sacct's ``--starttime``
+        semantics is practically total.
+
+        Returns ``None`` on any error so the caller can fall back to
+        ``sacct`` without the DB outage surfacing as zero-counts.
+        """
+        try:
+            from srunx.db.connection import init_db, open_connection
+            from srunx.db.repositories.base import now_iso
+            from srunx.db.repositories.jobs import JobRepository
+
+            delta = self._parse_timeframe_to_delta(self.config.timeframe)
+            to_at = now_iso()
+            from_at = (
+                (datetime.now(UTC) - delta)
+                .isoformat(timespec="milliseconds")
+                .replace("+00:00", "Z")
+            )
+
+            init_db(delete_legacy=False)
+            conn = open_connection()
+            try:
+                counts = JobRepository(conn).count_by_status_in_range(
+                    from_at,
+                    to_at,
+                    statuses=["COMPLETED", "FAILED", "CANCELLED"],
+                )
+            finally:
+                conn.close()
+
+            return (
+                counts.get("COMPLETED", 0),
+                counts.get("FAILED", 0),
+                counts.get("CANCELLED", 0),
+            )
+        except Exception as exc:  # noqa: BLE001 — best-effort; caller falls back
+            logger.debug(f"State DB unavailable for historical counts: {exc}")
+            return None
+
+    @staticmethod
+    def _parse_timeframe_to_delta(timeframe: str) -> timedelta:
+        """Parse ``<number><unit>`` (e.g. ``24h``, ``30m``) into a ``timedelta``."""
+        match = re.match(r"^(\d+)([smhd])$", timeframe)
+        if not match:
+            raise ValueError(
+                f"Invalid timeframe: {timeframe}. Expected e.g. '24h', '30m', '1d'."
+            )
+        value = int(match.group(1))
+        unit = match.group(2)
+        unit_to_kwarg = {"s": "seconds", "m": "minutes", "h": "hours", "d": "days"}
+        return timedelta(**{unit_to_kwarg[unit]: value})
 
     def _get_resource_stats(self) -> ResourceStats:
         """Get GPU and node resource statistics.

--- a/src/srunx/monitor/scheduler.py
+++ b/src/srunx/monitor/scheduler.py
@@ -323,12 +323,16 @@ class ScheduledReporter:
             return 0, 0, 0
 
     def _db_historical_counts(self) -> tuple[int, int, int] | None:
-        """Count terminal jobs submitted in timeframe via JobRepository.
+        """Count terminal jobs *completed* in timeframe via JobRepository.
 
-        ``submitted_at`` is used (not ``completed_at``) because that's
-        what ``count_by_status_in_range`` supports; for short reporter
-        timeframes (1h / 24h) the overlap with sacct's ``--starttime``
-        semantics is practically total.
+        Filters on ``completed_at`` — the terminal timestamp — so the
+        windowing matches ``sacct --starttime now-<timeframe>`` as
+        closely as the state DB can. Using ``submitted_at`` would miss
+        jobs that queued before the window but finished inside it, and
+        would over-count jobs submitted inside the window that are
+        still running. ``count_by_status_in_range`` accepts
+        ``timestamp_field`` (P3/#C follow-up) to make this column
+        choice explicit.
 
         Returns ``None`` on any error so the caller can fall back to
         ``sacct`` without the DB outage surfacing as zero-counts.
@@ -353,6 +357,7 @@ class ScheduledReporter:
                     from_at,
                     to_at,
                     statuses=["COMPLETED", "FAILED", "CANCELLED"],
+                    timestamp_field="completed_at",
                 )
             finally:
                 conn.close()

--- a/tests/db/repositories/test_jobs.py
+++ b/tests/db/repositories/test_jobs.py
@@ -269,6 +269,64 @@ def test_count_by_status_in_range_filters_statuses(repo: JobRepository) -> None:
     assert counts == {"COMPLETED": 1}
 
 
+def test_count_by_status_in_range_uses_timestamp_field(repo: JobRepository) -> None:
+    """``timestamp_field='completed_at'`` counts by terminal ts, not submit.
+
+    Exercises the P2-6 follow-up: the scheduler windows by when jobs
+    *finished*, so a row submitted before the window but completed inside
+    it must count, and vice versa.
+    """
+    # Submitted long ago, completed inside the window → counted under
+    # completed_at, missed under submitted_at.
+    repo.record_submission(
+        job_id=901,
+        name="long_running",
+        status="COMPLETED",
+        submission_source="cli",
+        submitted_at="2026-01-01T00:00:00Z",
+    )
+    repo.update_status(
+        901, "COMPLETED", completed_at="2026-04-19T12:00:00Z", duration_secs=1
+    )
+    # Submitted inside the window, not yet completed → excluded under
+    # completed_at because ``completed_at >= ?`` is false when it's NULL.
+    repo.record_submission(
+        job_id=902,
+        name="still_running",
+        status="RUNNING",
+        submission_source="cli",
+        submitted_at="2026-04-19T11:00:00Z",
+    )
+
+    by_completed = repo.count_by_status_in_range(
+        "2026-04-19T00:00:00Z",
+        "2026-04-20T00:00:00Z",
+        statuses=["COMPLETED"],
+        timestamp_field="completed_at",
+    )
+    assert by_completed == {"COMPLETED": 1}
+
+    by_submitted = repo.count_by_status_in_range(
+        "2026-04-19T00:00:00Z",
+        "2026-04-20T00:00:00Z",
+        statuses=["RUNNING"],
+        timestamp_field="submitted_at",
+    )
+    assert by_submitted == {"RUNNING": 1}
+
+
+def test_count_by_status_in_range_rejects_bad_field(repo: JobRepository) -> None:
+    """Column names are interpolated, so only whitelisted values are allowed."""
+    import pytest
+
+    with pytest.raises(ValueError, match="timestamp_field"):
+        repo.count_by_status_in_range(
+            "2026-04-19T00:00:00Z",
+            "2026-04-20T00:00:00Z",
+            timestamp_field="status; DROP TABLE jobs;--",  # noqa: S608 — negative test
+        )
+
+
 def test_delete_existing_returns_true(repo: JobRepository) -> None:
     repo.record_submission(
         job_id=901, name="t", status="PENDING", submission_source="cli"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -34,14 +34,21 @@ class TestHistoricalCountsDbFirst:
     """Preferred DB path introduced in P2-6 #C."""
 
     def test_db_path_returns_counts_when_rows_exist(self, tmp_srunx_db, monkeypatch):
-        from srunx.db.repositories.base import now_iso
+        from datetime import UTC, datetime, timedelta
+
         from srunx.db.repositories.jobs import JobRepository
 
         conn, _db_path = tmp_srunx_db
         repo = JobRepository(conn)
 
-        # Seed three rows inside the 24h window — submitted_at = now.
-        ts = now_iso()
+        # Seed with completed_at one minute ago so the reporter's
+        # half-open ``[from_at, now)`` range picks them up regardless
+        # of how fast the test runs.
+        ts = (
+            (datetime.now(UTC) - timedelta(minutes=1))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
         for i, status in enumerate(["COMPLETED", "COMPLETED", "FAILED"], start=1000):
             repo.record_submission(
                 job_id=i,
@@ -50,7 +57,8 @@ class TestHistoricalCountsDbFirst:
                 submission_source="cli",
                 submitted_at=ts,
             )
-        # One CANCELLED row.
+            repo.update_status(i, status, completed_at=ts)
+        # One CANCELLED row, also finished in-window.
         repo.record_submission(
             job_id=2000,
             name="cancelled_job",
@@ -58,6 +66,7 @@ class TestHistoricalCountsDbFirst:
             submission_source="cli",
             submitted_at=ts,
         )
+        repo.update_status(2000, "CANCELLED", completed_at=ts)
 
         reporter = _make_reporter()
         assert reporter._get_historical_counts() == (2, 1, 1)
@@ -70,7 +79,7 @@ class TestHistoricalCountsDbFirst:
         conn, _db_path = tmp_srunx_db
         repo = JobRepository(conn)
 
-        # Row submitted 30 hours ago — outside the 24h window.
+        # Row that *completed* 30 hours ago — outside the 24h window.
         stale = (
             (datetime.now(UTC) - timedelta(hours=30))
             .isoformat(timespec="milliseconds")
@@ -83,9 +92,54 @@ class TestHistoricalCountsDbFirst:
             submission_source="cli",
             submitted_at=stale,
         )
+        repo.update_status(3000, "COMPLETED", completed_at=stale)
 
         reporter = _make_reporter(timeframe="24h")
         assert reporter._get_historical_counts() == (0, 0, 0)
+
+    def test_db_path_counts_jobs_completed_in_window_regardless_of_submit(
+        self, tmp_srunx_db
+    ):
+        """Regression guard: jobs submitted *before* the window but
+        completed *inside* it must still count.
+
+        This is the difference between ``submitted_at`` and
+        ``completed_at`` semantics — the scheduler now uses
+        ``completed_at`` to match ``sacct --starttime`` intent.
+        """
+        from datetime import UTC, datetime, timedelta
+
+        from srunx.db.repositories.jobs import JobRepository
+
+        conn, _db_path = tmp_srunx_db
+        repo = JobRepository(conn)
+
+        stale_submit = (
+            (datetime.now(UTC) - timedelta(hours=30))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+        # completed_at one minute ago — definitively inside the 24h
+        # window, but also < now so the half-open range ``[from_at, to_at)``
+        # picks it up (the scheduler recomputes ``to_at = now_iso()``
+        # at query time; using exactly ``now`` here would race the
+        # upper-bound comparison).
+        recent_complete = (
+            (datetime.now(UTC) - timedelta(minutes=1))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+        repo.record_submission(
+            job_id=4000,
+            name="long_running",
+            status="COMPLETED",
+            submission_source="cli",
+            submitted_at=stale_submit,  # outside the 24h window
+        )
+        repo.update_status(4000, "COMPLETED", completed_at=recent_complete)
+
+        reporter = _make_reporter(timeframe="24h")
+        assert reporter._get_historical_counts() == (1, 0, 0)
 
     def test_db_path_skipped_when_user_given(self, tmp_srunx_db):
         """``user`` forces sacct — the state DB has no user column."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,6 +1,21 @@
-"""Tests for ScheduledReporter._get_historical_counts (L9)."""
+"""Tests for ScheduledReporter._get_historical_counts (L9).
 
+Coverage split:
+
+- ``TestHistoricalCountsDbFirst`` — new P2-6 path: state DB via
+  ``JobRepository.count_by_status_in_range``; user-less calls prefer
+  this over the sacct shell-out.
+- ``TestHistoricalCountsSacctFallback`` — legacy sacct parsing, still
+  active when ``user`` is given or the DB call fails. Each test here
+  stubs ``_db_historical_counts`` to ``None`` so the fallback runs.
+- ``TestParseTimeframeToDelta`` — the new timeframe parser the DB
+  path relies on.
+"""
+
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from srunx.monitor.report_types import ReportConfig
 from srunx.monitor.scheduler import ScheduledReporter
@@ -15,8 +30,85 @@ def _make_reporter(timeframe: str = "24h") -> ScheduledReporter:
     )
 
 
-class TestGetHistoricalCounts:
-    """Test sacct-based historical job counting."""
+class TestHistoricalCountsDbFirst:
+    """Preferred DB path introduced in P2-6 #C."""
+
+    def test_db_path_returns_counts_when_rows_exist(self, tmp_srunx_db, monkeypatch):
+        from srunx.db.repositories.base import now_iso
+        from srunx.db.repositories.jobs import JobRepository
+
+        conn, _db_path = tmp_srunx_db
+        repo = JobRepository(conn)
+
+        # Seed three rows inside the 24h window — submitted_at = now.
+        ts = now_iso()
+        for i, status in enumerate(["COMPLETED", "COMPLETED", "FAILED"], start=1000):
+            repo.record_submission(
+                job_id=i,
+                name=f"job_{i}",
+                status=status,
+                submission_source="cli",
+                submitted_at=ts,
+            )
+        # One CANCELLED row.
+        repo.record_submission(
+            job_id=2000,
+            name="cancelled_job",
+            status="CANCELLED",
+            submission_source="cli",
+            submitted_at=ts,
+        )
+
+        reporter = _make_reporter()
+        assert reporter._get_historical_counts() == (2, 1, 1)
+
+    def test_db_path_excludes_rows_outside_timeframe(self, tmp_srunx_db, monkeypatch):
+        from datetime import UTC, datetime, timedelta
+
+        from srunx.db.repositories.jobs import JobRepository
+
+        conn, _db_path = tmp_srunx_db
+        repo = JobRepository(conn)
+
+        # Row submitted 30 hours ago — outside the 24h window.
+        stale = (
+            (datetime.now(UTC) - timedelta(hours=30))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z")
+        )
+        repo.record_submission(
+            job_id=3000,
+            name="stale",
+            status="COMPLETED",
+            submission_source="cli",
+            submitted_at=stale,
+        )
+
+        reporter = _make_reporter(timeframe="24h")
+        assert reporter._get_historical_counts() == (0, 0, 0)
+
+    def test_db_path_skipped_when_user_given(self, tmp_srunx_db):
+        """``user`` forces sacct — the state DB has no user column."""
+        reporter = _make_reporter()
+
+        # _db_historical_counts should NOT be consulted for user-scoped
+        # calls. Make it explode if it is.
+        reporter._db_historical_counts = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("DB path must not run for user-scoped call")
+        )
+
+        with patch(
+            "subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="COMPLETED\n"),
+        ):
+            reporter._get_historical_counts(user="alice")
+
+
+class TestHistoricalCountsSacctFallback:
+    """Legacy sacct path — still active when ``user`` is set or DB fails."""
+
+    def _stub_db_path_to_miss(self, reporter: ScheduledReporter) -> None:
+        reporter._db_historical_counts = MagicMock(return_value=None)  # type: ignore[method-assign]
 
     @patch("subprocess.run")
     def test_parses_completed_failed_cancelled(self, mock_run):
@@ -25,6 +117,7 @@ class TestGetHistoricalCounts:
             stdout="COMPLETED\nCOMPLETED\nFAILED\nCANCELLED by 1000\nCOMPLETED\n",
         )
         reporter = _make_reporter()
+        self._stub_db_path_to_miss(reporter)
         c, f, ca = reporter._get_historical_counts()
         assert c == 3
         assert f == 1
@@ -34,23 +127,27 @@ class TestGetHistoricalCounts:
     def test_handles_empty_output(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="")
         reporter = _make_reporter()
+        self._stub_db_path_to_miss(reporter)
         assert reporter._get_historical_counts() == (0, 0, 0)
 
     @patch("subprocess.run")
     def test_handles_sacct_failure(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stdout="")
         reporter = _make_reporter()
+        self._stub_db_path_to_miss(reporter)
         assert reporter._get_historical_counts() == (0, 0, 0)
 
     @patch("subprocess.run", side_effect=FileNotFoundError)
     def test_handles_sacct_not_found(self, _mock_run):
         reporter = _make_reporter()
+        self._stub_db_path_to_miss(reporter)
         assert reporter._get_historical_counts() == (0, 0, 0)
 
     @patch("subprocess.run")
     def test_passes_user_filter(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="COMPLETED\n")
         reporter = _make_reporter()
+        # user-scoped calls always hit sacct — no stub needed.
         reporter._get_historical_counts(user="testuser")
         cmd = mock_run.call_args[0][0]
         assert "--user" in cmd
@@ -60,6 +157,32 @@ class TestGetHistoricalCounts:
     def test_uses_config_timeframe(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="")
         reporter = _make_reporter(timeframe="48h")
+        self._stub_db_path_to_miss(reporter)
         reporter._get_historical_counts()
         cmd = mock_run.call_args[0][0]
         assert "now-48h" in cmd
+
+
+class TestParseTimeframeToDelta:
+    """Parser backing the DB path's timeframe→timedelta conversion."""
+
+    def test_hours(self):
+        assert ScheduledReporter._parse_timeframe_to_delta("24h") == timedelta(hours=24)
+
+    def test_minutes(self):
+        assert ScheduledReporter._parse_timeframe_to_delta("30m") == timedelta(
+            minutes=30
+        )
+
+    def test_days(self):
+        assert ScheduledReporter._parse_timeframe_to_delta("7d") == timedelta(days=7)
+
+    def test_seconds(self):
+        assert ScheduledReporter._parse_timeframe_to_delta("90s") == timedelta(
+            seconds=90
+        )
+
+    @pytest.mark.parametrize("bad", ["", "24", "h24", "24x", "1.5h", "--1h"])
+    def test_rejects_invalid(self, bad):
+        with pytest.raises(ValueError):
+            ScheduledReporter._parse_timeframe_to_delta(bad)


### PR DESCRIPTION
Re-opens the scheduler DB-first change (previous PR auto-closed when its base branch was merged). Reads terminal counts from JobRepository.count_by_status_in_range when not user-scoped; sacct stays as fallback. Uses completed_at via a whitelisted timestamp_field kwarg to match sacct --starttime semantics.