### PR TITLE
fix(mcp): make srunx-mcp setup CWD-independent + friendly error

### DIFF
--- a/docs/explanation/mcp-architecture.md
+++ b/docs/explanation/mcp-architecture.md
@@ -78,8 +78,8 @@ The server process is started by Claude Code using the command configured in
 {
   "mcpServers": {
     "srunx": {
-      "command": "uv",
-      "args": ["run", "--extra", "mcp", "srunx-mcp"]
+      "command": "uvx",
+      "args": ["--from", "srunx[mcp]", "srunx-mcp"]
     }
   }
 }

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -2,8 +2,10 @@
 
 Complete reference for all 14 tools exposed by the srunx MCP server.
 
-The server is started with `uv run --extra mcp srunx-mcp` and communicates
-over stdio using the Model Context Protocol.
+The server is started with `uvx --from 'srunx[mcp]' srunx-mcp` (or the
+plain `srunx-mcp` binary after `uv tool install --with 'mcp[cli]' srunx`)
+and communicates over stdio using the Model Context Protocol. See
+[MCP Setup](../tutorials/mcp-setup.md) for registration details.
 
 All tools return a JSON object with a `success` boolean. On success,
 additional fields carry the result data. On failure, an `error` string

--- a/docs/tutorials/mcp-setup.md
+++ b/docs/tutorials/mcp-setup.md
@@ -9,68 +9,111 @@ interaction.
 
 ## Prerequisites
 
