### PR TITLE
refactor(outputs)!: resolve inter-job values at load time, rename to exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **`outputs` field renamed to `exports`** for all workflow jobs (YAML, Pydantic model, web API, frontend).
+- **Inter-job value propagation is now resolved at workflow load time** via `{{ deps.<job_name>.<key> }}`, not at runtime via shared env files.
+- **Removed**: `SRUNX_OUTPUTS_DIR`, `SRUNX_OUTPUTS`, dynamic `echo "key=value" >> $SRUNX_OUTPUTS` writes, and the `{% if outputs_dir %}` template block in `base.slurm.jinja`.
+- **Removed kwargs** from `Slurm.submit` / `Slurm.run` / `render_job_script`: `outputs_dir`, `dependency_names`, `job_outputs`.
+
+### Migration
+
+Before:
+```yaml
+- name: preprocess
+  outputs:
+    data_path: "{{ base_dir }}/data"
+- name: train
+  depends_on: [preprocess]
+  command: [python, train.py, --data, "$data_path"]
+```
+
+After:
+```yaml
+- name: preprocess
+  exports:
+    data_path: "{{ base_dir }}/data"
+- name: train
+  depends_on: [preprocess]
+  command: [python, train.py, --data, "{{ deps.preprocess.data_path }}"]
+```
+
+If you were using dynamic `echo "key=value" >> $SRUNX_OUTPUTS` at job runtime, that mechanism is no longer supported. Pass runtime-determined values between jobs via explicit files (e.g., `--out-file /shared/path/result.json`) or workflow-args-derived deterministic paths.
+
 ### Fixed
 
 #### Resource Monitor Improvements (2025-12-23)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ src/srunx/
 ### Core Components
 
 #### Models (`models.py`)
-- **BaseJob**: Base class for all job types with common fields (name, job_id, depends_on, outputs, status)
+- **BaseJob**: Base class for all job types with common fields (name, job_id, depends_on, exports, status)
 - **Job**: Complete SLURM job configuration with command, resources, and environment
 - **ShellJob**: Job that executes a shell script with variables (script_path, script_vars)
 - **JobResource**: Resource allocation (nodes, GPUs, memory, time, partition, nodelist)
@@ -286,11 +286,11 @@ src/srunx/
 
 ### Template System
 - Enhanced Jinja2 templates with conditional resource allocation
-- `base.slurm.jinja`: Full-featured template with all options, including inter-job outputs support
+- `base.slurm.jinja`: Full-featured template with all options; inter-job values are resolved at workflow load time via `exports` / `deps` (no runtime env-file wiring in the template)
 - Automatic environment setup integration
 
 ### Workflow Definition
-Enhanced YAML workflow format with variables and outputs:
+Enhanced YAML workflow format with variables and exports:
 ```yaml
 name: ml_pipeline
 args:
@@ -300,14 +300,14 @@ args:
 jobs:
   - name: preprocess
     command: ["python", "preprocess.py", "--output", "{{ base_dir }}/data"]
-    outputs:
+    exports:
       data_path: "{{ base_dir }}/data/processed"
     nodes: 1
 
   - name: train
-    command: ["python", "train.py", "--data", "$data_path"]
+    command: ["python", "train.py", "--data", "{{ deps.preprocess.data_path }}"]
     depends_on: [preprocess]
-    outputs:
+    exports:
       model_path: "{{ base_dir }}/models/best.pt"
     gpus_per_node: 1
     conda: ml_env
@@ -315,7 +315,7 @@ jobs:
     time_limit: "4:00:00"
 
   - name: evaluate
-    command: ["python", "evaluate.py", "--model", "$model_path"]
+    command: ["python", "evaluate.py", "--model", "{{ deps.train.model_path }}"]
     depends_on: [train]
 ```
 
@@ -324,13 +324,12 @@ jobs:
 - Supports `python:` prefix for dynamic evaluation (CLI only, rejected from web API for security)
 - Variables can reference each other with automatic dependency resolution
 
-#### Inter-Job Outputs
-- Jobs declare static `outputs` (dict of KEY=value) written to `$SRUNX_OUTPUTS` file at job start
-- Jobs can also write dynamic outputs at runtime: `echo "key=value" >> $SRUNX_OUTPUTS`
-- Dependent jobs automatically source parent output files via `$SRUNX_OUTPUTS_DIR/<job_name>.env`
-- Output variable keys must be valid shell identifiers (`^[A-Za-z_][A-Za-z0-9_]*$`)
-- Values are single-quoted in generated scripts to prevent shell injection
-- Outputs directory uses `chmod 700` for multi-tenant security
+#### Inter-Job Exports (Load-Time)
+- Jobs declare static `exports` (dict of KEY=value) — string literals expanded with workflow `args` at load time
+- Downstream jobs reference parent values as `{{ deps.<parent_name>.<key> }}`; Jinja (with `StrictUndefined`) substitutes literals into the child's fields at workflow load time, before any job is submitted
+- `deps.X` is only populated for names listed in the child's `depends_on`; referencing a non-dep or a missing key fails the workflow at load time
+- No runtime env-file mechanism: `$SRUNX_OUTPUTS`, `$SRUNX_OUTPUTS_DIR`, and dynamic `echo "key=value" >> $SRUNX_OUTPUTS` writes are gone
+- Values that can only be computed at runtime are out of scope — pass them explicitly (e.g. `--out-file /shared/path/result.json`) or make the path deterministic from `args`
 
 ### Key Improvements
 - **Unified Job Model**: Single `Job` class with comprehensive configuration
@@ -339,7 +338,7 @@ jobs:
 - **Better Error Handling**: Comprehensive validation and error messages
 - **Resource Management**: Full SLURM resource specification
 - **Workflow Validation**: Dependency checking and cycle detection
-- **Inter-Job Communication**: Runtime variable passing between workflow jobs via shared outputs directory
+- **Load-Time Value Propagation**: Parent-job `exports` are substituted into child jobs via `{{ deps.<parent>.<key> }}` at workflow load time, with StrictUndefined validation
 
 ### Notification + State Persistence (new in 2026-Q2)
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Instead of stitching together `sbatch`, `squeue`, SSH, and a pipeline runner, sr
 | Python API | ✅ | ✅ | ✅ | ✅ |
 | Web dashboard | ✅ | ❌ | ❌ | ❌ |
 | Workflow DAG with dependencies | ✅ | ❌ | ❌ | ✅ |
-| Inter-job runtime variable passing | ✅ | ❌ | ❌ | ⚠️ via files |
+| Inter-job value passing (load-time) | ✅ | ❌ | ❌ | ⚠️ via files |
 | GPU availability monitoring | ✅ | ❌ | ❌ | ❌ |
 | SSH remote submit + file sync | ✅ | ❌ | ❌ | ❌ |
 | Container support (Pyxis / Apptainer / Singularity) | ✅ | ⚠️ limited | ❌ | ⚠️ via rules |
@@ -148,11 +148,11 @@ args:
 jobs:
   - name: preprocess
     command: ["python", "preprocess.py", "--out", "{{ output_dir }}/data"]
-    outputs:
+    exports:
       DATA_PATH: "{{ output_dir }}/data/processed.parquet"
 
   - name: train
-    command: ["python", "train.py", "--model", "{{ model }}", "--data", "$DATA_PATH"]
+    command: ["python", "train.py", "--model", "{{ model }}", "--data", "{{ deps.preprocess.DATA_PATH }}"]
     depends_on: [preprocess]
     gpus_per_node: 2
     environment:
@@ -160,18 +160,18 @@ jobs:
         image: nvcr.io/nvidia/pytorch:24.01-py3
         mounts:
           - /data:/data
-    outputs:
+    exports:
       MODEL_PATH: "{{ output_dir }}/models/best.pt"
 
   - name: evaluate
