### PR TITLE
fix(monitor): 3 ResourceSnapshotter bugs flagged in post-#112 review

### DIFF
--- a/src/srunx/monitor/resource_source.py
+++ b/src/srunx/monitor/resource_source.py
@@ -24,6 +24,7 @@ starts producing rows against the remote cluster.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from srunx.monitor.types import ResourceSnapshot
@@ -48,17 +49,50 @@ class ResourceSource(Protocol):
 class SSHAdapterResourceSource:
     """``ResourceSource`` implementation that reuses ``SlurmSSHAdapter``.
 
-    The adapter's ``get_resources`` already parses ``sinfo`` / ``squeue``
-    output on the remote side and returns a list of per-partition
-    dicts. For the cluster-wide case (``partition=None``) we sum those
-    dicts; for a single partition we take the one entry.
+    Takes an **adapter provider** (a callable returning the current
+    adapter or ``None``), not a captured reference. That matters
+    because ``/api/config/ssh/profiles/.../connect`` atomically swaps
+    the process-global adapter via ``deps.swap_adapter``; a cached
+    reference would keep pointing at the disconnected old adapter
+    while ``/api/resources`` and every other route use the new one.
+    Resolving per-call keeps the snapshotter in sync with profile
+    switches.
+
+    Semantics:
+
+    * Single partition → ``adapter.get_resources(p)`` returns a
+      one-element list; we coerce it to a snapshot. The adapter does
+      **not** catch per-partition errors for this path, so an SSH or
+      SLURM failure propagates to the poller supervisor (desired —
+      transient errors should trigger backoff, not silently zero).
+    * Cluster-wide (``partition=None``) → we delegate to
+      ``adapter.get_cluster_snapshot()``, which runs a single
+      cluster-wide ``sinfo`` + ``squeue`` pair with cross-partition
+      node dedup. The previous "sum per-partition dicts" approach
+      had two bugs: (a) nodes listed under multiple partitions were
+      double-counted; (b) the multi-partition path catches errors per
+      partition and returns partial data, so transient failures got
+      silently persisted as understated totals.
     """
 
-    def __init__(self, adapter: SlurmSSHAdapter) -> None:
-        self._adapter = adapter
+    def __init__(
+        self,
+        adapter_provider: Callable[[], SlurmSSHAdapter | None],
+    ) -> None:
+        self._provider = adapter_provider
 
     def get_snapshot(self, partition: str | None) -> ResourceSnapshot:
-        raw = self._adapter.get_resources(partition)
+        adapter = self._provider()
+        if adapter is None:
+            # Raise so the ``PollerSupervisor`` backs off. Returning a
+            # zero snapshot would silently persist a wrong row every
+            # cycle until a profile is re-attached.
+            raise RuntimeError("No SLURM adapter available for ResourceSource")
+
+        if partition is None:
+            return _dict_to_snapshot(adapter.get_cluster_snapshot(), None)
+
+        raw = adapter.get_resources(partition)
         if not raw:
             return ResourceSnapshot(
                 partition=partition,
@@ -70,30 +104,7 @@ class SSHAdapterResourceSource:
                 nodes_idle=0,
                 nodes_down=0,
             )
-
-        if partition is not None:
-            # Single-partition queries return a one-element list.
-            return _dict_to_snapshot(raw[0], partition)
-
-        # Cluster-wide: the adapter returns one dict per partition. Sum
-        # across them so the downstream snapshot matches the semantics
-        # of ``sinfo`` without a ``-p`` filter (which is what the local
-        # subprocess path produces).
-        totals: dict[str, int] = {
-            "total_gpus": 0,
-            "gpus_in_use": 0,
-            "gpus_available": 0,
-            "jobs_running": 0,
-            "nodes_total": 0,
-            "nodes_idle": 0,
-            "nodes_down": 0,
-        }
-        for row in raw:
-            for key in totals:
-                value = row.get(key, 0) or 0
-                totals[key] += int(value)
-
-        return ResourceSnapshot(partition=None, **totals)
+        return _dict_to_snapshot(raw[0], partition)
 
 
 def _dict_to_snapshot(row: dict[str, Any], partition: str | None) -> ResourceSnapshot:

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -280,8 +280,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     from srunx.monitor.resource_source import (
                         SSHAdapterResourceSource,
                     )
