### PR TITLE
fix(mcp): supply missing outputs_dir and surface real SSH errors

### DIFF
--- a/src/srunx/mcp/server.py
+++ b/src/srunx/mcp/server.py
@@ -271,6 +271,9 @@ def submit_job(
                 srun_args=srun_args,
                 launch_prefix=launch_prefix,
                 container=environment.container,
+                outputs_dir=None,
+                job_outputs=job.outputs,
+                dependency_names=[],
                 **resource.model_dump(),
             )
             ssh_client = _get_ssh_client()

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -92,6 +92,7 @@ class SSHSlurmClient:
         self._slurm_path: str | None = None
         self.custom_env_vars: dict[str, str] = env_vars or {}
         self.verbose = verbose
+        self._last_error: Exception | None = None
 
         # ── Composed components (for standalone / advanced usage) ───
         self.connection = SSHConnection(
@@ -186,6 +187,7 @@ class SSHSlurmClient:
 
         except Exception as e:
             self.logger.error(f"Failed to connect to {self.hostname}: {e}")
+            self._last_error = e
             return False
 
     def disconnect(self):
@@ -250,8 +252,14 @@ class SSHSlurmClient:
     def __enter__(self):
         if self.connect():
             return self
-        else:
-            raise ConnectionError("Failed to establish SSH connection")
+        cause = self._last_error
+        target = self.hostname
+        if self.proxy_jump:
+            target += f" (via {self.proxy_jump})"
+        reason = f"{type(cause).__name__}: {cause}" if cause else "unknown error"
+        raise ConnectionError(
+            f"Failed to establish SSH connection to {target}: {reason}"
+        ) from cause
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.disconnect()

--- a/src/srunx/ssh/core/connection.py
+++ b/src/srunx/ssh/core/connection.py
@@ -49,6 +49,7 @@ class SSHConnection:
         self.temp_dir: str = temp_dir or os.getenv("SRUNX_TEMP_DIR") or "/tmp/srunx"
         self.custom_env_vars: dict[str, str] = env_vars or {}
         self.verbose = verbose
+        self._last_error: Exception | None = None
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -105,6 +106,7 @@ class SSHConnection:
 
         except Exception as e:
             self.logger.error(f"Failed to connect to {self.hostname}: {e}")
+            self._last_error = e
             return False
 
     def disconnect(self) -> None:
@@ -194,8 +196,14 @@ class SSHConnection:
     def __enter__(self) -> SSHConnection:
         if self.connect():
             return self
-        else:
-            raise ConnectionError("Failed to establish SSH connection")
+        cause = self._last_error
+        target = self.hostname
+        if self.proxy_jump:
+            target += f" (via {self.proxy_jump})"
+        reason = f"{type(cause).__name__}: {cause}" if cause else "unknown error"
+        raise ConnectionError(
+            f"Failed to establish SSH connection to {target}: {reason}"
+        ) from cause
 
     def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
         self.disconnect()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -390,6 +390,29 @@ class TestSubmitJob:
             assert result["success"] is False
             assert "slurm not available" in result["error"]
 
+    @patch("srunx.mcp.server._get_ssh_client")
+    def test_submit_ssh_real_template_render(self, mock_get_client):
+        """Regression test for #117: real template render must succeed."""
+        mock_client = MagicMock()
+        mock_returned_job = MagicMock()
+        mock_returned_job.job_id = "42"
+        mock_returned_job.name = "ssh_job"
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.submit_sbatch_job.return_value = mock_returned_job
+        mock_get_client.return_value = mock_client
+
+        result = submit_job(
+            command="echo hi",
+            name="ssh_job",
+            use_ssh=True,
+            work_dir="/remote/workdir",
+        )
+        assert result["success"] is True, result
+        script_content = mock_client.submit_sbatch_job.call_args[0][0]
+        assert "#SBATCH --job-name=ssh_job" in script_content
+        assert "SRUNX_OUTPUTS_DIR" not in script_content
+
 
 class TestListJobs:
     """Test list_jobs tool."""


### PR DESCRIPTION
## Summary

- `submit_job` の SSH 分岐が `outputs_dir` / `job_outputs` / `dependency_names` を Jinja context に渡していなかったため、`StrictUndefined` が正常な呼び出しを落としていた。これらを供給して #117 を解消。
- `SSHConnection` / `SSHSlurmClient` の `connect()` が paramiko 例外を握り潰し、`__enter__` が generic な `ConnectionError` を投げていたため、MCP 側からは根本原因が全く見えなかった。`self._last_error` に保持して `ConnectionError` にチェーンすることで、鍵パス・passphrase・host 解決など実際のエラーが表に出る (#118)。

Closes #117
Closes #118

## Test plan

- [x] `uv run pytest` — 1355 passed
- [x] `uv run mypy .` — clean
- [x] `uv run ruff check .` — clean
- [x] `tests/test_mcp_server.py` に #117 リグレッションテスト追加（実テンプレ render で `#SBATCH --job-name=...` を確認）
- [ ] 実機検証: Slack 経由で MCP `submit_job(use_ssh=true)` を投げて job が流れることを確認
- [ ] 実機検証: 誤った鍵パスのプロファイルで MCP tool を叩き、エラーメッセージに paramiko の原因が出ることを確認

## Follow-up

`outputs_dir` 周り（runtime env pipeline・命名・静的解決への縮退）はこの PR のスコープ外。別 issue で追跡する予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)