### PR TITLE
feat(monitor): route ResourceMonitor through SSH adapter — closes #111

### DIFF
--- a/src/srunx/monitor/resource_monitor.py
+++ b/src/srunx/monitor/resource_monitor.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from srunx.callbacks import Callback
 from srunx.monitor.base import BaseMonitor
+from srunx.monitor.resource_source import ResourceSource
 from srunx.monitor.types import MonitorConfig, ResourceSnapshot
 from srunx.utils import GPU_TRES_RE
 
@@ -16,6 +17,12 @@ class ResourceMonitor(BaseMonitor):
 
     Polls partition resources at configured intervals and notifies callbacks
     when resources become available or exhausted.
+
+    When a :class:`~srunx.monitor.resource_source.ResourceSource` is
+    injected, partition queries delegate to it instead of shelling out
+    to local ``sinfo`` / ``squeue``. That lets ``srunx ui`` talk to a
+    remote cluster through the existing SSH adapter — the previous
+    subprocess-only path only worked on a SLURM head/login node.
     """
 
     def __init__(
@@ -24,6 +31,7 @@ class ResourceMonitor(BaseMonitor):
         partition: str | None = None,
         config: MonitorConfig | None = None,
         callbacks: list[Callback] | None = None,
+        source: ResourceSource | None = None,
     ) -> None:
         """Initialize resource monitor.
 
@@ -32,6 +40,11 @@ class ResourceMonitor(BaseMonitor):
             partition: SLURM partition to monitor. Defaults to all partitions if None.
             config: Monitoring configuration. Defaults to MonitorConfig() if None.
             callbacks: List of notification callbacks. Defaults to empty list if None.
+            source: Optional pluggable backend. When provided, partition
+                queries delegate to ``source.get_snapshot(partition)``
+                instead of the local-subprocess fallback. Required when
+                ``sinfo`` / ``squeue`` aren't on the caller's PATH
+                (e.g. a developer laptop driving a remote cluster).
 
         Raises:
             ValueError: If min_gpus < 0.
@@ -43,12 +56,13 @@ class ResourceMonitor(BaseMonitor):
 
         self.min_gpus = min_gpus
         self.partition = partition
+        self._source = source
         self._was_available: bool | None = None  # None = uninitialized
         self._cached_snapshot: ResourceSnapshot | None = None
 
         logger.debug(
             f"ResourceMonitor initialized for min_gpus={min_gpus}, "
-            f"partition={partition or 'all'}"
+            f"partition={partition or 'all'}, source={source.__class__.__name__ if source else 'subprocess'}"
         )
 
     def _get_snapshot(self) -> ResourceSnapshot:
@@ -96,8 +110,12 @@ class ResourceMonitor(BaseMonitor):
     def get_partition_resources(self) -> ResourceSnapshot:
         """Query SLURM for GPU resource availability.
 
-        Uses sinfo to get total GPUs per partition and squeue to get GPUs in use.
-        Filters out DOWN/DRAIN/DRAINING nodes from availability calculation.
+        Delegates to the injected :class:`ResourceSource` when one was
+        provided (e.g. the SSH adapter for remote clusters). Otherwise
+        falls back to the local ``sinfo`` / ``squeue`` subprocess path —
+        unchanged behaviour for callers running on a SLURM head node.
+        Filters out DOWN/DRAIN/DRAINING nodes from availability
+        calculation.
 
         Returns:
             ResourceSnapshot with current resource state.
@@ -105,13 +123,12 @@ class ResourceMonitor(BaseMonitor):
         Raises:
             SlurmError: If SLURM command fails.
         """
-        # Get node and GPU statistics
+        if self._source is not None:
+            return self._source.get_snapshot(self.partition)
+
+        # Local-subprocess fallback: original implementation.
         nodes_total, nodes_idle, nodes_down, total_gpus = self._get_node_stats()
-
-        # Get GPUs in use and running jobs count
         gpus_in_use, jobs_running = self._get_gpu_usage()
