### PR TITLE
fix(web): skip ResourceSnapshotter when local sinfo is missing

### DIFF
--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -254,9 +254,29 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         if os.environ.get("SRUNX_DISABLE_DELIVERY_POLLER") != "1":
             pollers.append(DeliveryPoller(worker_id=f"delivery-{os.getpid()}"))
         if os.environ.get("SRUNX_DISABLE_RESOURCE_SNAPSHOTTER") != "1":
-            # ResourceSnapshotter needs a resource_monitor; if the SLURM
-            # adapter is down we skip it to avoid hammering a missing backend.
-            if adapter is not None:
+            # ResourceSnapshotter needs a local ``sinfo`` because
+            # ``ResourceMonitor.get_current_snapshot`` shells out directly —
+            # it does NOT tunnel through the SSH adapter. On a developer
+            # laptop that only has SSH profiles pointing at a remote
+            # SLURM cluster this is a guaranteed ``FileNotFoundError``
+            # every ``interval_seconds``, spamming the log until the
+            # process is killed. Gate the poller on ``sinfo`` being on
+            # PATH so the boot-time log line explains the skip once,
+            # then stay quiet.
+            import shutil
+
+            if adapter is None:
+                logger.info(
+                    "Skipping ResourceSnapshotter: no SLURM client is available"
+                )
+            elif shutil.which("sinfo") is None:
+                logger.info(
+                    "Skipping ResourceSnapshotter: local 'sinfo' not found on PATH. "
+                    "The snapshotter shells out locally; remote SLURM via SSH is "
+                    "not supported yet. Set SRUNX_DISABLE_RESOURCE_SNAPSHOTTER=1 "
+                    "to silence this at startup."
+                )
+            else:
                 try:
                     from srunx.monitor.resource_monitor import ResourceMonitor
 
@@ -271,10 +291,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                         "Skipping ResourceSnapshotter: init failed",
                         exc_info=True,
                     )
-            else:
-                logger.info(
-                    "Skipping ResourceSnapshotter: no SLURM client is available"
-                )
 
         if pollers:
             supervisor = PollerSupervisor(pollers)


### PR DESCRIPTION
## Problem

Running `srunx ui` on a developer laptop with an SSH profile pointing at a remote SLURM cluster was logging ERROR every 5 minutes:
```
poller resource_snapshotter cycle failed: [Errno 2] No such file or directory: 'sinfo'
```

## Root cause

- `ResourceSnapshotter` → `ResourceMonitor.get_current_snapshot` calls `subprocess.run(['sinfo', ...])` **locally** — it does NOT tunnel through the SSH adapter used by the jobs/workflow paths.
- Existing startup gate only checked `adapter is not None`. Adapter availability doesn't imply local `sinfo` exists on a laptop.
- `ResourceMonitor` catches `TimeoutExpired`/`CalledProcessError` but not `FileNotFoundError`, so the error propagated to the supervisor every cycle.

## Fix

Gate the snapshotter wire-up on `shutil.which('sinfo')` in addition to the adapter check. Logs one clear info line at startup and stays quiet.

## Follow-up (not in scope)

Proper fix: route `ResourceMonitor` through the SSH adapter so remote clusters are supported. Should be a separate issue.

## Test plan

- [x] 1339 pytest passed
- [x] ruff + mypy clean
- [x] Manual: `shutil.which('sinfo')` returns None on the reporter's Mac; the new branch emits the 'Skipping ResourceSnapshotter' info line and no cycle errors