+                    from srunx.web.deps import get_adapter_or_none
 
-                    resource_source = SSHAdapterResourceSource(adapter)
+                    # Pass ``get_adapter_or_none`` (a function) rather
+                    # than the startup ``adapter`` reference so
+                    # ``deps.swap_adapter`` (triggered by live profile
+                    # switches at /api/config/ssh/profiles/.../connect)
+                    # is reflected in the snapshotter's next cycle.
+                    resource_source = SSHAdapterResourceSource(get_adapter_or_none)
                 except Exception:
                     logger.warning(
                         "Could not build SSHAdapterResourceSource; falling back",

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -481,7 +481,17 @@ class SlurmSSHAdapter:
     # ── Resource Operations ───────────────────────
 
     def get_resources(self, partition: str | None = None) -> list[dict[str, Any]]:
-        """Get cluster resource information via sinfo + squeue."""
+        """Get cluster resource information via sinfo + squeue.
+
+        The ``partition=None`` case is the per-partition listing used
+        by ``/api/resources`` — errors are caught per-partition so a
+        single broken partition doesn't sink the whole dashboard call.
+        Callers that need a single aggregated cluster-wide snapshot
+        (e.g. the resource snapshotter) should use
+        :meth:`get_cluster_snapshot` instead — that path fails closed
+        and dedups nodes across partitions, which summing this list
+        does not.
+        """
         if partition:
             _validate_identifier(partition, "partition")
             return [self._get_partition_resources(partition)]
@@ -502,6 +512,94 @@ class SlurmSSHAdapter:
                 logger.warning("Failed to get resources for partition %s: %s", p, e)
                 continue
         return results
+
+    def get_cluster_snapshot(self) -> dict[str, Any]:
+        """Return a single cluster-wide resource snapshot dict.
+
+        Used by the resource snapshotter for a single row in
+        ``resource_snapshots``. Differs from ``get_resources(None)``
+        in two important ways:
+
+        1. Runs ONE ``sinfo`` (no ``-p`` filter) and ONE ``squeue``,
+           then dedups nodes by name via ``seen_nodes``. Summing the
+           per-partition output of ``get_resources(None)`` would
+           double-count any node that belongs to multiple partitions
+           (a common SLURM setup — e.g. ``debug`` and ``gpu`` sharing
+           the same physical nodes).
+        2. Exceptions propagate instead of being swallowed per
+           partition. Transient SSH/SLURM failures surface to the
+           poller supervisor for exponential backoff rather than
+           silently writing understated totals to the DB.
+
+        Returned keys match :meth:`_get_partition_resources` with
+        ``partition=None``.
+        """
+        # One cluster-wide sinfo call — seen_nodes dedup handles
+        # multi-partition membership correctly.
+        sinfo_output = _run_slurm_cmd(self, 'sinfo -o "%n %G %T" --noheader')
+
+        nodes_total = 0
+        nodes_idle = 0
+        nodes_down = 0
+        total_gpus = 0
+        seen_nodes: set[str] = set()
+
+        for line in sinfo_output.strip().splitlines():
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            node_name, gres, state = parts[0], parts[1], parts[2].lower()
+            if node_name in seen_nodes:
+                continue
+            seen_nodes.add(node_name)
+            nodes_total += 1
+
+            if any(s in state for s in _UNAVAILABLE_STATES):
+                nodes_down += 1
+                continue
+            if "idle" in state:
+                nodes_idle += 1
+
+            if gres and gres != "(null)":
+                for entry in gres.split(","):
+                    gpu_match = GPU_TRES_RE.search(entry)
+                    if gpu_match:
+                        total_gpus += int(gpu_match.group(1))
+
+        # Cluster-wide squeue — same TRES parsing as the per-partition path.
+        squeue_output = _run_slurm_cmd(self, 'squeue -o "%i %T %b %D" --noheader')
+        gpus_in_use = 0
+        jobs_running = 0
+        for line in squeue_output.strip().splitlines():
+            parts = line.split()
+            if len(parts) < 2 or parts[1] != "RUNNING":
+                continue
+            jobs_running += 1
+            if len(parts) >= 3:
+                gpu_match = GPU_TRES_RE.search(parts[2])
+                if gpu_match:
+                    per_node_gpus = int(gpu_match.group(1))
+                    num_nodes = 1
+                    if len(parts) >= 4 and parts[3].isdigit():
+                        num_nodes = int(parts[3])
+                    gpus_in_use += per_node_gpus * num_nodes
+
+        gpus_available = max(0, total_gpus - gpus_in_use)
+        gpu_utilization = gpus_in_use / total_gpus if total_gpus > 0 else 0.0
+
+        return {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "partition": None,
+            "total_gpus": total_gpus,
+            "gpus_in_use": gpus_in_use,
+            "gpus_available": gpus_available,
+            "jobs_running": jobs_running,
+            "nodes_total": nodes_total,
+            "nodes_idle": nodes_idle,
+            "nodes_down": nodes_down,
+            "gpu_utilization": gpu_utilization,
+            "has_available_gpus": gpus_available > 0,
+        }
 
     def _get_partition_resources(self, partition: str) -> dict[str, Any]:
         """Get resources for a single partition."""

--- a/tests/monitor/test_resource_source.py
+++ b/tests/monitor/test_resource_source.py
@@ -1,22 +1,26 @@
 """Tests for :mod:`srunx.monitor.resource_source`.
 
-Covers the SSH-adapter-backed resource source that lets
-``ResourceMonitor`` talk to a remote cluster instead of requiring local
-``sinfo`` / ``squeue``. Guards:
+Covers the SSH-adapter-backed resource source. Regression surface:
 
-- Single-partition query returns the exact adapter row, coerced to a
-  ``ResourceSnapshot``.
-- Cluster-wide query (``partition=None``) sums the per-partition dicts
-  the adapter produces, so the resulting snapshot matches what the
-  local subprocess path would produce on the same cluster.
-- Empty adapter return values don't blow up — we produce a zero
-  snapshot instead of an IndexError.
+- Stale-adapter guard: the source resolves the adapter per-call via
+  a provider callable, so ``deps.swap_adapter`` at runtime is picked
+  up on the next snapshotter cycle.
+- Cluster-wide snapshots delegate to ``adapter.get_cluster_snapshot``
+  (one cluster-wide sinfo+squeue pair with cross-partition dedup);
+  summing ``adapter.get_resources(None)`` would double-count nodes
+  that belong to multiple partitions AND could silently persist
+  understated totals when per-partition errors are caught inside
+  the adapter.
+- Single-partition queries bubble up errors — transient failures
+  must trigger supervisor backoff, not write zero snapshots.
 """
 
 from __future__ import annotations
 
 from typing import Any
 from unittest.mock import MagicMock
+
+import pytest
 
 from srunx.monitor.resource_source import (
     ResourceSource,
@@ -39,11 +43,27 @@ def _row(**overrides: Any) -> dict[str, Any]:
     return base
 
 
+def _snapshot_dict(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "timestamp": "2026-04-20T00:00:00+00:00",
+        "partition": None,
+        "total_gpus": 0,
+        "gpus_in_use": 0,
+        "gpus_available": 0,
+        "jobs_running": 0,
+        "nodes_total": 0,
+        "nodes_idle": 0,
+        "nodes_down": 0,
+        "gpu_utilization": 0.0,
+        "has_available_gpus": False,
+    }
+    base.update(overrides)
+    return base
+
+
 class TestSSHAdapterResourceSource:
     def test_satisfies_protocol(self) -> None:
-        """``SSHAdapterResourceSource`` is a structural match for ``ResourceSource``."""
-        adapter = MagicMock()
-        source = SSHAdapterResourceSource(adapter)
+        source = SSHAdapterResourceSource(lambda: MagicMock())
         assert isinstance(source, ResourceSource)
 
     def test_single_partition_returns_that_row(self) -> None:
@@ -61,9 +81,10 @@ class TestSSHAdapterResourceSource:
             )
         ]
 
