### PR TITLE
fix(ssh): honor ~/.ssh/config alias in CLI + surface test_connection root cause

### DIFF
--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -9,7 +9,7 @@ replacing the mixed argparse/typer architecture.
 import os
 import time
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console, RenderableType
@@ -997,6 +997,42 @@ def mount_remove(
     remove_mount_impl(profile_name, name, config)
 
 
+def _resolve_direct_profile(profile_obj: Any, ssh_config: str | None) -> dict[str, Any]:
+    """Build connection params from a "direct" profile, honoring ~/.ssh/config.
+
+    Profiles created with a bare hostname like "pyxis" may rely on an
+    ssh_config(5) alias that sets HostName / IdentityFile / Port / ProxyJump.
+    paramiko does not consult ssh_config on its own, so look the alias up
+    explicitly and merge whatever the profile itself did not set.
+    """
+    hostname = profile_obj.hostname
+    key_filename = profile_obj.key_filename
+    port = profile_obj.port
+    proxy_jump = profile_obj.proxy_jump
+
+    ssh_host = get_ssh_config_host(profile_obj.hostname, ssh_config)
+    if ssh_host and ssh_host.hostname:
+        hostname = ssh_host.hostname
+        if ssh_host.identity_file and not key_filename:
+            key_filename = ssh_host.identity_file
+        if ssh_host.port and port == 22:
+            port = ssh_host.port
+        if ssh_host.proxy_jump and not proxy_jump:
+            proxy_jump = ssh_host.proxy_jump
+
+    # Tilde expansion — paramiko treats ~ as a literal filename character.
+    if isinstance(key_filename, str):
+        key_filename = os.path.expanduser(key_filename)
+
+    return {
+        "hostname": hostname,
+        "username": profile_obj.username,
+        "key_filename": key_filename,
+        "port": port,
+        "proxy_jump": proxy_jump,
+    }
+
+
 def _determine_connection_params(
     host: str | None,
     profile: str | None,
@@ -1051,14 +1087,11 @@ def _determine_connection_params(
             }
             display_host = f"{profile} ({profile_obj.ssh_host})"
         else:
-            # Profile uses direct connection
-            connection_params = {
-                "hostname": profile_obj.hostname,
-                "username": profile_obj.username,
-                "key_filename": profile_obj.key_filename,
-                "port": profile_obj.port,
-                "proxy_jump": profile_obj.proxy_jump,
-            }
+            # Profile uses direct connection. If hostname happens to be an
+            # ssh_config alias, resolve HostName/IdentityFile/Port/ProxyJump
+            # from ~/.ssh/config so the user doesn't need to duplicate fields
+            # already declared there.
+            connection_params = _resolve_direct_profile(profile_obj, ssh_config)
             display_host = profile
 
     elif all([hostname, username, key_file]):
@@ -1097,14 +1130,7 @@ def _determine_connection_params(
                 }
                 display_host = f"current ({profile_obj.ssh_host})"
             else:
-                # Profile uses direct connection
-                connection_params = {
-                    "hostname": profile_obj.hostname,
-                    "username": profile_obj.username,
-                    "key_filename": profile_obj.key_filename,
-                    "port": profile_obj.port,
-                    "proxy_jump": profile_obj.proxy_jump,
-                }
+                connection_params = _resolve_direct_profile(profile_obj, ssh_config)
                 display_host = "current"
         else:
             console.print("[red]Error: No connection method specified[/red]")

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -215,7 +215,11 @@ class SSHSlurmClient:
 
         try:
             if not self.connect():
-                result["error"] = "Failed to establish SSH connection"
+                cause = self._last_error
+                reason = (
+                    f"{type(cause).__name__}: {cause}" if cause else "unknown error"
+                )
+                result["error"] = f"Failed to establish SSH connection: {reason}"
                 return result
 
             result["ssh_connected"] = True

--- a/src/srunx/ssh/core/connection.py
+++ b/src/srunx/ssh/core/connection.py
@@ -168,7 +168,11 @@ class SSHConnection:
 
         try:
             if not self.connect():
-                result["error"] = "Failed to establish SSH connection"
+                cause = self._last_error
+                reason = (
+                    f"{type(cause).__name__}: {cause}" if cause else "unknown error"
+                )
+                result["error"] = f"Failed to establish SSH connection: {reason}"
                 return result
 
             result["ssh_connected"] = True


### PR DESCRIPTION
## Summary

- CLI の `_determine_connection_params` が \"direct\" プロファイル（`profile.hostname = \"pyxis\"` のような alias）を resolve せず、paramiko が DNS 失敗する問題を修正。新ヘルパ `_resolve_direct_profile` が `~/.ssh/config` を参照し HostName / IdentityFile / Port / ProxyJump をマージする。MCP 側 (`src/srunx/mcp/server.py:_get_ssh_client`) と同じロジックを移植。
- `key_filename` の tilde-expansion も CLI 側で適用（paramiko は `~` を literal 扱い）。
- `SSHConnection.test_connection` / `SSHSlurmClient.test_connection` が `__enter__` とは別に generic な \"Failed to establish SSH connection\" を返していた（#118 の fix 対象外だった）。`self._last_error` を surface するよう修正 — これで `srunx ssh test` でも paramiko の実例外（FileNotFoundError / gaierror など）が見えるようになる。

## Why

#120 の PR (#121) の動作確認中、実 SSH SLURM 環境で `srunx ssh test` を走らせたら `Failed to establish SSH connection` しか出ず、原因が追えない問題に遭遇。paramiko の実例外 (`gaierror: nodename not known`) を surface したところ、profile.hostname = \"pyxis\" (ssh_config alias) が resolve されていないことが判明。

## Manual verification

- `srunx ssh test --profile pyxis` が \"✅ Connected\" を返すことを確認
- `srunx ssh submit <script> --profile pyxis` で sbatch submit → COMPLETED まで確認
- 誤った鍵パス / 未定義 alias のプロファイルで test_connection のエラー文言に paramiko 原因が含まれることを確認

## Test plan

- [x] `uv run pytest` — 1357 passed
- [x] `uv run mypy .` — clean
- [x] `uv run ruff check .` — clean
- [x] pre-commit hooks all pass
- [x] Live cluster: `srunx ssh test` / `srunx ssh submit` both succeed via ssh_config alias

## Related

- Follow-up to #118 (PR #119) which fixed only the MCP `__enter__` path
- Found while verifying #120 / PR #121 against a real SLURM cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)