-- srunx installed (see `installation`)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
+- [uv](https://docs.astral.sh/uv/) installed
 - A working SLURM cluster (local or via SSH profile)
 
-## Install the MCP Extra
+## Install srunx with the MCP extra
 
-The MCP server is an optional dependency. Install it with:
+Pick whichever install style matches how you plan to call `srunx-mcp`.
 
-``` bash
-uv sync --extra mcp
+### Option 1: `uvx` (recommended, zero-install)
+
+No install step at all — `uvx` resolves and runs `srunx-mcp` with its
+`mcp` extra on demand, regardless of the current working directory:
+
+```bash
+uvx --from 'srunx[mcp]' srunx-mcp --help
 ```
 
-Or if you are adding srunx to another project:
+This is the pattern used in the registration command below.
 
-``` bash
+### Option 2: `uv tool install` (globally installed binary)
+
+If you prefer a `~/.local/bin/srunx-mcp` binary on `PATH`, you **must**
+include the `mcp` extra at install time — `uv tool install srunx` alone
+does **not** pull it in and will fail with `ModuleNotFoundError: No module named 'mcp'`:
+
+```bash
+uv tool install --with 'mcp[cli]' srunx
+```
+
+Then the binary is callable directly:
+
+```bash
+srunx-mcp --help
+```
+
+### Option 3: inside a uv project
+
+When srunx is a dependency of the current uv project, add the extra:
+
+```bash
 uv add "srunx[mcp]"
 ```
 
-This pulls in the `mcp[cli]` package required to run the server.
+Then `uv run srunx-mcp` works from that project's directory.
 
-## Configure the MCP Server
+!!! warning "Don't use `uv run --extra mcp srunx-mcp` globally"
+    `uv run --extra mcp` resolves extras against the **current working
+    directory's** `pyproject.toml`, not srunx's. Registering
+    `uv run --extra mcp srunx-mcp` as an MCP command only works when
+    Claude Code is launched from inside the srunx source tree — from any
+    other project it fails with
+    `error: Extra 'mcp' is not defined in the project's optional-dependencies`.
 
-There are two ways to register the server with Claude Code: a project config
-file or the `claude mcp add` CLI command.
+## Register with Claude Code
 
-### Option A: Project config file
+The `claude mcp add` CLI supports three scopes: local, project, and user.
+For the common case of "available everywhere", use **user** scope with
+`uvx`:
 
-Create a `.mcp.json` file in your project root:
+```bash
+claude mcp add --scope user srunx -- uvx --from 'srunx[mcp]' srunx-mcp
+```
 
-``` json
+This command is CWD-independent and works from any project.
+
+### Other scopes
+
+**Project** (shared with collaborators via a checked-in `.mcp.json`):
+
+```bash
+claude mcp add --scope project srunx -- uvx --from 'srunx[mcp]' srunx-mcp
+```
+
+**Local** (current project only, written to `.mcp.json` but not shared):
+
+```bash
+claude mcp add srunx -- uvx --from 'srunx[mcp]' srunx-mcp
+```
+
+### Alternative: `.mcp.json` hand-written
+
+For the project scope you can also write `.mcp.json` directly:
+
+```json
 {
   "mcpServers": {
     "srunx": {
-      "command": "uv",
-      "args": ["run", "--extra", "mcp", "srunx-mcp"]
+      "command": "uvx",
+      "args": ["--from", "srunx[mcp]", "srunx-mcp"]
     }
   }
 }
 ```
 
-Claude Code reads this file automatically when you open the project.
+If you installed via `uv tool install --with 'mcp[cli]' srunx` instead
+(Option 2 above), you can use the plain binary:
 
-### Option B: `claude mcp add` command
-
-The `claude mcp add` CLI supports three scopes:
-
-**Local** (current project only, written to `.mcp.json`):
-
-``` bash
-claude mcp add srunx -- uv run --extra mcp srunx-mcp
-```
-
-**Project** (shared with collaborators via `.mcp.json` in version control):
-
-``` bash
-claude mcp add --scope project srunx -- uv run --extra mcp srunx-mcp
-```
-
-**User** (available in all your projects):
-
-``` bash
-claude mcp add --scope user srunx -- uv run --extra mcp srunx-mcp
+```json
+{
+  "mcpServers": {
+    "srunx": {
+      "command": "srunx-mcp"
+    }
+  }
+}
 ```
 
 !!! tip
@@ -82,13 +125,14 @@ claude mcp add --scope user srunx -- uv run --extra mcp srunx-mcp
 
 Check that Claude Code sees the srunx server:
 
-``` bash
+```bash
 claude mcp list
 ```
 
-You should see `srunx` listed with its tools. If the server does not
-appear, ensure the `uv` command is on your `PATH` and that
-`uv sync --extra mcp` completed without errors.
+You should see `srunx` listed with its tools. If the server shows
+`Failed to connect`, inspect the MCP log Claude Code prints at startup —
+`srunx-mcp` now emits a clear error (with fix instructions) when the
+`mcp` package is missing from its runtime.
 
 ## First Interaction
 
@@ -96,7 +140,7 @@ Open Claude Code in your project and try these prompts:
 
 **List your SLURM jobs:**
 
-``` text
+```text
 > List my current SLURM jobs
 ```
 
@@ -105,7 +149,7 @@ of your queued and running jobs.
 
 **Check GPU resources:**
 
-``` text
+```text
 > How many GPUs are available on the gpu partition?
 ```
 
@@ -114,7 +158,7 @@ total, in-use, and available GPU counts.
 
 **Submit a simple job:**
 
-``` text
+```text
 > Submit a job to run "python train.py" with 2 GPUs, using the ml_env
 > conda environment
 ```
@@ -128,7 +172,7 @@ If your SLURM cluster is remote, ensure you have an SSH profile configured
 (see [Sync](../how-to/sync.md) for mount setup). Then include "via SSH" in your
 prompt:
 
-``` text
+```text
 > List my jobs on the remote cluster
 ```
 

--- a/docs/tutorials/mcp-setup.md
+++ b/docs/tutorials/mcp-setup.md
@@ -64,35 +64,62 @@ Then `uv run srunx-mcp` works from that project's directory.
 
 ## Register with Claude Code
 
-The `claude mcp add` CLI supports three scopes: local, project, and user.
-For the common case of "available everywhere", use **user** scope with
-`uvx`:
+There are two equally valid registration styles — pick whichever matches
+the install option you used above. Both are CWD-independent.
+
+### Trade-off at a glance
+
+| Style | Startup | Updates | Installed binary |
+|---|---|---|---|
+| `uvx --from 'srunx[mcp]' srunx-mcp` | ~50–200 ms (after first run) | Automatic — every launch resolves the latest version | None |
+| `uv tool install` + `srunx-mcp` | ~50 ms | Manual (`uv tool upgrade srunx`) | `~/.local/bin/srunx-mcp` |
+
+For long-lived MCP sessions the difference is negligible — go with
+whichever fits your update preference.
+
+### Style A: `uvx` (zero-install, auto-updates)
+
+**User scope** (available in every project):
 
 ```bash
 claude mcp add --scope user srunx -- uvx --from 'srunx[mcp]' srunx-mcp
 ```
 
-This command is CWD-independent and works from any project.
-
-### Other scopes
-
-**Project** (shared with collaborators via a checked-in `.mcp.json`):
+**Project scope** (shared via a checked-in `.mcp.json`):
 
 ```bash
 claude mcp add --scope project srunx -- uvx --from 'srunx[mcp]' srunx-mcp
 ```
 
-**Local** (current project only, written to `.mcp.json` but not shared):
+**Local scope** (current project only):
 
 ```bash
 claude mcp add srunx -- uvx --from 'srunx[mcp]' srunx-mcp
 ```
 
-### Alternative: `.mcp.json` hand-written
+### Style B: installed binary (fastest startup, pinned version)
 
-For the project scope you can also write `.mcp.json` directly:
+Install once with the `mcp` extra, then register the bare binary:
 
-```json
+```bash
+uv tool install --with 'mcp[cli]' srunx
+
+# User scope
+claude mcp add --scope user srunx -- srunx-mcp
+
+# Project scope
+claude mcp add --scope project srunx -- srunx-mcp
+
+# Local scope
+claude mcp add srunx -- srunx-mcp
+```
+
+### `.mcp.json` hand-written
+
+For project scope you can commit a `.mcp.json` instead of running
+`claude mcp add`. Pick the block matching the style above:
+
+```json title=".mcp.json (Style A — uvx)"
 {
   "mcpServers": {
     "srunx": {
@@ -103,10 +130,7 @@ For the project scope you can also write `.mcp.json` directly:
 }
 ```
 
-If you installed via `uv tool install --with 'mcp[cli]' srunx` instead
-(Option 2 above), you can use the plain binary:
-
-```json
+```json title=".mcp.json (Style B — installed binary)"
 {
   "mcpServers": {
     "srunx": {

--- a/src/srunx/mcp/server.py
+++ b/src/srunx/mcp/server.py
@@ -3,11 +3,36 @@
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
 import yaml  # type: ignore
-from mcp.server.fastmcp import FastMCP
+
+try:
+    from mcp.server.fastmcp import FastMCP
+except ModuleNotFoundError:
+    sys.stderr.write(
+        "srunx-mcp: the 'mcp' package is not installed in this Python "
+        "environment.\n"
+        "\n"
+        "Fix:\n"
+        "  1. Preferred (zero-install):\n"
+        "       uvx --from 'srunx[mcp]' srunx-mcp\n"
+        "     Register it with Claude Code as:\n"
+        "       claude mcp add --scope user srunx -- "
+        "uvx --from 'srunx[mcp]' srunx-mcp\n"
+        "\n"
+        "  2. Globally installed binary:\n"
+        "       uv tool install --force --with 'mcp[cli]' srunx\n"
+        "     then register:\n"
+        "       claude mcp add --scope user srunx -- srunx-mcp\n"
+        "\n"
+        "Note: 'uv run --extra mcp srunx-mcp' resolves extras against the\n"
+        "current working directory's pyproject.toml, so it only works when\n"
+        "launched from inside the srunx source tree.\n"
+    )
+    sys.exit(1)
 
 mcp = FastMCP(
     "srunx",


### PR DESCRIPTION
## Summary

The documented MCP registration command in `docs/tutorials/mcp-setup.md` Option B

```bash
claude mcp add srunx -- uv run --extra mcp srunx-mcp
```

**only works when Claude Code is launched from inside the srunx source tree**.
`uv run --extra mcp` resolves the `mcp` extra against the current working
directory's `pyproject.toml`, not srunx's — from any other project it
fails with:

```
error: Extra 'mcp' is not defined in the project's optional-dependencies table
```

And `uv tool install srunx` alone does not pull in the `mcp` extra either,
so the installed `~/.local/bin/srunx-mcp` binary dies with
`ModuleNotFoundError: No module named 'mcp'`.

## Fixes

1. **Docs rewrite** (`docs/tutorials/mcp-setup.md`) — three CWD-independent install paths:
   - `uvx --from 'srunx[mcp]' srunx-mcp` (recommended, zero-install)
   - `uv tool install --with 'mcp[cli]' srunx` (global binary)
   - `uv add "srunx[mcp]"` (inside a uv project)
   - Explicit warning block against `uv run --extra mcp` for global registration.
2. **Consistent examples** across `docs/explanation/mcp-architecture.md` `.mcp.json` snippet and `docs/reference/mcp-tools.md` opening line.
3. **Friendly error** (`src/srunx/mcp/server.py`) — the `mcp.server.fastmcp` import is wrapped in `try/except ModuleNotFoundError`; on failure it prints the exact `uvx` / `uv tool install` commands to stderr and `sys.exit(1)`. Claude Code's MCP log shows this verbatim, so debugging takes seconds instead of minutes.

## Recommended command (user scope)

```bash
claude mcp add --scope user srunx -- uvx --from 'srunx[mcp]' srunx-mcp
```

## Test plan

- [x] `uv run python -c "from srunx.mcp import server"` — imports cleanly
- [x] `uv run mypy src/srunx/mcp/server.py` — pass
- [x] `uv run ruff check src/srunx/mcp/server.py` — pass
- [x] `uv run mkdocs build --strict` — 0 warnings
- [ ] Manual: register with `claude mcp add --scope user srunx -- uvx --from 'srunx[mcp]' srunx-mcp` from a non-srunx project and confirm `claude mcp list` shows it as connected (deferred — needs user environment)

Refs: user report (2026-04-20) — "claude mcp add srunx -- uv run --extra mcp srunx-mcp → Failed to connect from non-srunx project CWD".

🤖 Generated with [Claude Code](https://claude.com/claude-code)