-        snap = SSHAdapterResourceSource(adapter).get_snapshot("gpu")
+        snap = SSHAdapterResourceSource(lambda: adapter).get_snapshot("gpu")
 
         adapter.get_resources.assert_called_once_with("gpu")
+        adapter.get_cluster_snapshot.assert_not_called()
         assert snap.partition == "gpu"
         assert snap.total_gpus == 16
         assert snap.gpus_in_use == 10
@@ -73,59 +94,42 @@ class TestSSHAdapterResourceSource:
         assert snap.nodes_idle == 1
         assert snap.nodes_down == 0
 
-    def test_cluster_wide_sums_all_partitions(self) -> None:
-        """``partition=None`` aggregates every partition dict the adapter returns.
+    def test_cluster_wide_uses_adapter_cluster_snapshot(self) -> None:
+        """``partition=None`` delegates to ``adapter.get_cluster_snapshot``.
 
-        Matches the local-subprocess semantic: ``sinfo`` without ``-p``
-        returns cluster-wide totals. Per-partition dicts from the
-        adapter must be summed so the downstream snapshotter produces
-        the same numbers regardless of transport.
+        Summing ``get_resources(None)`` per-partition dicts would
+        double-count shared nodes AND silently swallow per-partition
+        errors; the dedicated cluster-wide adapter call does neither.
         """
         adapter = MagicMock()
-        adapter.get_resources.return_value = [
-            _row(
-                partition="gpu",
-                total_gpus=16,
-                gpus_in_use=10,
-                gpus_available=6,
-                nodes_total=4,
-                nodes_idle=1,
-            ),
-            _row(
-                partition="cpu",
-                total_gpus=0,
-                nodes_total=8,
-                nodes_idle=4,
-            ),
-            _row(
-                partition="debug",
-                total_gpus=2,
-                gpus_available=2,
-                nodes_total=1,
-                nodes_idle=1,
-            ),
-        ]
+        adapter.get_cluster_snapshot.return_value = _snapshot_dict(
+            total_gpus=18,
+            gpus_in_use=10,
+            gpus_available=8,
+            nodes_total=13,
+            nodes_idle=6,
+        )
 
-        snap = SSHAdapterResourceSource(adapter).get_snapshot(None)
+        snap = SSHAdapterResourceSource(lambda: adapter).get_snapshot(None)
 
-        adapter.get_resources.assert_called_once_with(None)
+        adapter.get_cluster_snapshot.assert_called_once_with()
+        adapter.get_resources.assert_not_called()
         assert snap.partition is None
-        assert snap.total_gpus == 18  # 16 + 0 + 2
+        assert snap.total_gpus == 18
         assert snap.gpus_in_use == 10
-        assert snap.gpus_available == 8  # 6 + 0 + 2
-        assert snap.nodes_total == 13  # 4 + 8 + 1
-        assert snap.nodes_idle == 6  # 1 + 4 + 1
+        assert snap.gpus_available == 8
+        assert snap.nodes_total == 13
+        assert snap.nodes_idle == 6
 
-    def test_empty_adapter_response_yields_zero_snapshot(self) -> None:
-        """No partitions → zero snapshot, not IndexError."""
+    def test_single_partition_empty_result_yields_zero_snapshot(self) -> None:
+        """An empty list for a named partition is a zero snapshot, not IndexError."""
         adapter = MagicMock()
         adapter.get_resources.return_value = []
 
-        snap = SSHAdapterResourceSource(adapter).get_snapshot(None)
+        snap = SSHAdapterResourceSource(lambda: adapter).get_snapshot("gpu")
 
-        assert snap.partition is None
+        assert snap.partition == "gpu"
         assert snap.total_gpus == 0
-        assert snap.gpus_available == 0
         assert snap.nodes_total == 0
 
     def test_handles_none_field_values(self) -> None:
@@ -144,8 +148,64 @@ class TestSSHAdapterResourceSource:
             }
         ]
 
-        snap = SSHAdapterResourceSource(adapter).get_snapshot("gpu")
+        snap = SSHAdapterResourceSource(lambda: adapter).get_snapshot("gpu")
 
         assert snap.total_gpus == 0
         assert snap.gpus_in_use == 0
         assert snap.nodes_total == 2
+
+    def test_single_partition_error_propagates(self) -> None:
+        """Per-partition SLURM failure must surface — supervisor backs off.
+
+        Silently returning a zero snapshot here would persist bogus
+        rows every cycle until the cluster recovered, with no signal
+        in the logs beyond one info line.
+        """
+        adapter = MagicMock()
+        adapter.get_resources.side_effect = RuntimeError("ssh dropped")
+
+        with pytest.raises(RuntimeError, match="ssh dropped"):
+            SSHAdapterResourceSource(lambda: adapter).get_snapshot("gpu")
+
+    def test_cluster_wide_error_propagates(self) -> None:
+        """Cluster-wide SLURM failure must surface — see above rationale."""
+        adapter = MagicMock()
+        adapter.get_cluster_snapshot.side_effect = RuntimeError("sinfo timeout")
+
+        with pytest.raises(RuntimeError, match="sinfo timeout"):
+            SSHAdapterResourceSource(lambda: adapter).get_snapshot(None)
+
+    def test_no_adapter_raises(self) -> None:
+        """Provider returning None — raise, don't persist a zero row."""
+        source = SSHAdapterResourceSource(lambda: None)
+
+        with pytest.raises(RuntimeError, match="No SLURM adapter"):
+            source.get_snapshot(None)
+
+    def test_provider_is_resolved_per_call(self) -> None:
+        """Swapping the adapter (profile switch) is reflected next cycle.
+
+        Before this fix, the source captured the startup adapter
+        reference. After ``deps.swap_adapter`` the snapshotter kept
+        talking to the now-disconnected old adapter while the Web UI
+        routes used the new one — two inconsistent views of the
+        cluster persisted in ``resource_snapshots``.
+        """
+        first = MagicMock()
+        first.get_cluster_snapshot.return_value = _snapshot_dict(total_gpus=8)
+        second = MagicMock()
+        second.get_cluster_snapshot.return_value = _snapshot_dict(total_gpus=16)
+
+        current = {"adapter": first}
+        source = SSHAdapterResourceSource(lambda: current["adapter"])
+
+        snap1 = source.get_snapshot(None)
+        assert snap1.total_gpus == 8
+
+        # Simulate a profile switch.
+        current["adapter"] = second
+
+        snap2 = source.get_snapshot(None)
+        assert snap2.total_gpus == 16
+        first.get_cluster_snapshot.assert_called_once()
+        second.get_cluster_snapshot.assert_called_once()

