### PR TITLE
docs(claudemd): drop legacy history.db note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,8 +340,6 @@ Background pollers (lifespan tasks managed by `PollerSupervisor`):
 
 All pollers are crash-resilient via a lease mechanism (`leased_until`, `worker_id`) and a `reclaim_expired_leases()` sweep at the start of every `DeliveryPoller` cycle.
 
-Legacy ``~/.srunx/history.db`` was removed in P2-4 (``srunx.history`` module deleted entirely; CLI history + reports read from the unified state DB via ``JobRepository``). On first ``init_db`` call the legacy file, if present, is silently deleted by ``_delete_legacy_history_db``.
-
 **Environment variables** that affect poller startup:
 - `SRUNX_DISABLE_POLLER=1` — disable ALL pollers (also applied automatically in `uvicorn --reload` dev mode).
 - `SRUNX_DISABLE_ACTIVE_WATCH_POLLER=1` — skip the SLURM → events producer.


### PR DESCRIPTION
CLAUDE.md describes current architecture; the P2-4 cutover is complete and the one-shot legacy cleanup doesn't aid day-to-day understanding. Drops the line entirely.