-    command: ["python", "eval.py", "--model", "$MODEL_PATH"]
+    command: ["python", "eval.py", "--model", "{{ deps.train.MODEL_PATH }}"]
     depends_on: [train]
 ```
 
 **What this shows off:**
 
 - **`args` with Jinja2** — reusable, parameterized pipelines (`{{ model }}`, `{{ output_dir }}`)
-- **Inter-job outputs** — downstream jobs read `$DATA_PATH` / `$MODEL_PATH` at runtime; you can also append from the job with `echo "key=value" >> $SRUNX_OUTPUTS`
+- **Inter-job exports** — parents declare `exports:`; children read them via `{{ deps.<parent>.<key> }}`, fully resolved at workflow load time (no runtime env files)
 - **Containers per job** — Pyxis / Apptainer / Singularity are first-class (`environment.container`)
 - **Dependency-driven scheduling** — `evaluate` blocks on `train`; parallel branches run automatically
 

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -57,8 +57,6 @@ class Slurm:
         record_history: bool = True,
         workflow_name: str | None = None,
         workflow_run_id: int | None = None,
-        outputs_dir: str | None = None,
-        dependency_names: list[str] | None = None,
     ) -> RunnableJobType:
         """Submit a job to SLURM.
 
@@ -73,8 +71,6 @@ class Slurm:
                 submitted from a workflow; persisted on the ``jobs`` row
                 so reports (``srunx report --workflow``, the Web history
                 JOIN) actually pick up CLI-launched workflow jobs.
-            outputs_dir: Shared directory for inter-job output variables.
-            dependency_names: Names of dependency jobs whose outputs should be sourced.
 
         Returns:
             Job instance with updated job_id and status.
@@ -93,8 +89,6 @@ class Slurm:
                     job,
                     temp_dir,
                     verbose,
-                    outputs_dir=outputs_dir,
-                    dependency_names=dependency_names,
                 )
                 logger.debug(f"Generated SLURM script at: {script_path}")
 
@@ -474,8 +468,6 @@ class Slurm:
         verbose: bool = False,
         workflow_name: str | None = None,
         workflow_run_id: int | None = None,
-        outputs_dir: str | None = None,
-        dependency_names: list[str] | None = None,
     ) -> RunnableJobType:
         """Submit a job and wait for completion."""
         submitted_job = self.submit(
@@ -485,8 +477,6 @@ class Slurm:
             verbose=verbose,
             workflow_name=workflow_name,
             workflow_run_id=workflow_run_id,
-            outputs_dir=outputs_dir,
-            dependency_names=dependency_names,
         )
         monitored_job = self.monitor(
             submitted_job, poll_interval=poll_interval, callbacks=callbacks

--- a/src/srunx/mcp/server.py
+++ b/src/srunx/mcp/server.py
@@ -271,9 +271,6 @@ def submit_job(
                 srun_args=srun_args,
                 launch_prefix=launch_prefix,
                 container=environment.container,
-                outputs_dir=None,
-                job_outputs=job.outputs,
-                dependency_names=[],
                 **resource.model_dump(),
             )
             ssh_client = _get_ssh_client()

--- a/src/srunx/models.py
+++ b/src/srunx/models.py
@@ -267,21 +267,23 @@ class BaseJob(BaseModel):
     depends_on: list[str] = Field(
         default_factory=list, description="Task dependencies for workflow execution"
     )
-    outputs: dict[str, str] = Field(
+    exports: dict[str, str] = Field(
         default_factory=dict,
-        description="Static output variables (KEY=VALUE) written to outputs file at job start",
+        description=(
+            "Values this job exports for downstream jobs to reference via "
+            "`{{ deps.<this_job>.<key> }}` at workflow load time."
+        ),
     )
 
-    @field_validator("outputs")
+    @field_validator("exports")
     @classmethod
-    def validate_output_keys(cls, v: dict[str, str]) -> dict[str, str]:
-        """Ensure output variable names are valid shell identifiers."""
-
+    def validate_export_keys(cls, v: dict[str, str]) -> dict[str, str]:
+        """Ensure export names are valid identifiers."""
         for key in v:
             if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
                 raise ValueError(
-                    f"Invalid output variable name: '{key}'. "
-                    "Must be a valid shell identifier (letters, digits, underscores)."
+                    f"Invalid export name: '{key}'. "
+                    "Must be a valid identifier (letters, digits, underscores)."
                 )
         return v
 
@@ -744,8 +746,6 @@ def render_job_script(
     job: Job,
     output_dir: Path | str | None = None,
     verbose: bool = False,
-    outputs_dir: str | None = None,
-    dependency_names: list[str] | None = None,
     extra_srun_args: str | None = None,
     extra_launch_prefix: str | None = None,
 ) -> str:
@@ -756,8 +756,6 @@ def render_job_script(
         job: Job configuration.
         output_dir: Directory where the generated script will be saved.
         verbose: Whether to print the rendered content.
-        outputs_dir: Shared directory for inter-job output variables (SRUNX_OUTPUTS_DIR).
-        dependency_names: Names of dependency jobs whose outputs should be sourced.
         extra_srun_args: Additional srun flags to append after auto-generated ones.
         extra_launch_prefix: Additional launch prefix to append after auto-generated ones.
 
@@ -790,9 +788,6 @@ def render_job_script(
         "srun_args": srun_args,
         "launch_prefix": launch_prefix,
         "container": job.environment.container,
-        "outputs_dir": outputs_dir,
-        "job_outputs": job.outputs,
-        "dependency_names": dependency_names or [],
         **job.resources.model_dump(),
     }
 

--- a/src/srunx/runner.py
+++ b/src/srunx/runner.py
@@ -259,6 +259,60 @@ def _find_jinja_refs(text: str) -> set[str]:
     return set(_JINJA_VAR_RE.findall(text))
 
 
+def _dependency_closure(jobs_data: list[dict[str, Any]], target: str) -> set[str]:
+    """Return *target* plus every job it transitively depends on."""
+    name_to_deps: dict[str, list[str]] = {
+        jd["name"]: list(jd.get("depends_on") or []) for jd in jobs_data if "name" in jd
+    }
+    closure: set[str] = set()
+    stack = [target]
+    while stack:
+        node = stack.pop()
+        if node in closure:
+            continue
+        if node not in name_to_deps:
+            continue
+        closure.add(node)
+        stack.extend(name_to_deps[node])
+    return closure
+
+
+class _DepsNamespace:
+    """Jinja-friendly wrapper for ``{{ deps.<job>.<key> }}`` access.
+
+    Plain dicts shadow user-declared keys with built-in methods — e.g.
+    ``{{ deps.a.items }}`` resolves to ``dict.items`` rather than the
+    user's export named ``items``. This wrapper forces attribute access
+    to go through dict lookup, wraps nested dict values recursively, and
+    raises ``AttributeError`` for missing keys so ``StrictUndefined``
+    can surface a clear error.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: dict[str, Any]):
+        self._data = data
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            value = self._data[name]
+        except KeyError as exc:
+            raise AttributeError(
+                f"'deps' has no entry '{name}'. "
+                "Check that it is listed in this job's 'depends_on' "
+                "and that the referenced key is declared in the parent's 'exports'."
+            ) from exc
+        if isinstance(value, dict):
+            return _DepsNamespace(value)
+        return value
+
+    def __getitem__(self, name: str) -> Any:
+        return self.__getattr__(name)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._data
+
+
 def _find_required_variables(jobs_yaml: str, args: dict[str, Any]) -> set[str]:
     """Return the set of arg keys that the jobs YAML transitively depends on.
 
@@ -436,21 +490,25 @@ class WorkflowRunner:
         default_project = data.get("default_project")
         jobs_data = data.get("jobs", [])
 
-        # Render Jinja templates in DAG order so each job can reference
-        # its dependencies' exports via `deps.<name>.<key>`. Full DAG is
-        # always resolved first; `single_job` filters *after* rendering
-        # so dep references still resolve.
-        rendered_jobs_data = cls._render_jobs_with_args_and_deps(jobs_data, args)
-
+        # For `single_job`, restrict rendering to the target and its
+        # transitive dependencies so unrelated broken jobs don't block
+        # a targeted re-run. Without single_job, render the full DAG.
         if single_job:
-            filtered = [
-                job for job in rendered_jobs_data if job.get("name") == single_job
-            ]
-            if not filtered:
+            if not any(jd.get("name") == single_job for jd in jobs_data):
                 raise WorkflowValidationError(
                     f"Job '{single_job}' not found in workflow"
                 )
-            rendered_jobs_data = filtered
+            closure_names = _dependency_closure(jobs_data, single_job)
+            render_input = [jd for jd in jobs_data if jd.get("name") in closure_names]
+        else:
+            render_input = jobs_data
+
+        rendered_jobs_data = cls._render_jobs_with_args_and_deps(render_input, args)
+
+        if single_job:
+            rendered_jobs_data = [
+                jd for jd in rendered_jobs_data if jd.get("name") == single_job
+            ]
 
         jobs = []
         for job_data in rendered_jobs_data:
@@ -469,12 +527,25 @@ class WorkflowRunner:
     ) -> list[dict[str, Any]]:
         """Render Jinja templates per-job in dependency order.
 
-        Each job is rendered with `{**args, 'deps': {<dep>: <dep>.exports}}`
-        where `deps` contains the already-rendered exports of every
-        predecessor listed in the job's `depends_on`. Uses
-        StrictUndefined so typos in `deps.X.Y` fail fast at load time.
+        Each job is rendered with `{**args, 'deps': <DepsNamespace>}`
+        where ``deps`` exposes the already-rendered ``exports`` of every
+        predecessor listed in the job's ``depends_on``. Uses
+        StrictUndefined so typos in ``deps.X.Y`` fail fast at load time.
+
+        Reject legacy ``outputs:`` keys explicitly rather than silently
+        dropping them, so stale YAML surfaces a clear error instead of
+        producing empty exports and a broken ``deps.X.Y`` resolution.
         """
         from graphlib import CycleError, TopologicalSorter
+
+        for jd in jobs_data:
+            if "outputs" in jd:
+                raise WorkflowValidationError(
+                    f"Job '{jd.get('name', '?')}' uses the removed 'outputs' key. "
+                    "Rename to 'exports' and update consumers to reference the value "
+                    "as '{{ deps.<job_name>.<key> }}' (load-time resolution). "
+                    "See CHANGELOG migration guide."
+                )
 
         # Evaluate args up front (supports `python:` prefix).
         if args:
@@ -498,11 +569,13 @@ class WorkflowRunner:
         rendered: dict[str, dict[str, Any]] = {}
         for job_name in order:
             raw = name_to_data[job_name]
-            deps_ctx = {
-                dep: rendered[dep].get("exports", {}) or {}
-                for dep in name_to_deps[job_name]
-                if dep in rendered
-            }
+            deps_ctx = _DepsNamespace(
+                {
+                    dep: rendered[dep].get("exports", {}) or {}
+                    for dep in name_to_deps[job_name]
+                    if dep in rendered
+                }
+            )
             context = {**evaluated_args, "deps": deps_ctx}
 
             job_yaml = yaml.dump(raw, default_flow_style=False)

--- a/src/srunx/runner.py
+++ b/src/srunx/runner.py
@@ -3,7 +3,6 @@
 import ast
 import datetime
 import math
-import os  # noqa: E402
 import re
 import time
 from collections import defaultdict
@@ -12,7 +11,6 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Self
-from uuid import uuid4
 
 import jinja2
 import yaml  # type: ignore
@@ -438,19 +436,21 @@ class WorkflowRunner:
         default_project = data.get("default_project")
         jobs_data = data.get("jobs", [])
 
-        # If single_job is specified, filter jobs_data to only include that job
+        # Render Jinja templates in DAG order so each job can reference
+        # its dependencies' exports via `deps.<name>.<key>`. Full DAG is
+        # always resolved first; `single_job` filters *after* rendering
+        # so dep references still resolve.
+        rendered_jobs_data = cls._render_jobs_with_args_and_deps(jobs_data, args)
+
         if single_job:
-            filtered_jobs_data = [
-                job for job in jobs_data if job.get("name") == single_job
+            filtered = [
+                job for job in rendered_jobs_data if job.get("name") == single_job
             ]
-            if not filtered_jobs_data:
+            if not filtered:
                 raise WorkflowValidationError(
                     f"Job '{single_job}' not found in workflow"
                 )
-            jobs_data = filtered_jobs_data
-
-        # Render Jinja templates in jobs_data using args
-        rendered_jobs_data = cls._render_jobs_with_args(jobs_data, args)
+            rendered_jobs_data = filtered
 
         jobs = []
         for job_data in rendered_jobs_data:
@@ -464,31 +464,58 @@ class WorkflowRunner:
         )
 
     @staticmethod
-    def _render_jobs_with_args(
+    def _render_jobs_with_args_and_deps(
         jobs_data: list[dict[str, Any]], args: dict[str, Any]
     ) -> list[dict[str, Any]]:
-        """Render Jinja templates in job data using args.
+        """Render Jinja templates per-job in dependency order.
 
-        Phases:
-        1. Find which variables are used in the jobs YAML
-        2. Resolve variable dependencies via topological sort
-        3. Evaluate all variables in dependency order
-        4. Render the jobs YAML with evaluated variables
+        Each job is rendered with `{**args, 'deps': {<dep>: <dep>.exports}}`
+        where `deps` contains the already-rendered exports of every
+        predecessor listed in the job's `depends_on`. Uses
+        StrictUndefined so typos in `deps.X.Y` fail fast at load time.
         """
-        if not args:
-            return jobs_data
+        from graphlib import CycleError, TopologicalSorter
 
-        jobs_yaml = yaml.dump(jobs_data, default_flow_style=False)
-        required = _find_required_variables(jobs_yaml, args)
-        evaluated = _evaluate_variables(args, required)
+        # Evaluate args up front (supports `python:` prefix).
+        if args:
+            jobs_yaml = yaml.dump(jobs_data, default_flow_style=False)
+            required = _find_required_variables(jobs_yaml, args)
+            evaluated_args = _evaluate_variables(args, required)
+        else:
+            evaluated_args = {}
 
-        template = jinja2.Template(jobs_yaml, undefined=jinja2.DebugUndefined)
+        name_to_data = {j["name"]: j for j in jobs_data if "name" in j}
+        name_to_deps = {
+            name: set(jd.get("depends_on", []) or []) & name_to_data.keys()
+            for name, jd in name_to_data.items()
+        }
+
         try:
-            rendered_yaml = template.render(**evaluated)
-            return yaml.safe_load(rendered_yaml)
-        except jinja2.TemplateError as e:
-            logger.error(f"Jinja template rendering failed: {e}")
-            raise WorkflowValidationError(f"Template rendering failed: {e}") from e
+            order = list(TopologicalSorter(name_to_deps).static_order())
+        except CycleError as e:
+            raise WorkflowValidationError(f"Circular job dependency: {e}") from e
+
+        rendered: dict[str, dict[str, Any]] = {}
+        for job_name in order:
+            raw = name_to_data[job_name]
+            deps_ctx = {
+                dep: rendered[dep].get("exports", {}) or {}
+                for dep in name_to_deps[job_name]
+                if dep in rendered
+            }
+            context = {**evaluated_args, "deps": deps_ctx}
+
+            job_yaml = yaml.dump(raw, default_flow_style=False)
+            try:
+                template = jinja2.Template(job_yaml, undefined=jinja2.StrictUndefined)
+                rendered_yaml = template.render(**context)
+            except jinja2.TemplateError as e:
+                raise WorkflowValidationError(
+                    f"Failed to render job '{job_name}': {e}"
+                ) from e
+            rendered[job_name] = yaml.safe_load(rendered_yaml)
+
+        return [rendered[j["name"]] for j in jobs_data if j.get("name") in rendered]
 
     def get_independent_jobs(self) -> list[RunnableJobType]:
         """Get all jobs that are independent of any other job."""
@@ -627,17 +654,6 @@ class WorkflowRunner:
             # update here is not fatal.
             mark_workflow_run_status(workflow_run_id, "running")
 
-        # Generate shared outputs directory for inter-job variable passing
-        any_job_has_outputs = any(
-            getattr(job, "outputs", None) for job in jobs_to_execute
-        )
-        any_job_has_deps = any(job.depends_on for job in jobs_to_execute)
-        outputs_dir: str | None = None
-        if any_job_has_outputs or any_job_has_deps:
-            run_id = uuid4().hex[:8]
-            base = os.getenv("SRUNX_TEMP_DIR", "/tmp/srunx")
-            outputs_dir = f"{base}/{self.workflow.name}_{run_id}"
-
         # Log execution plan
         if single_job:
             logger.info(f"🚀 Executing single job: {single_job}")
@@ -732,20 +748,11 @@ class WorkflowRunner:
             """Execute a single job."""
             logger.info(f"⚡ {'SUBMITTED':<12} Job {job.name:<12}")
 
-            # Resolve dependency names for outputs sourcing
-            dep_names = (
-                [dep.job_name for dep in job.parsed_dependencies]
-                if outputs_dir
-                else None
-            )
-
             try:
                 result = self.slurm.run(
                     job,
                     workflow_name=self.workflow.name,
                     workflow_run_id=workflow_run_id,
-                    outputs_dir=outputs_dir,
-                    dependency_names=dep_names,
                 )
                 return result
             except Exception as e:
@@ -1097,7 +1104,7 @@ class WorkflowRunner:
         base = {
             "name": data["name"],
             "depends_on": data.get("depends_on", []),
-            "outputs": data.get("outputs", {}),
+            "exports": data.get("exports", {}),
             "retry": data.get("retry", 0),
             "retry_delay": data.get("retry_delay", 60),
         }

--- a/src/srunx/template.py
+++ b/src/srunx/template.py
@@ -9,7 +9,7 @@ from pathlib import Path
 BUILTIN_TEMPLATES = {
     "base": {
         "name": "base",
-        "description": "SLURM job template with full resource control and inter-job outputs",
+        "description": "SLURM job template with full resource control",
         "path": "base.slurm.jinja",
         "use_case": "All job types including distributed training",
     },

--- a/src/srunx/templates/base.slurm.jinja
+++ b/src/srunx/templates/base.slurm.jinja
@@ -35,32 +35,6 @@ set -euxo pipefail
 
 export WORLD_SIZE=${SLURM_NTASKS:-1}
 
-{% if outputs_dir -%}
-# ── Outputs setup ──────────────────────────────────
-export SRUNX_OUTPUTS_DIR="{{ outputs_dir }}"
-export SRUNX_OUTPUTS="${SRUNX_OUTPUTS_DIR}/{{ job_name }}.env"
-mkdir -p "${SRUNX_OUTPUTS_DIR}" && chmod 700 "${SRUNX_OUTPUTS_DIR}"
-touch "${SRUNX_OUTPUTS}"
-{% if job_outputs -%}
-# Static outputs declared in workflow
-{% for key, value in job_outputs.items() -%}
-echo '{{ key }}={{ value | replace("'", "'\\''") }}' >> "${SRUNX_OUTPUTS}"
-export {{ key }}='{{ value | replace("'", "'\\''") }}'
-{% endfor -%}
-{% endif -%}
-
-{% if dependency_names -%}
-# Source outputs from dependency jobs
-{% for dep_name in dependency_names -%}
-if [ -f "${SRUNX_OUTPUTS_DIR}/{{ dep_name }}.env" ]; then
-    set -a
-    source "${SRUNX_OUTPUTS_DIR}/{{ dep_name }}.env"
-    set +a
-fi
-{% endfor -%}
-{% endif -%}
-{% endif -%}
-
 # Environment setup
 {% if environment_setup -%}
 {{ environment_setup }}

--- a/src/srunx/web/frontend/e2e/fixtures/mock-data.ts
+++ b/src/srunx/web/frontend/e2e/fixtures/mock-data.ts
@@ -63,7 +63,7 @@ export const MOCK_WORKFLOWS = [
         name: "preprocess",
         status: "COMPLETED",
         depends_on: [],
-        outputs: { data_path: "/data/experiments/preprocessed" },
+        exports: { data_path: "/data/experiments/preprocessed" },
         command: ["python", "preprocess.py"],
         resources: { nodes: 1, gpus_per_node: 0 },
       },
@@ -71,7 +71,7 @@ export const MOCK_WORKFLOWS = [
         name: "train",
         status: "RUNNING",
         depends_on: ["preprocess"],
-        outputs: { model_path: "/data/experiments/models/best.pt" },
+        exports: { model_path: "/data/experiments/models/best.pt" },
         command: ["python", "train.py"],
         resources: { nodes: 2, gpus_per_node: 4 },
       },
@@ -79,7 +79,7 @@ export const MOCK_WORKFLOWS = [
         name: "evaluate",
         status: "PENDING",
         depends_on: ["train"],
-        outputs: {},
+        exports: {},
         command: ["python", "evaluate.py"],
         resources: { nodes: 1, gpus_per_node: 1 },
       },
@@ -172,7 +172,7 @@ export const MOCK_TEMPLATES = [
   {
     name: "base",
     description:
-      "SLURM job template with full resource control and inter-job outputs",
+      "SLURM job template with full resource control and inter-job exports",
     use_case: "All job types including distributed training",
   },
   {
@@ -186,7 +186,7 @@ export const MOCK_TEMPLATES = [
 export const MOCK_TEMPLATE_DETAIL = {
   name: "base",
   description:
-    "SLURM job template with full resource control and inter-job outputs",
+    "SLURM job template with full resource control and inter-job exports",
   use_case: "All job types including distributed training",
   content:
     "#!/bin/bash\n#SBATCH --job-name={{ job_name }}\n#SBATCH --nodes={{ nodes }}\nsrun {{ command }}",

--- a/src/srunx/web/frontend/e2e/workflow-vars.spec.ts
+++ b/src/srunx/web/frontend/e2e/workflow-vars.spec.ts
@@ -5,7 +5,7 @@ test.beforeEach(async ({ page }) => {
   await setupMockRoutes(page);
 });
 
-test.describe("Workflow Variables (args & outputs)", () => {
+test.describe("Workflow Variables (args & exports)", () => {
   test("args button is visible in builder toolbar", async ({ page }) => {
     await page.goto("/workflows/new?mount=ml-project");
 
@@ -54,30 +54,30 @@ test.describe("Workflow Variables (args & outputs)", () => {
     await expect(valueInput).toHaveValue("/data/experiments");
   });
 
-  test("outputs section is visible in job property panel", async ({ page }) => {
+  test("exports section is visible in job property panel", async ({ page }) => {
     await page.goto("/workflows/new?mount=ml-project");
 
     await page.getByRole("button", { name: "Add Job" }).click();
     await expect(page.getByText("job_1")).toBeVisible();
     await page.locator("[data-id]").filter({ hasText: "job_1" }).click();
 
-    // Scroll the Add Output button into view
-    const addOutputBtn = page.getByRole("button", { name: "Add Output" });
-    await addOutputBtn.scrollIntoViewIfNeeded();
-    await expect(addOutputBtn).toBeVisible();
+    // Scroll the Add Export button into view
+    const addExportBtn = page.getByRole("button", { name: "Add Export" });
+    await addExportBtn.scrollIntoViewIfNeeded();
+    await expect(addExportBtn).toBeVisible();
   });
 
-  test("adding outputs creates key-value row", async ({ page }) => {
+  test("adding exports creates key-value row", async ({ page }) => {
     await page.goto("/workflows/new?mount=ml-project");
 
     await page.getByRole("button", { name: "Add Job" }).click();
     await page.locator("[data-id]").filter({ hasText: "job_1" }).click();
 
-    const addOutputBtn = page.getByRole("button", { name: "Add Output" });
-    await addOutputBtn.scrollIntoViewIfNeeded();
-    await addOutputBtn.click();
+    const addExportBtn = page.getByRole("button", { name: "Add Export" });
+    await addExportBtn.scrollIntoViewIfNeeded();
+    await addExportBtn.click();
 
-    // Should see key and value inputs for output
+    // Should see key and value inputs for export
     const keyInput = page.getByPlaceholder("name").first();
     const valueInput = page
       .locator('input[placeholder="/path/or/value"]')
@@ -92,15 +92,15 @@ test.describe("Workflow Variables (args & outputs)", () => {
     await expect(valueInput).toHaveValue("/data/model.pt");
   });
 
-  test("help text mentions $SRUNX_OUTPUTS", async ({ page }) => {
+  test("help text mentions deps.<job>.<key> syntax", async ({ page }) => {
     await page.goto("/workflows/new?mount=ml-project");
 
     await page.getByRole("button", { name: "Add Job" }).click();
     await page.locator("[data-id]").filter({ hasText: "job_1" }).click();
 
-    const srunxText = page.getByText("$SRUNX_OUTPUTS");
-    await srunxText.scrollIntoViewIfNeeded();
-    await expect(srunxText).toBeVisible();
+    const depsText = page.getByText(/deps\.job_1\./);
+    await depsText.scrollIntoViewIfNeeded();
+    await expect(depsText).toBeVisible();
   });
 
   test("args editor shows hint about variable_name syntax", async ({

--- a/src/srunx/web/frontend/src/components/JobPropertyPanel.tsx
+++ b/src/srunx/web/frontend/src/components/JobPropertyPanel.tsx
@@ -169,10 +169,10 @@ export function JobPropertyPanel({
     setBrowserTarget(null);
   }
 
-  // Convert outputs string ↔ KVEntry[]
-  const outputEntries: KVEntry[] = useMemo(() => {
-    if (!job.outputs.trim()) return [];
-    return job.outputs
+  // Convert exports string ↔ KVEntry[]
+  const exportEntries: KVEntry[] = useMemo(() => {
+    if (!job.exports.trim()) return [];
+    return job.exports
       .split("\n")
       .filter((l) => l.includes("="))
       .map((line) => {
@@ -182,11 +182,11 @@ export function JobPropertyPanel({
           value: line.slice(eq + 1).trim(),
         };
       });
-  }, [job.outputs]);
+  }, [job.exports]);
 
-  function handleOutputsChange(entries: KVEntry[]) {
+  function handleExportsChange(entries: KVEntry[]) {
     const text = entries.map((e) => `${e.key}=${e.value}`).join("\n");
-    onUpdate({ outputs: text });
+    onUpdate({ exports: text });
   }
 
   const hasContainer = job.container !== null;
@@ -624,17 +624,17 @@ export function JobPropertyPanel({
         </div>
       </div>
 
-      {/* ── Outputs ──────────────────────────── */}
+      {/* ── Exports ──────────────────────────── */}
       <div style={sectionDividerStyle}>
-        <div style={sectionTitleStyle}>Outputs</div>
+        <div style={sectionTitleStyle}>Exports</div>
         <KeyValueEditor
-          entries={outputEntries}
-          onChange={handleOutputsChange}
+          entries={exportEntries}
+          onChange={handleExportsChange}
           keyPlaceholder="name"
           valuePlaceholder="/path/or/value"
-          addLabel="Add Output"
+          addLabel="Add Export"
           compact
-          hint="Exported as env vars to dependent jobs via $SRUNX_OUTPUTS"
+          hint={`Referenced by dependent jobs as {{ deps.${job.name}.<key> }} at workflow load time`}
         />
       </div>
 

--- a/src/srunx/web/frontend/src/hooks/use-workflow-builder.ts
+++ b/src/srunx/web/frontend/src/hooks/use-workflow-builder.ts
@@ -48,7 +48,7 @@ function makeDefaultJob(id: string, name: string): BuilderJob {
     venv: null,
     container: null,
     env_vars: "",
-    outputs: "",
+    exports: "",
     work_dir: null,
     log_dir: null,
     retry: null,
@@ -111,15 +111,15 @@ function hasCycle(nodeIds: string[], edges: Edge[]): boolean {
 /* ── Workflow → Builder conversion ──────────────── */
 
 function workflowJobToBuilderJob(job: RunnableJob, id: string): BuilderJob {
-  // Convert outputs record to "KEY=value" per line string
-  const outputsRecord =
-    "outputs" in job
-      ? ((job as Record<string, unknown>).outputs as
+  // Convert exports record to "KEY=value" per line string
+  const exportsRecord =
+    "exports" in job
+      ? ((job as Record<string, unknown>).exports as
           | Record<string, string>
           | undefined)
       : undefined;
-  const outputsStr = outputsRecord
-    ? Object.entries(outputsRecord)
+  const exportsStr = exportsRecord
+    ? Object.entries(exportsRecord)
         .map(([k, v]) => `${k}=${v}`)
         .join("\n")
     : "";
@@ -146,7 +146,7 @@ function workflowJobToBuilderJob(job: RunnableJob, id: string): BuilderJob {
     venv: job.environment?.venv ?? null,
     container: null,
     env_vars: "",
-    outputs: outputsStr,
+    exports: exportsStr,
     work_dir: null,
     log_dir: null,
     retry: null,
@@ -448,16 +448,16 @@ export function useWorkflowBuilder() {
         if (Object.keys(environment).length > 0) {
           entry.environment = environment;
         }
-        // Build outputs
-        if (job.outputs.trim()) {
-          const outputs: Record<string, string> = {};
-          for (const line of job.outputs.split("\n")) {
+        // Build exports
+        if (job.exports.trim()) {
+          const exportsMap: Record<string, string> = {};
+          for (const line of job.exports.split("\n")) {
             const eq = line.indexOf("=");
             if (eq > 0) {
-              outputs[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
+              exportsMap[line.slice(0, eq).trim()] = line.slice(eq + 1).trim();
             }
           }
-          if (Object.keys(outputs).length > 0) entry.outputs = outputs;
+          if (Object.keys(exportsMap).length > 0) entry.exports = exportsMap;
         }
 
         if (job.work_dir !== null) entry.work_dir = job.work_dir;

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -146,7 +146,7 @@ export type BuilderJob = {
   venv: string | null;
   container: BuilderContainer | null;
   env_vars: string; // "KEY=VAL" per line, parsed on save
-  outputs: string; // "KEY=value" per line, parsed on save
+  exports: string; // "KEY=value" per line, parsed on save
   // Job-level
   work_dir: string | null;
   log_dir: string | null;
@@ -464,7 +464,7 @@ export type WorkflowCreateRequest = {
     command: string[];
     depends_on: string[];
     template?: string;
-    outputs?: Record<string, string>;
+    exports?: Record<string, string>;
     resources?: {
       nodes?: number;
       gpus_per_node?: number;

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -10,7 +10,6 @@ aggregates child job statuses into the workflow run via an internal
 from __future__ import annotations
 
 import functools
-import os  # noqa: E402
 import re
 import sqlite3
 import tempfile
@@ -67,7 +66,7 @@ class WorkflowJobInput(BaseModel):
     command: list[str]
     depends_on: list[str] = []
     template: str | None = None
-    outputs: dict[str, str] = Field(default_factory=dict)
+    exports: dict[str, str] = Field(default_factory=dict)
     resources: dict[str, Any] | None = None
     environment: dict[str, Any] | None = None
     work_dir: str | None = None
@@ -107,7 +106,7 @@ def _validate_and_build_workflow(data: dict[str, Any]) -> Workflow:
             "name": jd["name"],
             "command": jd["command"],
             "depends_on": jd.get("depends_on", []),
-            "outputs": jd.get("outputs", {}),
+            "exports": jd.get("exports", {}),
             "resources": resource,
             "environment": environment,
         }
@@ -152,9 +151,9 @@ def _workflow_to_yaml(
         if depends:
             entry["depends_on"] = depends
 
-        outputs = jd.get("outputs", {})
-        if outputs:
-            entry["outputs"] = outputs
+        exports = jd.get("exports", {})
+        if exports:
+            entry["exports"] = exports
 
         # Resources — only include non-None values
         raw_res = jd.get("resources") or {}
@@ -288,7 +287,7 @@ def _serialize_workflow(
             "job_id": job.job_id,
             "status": job._status.value,
             "depends_on": job.depends_on,
-            "outputs": job.outputs,
+            "exports": job.exports,
         }
         raw_job = raw_by_name.get(job.name, {})
         if raw_job.get("template"):
@@ -730,13 +729,11 @@ def _prepare_render_context(
     yaml_path: Path,
     workflow: Workflow,
     name: str,
-) -> tuple[dict[str, str], dict[str, dict[str, str]], str | None]:
-    """Parse raw YAML for template/extra args and build outputs dir.
+) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    """Parse raw YAML for template/extra args.
 
-    Returns (job_template_map, job_extra_args, wf_outputs_dir).
+    Returns (job_template_map, job_extra_args).
     """
-    from uuid import uuid4
-
     import yaml as _yaml
 
     raw_data = _yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
@@ -756,14 +753,7 @@ def _prepare_render_context(
         if extras:
             job_extra_args[rj_name] = extras
 
-    any_job_has_outputs = any(job.outputs for job in workflow.jobs)
-    any_job_has_deps = any(job.depends_on for job in workflow.jobs)
-    wf_outputs_dir: str | None = None
-    if any_job_has_outputs or any_job_has_deps:
-        base = os.getenv("SRUNX_TEMP_DIR", "/tmp/srunx")
-        wf_outputs_dir = f"{base}/{name}_{uuid4().hex[:8]}"
-
-    return job_template_map, job_extra_args, wf_outputs_dir
+    return job_template_map, job_extra_args
 
 
 def _render_scripts(
@@ -772,14 +762,12 @@ def _render_scripts(
     profile: Any,
     job_template_map: dict[str, str],
     job_extra_args: dict[str, dict[str, str]],
-    wf_outputs_dir: str | None,
 ) -> dict[str, str]:
     """Render SLURM scripts for all jobs in the workflow."""
     from srunx.models import render_job_script
     from srunx.template import TEMPLATES
 
     templates_dir = Path(__file__).resolve().parent.parent.parent / "templates"
-    job_names_in_wf = {job.name for job in workflow.jobs}
     scripts: dict[str, str] = {}
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -792,18 +780,11 @@ def _render_scripts(
                 else:
                     template_path = templates_dir / "base.slurm.jinja"
 
-                dep_names = [
-                    dep.job_name
-                    for dep in job.parsed_dependencies
-                    if dep.job_name in job_names_in_wf
-                ]
                 extras = job_extra_args.get(job.name, {})
                 rendered_path = render_job_script(
                     template_path,
                     job,
                     output_dir=tmpdir,
-                    outputs_dir=wf_outputs_dir,
-                    dependency_names=dep_names if wf_outputs_dir else None,
                     extra_srun_args=extras.get("srun_args"),
                     extra_launch_prefix=extras.get("launch_prefix"),
                 )
@@ -1075,7 +1056,7 @@ async def run_workflow(
         raise
 
     # Phase 2: Prepare render context and render scripts
-    job_template_map, job_extra_args, wf_outputs_dir = await anyio.to_thread.run_sync(
+    job_template_map, job_extra_args = await anyio.to_thread.run_sync(
         lambda: _prepare_render_context(yaml_path, workflow, name)
     )
 
@@ -1087,7 +1068,6 @@ async def run_workflow(
                 profile,
                 job_template_map,
                 job_extra_args,
-                wf_outputs_dir,
             )
         )
     except Exception as exc:

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -19,7 +19,7 @@ from typing import Any
 import anyio
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from srunx.db.connection import transaction
 from srunx.db.models import WorkflowRun as DBWorkflowRun
@@ -75,6 +75,18 @@ class WorkflowJobInput(BaseModel):
     retry_delay: int | None = None
     srun_args: str | None = None
     launch_prefix: str | None = None
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_outputs(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "outputs" in data:
+            raise ValueError(
+                "The 'outputs' field was renamed to 'exports' (see CHANGELOG). "
+                "Dependent jobs now reference values as '{{ deps.<job_name>.<key> }}'."
+            )
+        return data
 
 
 class WorkflowCreateRequest(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -682,119 +682,41 @@ class TestRenderJobScript:
         captured = capsys.readouterr()
         assert "Test template: test_job" in captured.out
 
-    def test_render_base_template_with_outputs(self, temp_dir):
-        """Test that outputs_dir and job_outputs render correctly."""
-        template_path = (
-            Path(__file__).resolve().parent.parent
-            / "src"
-            / "srunx"
-            / "templates"
-            / "base.slurm.jinja"
-        )
-        job = Job(
-            name="train",
-            command=["python", "train.py"],
-            outputs={"model_path": "/data/models/best.pt", "accuracy": "0.95"},
-            log_dir="",
-            work_dir="",
-        )
-        script_path = render_job_script(
-            template_path,
-            job,
-            temp_dir,
-            outputs_dir="/tmp/srunx/test_run",
-        )
-        content = Path(script_path).read_text()
-        assert 'SRUNX_OUTPUTS_DIR="/tmp/srunx/test_run"' in content
-        assert 'SRUNX_OUTPUTS="${SRUNX_OUTPUTS_DIR}/train.env"' in content
-        assert "mkdir -p" in content
-        assert "chmod 700" in content
-        assert "model_path" in content
-        assert "/data/models/best.pt" in content
-        assert "accuracy" in content
 
-    def test_render_base_template_with_dependency_sourcing(self, temp_dir):
-        """Test that dependency output files are sourced."""
-        template_path = (
-            Path(__file__).resolve().parent.parent
-            / "src"
-            / "srunx"
-            / "templates"
-            / "base.slurm.jinja"
-        )
-        job = Job(
-            name="evaluate",
-            command=["python", "eval.py"],
-            depends_on=["train"],
-            log_dir="",
-            work_dir="",
-        )
-        script_path = render_job_script(
-            template_path,
-            job,
-            temp_dir,
-            outputs_dir="/tmp/srunx/test_run",
-            dependency_names=["train"],
-        )
-        content = Path(script_path).read_text()
-        assert "${SRUNX_OUTPUTS_DIR}/train.env" in content
-        assert "source" in content
-        assert "set -a" in content
+class TestExportsValidation:
+    """Test exports field validation on BaseJob."""
 
-    def test_render_base_template_without_outputs(self, temp_dir):
-        """When outputs_dir is None, no outputs block is rendered."""
-        template_path = (
-            Path(__file__).resolve().parent.parent
-            / "src"
-            / "srunx"
-            / "templates"
-            / "base.slurm.jinja"
-        )
-        job = Job(
-            name="simple",
-            command=["echo", "hello"],
-            log_dir="",
-            work_dir="",
-        )
-        script_path = render_job_script(template_path, job, temp_dir)
-        content = Path(script_path).read_text()
-        assert "SRUNX_OUTPUTS" not in content
-
-
-class TestOutputsValidation:
-    """Test outputs field validation on BaseJob."""
-
-    def test_valid_output_keys(self):
+    def test_valid_export_keys(self):
         """Valid shell identifiers should pass."""
         job = BaseJob(
             name="test",
-            outputs={
+            exports={
                 "model_path": "/data/model.pt",
                 "BATCH_SIZE": "32",
                 "_private": "x",
             },
         )
-        assert len(job.outputs) == 3
+        assert len(job.exports) == 3
 
-    def test_invalid_output_key_with_spaces(self):
+    def test_invalid_export_key_with_spaces(self):
         """Keys with spaces should fail."""
-        with pytest.raises(ValidationError, match="Invalid output variable name"):
-            BaseJob(name="test", outputs={"bad key": "value"})
+        with pytest.raises(ValidationError, match="Invalid export name"):
+            BaseJob(name="test", exports={"bad key": "value"})
 
-    def test_invalid_output_key_with_semicolon(self):
+    def test_invalid_export_key_with_semicolon(self):
         """Keys with shell metacharacters should fail."""
-        with pytest.raises(ValidationError, match="Invalid output variable name"):
-            BaseJob(name="test", outputs={"foo;rm -rf /": "value"})
+        with pytest.raises(ValidationError, match="Invalid export name"):
+            BaseJob(name="test", exports={"foo;rm -rf /": "value"})
 
-    def test_invalid_output_key_starts_with_number(self):
+    def test_invalid_export_key_starts_with_number(self):
         """Keys starting with a number should fail."""
-        with pytest.raises(ValidationError, match="Invalid output variable name"):
-            BaseJob(name="test", outputs={"1var": "value"})
+        with pytest.raises(ValidationError, match="Invalid export name"):
+            BaseJob(name="test", exports={"1var": "value"})
 
-    def test_empty_outputs(self):
-        """Empty outputs dict should be fine."""
-        job = BaseJob(name="test", outputs={})
-        assert job.outputs == {}
+    def test_empty_exports(self):
+        """Empty exports dict should be fine."""
+        job = BaseJob(name="test", exports={})
+        assert job.exports == {}
 
 
 class TestRenderJobScriptExtraArgs:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -320,8 +320,8 @@ class TestWorkflowRunner:
         job = runner.workflow.jobs[0]
         assert job.command == ["echo", "hello"]
 
-    def test_from_yaml_invalid_template(self, temp_dir):
-        """Test that workflow loads successfully with DebugUndefined handling."""
+    def test_from_yaml_undefined_var_raises(self, temp_dir):
+        """Unresolved Jinja refs fail at load time (StrictUndefined)."""
         yaml_content = {
             "name": "invalid_template_workflow",
             "args": {"valid_var": "value"},
@@ -338,13 +338,11 @@ class TestWorkflowRunner:
         with open(yaml_path, "w") as f:
             yaml.dump(yaml_content, f)
 
-        # Should now load successfully with DebugUndefined handling
-        runner = WorkflowRunner.from_yaml(yaml_path)
-        assert runner.workflow.name == "invalid_template_workflow"
-        assert len(runner.workflow.jobs) == 1
+        with pytest.raises(WorkflowValidationError):
+            WorkflowRunner.from_yaml(yaml_path)
 
-    def test_render_jobs_with_args_static_method(self):
-        """Test _render_jobs_with_args static method."""
+    def test_render_jobs_with_args_and_deps_static_method(self):
+        """_render_jobs_with_args_and_deps resolves args in per-job render."""
         args = {
             "dataset": "mnist",
             "epochs": 10,
@@ -366,7 +364,7 @@ class TestWorkflowRunner:
             }
         ]
 
-        rendered_jobs = WorkflowRunner._render_jobs_with_args(jobs_data, args)
+        rendered_jobs = WorkflowRunner._render_jobs_with_args_and_deps(jobs_data, args)
 
         assert len(rendered_jobs) == 1
         job = rendered_jobs[0]
@@ -380,8 +378,8 @@ class TestWorkflowRunner:
         ]
         assert job["work_dir"] == "/results"
 
-    def test_render_jobs_with_args_no_args(self):
-        """Test _render_jobs_with_args with no args."""
+    def test_render_jobs_with_args_and_deps_no_args(self):
+        """Empty args still round-trips jobs through the render pipeline."""
         jobs_data = [
             {
                 "name": "simple_job",
@@ -389,22 +387,11 @@ class TestWorkflowRunner:
             }
         ]
 
-        rendered_jobs = WorkflowRunner._render_jobs_with_args(jobs_data, {})
+        rendered_jobs = WorkflowRunner._render_jobs_with_args_and_deps(jobs_data, {})
 
-        assert rendered_jobs == jobs_data
-
-    def test_render_jobs_with_args_empty_args(self):
-        """Test _render_jobs_with_args with empty args dict."""
-        jobs_data = [
-            {
-                "name": "simple_job",
-                "command": ["echo", "hello"],
-            }
-        ]
-
-        rendered_jobs = WorkflowRunner._render_jobs_with_args(jobs_data, {})
-
-        assert rendered_jobs == jobs_data
+        assert len(rendered_jobs) == 1
+        assert rendered_jobs[0]["name"] == "simple_job"
+        assert rendered_jobs[0]["command"] == ["echo", "hello"]
 
     @patch("srunx.runner.Slurm")
     def test_run_simple_workflow(self, mock_slurm_class):
@@ -438,8 +425,6 @@ class TestWorkflowRunner:
         mock_slurm.run.assert_called_once()
         call_kwargs = mock_slurm.run.call_args.kwargs
         assert call_kwargs["workflow_name"] == "test"
-        assert call_kwargs["outputs_dir"] is None
-        assert call_kwargs["dependency_names"] is None
         assert isinstance(call_kwargs["workflow_run_id"], int)
 
     @patch("srunx.runner.Slurm")
@@ -1254,23 +1239,23 @@ class TestEnhancedDependencies:
         assert not job.dependencies_satisfied({}, completed_job_names=completed_jobs)
 
 
-class TestWorkflowOutputs:
-    """Tests for workflow outputs feature."""
+class TestWorkflowExports:
+    """Tests for workflow exports feature (load-time deps resolution)."""
 
     @pytest.fixture
     def temp_dir(self, tmp_path):
         return tmp_path
 
-    def test_from_yaml_with_outputs(self, temp_dir):
-        """Test loading workflow YAML with outputs declared on jobs."""
+    def test_from_yaml_with_exports(self, temp_dir):
+        """Test loading workflow YAML with exports declared on jobs."""
         yaml_content = {
-            "name": "outputs_workflow",
+            "name": "exports_workflow",
             "args": {"base_dir": "/data/experiments"},
             "jobs": [
                 {
                     "name": "train",
                     "command": ["python", "train.py"],
-                    "outputs": {
+                    "exports": {
                         "model_path": "{{ base_dir }}/models/best.pt",
                         "metrics_dir": "{{ base_dir }}/metrics",
                     },
@@ -1285,126 +1270,141 @@ class TestWorkflowOutputs:
             ],
         }
 
-        yaml_path = temp_dir / "outputs_workflow.yaml"
+        yaml_path = temp_dir / "exports_workflow.yaml"
         with open(yaml_path, "w") as f:
             yaml.dump(yaml_content, f)
 
         runner = WorkflowRunner.from_yaml(yaml_path)
 
         train_job = next(j for j in runner.workflow.jobs if j.name == "train")
-        assert train_job.outputs == {
+        assert train_job.exports == {
             "model_path": "/data/experiments/models/best.pt",
             "metrics_dir": "/data/experiments/metrics",
         }
 
-    def test_parse_job_with_outputs(self):
-        """Test parse_job correctly passes outputs."""
+    def test_parse_job_with_exports(self):
+        """Test parse_job correctly passes exports."""
         data = {
             "name": "train",
             "command": ["python", "train.py"],
-            "outputs": {"model_path": "/data/model.pt"},
+            "exports": {"model_path": "/data/model.pt"},
         }
         job = WorkflowRunner.parse_job(data)
-        assert job.outputs == {"model_path": "/data/model.pt"}
+        assert job.exports == {"model_path": "/data/model.pt"}
 
-    def test_parse_job_without_outputs(self):
-        """Test parse_job defaults to empty outputs."""
+    def test_parse_job_without_exports(self):
+        """Test parse_job defaults to empty exports."""
         data = {
             "name": "train",
             "command": ["python", "train.py"],
         }
         job = WorkflowRunner.parse_job(data)
-        assert job.outputs == {}
+        assert job.exports == {}
 
-    @patch("srunx.runner.Slurm")
-    def test_run_generates_outputs_dir_when_outputs_present(self, mock_slurm_class):
-        """When jobs have outputs, outputs_dir should be generated and passed."""
-        mock_slurm = Mock()
-        mock_slurm_class.return_value = mock_slurm
+    def test_deps_reference_resolved_at_load_time(self, temp_dir):
+        """deps.<name>.<key> is resolved to literal string at from_yaml."""
+        yaml_content = {
+            "name": "wf",
+            "args": {"base": "/data"},
+            "jobs": [
+                {
+                    "name": "preprocess",
+                    "command": ["echo", "pre"],
+                    "exports": {"data_path": "{{ base }}/processed"},
+                },
+                {
+                    "name": "train",
+                    "command": [
+                        "python",
+                        "train.py",
+                        "--data",
+                        "{{ deps.preprocess.data_path }}",
+                    ],
+                    "depends_on": ["preprocess"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
 
-        job = Job(
-            name="train",
-            command=["python", "train.py"],
-            outputs={"model": "/path/to/model"},
-            environment=JobEnvironment(conda="env"),
-        )
-        job.status = JobStatus.COMPLETED
-        mock_slurm.run.return_value = job
+        runner = WorkflowRunner.from_yaml(yaml_path)
+        train = next(j for j in runner.workflow.jobs if j.name == "train")
+        assert train.command == [
+            "python",
+            "train.py",
+            "--data",
+            "/data/processed",
+        ]
 
-        workflow = Workflow(name="test", jobs=[job])
-        runner = WorkflowRunner(workflow)
-        runner.run()
+    def test_deps_missing_key_raises(self, temp_dir):
+        """Reference to non-existent deps.X.Y fails at load time (StrictUndefined)."""
+        yaml_content = {
+            "name": "wf",
+            "jobs": [
+                {"name": "a", "command": ["echo", "a"], "exports": {"good": "x"}},
+                {
+                    "name": "b",
+                    "command": ["echo", "{{ deps.a.bad }}"],
+                    "depends_on": ["a"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        with pytest.raises(WorkflowValidationError):
+            WorkflowRunner.from_yaml(yaml_path)
 
-        call_kwargs = mock_slurm.run.call_args[1]
-        assert call_kwargs["outputs_dir"] is not None
-        assert call_kwargs["outputs_dir"].startswith("/tmp/srunx/test_")
+    def test_deps_undeclared_dep_raises(self, temp_dir):
+        """Referencing a job not in depends_on fails at load time."""
+        yaml_content = {
+            "name": "wf",
+            "jobs": [
+                {"name": "a", "command": ["echo", "a"], "exports": {"x": "1"}},
+                {
+                    "name": "b",
+                    "command": ["echo", "{{ deps.a.x }}"],
+                    # Note: depends_on NOT declared
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        with pytest.raises(WorkflowValidationError):
+            WorkflowRunner.from_yaml(yaml_path)
 
-    @patch("srunx.runner.Slurm")
-    def test_run_generates_outputs_dir_when_dependencies_present(
-        self, mock_slurm_class
-    ):
-        """When jobs have dependencies, outputs_dir should be generated."""
-        mock_slurm = Mock()
-        mock_slurm_class.return_value = mock_slurm
-
-        job1 = Job(
-            name="job1",
-            command=["echo", "1"],
-            environment=JobEnvironment(conda="env"),
-        )
-        job2 = Job(
-            name="job2",
-            command=["echo", "2"],
-            depends_on=["job1"],
-            environment=JobEnvironment(conda="env"),
-        )
-        job1._status = JobStatus.PENDING
-        job2._status = JobStatus.PENDING
-
-        def mock_run(job, **kwargs):
-            job.status = JobStatus.COMPLETED
-            return job
-
-        mock_slurm.run.side_effect = mock_run
-
-        workflow = Workflow(name="dep_test", jobs=[job1, job2])
-        runner = WorkflowRunner(workflow)
-        runner.run()
-
-        # Both calls should receive the same outputs_dir
-        calls = mock_slurm.run.call_args_list
-        assert len(calls) == 2
-        dir1 = calls[0][1]["outputs_dir"]
-        dir2 = calls[1][1]["outputs_dir"]
-        assert dir1 is not None
-        assert dir1 == dir2
-        assert dir1.startswith("/tmp/srunx/dep_test_")
-
-        # job2 should have dependency_names=["job1"]
-        dep_names = calls[1][1]["dependency_names"]
-        assert dep_names == ["job1"]
-
-    @patch("srunx.runner.Slurm")
-    def test_run_no_outputs_dir_when_no_outputs_or_deps(self, mock_slurm_class):
-        """When no outputs or dependencies, outputs_dir should be None."""
-        mock_slurm = Mock()
-        mock_slurm_class.return_value = mock_slurm
-
-        job = Job(
-            name="simple",
-            command=["echo", "hello"],
-            environment=JobEnvironment(conda="env"),
-        )
-        job.status = JobStatus.COMPLETED
-        mock_slurm.run.return_value = job
-
-        workflow = Workflow(name="simple", jobs=[job])
-        runner = WorkflowRunner(workflow)
-        runner.run()
-
-        call_kwargs = mock_slurm.run.call_args[1]
-        assert call_kwargs["outputs_dir"] is None
-        assert call_kwargs["dependency_names"] is None
+    def test_transitive_deps_composition(self, temp_dir):
+        """Exports can reference earlier deps' exports at load time."""
+        yaml_content = {
+            "name": "wf",
+            "args": {"base": "/exp"},
+            "jobs": [
+                {
+                    "name": "a",
+                    "command": ["echo", "a"],
+                    "exports": {"dir": "{{ base }}/a"},
+                },
+                {
+                    "name": "b",
+                    "command": ["echo", "b"],
+                    "depends_on": ["a"],
+                    "exports": {"dir": "{{ deps.a.dir }}/b"},
+                },
+                {
+                    "name": "c",
+                    "command": ["echo", "{{ deps.b.dir }}"],
+                    "depends_on": ["b"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path)
+        c = next(j for j in runner.workflow.jobs if j.name == "c")
+        assert c.command == ["echo", "/exp/a/b"]
 
 
 class TestSafeEvalExec:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1538,6 +1538,110 @@ class TestWorkflowExports:
             "/shared/prep_result",
         ]
 
+    def test_exports_key_shadowing_dict_method(self, temp_dir):
+        """Export keys colliding with dict methods (items/get/keys/...) must
+        still resolve to the user's value, not the method reference."""
+        yaml_content = {
+            "name": "wf",
+            "jobs": [
+                {
+                    "name": "a",
+                    "command": ["echo", "a"],
+                    "exports": {
+                        "items": "ITEMS_VALUE",
+                        "keys": "KEYS_VALUE",
+                        "get": "GET_VALUE",
+                    },
+                },
+                {
+                    "name": "b",
+                    "command": [
+                        "echo",
+                        "{{ deps.a.items }}",
+                        "{{ deps.a.keys }}",
+                        "{{ deps.a.get }}",
+                    ],
+                    "depends_on": ["a"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path)
+        b = next(j for j in runner.workflow.jobs if j.name == "b")
+        assert b.command == [
+            "echo",
+            "ITEMS_VALUE",
+            "KEYS_VALUE",
+            "GET_VALUE",
+        ]
+
+    def test_legacy_outputs_key_rejected(self, temp_dir):
+        """Legacy 'outputs:' key must fail fast with a migration message,
+        not silently drop the values."""
+        yaml_content = {
+            "name": "wf",
+            "jobs": [
+                {"name": "a", "command": ["echo", "a"], "outputs": {"x": "1"}},
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        with pytest.raises(WorkflowValidationError, match="'outputs'"):
+            WorkflowRunner.from_yaml(yaml_path)
+
+    def test_single_job_ignores_unrelated_broken_jinja(self, temp_dir):
+        """A broken Jinja reference in a sibling job should not prevent
+        single_job rendering of the target."""
+        yaml_content = {
+            "name": "wf",
+            "jobs": [
+                {"name": "target", "command": ["echo", "target"]},
+                {
+                    "name": "broken",
+                    "command": ["echo", "{{ undefined_var }}"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path, single_job="target")
+        assert [j.name for j in runner.workflow.jobs] == ["target"]
+
+    def test_single_job_still_requires_its_own_deps(self, temp_dir):
+        """single_job=target must still render target's transitive
+        dependency chain so {{ deps.X.Y }} in target resolves."""
+        yaml_content = {
+            "name": "wf",
+            "args": {"base": "/d"},
+            "jobs": [
+                {
+                    "name": "prep",
+                    "command": ["echo", "prep"],
+                    "exports": {"p": "{{ base }}/out"},
+                },
+                {
+                    "name": "train",
+                    "command": ["python", "t.py", "--in", "{{ deps.prep.p }}"],
+                    "depends_on": ["prep"],
+                },
+                {
+                    "name": "sibling",
+                    "command": ["echo", "{{ undefined_var }}"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path, single_job="train")
+        train = runner.workflow.jobs[0]
+        assert train.name == "train"
+        assert train.command == ["python", "t.py", "--in", "/d/out"]
+
 
 class TestSafeEvalExec:
     """Test that the eval/exec sandbox blocks dangerous operations."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1406,6 +1406,138 @@ class TestWorkflowExports:
         c = next(j for j in runner.workflow.jobs if j.name == "c")
         assert c.command == ["echo", "/exp/a/b"]
 
+    def test_cycle_detection_raises(self, temp_dir):
+        """Circular job dependencies fail at from_yaml (CycleError)."""
+        yaml_content = {
+            "name": "cyc",
+            "jobs": [
+                {"name": "a", "command": ["echo", "a"], "depends_on": ["b"]},
+                {"name": "b", "command": ["echo", "b"], "depends_on": ["a"]},
+            ],
+        }
+        yaml_path = temp_dir / "cyc.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        with pytest.raises(WorkflowValidationError, match="[Cc]ircular"):
+            WorkflowRunner.from_yaml(yaml_path)
+
+    def test_python_arg_feeds_exports_feeds_deps(self, temp_dir):
+        """python: args → exports → deps.X.Y chain resolves at load time."""
+        yaml_content = {
+            "name": "wf",
+            "args": {
+                "stamp": "python: 'run_2026'",
+                "base": "{{ stamp }}_/data",
+            },
+            "jobs": [
+                {
+                    "name": "prep",
+                    "command": ["echo", "prep"],
+                    "exports": {"out": "{{ base }}/prep"},
+                },
+                {
+                    "name": "train",
+                    "command": ["python", "t.py", "--in", "{{ deps.prep.out }}"],
+                    "depends_on": ["prep"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path)
+        train = next(j for j in runner.workflow.jobs if j.name == "train")
+        assert train.command == ["python", "t.py", "--in", "run_2026_/data/prep"]
+
+    def test_deps_reference_in_work_dir_and_log_dir(self, temp_dir):
+        """deps.X.Y resolves when placed in non-command fields."""
+        yaml_content = {
+            "name": "wf",
+            "jobs": [
+                {
+                    "name": "a",
+                    "command": ["echo", "a"],
+                    "exports": {"root": "/shared/job_a"},
+                },
+                {
+                    "name": "b",
+                    "command": ["echo", "b"],
+                    "depends_on": ["a"],
+                    "work_dir": "{{ deps.a.root }}/work",
+                    "log_dir": "{{ deps.a.root }}/logs",
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path)
+        b = next(j for j in runner.workflow.jobs if j.name == "b")
+        assert b.work_dir == "/shared/job_a/work"
+        assert b.log_dir == "/shared/job_a/logs"
+
+    def test_single_job_filter_preserves_deps_resolution(self, temp_dir):
+        """single_job='train' still resolves {{ deps.prep.* }} via full DAG render."""
+        yaml_content = {
+            "name": "wf",
+            "args": {"base": "/data"},
+            "jobs": [
+                {
+                    "name": "prep",
+                    "command": ["echo", "prep"],
+                    "exports": {"p": "{{ base }}/prep"},
+                },
+                {
+                    "name": "train",
+                    "command": ["python", "t.py", "--in", "{{ deps.prep.p }}"],
+                    "depends_on": ["prep"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path, single_job="train")
+        assert len(runner.workflow.jobs) == 1
+        assert runner.workflow.jobs[0].name == "train"
+        assert runner.workflow.jobs[0].command == [
+            "python",
+            "t.py",
+            "--in",
+            "/data/prep",
+        ]
+
+    def test_shell_job_with_exports_resolves_for_dependents(self, temp_dir):
+        """ShellJob.exports is consumable by downstream jobs at load time."""
+        script_path = temp_dir / "prep.slurm.jinja"
+        script_path.write_text("#!/bin/bash\necho prep\n")
+        yaml_content = {
+            "name": "wf",
+            "jobs": [
+                {
+                    "name": "prep",
+                    "script_path": str(script_path),
+                    "exports": {"out": "/shared/prep_result"},
+                },
+                {
+                    "name": "train",
+                    "command": ["python", "t.py", "--in", "{{ deps.prep.out }}"],
+                    "depends_on": ["prep"],
+                },
+            ],
+        }
+        yaml_path = temp_dir / "wf.yaml"
+        with open(yaml_path, "w") as f:
+            yaml.dump(yaml_content, f)
+        runner = WorkflowRunner.from_yaml(yaml_path)
+        train = next(j for j in runner.workflow.jobs if j.name == "train")
+        assert train.command == [
+            "python",
+            "t.py",
+            "--in",
+            "/shared/prep_result",
+        ]
+
 
 class TestSafeEvalExec:
     """Test that the eval/exec sandbox blocks dangerous operations."""

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -1061,6 +1061,26 @@ class TestWorkflowsRouter:
         resp = client.post("/api/workflows/create", json=payload)
         assert resp.status_code == 422
 
+    def test_create_workflow_rejects_legacy_outputs_key(
+        self, client: TestClient
+    ) -> None:
+        """Legacy 'outputs:' in the request body must 422, not silently drop."""
+        payload = {
+            "name": "legacy-outputs",
+            "default_project": MOUNT,
+            "jobs": [
+                {
+                    "name": "train",
+                    "command": ["echo"],
+                    "outputs": {"model_path": "/x"},
+                },
+            ],
+        }
+        resp = client.post("/api/workflows/create", json=payload)
+        assert resp.status_code == 422
+        body = resp.json()
+        assert "outputs" in str(body).lower() and "exports" in str(body).lower()
+
 
 # ── Config SSH Connect / Test / Status ───────────────
 

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -1007,16 +1007,16 @@ class TestWorkflowsRouter:
         data = resp.json()
         assert data["args"] == {"base_dir": "/data/exp", "lr": "0.001"}
 
-    def test_create_workflow_with_outputs(self, client: TestClient) -> None:
-        """Jobs with outputs should be persisted and returned."""
+    def test_create_workflow_with_exports(self, client: TestClient) -> None:
+        """Jobs with exports should be persisted and returned."""
         payload = {
-            "name": "outputs-test",
+            "name": "exports-test",
             "default_project": MOUNT,
             "jobs": [
                 {
                     "name": "train",
                     "command": ["python", "train.py"],
-                    "outputs": {"model_path": "/data/model.pt"},
+                    "exports": {"model_path": "/data/model.pt"},
                 },
                 {
                     "name": "eval",
@@ -1030,8 +1030,8 @@ class TestWorkflowsRouter:
         data = resp.json()
         train_job = next(j for j in data["jobs"] if j["name"] == "train")
         eval_job = next(j for j in data["jobs"] if j["name"] == "eval")
-        assert train_job["outputs"] == {"model_path": "/data/model.pt"}
-        assert eval_job["outputs"] == {}
+        assert train_job["exports"] == {"model_path": "/data/model.pt"}
+        assert eval_job["exports"] == {}
 
     def test_create_workflow_rejects_python_args(self, client: TestClient) -> None:
         """Args containing 'python:' should be rejected from web."""
@@ -1045,78 +1045,21 @@ class TestWorkflowsRouter:
         assert resp.status_code == 422
         assert "python:" in resp.json()["detail"]
 
-    def test_create_workflow_invalid_output_key(self, client: TestClient) -> None:
-        """Output keys with invalid shell identifiers should be rejected."""
+    def test_create_workflow_invalid_export_key(self, client: TestClient) -> None:
+        """Export keys with invalid shell identifiers should be rejected."""
         payload = {
-            "name": "bad-outputs",
+            "name": "bad-exports",
             "default_project": MOUNT,
             "jobs": [
                 {
                     "name": "train",
                     "command": ["echo"],
-                    "outputs": {"bad key": "value"},
+                    "exports": {"bad key": "value"},
                 },
             ],
         }
         resp = client.post("/api/workflows/create", json=payload)
         assert resp.status_code == 422
-
-    def test_run_workflow_with_outputs_includes_outputs_in_script(
-        self, client: TestClient, mock_adapter: MagicMock
-    ) -> None:
-        """Running a workflow with outputs should include SRUNX_OUTPUTS_DIR in scripts."""
-        # Create workflow with outputs
-        create_payload = {
-            "name": "outputs-run",
-            "default_project": MOUNT,
-            "jobs": [
-                {
-                    "name": "train",
-                    "command": ["python", "train.py"],
-                    "outputs": {"model_path": "/data/model.pt"},
-                },
-                {
-                    "name": "eval",
-                    "command": ["python", "eval.py"],
-                    "depends_on": ["train"],
-                },
-            ],
-        }
-        resp = client.post("/api/workflows/create", json=create_payload)
-        assert resp.status_code == 200
-
-        call_count = 0
-
-        def mock_submit(script_content, job_name=None, dependency=None):
-            nonlocal call_count
-            call_count += 1
-            return {
-                "name": job_name or "job",
-                "job_id": 20000 + call_count,
-                "status": "PENDING",
-                "depends_on": [],
-                "command": [],
-                "resources": {},
-            }
-
-        mock_adapter.submit_job.side_effect = mock_submit
-
-        resp = client.post("/api/workflows/outputs-run/run", params={"mount": MOUNT})
-        assert resp.status_code == 202
-
-        # Check that submitted scripts contain SRUNX_OUTPUTS_DIR
-        calls = mock_adapter.submit_job.call_args_list
-        train_script = (
-            calls[0][0][0] if calls[0][0] else calls[0].kwargs.get("script_content", "")
-        )
-        assert "SRUNX_OUTPUTS_DIR" in train_script
-        assert "model_path" in train_script
-
-        eval_script = (
-            calls[1][0][0] if calls[1][0] else calls[1].kwargs.get("script_content", "")
-        )
-        assert "SRUNX_OUTPUTS_DIR" in eval_script
-        assert "train.env" in eval_script  # Should source train's outputs
 
 
 # ── Config SSH Connect / Test / Status ───────────────


### PR DESCRIPTION
## Summary

`outputs` → `exports` へ改名し、ジョブ間値受け渡しを **workflow load 時の Jinja 解決** に縮退。runtime env ファイル機構（`SRUNX_OUTPUTS_DIR` / `$SRUNX_OUTPUTS` / `source dep.env`）を全廃。

参照構文: `$data_path` → `{{ deps.preprocess.data_path }}`

Closes #120

## Why

`exports` の値は load 時に確定する（`args` + `python:` で導出される path 文字列）。runtime で env ファイルを経由する従来方式は以下のリスクをもたらしていた:

- 動的 `echo "key=value" >> $SRUNX_OUTPUTS` の書き込みが escape 無しで、依存 job が `source` 評価 → injection 経路
- NFS での multi-task append に atomicity 保証なし（ファイル破損）
- consumer 側に静的依存宣言がなく、key の typo / rename は runtime でしか発覚しない
- `ShellJob.outputs` は silent no-op（`render_shell_job_script` が引数を受け取らない）
- `outputs_dir` 生成ロジックが `runner.py` と `web/routers/workflows.py` で duplicate、条件分岐も食い違い
- 共有 FS への暗黙依存

Load-time literal substitution に変えたことでこれらは構造的に消える。

## Key changes

### Breaking

- `BaseJob.outputs` / YAML `outputs:` → `exports:`
- Dependent jobs reference via `{{ deps.<name>.<key> }}` (not `$key` env var)
- `outputs_dir`, `dependency_names`, `job_outputs` kwargs を `render_job_script` / `Slurm.submit` / `Slurm.run` から削除
- `SRUNX_OUTPUTS_DIR` / `SRUNX_OUTPUTS` 環境変数と動的 `echo ... >> $SRUNX_OUTPUTS` は未サポートに
- `base.slurm.jinja` の outputs ブロック削除
- Frontend: `BuilderJob.exports`, UI label \"Exports\", hint text 更新

### New

- `WorkflowRunner._render_jobs_with_args_and_deps`: depends_on を topological sort し、各 job を順に Jinja render。`deps` context に先行 job の exports を露出
- StrictUndefined により `deps.X.Y` の typo / 未宣言依存参照が load 時にエラー（static validator の役割を兼ねる）
- `single_job` filter は full DAG render 後に移動 — deps 参照が解決される

## Migration

### Before
\`\`\`yaml
jobs:
  - name: preprocess
    outputs:
      data_path: \"{{ base_dir }}/data\"
  - name: train
    depends_on: [preprocess]
    command: [python, train.py, --data, \"\$data_path\"]
\`\`\`

### After
\`\`\`yaml
jobs:
  - name: preprocess
    exports:
      data_path: \"{{ base_dir }}/data\"
  - name: train
    depends_on: [preprocess]
    command: [python, train.py, --data, \"{{ deps.preprocess.data_path }}\"]
\`\`\`

Dynamic `echo \"k=v\" >> \$SRUNX_OUTPUTS` を使っていた場合、runtime 決定値は**サポート外**に。共有 FS 上のファイル出力（`--out-file /shared/path.json` など）で自前対応してください。

CHANGELOG.md にも migration guide を追記。

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/e2e` — 1506 passed
- [x] `uv run mypy .` — clean
- [x] `uv run ruff check .` — clean
- [x] `npx tsc --noEmit` (frontend) — clean
- [x] pre-commit hooks (ruff, mypy, tsc, web pytest) — all passed
- [ ] 実 SLURM cluster で workflow の exports → deps 解決を end-to-end 確認
- [ ] Web UI で exports + deps.X.Y の workflow を dry-run submit し、scripts に literal 値が埋まることを目視

## Related

- #119 (#117 #118 fix) で追加した `outputs_dir=None` inline patch はこの PR で source 諸共削除
- `ShellJob.outputs` silent no-op は副次的に解消（`exports` は metadata として Job/ShellJob 統一）

🤖 Generated with [Claude Code](https://claude.com/claude-code)