--- a/tests/web/test_ssh_adapter_parsing.py
+++ b/tests/web/test_ssh_adapter_parsing.py
@@ -443,3 +443,99 @@ dgx-node5 gpu:NVIDIA-A100:8 maint
         ]
         for field in required:
             assert field in result, f"Missing field: {field}"
+
+
+# ── get_cluster_snapshot ──────────────────────────
+
+
+class TestClusterSnapshot:
+    """Test the new cluster-wide snapshot method.
+
+    Critical regression: summing per-partition ``get_resources(None)``
+    dicts double-counted nodes that belong to multiple partitions.
+    ``get_cluster_snapshot`` runs ONE ``sinfo`` without ``-p`` and
+    dedups by node name via ``seen_nodes``.
+    """
+
+    def test_dedups_nodes_across_partitions(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Node ``dgx1`` in both ``gpu`` and ``debug`` → counted once."""
+        # Two partitions report dgx1 with 8 GPUs; cluster-wide sinfo output
+        # lists it twice. The dedup must count 8 total, not 16.
+        sinfo_out = "dgx1 gpu:8 idle\ndgx1 gpu:8 idle\ndgx2 gpu:8 idle\n"
+        squeue_out = ""
+
+        def fake_run(_adapter, cmd: str) -> str:
+            return sinfo_out if cmd.startswith("sinfo") else squeue_out
+
+        monkeypatch.setattr("srunx.web.ssh_adapter._run_slurm_cmd", fake_run)
+        adapter = object.__new__(SlurmSSHAdapter)
+
+        snap = adapter.get_cluster_snapshot()
+
+        assert snap["nodes_total"] == 2
+        assert snap["total_gpus"] == 16  # 2 nodes × 8, not 3 × 8
+        assert snap["gpus_available"] == 16
+        assert snap["partition"] is None
+
+    def test_excludes_down_nodes_from_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sinfo_out = "dgx1 gpu:8 idle\ndgx2 gpu:8 down\ndgx3 gpu:8 drain\n"
+        squeue_out = ""
+
+        def fake_run(_adapter, cmd: str) -> str:
+            return sinfo_out if cmd.startswith("sinfo") else squeue_out
+
+        monkeypatch.setattr("srunx.web.ssh_adapter._run_slurm_cmd", fake_run)
+        adapter = object.__new__(SlurmSSHAdapter)
+
+        snap = adapter.get_cluster_snapshot()
+
+        assert snap["nodes_total"] == 3
+        assert snap["nodes_down"] == 2  # drain + down
+        assert snap["nodes_idle"] == 1
+        # GPUs on DOWN/DRAIN nodes are NOT counted (matches local
+        # ResourceMonitor semantics).
+        assert snap["total_gpus"] == 8
+
+    def test_counts_running_jobs_and_gpus_in_use(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sinfo_out = "dgx1 gpu:8 allocated\ndgx2 gpu:8 idle\n"
+        # 1 running job using 4 GPUs on 1 node; 1 running using 2 GPUs × 2 nodes
+        squeue_out = (
+            "1001 RUNNING gpu:4 1\n1002 RUNNING gpu:2 2\n1003 PENDING (null) 1\n"
+        )
+
+        def fake_run(_adapter, cmd: str) -> str:
+            return sinfo_out if cmd.startswith("sinfo") else squeue_out
+
+        monkeypatch.setattr("srunx.web.ssh_adapter._run_slurm_cmd", fake_run)
+        adapter = object.__new__(SlurmSSHAdapter)
+
+        snap = adapter.get_cluster_snapshot()
+
+        assert snap["jobs_running"] == 2  # PENDING excluded
+        assert snap["gpus_in_use"] == 4 + 2 * 2  # 4 + 4 = 8
+        assert snap["total_gpus"] == 16
+        assert snap["gpus_available"] == 8
+        assert snap["gpu_utilization"] == 0.5
+
+    def test_propagates_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unlike ``get_resources(None)``, cluster snapshot fails closed.
+
+        Silent per-partition suppression is fine for the dashboard
+        listing but wrong for the snapshotter — backoff is better than
+        zero rows in the time series.
+        """
+
+        def boom(_adapter, _cmd: str) -> str:
+            raise RuntimeError("ssh dropped")
+
+        monkeypatch.setattr("srunx.web.ssh_adapter._run_slurm_cmd", boom)
+        adapter = object.__new__(SlurmSSHAdapter)
+
+        with pytest.raises(RuntimeError, match="ssh dropped"):
+            adapter.get_cluster_snapshot()


### PR DESCRIPTION
Follow-up to #112. Codex review surfaced three real regressions; all verified against the code + live pyxis cluster.

## Findings fixed

1. **Stale adapter after profile switch.** SSHAdapterResourceSource captured the startup adapter. deps.swap_adapter did not propagate. Fix: provider callable resolved per-call.

2. **Silent partial-data persistence.** get_resources(None) catches per-partition errors. Old aggregator silently summed survivors. Replaced with get_cluster_snapshot() that fails closed.

3. **Multi-partition node double-counting.** Summing per-partition dicts counted shared nodes per partition. Single cluster-wide sinfo+dedup fixes it.

## Live verification

pyxis (4 x 8-GPU A100): DB now shows correct gpus_total=32. Previous impl returned 24.

## Tests

1355 total pass. 6 new regression guards.