-
-        # Calculate available GPUs
         gpus_available = max(0, total_gpus - gpus_in_use)
 
         return ResourceSnapshot(

--- a/src/srunx/monitor/resource_source.py
+++ b/src/srunx/monitor/resource_source.py
@@ -1,0 +1,110 @@
+"""Pluggable resource-query backend for :class:`ResourceMonitor`.
+
+Before this module, ``ResourceMonitor`` always shelled out to local
+``sinfo`` / ``squeue`` via ``subprocess.run``. That assumed srunx was
+running on a SLURM head/login node — false on a developer laptop that
+talks to a remote cluster over SSH. ``srunx ui`` would then spam
+``FileNotFoundError: 'sinfo'`` every ``ResourceSnapshotter`` cycle.
+
+This module decouples "fetch cluster state" from "interpret it":
+
+* :class:`ResourceSource` is a structural contract.
+* :class:`SSHAdapterResourceSource` adapts the existing
+  :class:`srunx.web.ssh_adapter.SlurmSSHAdapter.get_resources` so
+  remote clusters flow through the same code path already used by
+  ``/api/resources``. When ``partition=None`` it sums across every
+  partition so the cluster-wide snapshot matches the local subprocess
+  behaviour.
+
+``ResourceMonitor`` keeps its local subprocess path as the default.
+Callers (notably :func:`srunx.web.app.create_app`) inject an
+adapter-backed source when one is available, and the snapshotter
+starts producing rows against the remote cluster.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from srunx.monitor.types import ResourceSnapshot
+
+if TYPE_CHECKING:
+    from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+
+@runtime_checkable
+class ResourceSource(Protocol):
+    """Pluggable backend for :class:`ResourceMonitor` partition queries.
+
+    Implementations hide the transport (local subprocess vs remote
+    SSH) so ``ResourceMonitor`` can stay ignorant of how the numbers
+    are produced. ``partition=None`` means "cluster-wide"; concrete
+    implementations aggregate across partitions.
+    """
+
+    def get_snapshot(self, partition: str | None) -> ResourceSnapshot: ...
+
+
+class SSHAdapterResourceSource:
+    """``ResourceSource`` implementation that reuses ``SlurmSSHAdapter``.
+
+    The adapter's ``get_resources`` already parses ``sinfo`` / ``squeue``
+    output on the remote side and returns a list of per-partition
+    dicts. For the cluster-wide case (``partition=None``) we sum those
+    dicts; for a single partition we take the one entry.
+    """
+
+    def __init__(self, adapter: SlurmSSHAdapter) -> None:
+        self._adapter = adapter
+
+    def get_snapshot(self, partition: str | None) -> ResourceSnapshot:
+        raw = self._adapter.get_resources(partition)
+        if not raw:
+            return ResourceSnapshot(
+                partition=partition,
+                total_gpus=0,
+                gpus_in_use=0,
+                gpus_available=0,
+                jobs_running=0,
+                nodes_total=0,
+                nodes_idle=0,
+                nodes_down=0,
+            )
+
+        if partition is not None:
+            # Single-partition queries return a one-element list.
+            return _dict_to_snapshot(raw[0], partition)
+
+        # Cluster-wide: the adapter returns one dict per partition. Sum
+        # across them so the downstream snapshot matches the semantics
+        # of ``sinfo`` without a ``-p`` filter (which is what the local
+        # subprocess path produces).
+        totals: dict[str, int] = {
+            "total_gpus": 0,
+            "gpus_in_use": 0,
+            "gpus_available": 0,
+            "jobs_running": 0,
+            "nodes_total": 0,
+            "nodes_idle": 0,
+            "nodes_down": 0,
+        }
+        for row in raw:
+            for key in totals:
+                value = row.get(key, 0) or 0
+                totals[key] += int(value)
+
+        return ResourceSnapshot(partition=None, **totals)
+
+
+def _dict_to_snapshot(row: dict[str, Any], partition: str | None) -> ResourceSnapshot:
+    """Coerce a ``SlurmSSHAdapter.get_resources`` row into a snapshot."""
+    return ResourceSnapshot(
+        partition=row.get("partition", partition),
+        total_gpus=int(row.get("total_gpus", 0) or 0),
+        gpus_in_use=int(row.get("gpus_in_use", 0) or 0),
+        gpus_available=int(row.get("gpus_available", 0) or 0),
+        jobs_running=int(row.get("jobs_running", 0) or 0),
+        nodes_total=int(row.get("nodes_total", 0) or 0),
+        nodes_idle=int(row.get("nodes_idle", 0) or 0),
+        nodes_down=int(row.get("nodes_down", 0) or 0),
+    )

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -254,27 +254,47 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         if os.environ.get("SRUNX_DISABLE_DELIVERY_POLLER") != "1":
             pollers.append(DeliveryPoller(worker_id=f"delivery-{os.getpid()}"))
         if os.environ.get("SRUNX_DISABLE_RESOURCE_SNAPSHOTTER") != "1":
-            # ResourceSnapshotter needs a local ``sinfo`` because
-            # ``ResourceMonitor.get_current_snapshot`` shells out directly —
-            # it does NOT tunnel through the SSH adapter. On a developer
-            # laptop that only has SSH profiles pointing at a remote
-            # SLURM cluster this is a guaranteed ``FileNotFoundError``
-            # every ``interval_seconds``, spamming the log until the
-            # process is killed. Gate the poller on ``sinfo`` being on
-            # PATH so the boot-time log line explains the skip once,
-            # then stay quiet.
+            # ResourceMonitor now accepts an injected ``ResourceSource``.
+            # When the SSH adapter is configured we route partition
+            # queries through it so a laptop driving a remote cluster
+            # produces ``resource_snapshots`` rows identical to what a
+            # head-node deployment would record. Fall back to the
+            # local-subprocess path only when ``sinfo`` is available
+            # on PATH (i.e. we actually are on a SLURM head node) or
+            # when the admin explicitly wants to keep the legacy
+            # behaviour via ``SRUNX_RESOURCE_SOURCE=subprocess``.
             import shutil
 
-            if adapter is None:
-                logger.info(
-                    "Skipping ResourceSnapshotter: no SLURM client is available"
-                )
+            source_mode = os.environ.get("SRUNX_RESOURCE_SOURCE", "auto")
+            resource_source = None
+            skip_reason: str | None = None
+
+            if source_mode == "subprocess":
+                if shutil.which("sinfo") is None:
+                    skip_reason = (
+                        "SRUNX_RESOURCE_SOURCE=subprocess but local "
+                        "'sinfo' is not on PATH"
+                    )
+            elif adapter is not None:
+                try:
+                    from srunx.monitor.resource_source import (
+                        SSHAdapterResourceSource,
+                    )
+
+                    resource_source = SSHAdapterResourceSource(adapter)
+                except Exception:
+                    logger.warning(
+                        "Could not build SSHAdapterResourceSource; falling back",
+                        exc_info=True,
+                    )
             elif shutil.which("sinfo") is None:
+                skip_reason = "no SLURM client configured and local 'sinfo' not on PATH"
+
+            if skip_reason is not None:
                 logger.info(
-                    "Skipping ResourceSnapshotter: local 'sinfo' not found on PATH. "
-                    "The snapshotter shells out locally; remote SLURM via SSH is "
-                    "not supported yet. Set SRUNX_DISABLE_RESOURCE_SNAPSHOTTER=1 "
-                    "to silence this at startup."
+                    "Skipping ResourceSnapshotter: %s. Set "
+                    "SRUNX_DISABLE_RESOURCE_SNAPSHOTTER=1 to silence this.",
+                    skip_reason,
                 )
             else:
                 try:
@@ -283,7 +303,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     # min_gpus=0 because we're observing, not waiting on a threshold.
                     pollers.append(
                         ResourceSnapshotter(
-                            resource_monitor=ResourceMonitor(min_gpus=0),
+                            resource_monitor=ResourceMonitor(
+                                min_gpus=0, source=resource_source
+                            ),
                         )
                     )
                 except Exception:

--- a/tests/monitor/test_resource_source.py
+++ b/tests/monitor/test_resource_source.py
@@ -1,0 +1,151 @@
+"""Tests for :mod:`srunx.monitor.resource_source`.
+
+Covers the SSH-adapter-backed resource source that lets
+``ResourceMonitor`` talk to a remote cluster instead of requiring local
+``sinfo`` / ``squeue``. Guards:
+
+- Single-partition query returns the exact adapter row, coerced to a
+  ``ResourceSnapshot``.
+- Cluster-wide query (``partition=None``) sums the per-partition dicts
+  the adapter produces, so the resulting snapshot matches what the
+  local subprocess path would produce on the same cluster.
+- Empty adapter return values don't blow up — we produce a zero
+  snapshot instead of an IndexError.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from srunx.monitor.resource_source import (
+    ResourceSource,
+    SSHAdapterResourceSource,
+)
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "partition": "gpu",
+        "total_gpus": 0,
+        "gpus_in_use": 0,
+        "gpus_available": 0,
+        "jobs_running": 0,
+        "nodes_total": 0,
+        "nodes_idle": 0,
+        "nodes_down": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSSHAdapterResourceSource:
+    def test_satisfies_protocol(self) -> None:
+        """``SSHAdapterResourceSource`` is a structural match for ``ResourceSource``."""
+        adapter = MagicMock()
+        source = SSHAdapterResourceSource(adapter)
+        assert isinstance(source, ResourceSource)
+
+    def test_single_partition_returns_that_row(self) -> None:
+        adapter = MagicMock()
+        adapter.get_resources.return_value = [
+            _row(
+                partition="gpu",
+                total_gpus=16,
+                gpus_in_use=10,
+                gpus_available=6,
+                jobs_running=3,
+                nodes_total=4,
+                nodes_idle=1,
+                nodes_down=0,
+            )
+        ]
+
+        snap = SSHAdapterResourceSource(adapter).get_snapshot("gpu")
+
+        adapter.get_resources.assert_called_once_with("gpu")
+        assert snap.partition == "gpu"
+        assert snap.total_gpus == 16
+        assert snap.gpus_in_use == 10
+        assert snap.gpus_available == 6
+        assert snap.jobs_running == 3
+        assert snap.nodes_total == 4
+        assert snap.nodes_idle == 1
+        assert snap.nodes_down == 0
+
+    def test_cluster_wide_sums_all_partitions(self) -> None:
+        """``partition=None`` aggregates every partition dict the adapter returns.
+
+        Matches the local-subprocess semantic: ``sinfo`` without ``-p``
+        returns cluster-wide totals. Per-partition dicts from the
+        adapter must be summed so the downstream snapshotter produces
+        the same numbers regardless of transport.
+        """
+        adapter = MagicMock()
+        adapter.get_resources.return_value = [
+            _row(
+                partition="gpu",
+                total_gpus=16,
+                gpus_in_use=10,
+                gpus_available=6,
+                nodes_total=4,
+                nodes_idle=1,
+            ),
+            _row(
+                partition="cpu",
+                total_gpus=0,
+                nodes_total=8,
+                nodes_idle=4,
+            ),
+            _row(
+                partition="debug",
+                total_gpus=2,
+                gpus_available=2,
+                nodes_total=1,
+                nodes_idle=1,
+            ),
+        ]
+
+        snap = SSHAdapterResourceSource(adapter).get_snapshot(None)
+
+        adapter.get_resources.assert_called_once_with(None)
+        assert snap.partition is None
+        assert snap.total_gpus == 18  # 16 + 0 + 2
+        assert snap.gpus_in_use == 10
+        assert snap.gpus_available == 8  # 6 + 0 + 2
+        assert snap.nodes_total == 13  # 4 + 8 + 1
+        assert snap.nodes_idle == 6  # 1 + 4 + 1
+
+    def test_empty_adapter_response_yields_zero_snapshot(self) -> None:
+        """No partitions → zero snapshot, not IndexError."""
+        adapter = MagicMock()
+        adapter.get_resources.return_value = []
+
+        snap = SSHAdapterResourceSource(adapter).get_snapshot(None)
+
+        assert snap.partition is None
+        assert snap.total_gpus == 0
+        assert snap.gpus_available == 0
+        assert snap.nodes_total == 0
+
+    def test_handles_none_field_values(self) -> None:
+        """Adapter rows with ``None`` for numeric fields coerce to 0."""
+        adapter = MagicMock()
+        adapter.get_resources.return_value = [
+            {
+                "partition": "gpu",
+                "total_gpus": None,
+                "gpus_in_use": None,
+                "gpus_available": None,
+                "jobs_running": None,
+                "nodes_total": 2,
+                "nodes_idle": None,
+                "nodes_down": None,
+            }
+        ]
+
+        snap = SSHAdapterResourceSource(adapter).get_snapshot("gpu")
+
+        assert snap.total_gpus == 0
+        assert snap.gpus_in_use == 0
+        assert snap.nodes_total == 2

--- a/tests/test_resource_monitor.py
+++ b/tests/test_resource_monitor.py
@@ -463,3 +463,95 @@ class TestResourceMonitor:
         assert nodes_idle == 0
         assert nodes_down == 0
         assert total_gpus == 0
+
+
+class TestResourceMonitorSourceInjection:
+    """Regression: injecting a ``ResourceSource`` bypasses subprocess.
+
+    ``srunx ui`` on a laptop has no local ``sinfo``; routing the
+    snapshotter through the SSH adapter is the entire point of the
+    pluggable source. These tests pin the wiring so a future refactor
+    can't silently re-introduce the subprocess call.
+    """
+
+    def test_delegates_to_source(self):
+        from unittest.mock import MagicMock
+
+        from srunx.monitor.resource_monitor import ResourceMonitor
+        from srunx.monitor.types import ResourceSnapshot
+
+        expected = ResourceSnapshot(
+            partition="gpu",
+            total_gpus=8,
+            gpus_in_use=5,
+            gpus_available=3,
+            jobs_running=2,
+            nodes_total=4,
+            nodes_idle=1,
+            nodes_down=0,
+        )
+        source = MagicMock()
+        source.get_snapshot.return_value = expected
+
+        monitor = ResourceMonitor(min_gpus=0, partition="gpu", source=source)
+
+        result = monitor.get_partition_resources()
+        assert result is expected
+        source.get_snapshot.assert_called_once_with("gpu")
+
+    def test_does_not_shell_out_when_source_is_injected(self, monkeypatch):
+        """With a source injected, ``subprocess.run`` must never fire.
+
+        A laptop without ``sinfo`` would raise ``FileNotFoundError``
+        on subprocess.run; this guard makes sure the source path
+        short-circuits before we get there.
+        """
+        import subprocess
+        from unittest.mock import MagicMock
+
+        from srunx.monitor.resource_monitor import ResourceMonitor
+        from srunx.monitor.types import ResourceSnapshot
+
+        def fail(*args, **kwargs):
+            raise AssertionError("subprocess.run must not be called")
+
+        monkeypatch.setattr(subprocess, "run", fail)
+
+        source = MagicMock()
+        source.get_snapshot.return_value = ResourceSnapshot(
+            partition=None,
+            total_gpus=0,
+            gpus_in_use=0,
+            gpus_available=0,
+            jobs_running=0,
+            nodes_total=0,
+            nodes_idle=0,
+            nodes_down=0,
+        )
+
+        monitor = ResourceMonitor(min_gpus=0, source=source)
+        snap = monitor.get_current_snapshot()
+
+        assert snap.total_gpus == 0
+        source.get_snapshot.assert_called_once_with(None)
+
+    def test_no_source_uses_subprocess_path(self, monkeypatch):
+        """Backward compat: ``source=None`` keeps the old subprocess path."""
+        from srunx.monitor.resource_monitor import ResourceMonitor
+
+        stats_called = {"node": False, "gpu": False}
+
+        def fake_node_stats(self):
+            stats_called["node"] = True
+            return (0, 0, 0, 0)
+
+        def fake_gpu_usage(self):
+            stats_called["gpu"] = True
+            return (0, 0)
+
+        monkeypatch.setattr(ResourceMonitor, "_get_node_stats", fake_node_stats)
+        monkeypatch.setattr(ResourceMonitor, "_get_gpu_usage", fake_gpu_usage)
+
+        ResourceMonitor(min_gpus=0).get_partition_resources()
+
+        assert stats_called["node"] and stats_called["gpu"]


### PR DESCRIPTION
Closes #111. Long-term fix for the root cause: ResourceMonitor now takes a pluggable ResourceSource, and create_app wires in an SSH-adapter-backed source so srunx ui on a laptop populates resource_snapshots from the remote cluster.

## Design

- New srunx.monitor.resource_source module: ResourceSource protocol + SSHAdapterResourceSource (reuses SlurmSSHAdapter.get_resources, the same path /api/resources uses).
- partition=None aggregates per-partition dicts so the cluster-wide snapshot matches local sinfo semantics.
- ResourceMonitor gets an optional source param; when None, keeps the subprocess fallback for cluster-node deployments.

## Wiring

- create_app injects SSHAdapterResourceSource(adapter) when an adapter is configured.
- New env var SRUNX_RESOURCE_SOURCE (auto default, subprocess to force legacy) — opt-in escape hatch.
- #110's sinfo-existence gate only kicks in now when an admin explicitly forces subprocess and sinfo is missing.

## Live verification

Smoke-tested on a Mac (no local sinfo) against the pyxis cluster:
- Boot log: resource snapshotter cycle complete
- DB: real row written with gpus_total=24, gpus_available=8

## Tests

- 8 new (5 protocol/adapter, 3 ResourceMonitor source injection including a subprocess-must-not-fire regression)
- 1347 total pytest pass; ruff + mypy clean
