### PR TITLE
Phase 3: SSH status fix + V4 migration + Codex follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -388,12 +388,15 @@ Constraints / Phase 1 limitations:
   CLI and MCP sweeps still run cells through the local `Slurm` singleton —
   the orchestrator's default `executor_factory=None` preserves that
   behaviour bit-for-bit.
-- MCP-originated sweep cells record `workflow_runs.triggered_by='web'` (the
-  v1 CHECK constraint does not yet allow `'mcp'`). Parent `sweep_runs.submission_source`
-  correctly stores `'mcp'` for audit. Widening the child CHECK is Phase 2 scope.
+- MCP-originated sweep cells record `workflow_runs.triggered_by='mcp'`
+  (V4 migration widened the CHECK allowlist); parent
+  `sweep_runs.submission_source` is `'mcp'` for the same sweep so cell
+  and parent origins always agree.
 
 DB schema (V3 migration): `sweep_runs` table + `workflow_runs.sweep_run_id`
-FK + widened `events.kind` / `watches.kind` CHECK allowlist. Each cell has a
+FK + widened `events.kind` / `watches.kind` CHECK allowlist. V4 migration
+widens `workflow_runs.triggered_by` CHECK to admit `'mcp'` alongside
+`'cli'`/`'web'`/`'schedule'`. Each cell has a
 per-cell `workflow_runs` row and inherits the parent's `sweep_run_id`. The
 parent `sweep_runs` row tracks aggregate counters (cells_pending /
 cells_running / cells_completed / cells_failed / cells_cancelled) that the

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -281,6 +281,43 @@ def _preview_sweep_dry_run(
         console.print(f"  Cell {i}: {cell}")
 
 
+def _validate_all_sweep_cells(
+    *,
+    yaml_file: Path,
+    workflow_data: dict[str, Any],
+    args_override: dict[str, Any],
+    sweep_spec: SweepSpec,
+    callbacks: list[Callback],
+) -> None:
+    """Load + validate the workflow once per expanded matrix cell.
+
+    Reuses :func:`srunx.sweep.expand.expand_matrix` to produce the same
+    per-cell arg overlay the orchestrator will feed into
+    :meth:`WorkflowRunner.from_yaml` at execution time. The first cell
+    that fails Jinja rendering or workflow validation is reported with
+    its index and effective args, matching the error shape used by the
+    non-sweep validator.
+    """
+    from srunx.sweep.expand import expand_matrix
+
+    base_args: dict[str, Any] = {
+        **(workflow_data.get("args") or {}),
+        **args_override,
+    }
+    cells = expand_matrix(sweep_spec.matrix, base_args)
+
+    for idx, cell_args in enumerate(cells):
+        try:
+            runner = WorkflowRunner.from_yaml(
+                yaml_file, callbacks=callbacks, args_override=cell_args
+            )
+            runner.workflow.validate()
+        except WorkflowValidationError as exc:
+            raise WorkflowValidationError(
+                f"cell {idx} args={cell_args}: {exc}"
+            ) from exc
+
+
 def _run_sweep(
     yaml_file: Path,
     workflow_data: dict[str, Any],
@@ -425,13 +462,16 @@ def _execute_workflow(
 
         if sweep_spec is not None:
             if validate:
-                # Validate the workflow at least once (cell 0's rendering);
-                # matrix expansion semantics are already validated via
-                # merge_sweep_specs + expand.
-                runner = WorkflowRunner.from_yaml(
-                    yaml_file, callbacks=callbacks, args_override=args_override
+                # Validate every matrix cell: a Jinja undefined or type
+                # error in a non-zero cell (e.g. only cell 3 references
+                # an undeclared arg) must still fail the validator.
+                _validate_all_sweep_cells(
+                    yaml_file=yaml_file,
+                    workflow_data=workflow_data,
+                    args_override=args_override,
+                    sweep_spec=sweep_spec,
+                    callbacks=callbacks,
                 )
-                runner.workflow.validate()
                 logger.info("Workflow validation successful")
                 return
 

--- a/src/srunx/db/cli_helpers.py
+++ b/src/srunx/db/cli_helpers.py
@@ -144,42 +144,6 @@ def create_cli_workflow_run(
         return None
 
 
-def mark_workflow_run_status(
-    workflow_run_id: int,
-    status: str,
-    *,
-    error: str | None = None,
-) -> None:
-    """Best-effort ``workflow_runs.status`` update for CLI flows.
-
-    Used by :class:`srunx.runner.WorkflowRunner` to flip the row
-    through ``running`` → ``completed`` / ``failed`` / ``cancelled``
-    as the CLI workflow progresses. Mirrors the Web router's
-    ``update_status`` calls. Silently swallows DB errors.
-    """
-    try:
-        from srunx.db.connection import init_db, open_connection
-        from srunx.db.repositories.base import now_iso
-        from srunx.db.repositories.workflow_runs import WorkflowRunRepository
-
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
-            completed_at = (
-                now_iso() if status in {"completed", "failed", "cancelled"} else None
-            )
-            WorkflowRunRepository(conn).update_status(
-                workflow_run_id,
-                status,  # type: ignore[arg-type]
-                error=error,
-                completed_at=completed_at,
-            )
-        finally:
-            conn.close()
-    except Exception as exc:  # noqa: BLE001 — best-effort
-        logger.debug(f"mark_workflow_run_status failed: {exc}")
-
-
 def record_completion(job_id: int, status: JobStatus) -> None:
     """Mark ``job_id`` terminal in ``jobs`` + append a cli_monitor transition.
 

--- a/src/srunx/db/migrations.py
+++ b/src/srunx/db/migrations.py
@@ -287,6 +287,57 @@ CREATE INDEX idx_watches_open        ON watches(closed_at) WHERE closed_at IS NU
 
 
 # ---------------------------------------------------------------------------
+# v4 schema: widen workflow_runs.triggered_by CHECK to admit 'mcp'.
+#
+# Motivation: Phase 1 sweep orchestrator fudged MCP-originated cells as
+# triggered_by='web' because the v1 CHECK allowlist was
+# ('cli','web','schedule') and SQLite cannot ALTER CHECK in place — the
+# widen requires a full table rebuild. 'schedule' stays in the allowlist
+# as a reserved value even though no writer emits it yet (forward compat
+# with planned scheduled-workflow triggers). The accompanying Phase 3
+# commit removes the orchestrator workaround so MCP cells record their
+# true origin, which the notification + audit paths consume verbatim.
+#
+# Table-rebuild is mandatory because ``workflow_runs`` is referenced by
+# ``jobs.workflow_run_id`` (ON DELETE SET NULL) and
+# ``workflow_run_jobs.workflow_run_id`` (ON DELETE CASCADE); the
+# DROP + RENAME therefore has to run under ``PRAGMA foreign_keys=OFF``
+# (``requires_fk_off=True``). All V3-era columns (notably
+# ``sweep_run_id`` + its index) are re-declared here so V3's work is
+# preserved.
+# ---------------------------------------------------------------------------
+
+SCHEMA_V4 = """
+CREATE TABLE workflow_runs_v4 (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_name      TEXT NOT NULL,
+    workflow_yaml_path TEXT,
+    status             TEXT NOT NULL
+                         CHECK (status IN ('pending','running','completed','failed','cancelled')),
+    started_at         TEXT NOT NULL,
+    completed_at       TEXT,
+    args               TEXT,
+    error              TEXT,
+    triggered_by       TEXT NOT NULL
+                         CHECK (triggered_by IN ('cli','web','schedule','mcp')),
+    sweep_run_id       INTEGER REFERENCES sweep_runs(id) ON DELETE SET NULL
+);
+INSERT INTO workflow_runs_v4 (
+    id, workflow_name, workflow_yaml_path, status, started_at, completed_at,
+    args, error, triggered_by, sweep_run_id
+)
+    SELECT id, workflow_name, workflow_yaml_path, status, started_at, completed_at,
+           args, error, triggered_by, sweep_run_id
+    FROM workflow_runs;
+DROP TABLE workflow_runs;
+ALTER TABLE workflow_runs_v4 RENAME TO workflow_runs;
+CREATE INDEX idx_workflow_runs_status       ON workflow_runs(status);
+CREATE INDEX idx_workflow_runs_started_at   ON workflow_runs(started_at);
+CREATE INDEX idx_workflow_runs_sweep_run_id ON workflow_runs(sweep_run_id);
+"""
+
+
+# ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
 
@@ -320,6 +371,12 @@ MIGRATIONS: list[Migration] = [
         version=3,
         name="v3_sweep_runs",
         sql=SCHEMA_V3,
+        requires_fk_off=True,
+    ),
+    Migration(
+        version=4,
+        name="v4_widen_triggered_by_mcp",
+        sql=SCHEMA_V4,
         requires_fk_off=True,
     ),
 ]

--- a/src/srunx/db/models.py
+++ b/src/srunx/db/models.py
@@ -46,7 +46,7 @@ DeliveryStatus = Literal["pending", "sending", "delivered", "abandoned"]
 TransitionSource = Literal["poller", "cli_monitor", "webhook"]
 SubmissionSource = Literal["cli", "web", "workflow"]
 WorkflowRunStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
-WorkflowRunTriggeredBy = Literal["cli", "web", "schedule"]
+WorkflowRunTriggeredBy = Literal["cli", "web", "schedule", "mcp"]
 SweepStatus = Literal[
     "pending",
     "running",

--- a/src/srunx/rendering.py
+++ b/src/srunx/rendering.py
@@ -3,9 +3,10 @@
 Previously the render path forked between ``src/srunx/web/routers/workflows.py``
 (mount-aware dry-run / submit for Web non-sweep) and
 ``src/srunx/web/ssh_adapter.py::SlurmSSHAdapter.run`` (mount-agnostic sweep
-cell render). This module unifies them: all three submission surfaces
-(Web non-sweep, Web sweep, MCP) call :func:`render_workflow_for_submission`,
-which (a) resolves mount information into the ``Job`` rows before render,
+cell render). This module unifies them: Web submission (both non-sweep
+and sweep) and MCP sweep call :func:`render_workflow_for_submission`;
+MCP non-sweep still renders via the local ``Slurm`` path. The helper
+(a) resolves mount information into the ``Job`` rows before render,
 (b) delegates to the existing :func:`srunx.models.render_job_script` for
 the template substitution, and (c) returns a :class:`RenderedWorkflow`
 with per-job ``script_text`` + metadata.
@@ -14,11 +15,6 @@ The render itself stays mount-agnostic — ``Job.work_dir`` /
 ``Job.log_dir`` (Phase 2 render parity fields) are the single source of
 truth for path fields. Translation from local → remote paths happens
 *before* the template is invoked; the template never sees mount info.
-
-Batch 2 migration (separate PR) will refactor
-``workflows.py::_prepare_render_context`` / ``_render_scripts`` and
-``SlurmSSHAdapter.run`` to delegate here instead of re-implementing
-render locally.
 """
 
 from __future__ import annotations

--- a/src/srunx/runner.py
+++ b/src/srunx/runner.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager, nullcontext
+from functools import cached_property
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING, Any, Self
@@ -521,12 +522,25 @@ class WorkflowRunner:
                 is performed.
         """
         self.workflow = workflow
-        self.slurm = Slurm(callbacks=callbacks)
         self.callbacks = callbacks or []
         self.args = args or {}
         self.default_project = default_project
         self._executor_factory = executor_factory
         self._submission_context = submission_context
+
+    @cached_property
+    def slurm(self) -> Slurm:
+        """Local :class:`Slurm` client, constructed on first access.
+
+        Lazy construction matters when an ``executor_factory`` is
+        injected (SSH-backed pool for the Web sweep path): that path
+        never touches ``self.slurm`` and eagerly instantiating a local
+        :class:`Slurm` on a machine without local SLURM would emit a
+        spurious warning. :func:`_get_executor_cm` guards access behind
+        the ``executor_factory is None`` branch so this property is only
+        materialised when actually needed.
+        """
+        return Slurm(callbacks=self.callbacks)
 
     def _get_executor_cm(
         self,

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -48,6 +48,43 @@ __all__ = ["SSHSlurmClient", "SlurmJob"]
 
 _logger = get_logger(__name__)
 
+# scontrol prints whitespace-separated ``Key=Value`` tokens; ``JobState=`` is
+# the observed state (e.g. RUNNING, COMPLETED) and ``ExitCode=N:M`` carries
+# the process exit code (N) and terminating signal (M). Match until the next
+# whitespace so multi-word values stop at the token boundary.
+_SCONTROL_JOBSTATE_RE = re.compile(r"JobState=(\S+)")
+_SCONTROL_EXITCODE_RE = re.compile(r"ExitCode=(\d+):(\d+)")
+
+
+def _parse_scontrol_status(output: str) -> str | None:
+    """Extract a SLURM state string from ``scontrol show job`` output.
+
+    Returns ``None`` when the output is empty or lacks a ``JobState=`` token
+    — callers treat that as "scontrol didn't know either" and fall through
+    to the NOT_FOUND sentinel. When ``JobState=COMPLETED`` appears we also
+    consult ``ExitCode`` to disambiguate: a non-zero exit code or signal
+    means the job actually failed (SLURM reports COMPLETED for any clean
+    exit regardless of the process's own status), so we downgrade to
+    FAILED. Other states pass through unchanged so RUNNING / PENDING /
+    CANCELLED / TIMEOUT remain distinguishable.
+    """
+    if not output or not output.strip():
+        return None
+
+    state_match = _SCONTROL_JOBSTATE_RE.search(output)
+    if not state_match:
+        return None
+
+    state = state_match.group(1).strip().upper()
+    if state == "COMPLETED":
+        exit_match = _SCONTROL_EXITCODE_RE.search(output)
+        if exit_match:
+            exit_code = int(exit_match.group(1))
+            signal = int(exit_match.group(2))
+            if exit_code != 0 or signal != 0:
+                return "FAILED"
+    return state
+
 
 class SSHSlurmClient:
     """Backward-compatible facade composing all SSH/SLURM components.
@@ -687,6 +724,21 @@ class SSHSlurmClient:
             stdout, stderr, exit_code = self._execute_slurm_command(squeue_cmd)
             if exit_code == 0 and stdout.strip():
                 return stdout.strip().split("\n")[0].strip()
+
+            # scontrol fallback: on pyxis/slurmdbd-unreachable clusters sacct
+            # returns empty for finished jobs, and once a job leaves the
+            # queue squeue returns empty too. scontrol keeps the record in
+            # memory for MinJobAge (~5 min default) and does not depend on
+            # slurmdbd, so it disambiguates COMPLETED vs FAILED via ExitCode
+            # for the critical post-completion window.
+            quoted_id = shlex.quote(job_id)
+            scontrol_out, _, scontrol_rc = self._execute_slurm_command(
+                f"scontrol show job {quoted_id} 2>/dev/null"
+            )
+            if scontrol_rc == 0 and scontrol_out.strip():
+                parsed = _parse_scontrol_status(scontrol_out)
+                if parsed is not None:
+                    return parsed
 
             return "NOT_FOUND"
 

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -327,6 +327,20 @@ class SlurmRemoteClient:
             if exit_code == 0 and stdout.strip():
                 return stdout.strip().split("\n")[0].strip()
 
+            # scontrol fallback: pyxis/slurmdbd-unreachable clusters return
+            # empty sacct output, and finished jobs drop out of squeue. See
+            # srunx.ssh.core.client._parse_scontrol_status for the rationale.
+            from .client import _parse_scontrol_status
+
+            quoted_id = shlex.quote(job_id)
+            scontrol_out, _, scontrol_rc = self.execute_slurm_command(
+                f"scontrol show job {quoted_id} 2>/dev/null"
+            )
+            if scontrol_rc == 0 and scontrol_out.strip():
+                parsed = _parse_scontrol_status(scontrol_out)
+                if parsed is not None:
+                    return parsed
+
             return "NOT_FOUND"
 
         except Exception as e:

--- a/src/srunx/sweep/orchestrator.py
+++ b/src/srunx/sweep/orchestrator.py
@@ -46,16 +46,6 @@ def get_active_orchestrator(sweep_run_id: int) -> SweepOrchestrator | None:
 
 logger = get_logger(__name__)
 
-# Map the orchestrator-level submission_source to the child workflow_runs
-# triggered_by CHECK-constraint value. MCP is recorded as 'web' in the
-# child (see design.md § submission_source/triggered_by 対応表) because
-# the v1 CHECK allowlist is ('cli','web','schedule').
-_TRIGGERED_BY_BY_SOURCE: dict[Literal["cli", "web", "mcp"], WorkflowRunTriggeredBy] = {
-    "cli": "cli",
-    "web": "web",
-    "mcp": "web",
-}
-
 
 class SweepOrchestrator:
     """Drive sweep execution: materialize cells, run them, aggregate status."""
@@ -163,7 +153,11 @@ class SweepOrchestrator:
             if self.workflow_yaml_path is not None
             else None
         )
-        triggered_by = _TRIGGERED_BY_BY_SOURCE[self.submission_source]
+        # submission_source ('cli'|'web'|'mcp') is a strict subset of
+        # workflow_runs.triggered_by after the V4 CHECK widening, so the
+        # value flows through unchanged — every origin records its true
+        # identity on the child rows.
+        triggered_by: WorkflowRunTriggeredBy = self.submission_source
 
         sweep_repo = SweepRunRepository(conn)
         wr_repo = WorkflowRunRepository(conn)

--- a/src/srunx/sweep/orchestrator.py
+++ b/src/srunx/sweep/orchestrator.py
@@ -27,6 +27,7 @@ from srunx.logging import get_logger
 from srunx.notifications.service import NotificationService
 from srunx.rendering import SubmissionRenderContext
 from srunx.sweep import CellSpec, SweepSpec
+from srunx.sweep.state_service import WorkflowRunStateService
 
 # In-process registry of live orchestrators keyed by ``sweep_run_id``.
 # The cancel endpoint (``POST /api/sweep_runs/{id}/cancel``) looks up
@@ -359,6 +360,18 @@ class SweepOrchestrator:
         async with sem:
             if self._cancelled:
                 return
+            # Close the drain/fail_fast TOCTOU race via a DB-level optimistic
+            # lock: a concurrent ``_drain`` flips this cell's row to
+            # ``cancelled`` atomically, so the ``pending → running`` UPDATE
+            # either wins (we own the cell and may submit) or loses (drain
+            # got there first — bail out instead of submitting to SLURM).
+            # Runner's own pending→running flip downstream is already
+            # idempotent (``_transition_workflow_run`` swallows ``False``).
+            claimed = await anyio.to_thread.run_sync(
+                partial(self._claim_cell_running, cell.workflow_run_id)
+            )
+            if not claimed:
+                return
             final_status: str = "failed"
             error: str | None = None
             try:
@@ -379,6 +392,27 @@ class SweepOrchestrator:
                 self._record_cell_failure(cell, error)
             self._on_cell_done(cell, sweep_run_id, final_status, error)
 
+    def _claim_cell_running(self, workflow_run_id: int) -> bool:
+        """Atomically flip a cell from ``pending`` to ``running``.
+
+        Returns True iff the caller won the optimistic UPDATE (i.e. the
+        row was still ``pending`` at claim time). A False result means a
+        concurrent ``_drain`` already cancelled the cell — the caller
+        must skip ``_run_cell_sync`` to avoid a wasted SLURM submission.
+        """
+        init_db(delete_legacy=True)
+        conn = open_connection()
+        try:
+            with transaction(conn, "IMMEDIATE"):
+                return WorkflowRunStateService.update(
+                    conn=conn,
+                    workflow_run_id=workflow_run_id,
+                    from_status="pending",
+                    to_status="running",
+                )
+        finally:
+            conn.close()
+
     def _record_cell_failure(self, cell: CellSpec, error: str) -> None:
         """Best-effort failed transition for a cell the runner never finalized.
 
@@ -388,8 +422,6 @@ class SweepOrchestrator:
         before raising. Swallows all exceptions so a DB hiccup here
         cannot mask the original cell failure.
         """
-        from srunx.sweep.state_service import WorkflowRunStateService
-
         try:
             init_db(delete_legacy=True)
             conn = open_connection()

--- a/src/srunx/sweep/reconciler.py
+++ b/src/srunx/sweep/reconciler.py
@@ -13,20 +13,54 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import anyio
 
+from srunx.client_protocol import WorkflowJobExecutorFactory
 from srunx.db.connection import init_db, open_connection, transaction
 from srunx.db.models import SweepRun
 from srunx.db.repositories.sweep_runs import SweepRunRepository
 from srunx.logging import get_logger
+from srunx.rendering import SubmissionRenderContext
 from srunx.sweep import CellSpec, SweepSpec
 from srunx.sweep.aggregator import evaluate_and_fire_sweep_status_event
 from srunx.sweep.orchestrator import SweepOrchestrator
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ExecutorFactoryBundle:
+    """Per-sweep executor wiring returned by a reconciler provider.
+
+    The bundle keeps the three cross-cutting injections the orchestrator
+    needs to behave identically to the originally-submitting process
+    (before the crash / restart):
+
+    - ``factory``: passed to each cell's ``WorkflowRunner`` so cells
+      submit through the correct executor (e.g. an SSH pool lease for
+      Web-originated sweeps instead of the local ``Slurm`` singleton).
+    - ``submission_context``: mount-aware render context for path
+      translation (the Web dispatcher builds this from the active
+      profile's selected mount).
+    - ``cleanup``: optional finalizer invoked after the sweep resume
+      returns (success or crash). Used by Web to close a per-sweep
+      SSH pool; ``None`` means "nothing to clean up".
+    """
+
+    factory: WorkflowJobExecutorFactory
+    submission_context: SubmissionRenderContext | None = None
+    cleanup: Callable[[], None] | None = None
+
+
+# Provider signature: given a :class:`SweepRun`, return a bundle to wire
+# into the resumed orchestrator, or ``None`` to keep the legacy local
+# ``Slurm`` behaviour (CLI-originated sweeps).
+ExecutorFactoryProvider = Callable[[SweepRun], ExecutorFactoryBundle | None]
 
 
 class SweepReconciler:
@@ -38,13 +72,25 @@ class SweepReconciler:
     """
 
     @classmethod
-    def scan_and_resume(cls) -> None:
+    def scan_and_resume(
+        cls,
+        *,
+        executor_factory_provider: ExecutorFactoryProvider | None = None,
+    ) -> None:
         """Walk incomplete sweeps and either finalize or resume them.
 
         Synchronous entry point used by the CLI startup path. Uses
         ``anyio.run`` internally to drive orchestrator resume tasks so
         the caller blocks until every resume task group has scheduled
         its pending cells.
+
+        ``executor_factory_provider`` is invoked once per resumed sweep
+        with the :class:`SweepRun` row; returning a bundle replaces the
+        orchestrator's default local-``Slurm`` execution with the
+        provided factory + context (and arranges for cleanup after the
+        resume completes). ``None`` (default) preserves the CLI-path
+        behaviour and is the expected value for the synchronous entry
+        point.
         """
         sweeps = cls._load_incomplete_sweeps()
 
@@ -59,10 +105,17 @@ class SweepReconciler:
                 )
                 continue
 
-            cls._reconcile_one(sweep.id)
+            cls._reconcile_one(
+                sweep,
+                executor_factory_provider=executor_factory_provider,
+            )
 
     @classmethod
-    async def scan_and_resume_async(cls) -> None:
+    async def scan_and_resume_async(
+        cls,
+        *,
+        executor_factory_provider: ExecutorFactoryProvider | None = None,
+    ) -> None:
         """Async twin of :meth:`scan_and_resume`.
 
         Used by the FastAPI lifespan so we don't spin up a nested
@@ -70,6 +123,12 @@ class SweepReconciler:
         bookkeeping steps still run synchronously (they're tiny, purely
         local sqlite3 reads) — only the orchestrator resume is awaited
         directly instead of going through ``anyio.run``.
+
+        ``executor_factory_provider`` is supplied by the Web lifespan so
+        sweeps originally submitted via the Web API (``submission_source
+        ∈ {'web','mcp'}``) resume through the configured SSH adapter
+        instead of the local ``Slurm`` singleton. See
+        :class:`ExecutorFactoryBundle` for the wiring contract.
         """
         sweeps = cls._load_incomplete_sweeps()
 
@@ -82,7 +141,10 @@ class SweepReconciler:
                 )
                 continue
 
-            await cls._reconcile_one_async(sweep.id)
+            await cls._reconcile_one_async(
+                sweep,
+                executor_factory_provider=executor_factory_provider,
+            )
 
     @classmethod
     def _load_incomplete_sweeps(cls) -> list[SweepRun]:
@@ -99,20 +161,44 @@ class SweepReconciler:
     # ------------------------------------------------------------------
 
     @classmethod
-    def _reconcile_one(cls, sweep_run_id: int) -> None:
-        plan = cls._prepare_reconcile_plan(sweep_run_id)
+    def _reconcile_one(
+        cls,
+        sweep: SweepRun,
+        *,
+        executor_factory_provider: ExecutorFactoryProvider | None = None,
+    ) -> None:
+        assert sweep.id is not None  # caller filtered ``sweep.id is None``
+        plan = cls._prepare_reconcile_plan(sweep.id)
         if plan is None:
             return
         sweep_row, pending = plan
-        cls._spawn_resume(sweep_run_id, sweep_row, pending)
+        cls._spawn_resume(
+            sweep.id,
+            sweep_row,
+            pending,
+            sweep=sweep,
+            executor_factory_provider=executor_factory_provider,
+        )
 
     @classmethod
-    async def _reconcile_one_async(cls, sweep_run_id: int) -> None:
-        plan = cls._prepare_reconcile_plan(sweep_run_id)
+    async def _reconcile_one_async(
+        cls,
+        sweep: SweepRun,
+        *,
+        executor_factory_provider: ExecutorFactoryProvider | None = None,
+    ) -> None:
+        assert sweep.id is not None  # caller filtered ``sweep.id is None``
+        plan = cls._prepare_reconcile_plan(sweep.id)
         if plan is None:
             return
         sweep_row, pending = plan
-        await cls._spawn_resume_async(sweep_run_id, sweep_row, pending)
+        await cls._spawn_resume_async(
+            sweep.id,
+            sweep_row,
+            pending,
+            sweep=sweep,
+            executor_factory_provider=executor_factory_provider,
+        )
 
     @classmethod
     def _prepare_reconcile_plan(
@@ -173,6 +259,9 @@ class SweepReconciler:
         sweep_run_id: int,
         sweep_row: sqlite3.Row,
         pending_cells: list[CellSpec],
+        *,
+        sweep: SweepRun,
+        executor_factory_provider: ExecutorFactoryProvider | None = None,
     ) -> None:
         """Drive the resume through a fresh :class:`SweepOrchestrator`.
 
@@ -180,17 +269,30 @@ class SweepReconciler:
         lifespan-startup caller (synchronous) blocks until the resume
         task group has scheduled every pending cell.
         """
-        orch = cls._build_orchestrator(sweep_run_id, sweep_row)
-        if orch is None:
-            return
-
-        async def _resume() -> None:
-            await orch.resume_from_db(sweep_run_id, pending_cells)
-
+        bundle = cls._resolve_bundle(sweep, executor_factory_provider)
         try:
-            anyio.run(_resume)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(f"reconciler: sweep {sweep_run_id} resume raised: {exc!r}")
+            try:
+                orch = cls._build_orchestrator(sweep_run_id, sweep_row, sweep, bundle)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    f"reconciler: sweep {sweep_run_id} orchestrator "
+                    f"construction failed: {exc!r}"
+                )
+                return
+            if orch is None:
+                return
+
+            async def _resume() -> None:
+                await orch.resume_from_db(sweep_run_id, pending_cells)
+
+            try:
+                anyio.run(_resume)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    f"reconciler: sweep {sweep_run_id} resume raised: {exc!r}"
+                )
+        finally:
+            cls._run_bundle_cleanup(sweep_run_id, bundle)
 
     @classmethod
     async def _spawn_resume_async(
@@ -198,6 +300,9 @@ class SweepReconciler:
         sweep_run_id: int,
         sweep_row: sqlite3.Row,
         pending_cells: list[CellSpec],
+        *,
+        sweep: SweepRun,
+        executor_factory_provider: ExecutorFactoryProvider | None = None,
     ) -> None:
         """Async twin of :meth:`_spawn_resume`.
 
@@ -206,22 +311,96 @@ class SweepReconciler:
         to a worker thread per :meth:`SweepOrchestrator._run_cell`, so
         the lifespan task group stays responsive while cells run.
         """
-        orch = cls._build_orchestrator(sweep_run_id, sweep_row)
-        if orch is None:
-            return
-
+        bundle = cls._resolve_bundle(sweep, executor_factory_provider)
         try:
-            await orch.resume_from_db(sweep_run_id, pending_cells)
+            try:
+                orch = cls._build_orchestrator(sweep_run_id, sweep_row, sweep, bundle)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    f"reconciler: sweep {sweep_run_id} orchestrator "
+                    f"construction failed: {exc!r}"
+                )
+                return
+            if orch is None:
+                return
+
+            try:
+                await orch.resume_from_db(sweep_run_id, pending_cells)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    f"reconciler: sweep {sweep_run_id} resume raised: {exc!r}"
+                )
+        finally:
+            await cls._run_bundle_cleanup_async(sweep_run_id, bundle)
+
+    @classmethod
+    def _resolve_bundle(
+        cls,
+        sweep: SweepRun,
+        executor_factory_provider: ExecutorFactoryProvider | None,
+    ) -> ExecutorFactoryBundle | None:
+        """Invoke the provider (if any) and swallow provider exceptions.
+
+        A provider that raises must not take the whole startup pass down
+        — fall back to the CLI-style ``None`` bundle so resume still
+        happens through the local ``Slurm`` client.
+        """
+        if executor_factory_provider is None:
+            return None
+        try:
+            return executor_factory_provider(sweep)
         except Exception as exc:  # noqa: BLE001
-            logger.warning(f"reconciler: sweep {sweep_run_id} resume raised: {exc!r}")
+            logger.warning(
+                f"reconciler: executor_factory_provider raised for sweep "
+                f"{sweep.id} ({sweep.submission_source!r}); falling back to "
+                f"local Slurm: {exc!r}"
+            )
+            return None
+
+    @classmethod
+    def _run_bundle_cleanup(
+        cls, sweep_run_id: int, bundle: ExecutorFactoryBundle | None
+    ) -> None:
+        if bundle is None or bundle.cleanup is None:
+            return
+        try:
+            bundle.cleanup()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"reconciler: sweep {sweep_run_id} bundle cleanup raised: {exc!r}"
+            )
+
+    @classmethod
+    async def _run_bundle_cleanup_async(
+        cls, sweep_run_id: int, bundle: ExecutorFactoryBundle | None
+    ) -> None:
+        if bundle is None or bundle.cleanup is None:
+            return
+        try:
+            await anyio.to_thread.run_sync(bundle.cleanup)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"reconciler: sweep {sweep_run_id} bundle cleanup raised: {exc!r}"
+            )
 
     @classmethod
     def _build_orchestrator(
         cls,
         sweep_run_id: int,
         sweep_row: sqlite3.Row,
+        sweep: SweepRun,
+        bundle: ExecutorFactoryBundle | None,
     ) -> SweepOrchestrator | None:
-        """Rebuild the minimal SweepOrchestrator needed for a resume."""
+        """Rebuild the minimal SweepOrchestrator needed for a resume.
+
+        ``submission_source`` is copied from the DB row (no more
+        hard-coded ``"cli"``) so resumed sweeps keep their audit trail
+        intact — Web-originated sweeps stay ``"web"``, MCP ``"mcp"``,
+        and CLI ``"cli"``. ``bundle`` optionally plugs the Web's SSH
+        pool lease + mount-aware submission context into each cell's
+        ``WorkflowRunner``; passing ``None`` falls back to the local
+        ``Slurm`` executor (the CLI / no-provider case).
+        """
         yaml_path = sweep_row["workflow_yaml_path"]
         if yaml_path is None:
             logger.warning(
@@ -238,12 +417,17 @@ class SweepReconciler:
             max_parallel=int(sweep_row["max_parallel"]),
         )
 
+        executor_factory = bundle.factory if bundle is not None else None
+        submission_context = bundle.submission_context if bundle is not None else None
+
         return SweepOrchestrator(
             workflow_yaml_path=Path(yaml_path),
             workflow_data={"name": sweep_row["name"]},
             args_override=None,
             sweep_spec=sweep_spec,
-            submission_source="cli",
+            submission_source=sweep.submission_source,
+            executor_factory=executor_factory,
+            submission_context=submission_context,
         )
 
 
@@ -283,4 +467,4 @@ def _list_pending_cells(conn: sqlite3.Connection, sweep_run_id: int) -> list[Cel
     return cells
 
 
-__all__ = ["SweepReconciler"]
+__all__ = ["ExecutorFactoryBundle", "ExecutorFactoryProvider", "SweepReconciler"]

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -11,7 +12,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from srunx.db.models import SweepRun
 from srunx.logging import get_logger
+from srunx.rendering import SubmissionRenderContext
+from srunx.ssh.core.config import MountConfig
+from srunx.sweep.reconciler import ExecutorFactoryBundle, ExecutorFactoryProvider
 
 from .config import get_web_config
 from .deps import set_adapter
@@ -28,6 +33,7 @@ from .routers import subscriptions as subscriptions_router
 from .routers import sweep_runs as sweep_runs_router
 from .routers import watches as watches_router
 from .ssh_adapter import SlurmSSHAdapter
+from .ssh_executor import SlurmSSHExecutorPool
 
 _FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
 logger = get_logger(__name__)
@@ -142,6 +148,73 @@ def _print_ui_banner(
     )
 
 
+def _build_web_executor_factory_provider(
+    adapter: SlurmSSHAdapter | None,
+) -> ExecutorFactoryProvider | None:
+    """Return a :data:`ExecutorFactoryProvider` for Web-originated sweeps.
+
+    The reconciler calls this provider once per resumed sweep. For
+    ``submission_source in {'web','mcp'}`` it constructs a per-sweep
+    :class:`SlurmSSHExecutorPool` clone (from the startup adapter's
+    :class:`SlurmSSHAdapterSpec`) plus the active profile's mounts as a
+    :class:`SubmissionRenderContext`, so the resumed orchestrator routes
+    cells through the same SSH adapter + mount translation the original
+    dispatcher used. Pool cleanup runs when the sweep's resume completes.
+
+    For CLI-originated sweeps the provider returns ``None`` so the
+    reconciler falls back to the local :class:`Slurm` executor — same
+    behaviour as a CLI `srunx flow` invocation.
+
+    When no SSH adapter is configured at startup the provider is
+    ``None`` entirely (the caller sees a plain resume); Web / MCP sweeps
+    then surface the original "workflow_yaml_path missing" or executor
+    failure instead of silently falling back to a local Slurm binary
+    the Web host likely doesn't have.
+    """
+    if adapter is None:
+        return None
+
+    spec = adapter.connection_spec
+    # Cap the pool size — mirrors the dispatcher's
+    # ``min(max_parallel, 8)`` clamp. Resume workloads observe
+    # ``max_parallel`` from the DB, but we don't know it at provider
+    # construction time; cap at 8 here (the dispatcher's ceiling) and
+    # let the orchestrator's semaphore do the real gating.
+    try:
+        pool_size = max(1, int(os.environ.get("SRUNX_SSH_POOL_SIZE", "4")))
+    except ValueError:
+        pool_size = 4
+    pool_size = min(pool_size, 8)
+
+    # Resolve an immutable mounts snapshot for every sweep resumed in
+    # this pass. Each sweep still uses its own ``SubmissionRenderContext``
+    # instance so the reconciler doesn't share mutable state across
+    # sweeps. ``mount_name=None`` / ``default_work_dir=None`` because
+    # the original selected-mount name isn't stored on ``sweep_runs``
+    # (no new columns); absolute ``work_dir`` paths under a mount's
+    # ``local`` still get translated since the full mounts tuple is
+    # present.
+    mounts: tuple[MountConfig, ...] = tuple(spec.mounts)
+
+    def provider(sweep: SweepRun) -> ExecutorFactoryBundle | None:
+        if sweep.submission_source == "cli":
+            return None
+
+        pool = SlurmSSHExecutorPool(spec, callbacks=[], size=pool_size)
+        context = SubmissionRenderContext(
+            mount_name=None,
+            mounts=mounts,
+            default_work_dir=None,
+        )
+        return ExecutorFactoryBundle(
+            factory=pool.lease,
+            submission_context=context,
+            cleanup=pool.close,
+        )
+
+    return provider
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Manage SSH connection lifecycle + background pollers.
@@ -232,8 +305,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         verbose=config.verbose,
     )
 
-    import os
-
     import anyio
 
     from srunx.pollers.active_watch_poller import ActiveWatchPoller
@@ -246,11 +317,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # the active-watch poller never races the orchestrator on observation
     # of resumed cells. Skipped under --reload / SRUNX_DISABLE_POLLER=1
     # for parity with the poller gating.
+    #
+    # The Web-side provider restores, for every Web / MCP-originated
+    # sweep, the per-sweep :class:`SlurmSSHExecutorPool` + mount-aware
+    # :class:`SubmissionRenderContext` the dispatcher originally wired
+    # in (see :func:`srunx.web.routers.workflows._dispatch_sweep`). CLI
+    # sweeps (``submission_source == 'cli'``) stay on the local
+    # :class:`Slurm` path by returning ``None`` from the provider.
     if should_start_pollers():
         try:
             from srunx.sweep.reconciler import SweepReconciler
 
-            await SweepReconciler.scan_and_resume_async()
+            provider = _build_web_executor_factory_provider(adapter)
+            await SweepReconciler.scan_and_resume_async(
+                executor_factory_provider=provider,
+            )
         except Exception:
             logger.warning("SweepReconciler startup pass raised", exc_info=True)
 

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -313,9 +313,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     from srunx.pollers.resource_snapshotter import ResourceSnapshotter
     from srunx.pollers.supervisor import Poller, PollerSupervisor
 
-    # 4. Sweep crash-recovery pass. Runs before the poller supervisor so
-    # the active-watch poller never races the orchestrator on observation
-    # of resumed cells. Skipped under --reload / SRUNX_DISABLE_POLLER=1
+    # 4. Sweep crash-recovery pass. Spawned as a background task on the
+    # lifespan task group so the server can become ready without waiting
+    # for every incomplete sweep to be reconciled — with many crashed
+    # sweeps in the DB the sequential per-sweep resume would otherwise
+    # block ``yield`` for tens of seconds. Running concurrently with the
+    # active-watch poller is safe because ``workflow_runs.status`` is the
+    # source of truth; a poller observing a cell before the orchestrator
+    # has registered it just produces an extra transition row, never a
+    # missed terminal. Skipped under --reload / SRUNX_DISABLE_POLLER=1
     # for parity with the poller gating.
     #
     # The Web-side provider restores, for every Web / MCP-originated
@@ -324,11 +330,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     # in (see :func:`srunx.web.routers.workflows._dispatch_sweep`). CLI
     # sweeps (``submission_source == 'cli'``) stay on the local
     # :class:`Slurm` path by returning ``None`` from the provider.
+    reconciler_provider: ExecutorFactoryProvider | None = None
     if should_start_pollers():
+        reconciler_provider = _build_web_executor_factory_provider(adapter)
+
+    async def _resume_sweeps_in_background(
+        provider: ExecutorFactoryProvider | None,
+    ) -> None:
         try:
             from srunx.sweep.reconciler import SweepReconciler
 
-            provider = _build_web_executor_factory_provider(adapter)
             await SweepReconciler.scan_and_resume_async(
                 executor_factory_provider=provider,
             )
@@ -426,6 +437,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         async with anyio.create_task_group() as tg:
             app.state.task_group = tg
             app.state.poller_supervisor = supervisor
+            if should_start_pollers():
+                tg.start_soon(_resume_sweeps_in_background, reconciler_provider)
             if supervisor is not None:
                 tg.start_soon(supervisor.start_all)
             yield

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -1150,6 +1150,31 @@ async def _dispatch_sweep(
     except Exception as exc:  # noqa: BLE001 — Pydantic / value errors
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+    # C3 (security): apply the same ShellJob script-root guard the
+    # non-sweep path runs, before any DB materialize side effect. The
+    # matrix axes in ``sweep.matrix`` are scalars (validated by
+    # ``expand_matrix``) so a per-cell check would only be redundant;
+    # the base workflow's ShellJob ``script_path`` is the entire attack
+    # surface. ``mount`` is required by the caller (``run_workflow``)
+    # so it is non-None in practice; keep the guard defensive for
+    # direct callers.
+    profile = await anyio.to_thread.run_sync(_get_current_profile)
+    if mount is not None:
+        try:
+            base_runner = await anyio.to_thread.run_sync(
+                lambda: WorkflowRunner.from_yaml(
+                    yaml_path,
+                    args_override=body.args_override or None,
+                )
+            )
+        except WorkflowValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except Exception as exc:  # noqa: BLE001 — YAML load / Jinja errors
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        await anyio.to_thread.run_sync(
+            lambda: _enforce_shell_script_roots(base_runner.workflow, mount, profile)
+        )
+
     endpoint_id: int | None = None
     if body.notify and body.endpoint_id is not None:
         endpoint_id = body.endpoint_id
@@ -1173,8 +1198,8 @@ async def _dispatch_sweep(
 
     # Hand the mount-aware render context through to the orchestrator so
     # every sweep cell's ``WorkflowRunner`` sees the same ``work_dir`` /
-    # ``log_dir`` translation as the non-sweep path.
-    profile = await anyio.to_thread.run_sync(_get_current_profile)
+    # ``log_dir`` translation as the non-sweep path. ``profile`` was
+    # already resolved above for the ShellJob script-root guard.
     submission_context = _build_submission_context(mount, profile)
 
     orchestrator = SweepOrchestrator(

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -50,6 +50,42 @@ _TERMINAL_STATES = {
 }
 
 
+class SSHMonitorTimeoutError(RuntimeError):
+    """Raised when ``_monitor_until_terminal`` exceeds its timeout.
+
+    Subclass of ``RuntimeError`` so the sweep orchestrator's existing
+    broad-except cell-failure handler still catches it — the typed
+    subclass just lets targeted callers (e.g. tests, future UI status
+    reporting) distinguish timeout from a genuine SLURM-state-derived
+    failure without widening the exception surface.
+    """
+
+
+def _resolve_monitor_timeout_default() -> float | None:
+    """Return the default per-job monitor timeout from the environment.
+
+    ``SRUNX_SSH_MONITOR_TIMEOUT`` accepts a non-negative float (seconds).
+    An unset / empty / ``"0"`` / non-numeric value means "no timeout",
+    preserving the pre-Phase-3 behaviour for users who haven't opted in.
+    """
+    import os
+
+    raw = os.getenv("SRUNX_SSH_MONITOR_TIMEOUT")
+    if not raw:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            f"Ignoring invalid SRUNX_SSH_MONITOR_TIMEOUT={raw!r} "
+            "(expected non-negative seconds)"
+        )
+        return None
+    if value <= 0:
+        return None
+    return value
+
+
 @dataclass(frozen=True)
 class SlurmSSHAdapterSpec:
     """Connection spec used to clone a :class:`SlurmSSHAdapter` for pooling.
@@ -543,6 +579,28 @@ class SlurmSSHAdapter:
                     nodelist=(parts[5].strip() or None),
                 )
 
+        # --- scontrol fallback: pyxis clusters where sacct is unreachable ---
+        # slurmdbd outages leave sacct returning empty for just-finished
+        # jobs. scontrol keeps the record in memory for ~5 minutes
+        # (MinJobAge) without needing the accounting DB, so we probe it
+        # per-missing-id. Per-id cost is acceptable because the poller
+        # runs every 15s and the missing set is only the final-transition
+        # tail, not the full active set.
+        from srunx.ssh.core.client import _parse_scontrol_status
+
+        still_missing = [j for j in job_ids if j not in results]
+        for jid in still_missing:
+            try:
+                scontrol_out = _run_slurm_cmd(
+                    self, f"scontrol show job {jid} 2>/dev/null"
+                )
+            except RuntimeError:
+                continue
+            parsed = _parse_scontrol_status(scontrol_out)
+            if parsed is None:
+                continue
+            results[jid] = JobStatusInfo(status=parsed)
+
         return results
 
     def get_job(self, job_id: int) -> dict[str, Any]:
@@ -773,12 +831,28 @@ class SlurmSSHAdapter:
 
         # --- 5. Monitor to terminal ---
         terminal_status = self._monitor_until_terminal(job_id)
-        try:
-            job.status = JobStatus(terminal_status)
-        except ValueError:
-            # Unknown / NOT_FOUND — treat as FAILED so the runner's retry
-            # path trips instead of silently returning a non-terminal job.
-            job.status = JobStatus.FAILED
+        # NOT_FOUND means all three of sacct/squeue/scontrol lost track of
+        # the job (typically because MinJobAge expired before we polled on
+        # a pyxis cluster where sacct is unreachable). The job almost
+        # certainly ran; we just can't prove COMPLETED vs FAILED. Surfacing
+        # UNKNOWN is strictly more informative than silent FAILED and lets
+        # the sweep runner distinguish "provably failed" from "unknowable".
+        if terminal_status == "NOT_FOUND":
+            logger.warning(
+                f"Job {job_id} ({job.name!r}) disappeared from sacct/squeue/"
+                "scontrol before a terminal status could be confirmed; "
+                "recording UNKNOWN"
+            )
+            job.status = JobStatus.UNKNOWN
+        else:
+            try:
+                job.status = JobStatus(terminal_status)
+            except ValueError:
+                logger.warning(
+                    f"Job {job_id} ({job.name!r}) returned unrecognised "
+                    f"SLURM state {terminal_status!r}; recording UNKNOWN"
+                )
+                job.status = JobStatus.UNKNOWN
 
         # --- 6. Dispatch terminal callback + handle failure ---
         self._record_completion_safe(job_id, job.status)
@@ -798,20 +872,54 @@ class SlurmSSHAdapter:
 
         return job
 
-    def _monitor_until_terminal(self, job_id: int, poll_interval: int = 10) -> str:
+    def _monitor_until_terminal(
+        self,
+        job_id: int,
+        poll_interval: int = 10,
+        *,
+        timeout: float | None = -1.0,
+    ) -> str:
         """Poll remote job status until it reaches a terminal SLURM state.
 
         Returns the raw SLURM state string (e.g. ``"COMPLETED"``). Uses
         :meth:`get_job_status` so the lock + reconnection discipline is
         uniform with the rest of the adapter.
+
+        ``timeout`` caps the total wait (wall-clock seconds); on expiry
+        raises :class:`SSHMonitorTimeoutError` so the sweep orchestrator's
+        cell-failure path records the cell as failed without tearing down
+        the pooled adapter's SSH session. ``None`` waits indefinitely.
+        The ``-1.0`` default is a sentinel meaning "unspecified" — in that
+        case we fall back to ``SRUNX_SSH_MONITOR_TIMEOUT`` (seconds,
+        ``""`` or unset means no timeout) so ops can bound hung jobs
+        cluster-wide without a code change.
         """
         import time as _time
 
+        effective_timeout: float | None
+        if timeout is not None and timeout < 0:
+            # Sentinel — caller did not specify a timeout. Pick up the env
+            # var default (which may itself be None to preserve the
+            # pre-Phase-3 "wait forever" semantics).
+            effective_timeout = _resolve_monitor_timeout_default()
+        else:
+            effective_timeout = timeout
+
         terminal = {"COMPLETED", "FAILED", "CANCELLED", "TIMEOUT", "NOT_FOUND"}
+        start = _time.monotonic()
         while True:
             status = self.get_job_status(job_id)
             if status in terminal:
                 return status
+            if (
+                effective_timeout is not None
+                and (_time.monotonic() - start) >= effective_timeout
+            ):
+                raise SSHMonitorTimeoutError(
+                    f"Timed out after {effective_timeout:.1f}s waiting for "
+                    f"job {job_id} to reach a terminal state (last status: "
+                    f"{status!r})"
+                )
             _time.sleep(poll_interval)
 
     @staticmethod

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -767,9 +767,14 @@ class SlurmSSHAdapter:
         from srunx.template import get_template_path
 
         # --- 0. Mount-aware path normalization (no-op when context is None). ---
-        # ``normalize_job_for_submission`` returns the same object when no
-        # rewrite is needed, so the ``None`` path is cost-free and the
-        # pre-Batch-2a rendered script stays bit-identical.
+        # ``normalize_job_for_submission`` returns a ``model_copy`` when any
+        # path needs rewriting, so the normalized copy is only safe to use
+        # for rendering/submission; we must propagate the terminal status
+        # and ``job_id`` back to the caller's original instance at the end
+        # of :meth:`run`, otherwise ``WorkflowRunner``'s ``all_jobs`` check
+        # sees the untouched PENDING status and declares the cell
+        # incomplete even when SLURM reported COMPLETED.
+        original_job = job
         job = normalize_job_for_submission(job, submission_context)
 
         # Resolve the template path once, honouring the Job-level override
@@ -867,10 +872,17 @@ class SlurmSSHAdapter:
             except Exception as exc:  # noqa: BLE001
                 logger.warning(f"Terminal callback failed for job {job.name}: {exc}")
 
+        # Propagate terminal status + job_id back to the caller's
+        # original instance so the ``WorkflowRunner.all_jobs`` check
+        # observes them. See the rationale above step 0.
+        if original_job is not job:
+            original_job.status = job.status
+            original_job.job_id = job.job_id
+
         if job.status in {JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.TIMEOUT}:
             raise RuntimeError(f"Job '{job.name}' ended with status {job.status.value}")
 
-        return job
+        return original_job
 
     def _monitor_until_terminal(
         self,

--- a/tests/cli/test_workflow_sweep.py
+++ b/tests/cli/test_workflow_sweep.py
@@ -280,3 +280,117 @@ class TestSweepFlag:
         assert "Sweep dry run" in result.stdout
         assert "Cell count: 3" in result.stdout
         orch_cls.assert_not_called()
+
+
+def _write_cell_validation_workflow(tmp_path: Path) -> Path:
+    """Workflow whose per-cell Jinja render depends on ``stage_pick``.
+
+    ``stage1`` exports ``model_a`` / ``model_b``; ``stage2`` references
+    ``deps.stage1[stage_pick]`` so the cell's ``stage_pick`` value
+    determines whether the render succeeds under ``StrictUndefined``.
+    """
+    data: dict[str, Any] = {
+        "name": "cell_validate",
+        "args": {"stage_pick": "model_a"},
+        "jobs": [
+            {
+                "name": "stage1",
+                "command": ["echo", "stage1"],
+                "environment": {"conda": "env"},
+                "exports": {
+                    "model_a": "/path/a",
+                    "model_b": "/path/b",
+                },
+            },
+            {
+                "name": "stage2",
+                "command": [
+                    "echo",
+                    "{{ stage_pick }}",
+                    "{{ deps.stage1[stage_pick] }}",
+                ],
+                "environment": {"conda": "env"},
+                "depends_on": ["stage1"],
+            },
+        ],
+    }
+    path = tmp_path / "wf.yaml"
+    path.write_text(yaml.dump(data))
+    return path
+
+
+class TestSweepValidateAllCells:
+    """Regression tests for I2: ``--validate`` must check every matrix cell."""
+
+    def test_validate_detects_error_in_non_zero_cell(
+        self, tmp_path: Path, isolated_db: Path
+    ) -> None:
+        """Cells 0-1 render fine; cell 2 references a missing export key."""
+        yaml_path = _write_cell_validation_workflow(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            workflow_app,
+            [
+                "--sweep",
+                "stage_pick=model_a,model_b,bogus",
+                "--max-parallel",
+                "2",
+                "--validate",
+                str(yaml_path),
+            ],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        output = result.stdout + (result.stderr or "")
+        assert "validation error" in output.lower()
+        assert "bogus" in output
+
+    def test_validate_passes_for_fully_valid_sweep(
+        self, tmp_path: Path, isolated_db: Path
+    ) -> None:
+        """Every cell renders → exit 0."""
+        yaml_path = _write_cell_validation_workflow(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            workflow_app,
+            [
+                "--sweep",
+                "stage_pick=model_a,model_b",
+                "--max-parallel",
+                "2",
+                "--validate",
+                str(yaml_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert "Workflow validation successful" in (
+            result.stdout + (result.stderr or "")
+        )
+
+    def test_validate_reports_failing_cell_args(
+        self, tmp_path: Path, isolated_db: Path
+    ) -> None:
+        """The error message must name the cell index + its effective args."""
+        yaml_path = _write_cell_validation_workflow(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            workflow_app,
+            [
+                "--sweep",
+                "stage_pick=model_a,bogus",
+                "--max-parallel",
+                "2",
+                "--validate",
+                str(yaml_path),
+            ],
+        )
+
+        assert result.exit_code == 1, result.stdout
+        output = result.stdout + (result.stderr or "")
+        assert "cell 1" in output
+        assert "stage_pick" in output
+        assert "bogus" in output

--- a/tests/db/test_cli_helpers.py
+++ b/tests/db/test_cli_helpers.py
@@ -14,7 +14,6 @@ import pytest
 from srunx.db.cli_helpers import (
     compute_workflow_stats,
     create_cli_workflow_run,
-    mark_workflow_run_status,
     record_submission_from_job,
 )
 from srunx.models import Job, JobEnvironment, JobResource
@@ -105,52 +104,3 @@ class TestWorkflowStatsRoundTrip:
 
         stats = compute_workflow_stats("unlinked_flow")
         assert stats["total_jobs"] == 0  # JOIN misses the row
-
-
-class TestMarkWorkflowRunStatus:
-    def test_updates_status(self, _isolated_db):
-        run_id = create_cli_workflow_run(workflow_name="flow")
-        assert run_id is not None
-
-        mark_workflow_run_status(run_id, "completed")
-
-        from srunx.db.connection import open_connection
-        from srunx.db.repositories.workflow_runs import WorkflowRunRepository
-
-        conn = open_connection()
-        try:
-            row = WorkflowRunRepository(conn).get(run_id)
-        finally:
-            conn.close()
-        assert row is not None
-        assert row.status == "completed"
-        assert row.completed_at is not None
-
-    def test_failed_records_error(self, _isolated_db):
-        run_id = create_cli_workflow_run(workflow_name="flow")
-        assert run_id is not None
-
-        mark_workflow_run_status(run_id, "failed", error="boom")
-
-        from srunx.db.connection import open_connection
-        from srunx.db.repositories.workflow_runs import WorkflowRunRepository
-
-        conn = open_connection()
-        try:
-            row = WorkflowRunRepository(conn).get(run_id)
-        finally:
-            conn.close()
-        assert row is not None
-        assert row.status == "failed"
-        assert row.error == "boom"
-
-    def test_swallows_db_errors(self, _isolated_db, monkeypatch):
-        """Best-effort — caller never sees the exception."""
-        import srunx.db.connection as connection_mod
-
-        def boom(*a, **kw):
-            raise RuntimeError("disk full")
-
-        monkeypatch.setattr(connection_mod, "init_db", boom)
-        # Must not raise.
-        mark_workflow_run_status(12345, "completed")

--- a/tests/db/test_migration_v4.py
+++ b/tests/db/test_migration_v4.py
@@ -1,0 +1,328 @@
+"""Integration tests for the V4 migration: widen workflow_runs.triggered_by.
+
+Covers the Phase 3 A-3 change: the ``triggered_by`` CHECK allowlist is
+extended from ``('cli','web','schedule')`` to
+``('cli','web','schedule','mcp')`` via a full table rebuild. The rebuild
+must preserve every V3-era column (notably ``sweep_run_id``), every
+index, and every inbound foreign-key reference.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import (
+    MIGRATIONS,
+    _apply_fk_off_migration,
+    _apply_tx_migration,
+    _ensure_schema_version_table,
+    apply_migrations,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — mirror tests/db/test_migration_v3.py style
+# ---------------------------------------------------------------------------
+
+
+def _apply_through_version(conn: sqlite3.Connection, target: int) -> None:
+    """Apply every registered migration with ``version <= target``."""
+    _ensure_schema_version_table(conn)
+    applied = {
+        row[0] for row in conn.execute("SELECT name FROM schema_version").fetchall()
+    }
+    for mig in MIGRATIONS:
+        if mig.version > target:
+            break
+        if mig.name in applied:
+            continue
+        if mig.requires_fk_off:
+            _apply_fk_off_migration(conn, mig)
+        else:
+            _apply_tx_migration(conn, mig)
+
+
+def _index_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA index_list('{table}')").fetchall()
+    return {r["name"] for r in rows if not r["name"].startswith("sqlite_autoindex_")}
+
+
+# ---------------------------------------------------------------------------
+# Apply scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_v4_applies_on_top_of_v3_db(tmp_path: Path) -> None:
+    """V4 must apply cleanly on a DB that was originally migrated to V3."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        _apply_through_version(conn, 3)
+        applied_v3 = {
+            row[0] for row in conn.execute("SELECT name FROM schema_version").fetchall()
+        }
+        assert "v3_sweep_runs" in applied_v3
+        assert "v4_widen_triggered_by_mcp" not in applied_v3
+
+        apply_migrations(conn)
+        applied_all = {
+            row[0] for row in conn.execute("SELECT name FROM schema_version").fetchall()
+        }
+    finally:
+        conn.close()
+
+    assert "v4_widen_triggered_by_mcp" in applied_all
+
+
+def test_v4_idempotent(tmp_path: Path) -> None:
+    """A second ``apply_migrations`` call is a no-op."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        second = apply_migrations(conn)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM schema_version "
+            "WHERE name = 'v4_widen_triggered_by_mcp'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert second == []
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# CHECK constraint behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_runs_triggered_by_mcp_allowed(tmp_path: Path) -> None:
+    """After V4, ``triggered_by='mcp'`` is a valid CHECK value."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        conn.execute(
+            "INSERT INTO workflow_runs "
+            "(workflow_name, status, started_at, triggered_by) "
+            "VALUES (?, ?, ?, ?)",
+            ("mcp_sweep_cell", "pending", "2026-04-22T10:00:00.000Z", "mcp"),
+        )
+        row = conn.execute(
+            "SELECT triggered_by FROM workflow_runs WHERE workflow_name = ?",
+            ("mcp_sweep_cell",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["triggered_by"] == "mcp"
+
+
+def test_workflow_runs_triggered_by_invalid_rejected(tmp_path: Path) -> None:
+    """Values outside the V4 allowlist still fail the CHECK constraint."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO workflow_runs "
+                "(workflow_name, status, started_at, triggered_by) "
+                "VALUES (?, ?, ?, ?)",
+                ("bogus", "pending", "2026-04-22T10:00:00.000Z", "garbage"),
+            )
+    finally:
+        conn.close()
+
+
+def test_workflow_runs_triggered_by_schedule_still_allowed(tmp_path: Path) -> None:
+    """The reserved ``'schedule'`` value survives V4 for forward compat."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        conn.execute(
+            "INSERT INTO workflow_runs "
+            "(workflow_name, status, started_at, triggered_by) "
+            "VALUES (?, ?, ?, ?)",
+            ("scheduled_wf", "pending", "2026-04-22T10:00:00.000Z", "schedule"),
+        )
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Data + index preservation through table rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_existing_workflow_runs_row_survives_v4(tmp_path: Path) -> None:
+    """A workflow_runs row written before V4 must round-trip unchanged."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        _apply_through_version(conn, 3)
+        conn.execute(
+            "INSERT INTO workflow_runs "
+            "(workflow_name, workflow_yaml_path, status, started_at, "
+            " completed_at, args, error, triggered_by, sweep_run_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "pre_v4_wf",
+                "/tmp/wf.yaml",
+                "completed",
+                "2026-04-20T10:00:00.000Z",
+                "2026-04-20T10:05:00.000Z",
+                '{"lr": 0.01}',
+                None,
+                "web",
+                None,
+            ),
+        )
+        apply_migrations(conn)
+
+        row = conn.execute(
+            "SELECT workflow_name, workflow_yaml_path, status, started_at, "
+            "completed_at, args, error, triggered_by, sweep_run_id "
+            "FROM workflow_runs WHERE workflow_name = ?",
+            ("pre_v4_wf",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["workflow_name"] == "pre_v4_wf"
+    assert row["workflow_yaml_path"] == "/tmp/wf.yaml"
+    assert row["status"] == "completed"
+    assert row["started_at"] == "2026-04-20T10:00:00.000Z"
+    assert row["completed_at"] == "2026-04-20T10:05:00.000Z"
+    assert row["args"] == '{"lr": 0.01}'
+    assert row["error"] is None
+    assert row["triggered_by"] == "web"
+    assert row["sweep_run_id"] is None
+
+
+def test_workflow_runs_indexes_preserved_after_v4(tmp_path: Path) -> None:
+    """The three indexes defined in V1+V3 must survive the V4 rebuild."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        names = _index_names(conn, "workflow_runs")
+    finally:
+        conn.close()
+
+    assert {
+        "idx_workflow_runs_status",
+        "idx_workflow_runs_started_at",
+        "idx_workflow_runs_sweep_run_id",
+    }.issubset(names)
+
+
+def test_workflow_runs_sweep_run_id_fk_preserved(tmp_path: Path) -> None:
+    """workflow_runs.sweep_run_id → sweep_runs(id) ON DELETE SET NULL must persist."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        row = conn.execute(
+            'SELECT "table", "from", "to", on_delete '
+            "FROM pragma_foreign_key_list('workflow_runs') "
+            "WHERE \"table\" = 'sweep_runs'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["from"] == "sweep_run_id"
+    assert row["to"] == "id"
+    assert row["on_delete"] == "SET NULL"
+
+
+def test_workflow_runs_fks_globally_consistent_after_v4(tmp_path: Path) -> None:
+    """``PRAGMA foreign_key_check`` must report no violations after V4."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+    finally:
+        conn.close()
+
+    assert list(violations) == []
+
+
+# ---------------------------------------------------------------------------
+# Inbound FK references still resolve after the rebuild
+# ---------------------------------------------------------------------------
+
+
+def test_jobs_workflow_run_id_fk_still_resolves(tmp_path: Path) -> None:
+    """jobs.workflow_run_id → workflow_runs(id) must survive the rebuild.
+
+    The V4 migration drops and re-creates ``workflow_runs``; without
+    ``PRAGMA foreign_keys=OFF`` during the rebuild, inbound references
+    from ``jobs`` would be invalidated.
+    """
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        cur = conn.execute(
+            "INSERT INTO workflow_runs "
+            "(workflow_name, status, started_at, triggered_by) "
+            "VALUES (?, ?, ?, ?)",
+            ("inbound_fk_wf", "pending", "2026-04-22T10:00:00.000Z", "mcp"),
+        )
+        wr_id = cur.lastrowid
+
+        conn.execute(
+            "INSERT INTO jobs "
+            "(job_id, name, status, submitted_at, workflow_run_id, submission_source) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (123_456, "j1", "PENDING", "2026-04-22T10:00:01.000Z", wr_id, "workflow"),
+        )
+        row = conn.execute(
+            "SELECT workflow_run_id FROM jobs WHERE job_id = ?", (123_456,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["workflow_run_id"] == wr_id
+
+
+def test_workflow_run_jobs_cascade_delete_still_works(tmp_path: Path) -> None:
+    """workflow_run_jobs.workflow_run_id ON DELETE CASCADE must still fire."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        cur = conn.execute(
+            "INSERT INTO workflow_runs "
+            "(workflow_name, status, started_at, triggered_by) "
+            "VALUES (?, ?, ?, ?)",
+            ("cascade_wf", "pending", "2026-04-22T10:00:00.000Z", "mcp"),
+        )
+        wr_id = cur.lastrowid
+
+        conn.execute(
+            "INSERT INTO workflow_run_jobs (workflow_run_id, job_name) VALUES (?, ?)",
+            (wr_id, "step1"),
+        )
+
+        # Deleting the parent must cascade.
+        conn.execute("DELETE FROM workflow_runs WHERE id = ?", (wr_id,))
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM workflow_run_jobs WHERE workflow_run_id = ?",
+            (wr_id,),
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert remaining == 0

--- a/tests/db/test_migration_v4_apply.py
+++ b/tests/db/test_migration_v4_apply.py
@@ -1,0 +1,152 @@
+"""Tests for ``apply_migrations`` handling of the V4 FK-off migration.
+
+Mirrors ``test_migration_v3_apply.py``: verifies the Phase 3 A-3 CHECK
+widening migration is applied via ``_apply_fk_off_migration``, is
+idempotent, restores the ``foreign_keys`` pragma, and — most
+importantly — rolls back atomically on partial failure. The
+``workflow_runs`` table must not be left half-rebuilt (missing columns,
+missing indexes, or missing ``sweep_run_id`` data) if any DDL
+statement inside the V4 script raises.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+
+
+def _fk_pragma(conn: Any) -> int:
+    row = conn.execute("PRAGMA foreign_keys").fetchone()
+    return int(row[0])
+
+
+def test_apply_migrations_runs_v4_on_fresh_db(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        applied = apply_migrations(conn)
+    finally:
+        conn.close()
+    assert "v1_initial" in applied
+    assert "v2_dashboard_indexes" in applied
+    assert "v3_sweep_runs" in applied
+    assert "v4_widen_triggered_by_mcp" in applied
+
+
+def test_apply_migrations_is_idempotent_with_v4(tmp_path: Path) -> None:
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        first = apply_migrations(conn)
+        second = apply_migrations(conn)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM schema_version "
+            "WHERE name = 'v4_widen_triggered_by_mcp'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "v4_widen_triggered_by_mcp" in first
+    assert second == []
+    assert count == 1
+
+
+def test_apply_migrations_restores_foreign_keys_pragma_after_v4(
+    tmp_path: Path,
+) -> None:
+    """After V4 toggles FK OFF/ON the pragma must be restored."""
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        apply_migrations(conn)
+        assert _fk_pragma(conn) == 1
+    finally:
+        conn.close()
+
+    # A fresh connection must also observe FK ON (the default).
+    conn2 = open_connection(db)
+    try:
+        assert _fk_pragma(conn2) == 1
+    finally:
+        conn2.close()
+
+
+def test_v4_migration_rolls_back_on_partial_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """V4 must be atomic: a mid-script failure leaves the schema at V3.
+
+    Same rollback contract as the V3 atomicity test — if the migration
+    raises after CREATE TABLE workflow_runs_v4 but before the DROP +
+    RENAME, the rollback must undo the new table so the original
+    ``workflow_runs`` (with the V3 CHECK constraint) remains intact and
+    no ``v4_widen_triggered_by_mcp`` row is recorded in
+    ``schema_version``.
+    """
+    from srunx.db import migrations as mig
+
+    db = tmp_path / "srunx.db"
+    conn = open_connection(db)
+    try:
+        # Apply V1..V3 first so V4 is the pending migration that the
+        # patched ``apply_migrations`` call exercises.
+        original_migrations = list(mig.MIGRATIONS)
+        monkeypatch.setattr(mig, "MIGRATIONS", original_migrations[:3])
+        mig.apply_migrations(conn)
+        monkeypatch.setattr(mig, "MIGRATIONS", original_migrations)
+
+        # Inject a broken statement right after CREATE TABLE
+        # workflow_runs_v4 so the new table exists momentarily but the
+        # DROP + RENAME never runs. The BEGIN IMMEDIATE wrapper must
+        # roll everything back — including the CREATE.
+        real_split = mig._split_sql_statements
+
+        def exploding_split(sql: str) -> list[str]:
+            statements = real_split(sql)
+            if "CREATE TABLE workflow_runs_v4" in sql:
+                statements.insert(1, "THIS IS NOT VALID SQL;")
+            return statements
+
+        monkeypatch.setattr(mig, "_split_sql_statements", exploding_split)
+
+        with pytest.raises(Exception):
+            mig.apply_migrations(conn)
+
+        # The half-built shadow table must be gone.
+        shadow = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='workflow_runs_v4'"
+        ).fetchall()
+        assert shadow == []
+
+        # The original workflow_runs (with the V3 CHECK) must still
+        # exist and still reject ``triggered_by='mcp'``.
+        existing = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='workflow_runs'"
+        ).fetchall()
+        assert len(existing) == 1
+
+        import sqlite3 as _sqlite3
+
+        with pytest.raises(_sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO workflow_runs "
+                "(workflow_name, status, started_at, triggered_by) "
+                "VALUES (?, ?, ?, ?)",
+                ("rollback_check", "pending", "2026-04-22T10:00:00.000Z", "mcp"),
+            )
+
+        # No V4 row in schema_version.
+        recorded = conn.execute(
+            "SELECT name FROM schema_version WHERE name = 'v4_widen_triggered_by_mcp'"
+        ).fetchall()
+        assert recorded == []
+
+        # FK enforcement restored regardless of outcome.
+        assert _fk_pragma(conn) == 1
+    finally:
+        conn.close()

--- a/tests/ssh/test_status_fallback.py
+++ b/tests/ssh/test_status_fallback.py
@@ -1,0 +1,148 @@
+"""Phase 3 A-1: scontrol fallback for SLURM status on pyxis clusters.
+
+Exercises the parser and the three-tier sacct → squeue → scontrol probe
+chain in :meth:`SSHSlurmClient.get_job_status`, which is the path the
+SSH sweep/web surface uses when slurmdbd is unreachable and jobs drop
+off squeue.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from srunx.ssh.core.client import SSHSlurmClient, _parse_scontrol_status
+
+# ── Pure parser ──────────────────────────────────────────────────────
+
+
+class TestParseScontrolStatus:
+    def test_parses_running(self) -> None:
+        out = "JobId=123 JobName=foo JobState=RUNNING Reason=None ExitCode=0:0"
+        assert _parse_scontrol_status(out) == "RUNNING"
+
+    def test_parses_pending(self) -> None:
+        out = "JobId=1 JobState=PENDING Reason=Resources ExitCode=0:0"
+        assert _parse_scontrol_status(out) == "PENDING"
+
+    def test_completed_with_clean_exit_is_completed(self) -> None:
+        out = "JobId=1 JobState=COMPLETED Reason=None ExitCode=0:0"
+        assert _parse_scontrol_status(out) == "COMPLETED"
+
+    def test_completed_with_nonzero_exit_downgrades_to_failed(self) -> None:
+        out = "JobId=1 JobState=COMPLETED Reason=None ExitCode=1:0"
+        assert _parse_scontrol_status(out) == "FAILED"
+
+    def test_completed_with_signal_downgrades_to_failed(self) -> None:
+        out = "JobId=1 JobState=COMPLETED Reason=None ExitCode=0:9"
+        assert _parse_scontrol_status(out) == "FAILED"
+
+    def test_failed_state_passes_through(self) -> None:
+        out = "JobId=1 JobState=FAILED Reason=NonZeroExit ExitCode=1:0"
+        assert _parse_scontrol_status(out) == "FAILED"
+
+    def test_cancelled_state_passes_through(self) -> None:
+        out = "JobId=1 JobState=CANCELLED Reason=None ExitCode=0:15"
+        assert _parse_scontrol_status(out) == "CANCELLED"
+
+    def test_empty_input_returns_none(self) -> None:
+        assert _parse_scontrol_status("") is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        assert _parse_scontrol_status("   \n  \t  \n") is None
+
+    def test_missing_jobstate_returns_none(self) -> None:
+        out = "JobId=1 JobName=foo Reason=None"
+        assert _parse_scontrol_status(out) is None
+
+    def test_multiline_output(self) -> None:
+        out = (
+            "JobId=42 JobName=train\n"
+            "   UserId=u(1000) GroupId=g(1000)\n"
+            "   Priority=1 JobState=COMPLETED Reason=None ExitCode=0:0\n"
+            "   RunTime=00:05:12 TimeLimit=01:00:00\n"
+        )
+        assert _parse_scontrol_status(out) == "COMPLETED"
+
+
+# ── get_job_status three-tier fallback ───────────────────────────────
+
+
+def _bare_ssh_client() -> SSHSlurmClient:
+    """Minimal SSHSlurmClient instance bypassing paramiko / config init."""
+    client = object.__new__(SSHSlurmClient)
+    client.logger = MagicMock()
+    return client
+
+
+def _stub_exec(responses: list[tuple[str, str, int]]):
+    """Return an `_execute_slurm_command` stub that pops responses in order."""
+    idx = {"i": 0}
+
+    def _exec(cmd: str) -> tuple[str, str, int]:
+        i = idx["i"]
+        idx["i"] += 1
+        assert i < len(responses), f"unexpected call #{i}: {cmd!r}"
+        return responses[i]
+
+    _exec.calls_made = idx  # type: ignore[attr-defined]
+    return _exec
+
+
+class TestGetJobStatusFallback:
+    def test_sacct_hit_short_circuits(self) -> None:
+        client = _bare_ssh_client()
+        client._execute_slurm_command = _stub_exec(  # type: ignore[method-assign]
+            [("12345  COMPLETED\n", "", 0)]
+        )
+        assert client.get_job_status("12345") == "COMPLETED"
+
+    def test_squeue_hit_when_sacct_empty(self) -> None:
+        client = _bare_ssh_client()
+        client._execute_slurm_command = _stub_exec(  # type: ignore[method-assign]
+            [("", "", 0), ("RUNNING\n", "", 0)]
+        )
+        assert client.get_job_status("123") == "RUNNING"
+
+    def test_uses_scontrol_when_sacct_and_squeue_empty(self) -> None:
+        """Core A-1 regression: pyxis, sacct empty, job dropped from squeue."""
+        client = _bare_ssh_client()
+        scontrol_out = (
+            "JobId=777 JobName=ok JobState=COMPLETED Reason=None ExitCode=0:0"
+        )
+        client._execute_slurm_command = _stub_exec(  # type: ignore[method-assign]
+            [
+                ("", "", 0),  # sacct
+                ("", "", 0),  # squeue
+                (scontrol_out, "", 0),  # scontrol
+            ]
+        )
+        assert client.get_job_status("777") == "COMPLETED"
+
+    def test_scontrol_nonzero_exit_yields_failed(self) -> None:
+        client = _bare_ssh_client()
+        scontrol_out = "JobId=777 JobState=COMPLETED Reason=NonZeroExit ExitCode=1:0"
+        client._execute_slurm_command = _stub_exec(  # type: ignore[method-assign]
+            [("", "", 0), ("", "", 0), (scontrol_out, "", 0)]
+        )
+        assert client.get_job_status("777") == "FAILED"
+
+    def test_all_three_sources_empty_returns_not_found(self) -> None:
+        client = _bare_ssh_client()
+        client._execute_slurm_command = _stub_exec(  # type: ignore[method-assign]
+            [("", "", 0), ("", "", 0), ("", "", 0)]
+        )
+        assert client.get_job_status("999") == "NOT_FOUND"
+
+    def test_scontrol_command_failure_returns_not_found(self) -> None:
+        """scontrol exiting non-zero (e.g. permission denied) → NOT_FOUND."""
+        client = _bare_ssh_client()
+        client._execute_slurm_command = _stub_exec(  # type: ignore[method-assign]
+            [("", "", 0), ("", "", 0), ("", "no job", 1)]
+        )
+        assert client.get_job_status("999") == "NOT_FOUND"
+
+    def test_invalid_job_id_short_circuits_without_probing(self) -> None:
+        client = _bare_ssh_client()
+        # No stubs registered — if get_job_status reaches _execute_slurm_command
+        # it would AttributeError.
+        assert client.get_job_status("not; a-number") == "ERROR"

--- a/tests/sweep/test_orchestrator.py
+++ b/tests/sweep/test_orchestrator.py
@@ -360,6 +360,115 @@ class TestCellFailure:
 
 
 # ---------------------------------------------------------------------------
+# C1 atomic-claim regression: drain must beat late sem wake to SLURM submit
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicCellClaim:
+    """Regression: drained cell must not call ``_run_cell_sync`` even if a
+    racing task already passed the ``if self._cancelled`` check.
+
+    Simulates the narrow TOCTOU window where a queued cell wakes from the
+    semaphore before the fail-fast drain flips ``_cancelled``. The
+    ``_claim_cell_running`` DB-level optimistic UPDATE must fail (because
+    drain already set the row to ``cancelled``) so ``_run_cell_sync`` is
+    never called.
+    """
+
+    def test_race_drain_vs_acquire_skips_drained_cell(
+        self,
+        isolated_db: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        orch = _build_orchestrator(
+            tmp_path,
+            matrix={"lr": [0.1, 0.01]},
+            fail_fast=False,  # we'll simulate the drain manually
+            max_parallel=2,
+        )
+
+        # Materialize up-front so we know both workflow_run_ids.
+        cells = orch._expand_cells()
+        sweep_run_id = orch._materialize(cells)
+        assert len(orch._cells) == 2
+
+        # Simulate a concurrent drain: flip cell 1's row to cancelled
+        # BEFORE the orchestrator attempts its atomic claim. This mirrors
+        # the fail-fast race where ``_drain`` wins between
+        # ``_cancelled`` being observed False and the claim firing.
+        from srunx.sweep.orchestrator import drain_sweep_pending_cells
+
+        # Drain everything that's still pending. Since no cell has moved
+        # off ``pending`` yet, both cells will be marked ``cancelled``.
+        drain_sweep_pending_cells(sweep_run_id)
+
+        call_counts: dict[int, int] = {}
+
+        def _run_cell_sync(self: SweepOrchestrator, cell: CellSpec) -> None:
+            call_counts[cell.cell_index] = call_counts.get(cell.cell_index, 0) + 1
+            _simulate_cell(cell.workflow_run_id, final_status="completed")
+
+        monkeypatch.setattr(SweepOrchestrator, "_run_cell_sync", _run_cell_sync)
+
+        # Resume with the already-materialized (now drained) cells. Every
+        # cell's atomic claim must return False because the rows are
+        # ``cancelled``, so ``_run_cell_sync`` is never invoked.
+        import anyio
+
+        anyio.run(orch.arun_from_materialized, sweep_run_id)
+
+        assert call_counts == {}, (
+            "atomic claim should have skipped drained cells; "
+            f"_run_cell_sync was invoked for indices: {sorted(call_counts)}"
+        )
+
+        # Every cell remains cancelled; nothing transitioned to running.
+        cells_rows = _read_cells(sweep_run_id)
+        assert [r["status"] for r in cells_rows] == ["cancelled", "cancelled"]
+
+    def test_claim_succeeds_for_normal_cells(
+        self,
+        isolated_db: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Happy path: every cell's atomic claim returns True exactly once."""
+        orch = _build_orchestrator(
+            tmp_path,
+            matrix={"lr": [0.1, 0.01, 0.001]},
+            fail_fast=False,
+            max_parallel=3,
+        )
+
+        claim_results: list[bool] = []
+        original_claim = SweepOrchestrator._claim_cell_running
+
+        def _recording_claim(self: SweepOrchestrator, workflow_run_id: int) -> bool:
+            result = original_claim(self, workflow_run_id)
+            claim_results.append(result)
+            return result
+
+        monkeypatch.setattr(SweepOrchestrator, "_claim_cell_running", _recording_claim)
+        monkeypatch.setattr(
+            SweepOrchestrator,
+            "_run_cell_sync",
+            lambda self, cell: _simulate_cell(cell.workflow_run_id),
+        )
+
+        sweep = orch.run()
+        assert sweep.id is not None
+
+        # Every cell claimed exactly once and each claim won.
+        assert len(claim_results) == 3
+        assert all(claim_results)
+
+        row = _read_sweep(sweep.id)
+        assert row["cells_completed"] == 3
+        assert row["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
 # C2 regression: from_yaml-style failure must transition cell to failed
 # ---------------------------------------------------------------------------
 

--- a/tests/sweep/test_reconciler.py
+++ b/tests/sweep/test_reconciler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import yaml  # type: ignore
@@ -56,6 +57,7 @@ def _seed_sweep(
     cells_cancelled: int = 0,
     max_parallel: int = 2,
     fail_fast: bool = False,
+    submission_source: str = "cli",
 ) -> int:
     conn = open_connection()
     try:
@@ -83,7 +85,7 @@ def _seed_sweep(
                 cells_completed,
                 cells_failed,
                 cells_cancelled,
-                "cli",
+                submission_source,
                 now_iso(),
             ),
         )
@@ -164,6 +166,7 @@ class TestReconciler:
             sweep_run_id: int,
             sweep_row: Any,
             pending_cells: list[CellSpec],
+            **_kwargs: Any,
         ) -> None:
             spawn_calls.append(sweep_run_id)
 
@@ -207,6 +210,7 @@ class TestReconciler:
             sweep_run_id: int,
             sweep_row: Any,
             pending_cells: list[CellSpec],
+            **_kwargs: Any,
         ) -> None:
             spawn_calls.append(sweep_run_id)
 
@@ -248,6 +252,7 @@ class TestReconciler:
             sweep_run_id: int,
             sweep_row: Any,
             pending_cells: list[CellSpec],
+            **_kwargs: Any,
         ) -> None:
             spawn_calls.append(
                 (sweep_run_id, [c.workflow_run_id for c in pending_cells])
@@ -292,6 +297,7 @@ class TestReconciler:
             sweep_run_id: int,
             sweep_row: Any,
             pending_cells: list[CellSpec],
+            **_kwargs: Any,
         ) -> None:
             spawn_calls.append(sweep_run_id)
 
@@ -387,3 +393,247 @@ class TestReconciler:
         finally:
             conn.close()
         assert pre_completed["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# C4: executor_factory_provider + submission_source restoration
+# ---------------------------------------------------------------------------
+
+
+class TestReconcilerExecutorFactoryProvider:
+    """C4: the reconciler must restore the SSH executor factory + submission
+    context for Web / MCP sweeps on resume, and must keep the original
+    ``submission_source`` verbatim instead of hard-coding ``'cli'``.
+    """
+
+    def test_uses_provided_executor_factory_for_web_sweeps(
+        self,
+        isolated_db: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Web-originated sweep → provider's factory reaches the orchestrator
+        and is forwarded verbatim to the per-cell ``WorkflowRunner``.
+        """
+        from srunx.sweep.reconciler import ExecutorFactoryBundle
+
+        yaml_path = _write_yaml(tmp_path)
+        sweep_id = _seed_sweep(
+            yaml_path=str(yaml_path),
+            status="running",
+            cell_count=2,
+            cells_pending=1,
+            cells_running=0,
+            cells_completed=1,
+            max_parallel=2,
+            submission_source="web",
+        )
+        _seed_cells(sweep_id, ["completed", "pending"])
+
+        sentinel_factory = MagicMock(name="sentinel_factory")
+        provider_calls: list[Any] = []
+
+        def provider(sweep: Any) -> ExecutorFactoryBundle:
+            provider_calls.append(sweep)
+            return ExecutorFactoryBundle(factory=sentinel_factory)
+
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_init(self: Any, **kwargs: Any) -> None:
+            captured_kwargs.update(kwargs)
+            # Raise so _reconcile_one returns early without running cells —
+            # we only need to verify the wiring at construction time.
+            raise RuntimeError("abort after construction")
+
+        monkeypatch.setattr(SweepOrchestrator, "__init__", fake_init)
+
+        SweepReconciler.scan_and_resume(executor_factory_provider=provider)
+
+        assert len(provider_calls) == 1
+        assert provider_calls[0].id == sweep_id
+        assert provider_calls[0].submission_source == "web"
+        # Factory was forwarded verbatim.
+        assert captured_kwargs.get("executor_factory") is sentinel_factory
+
+    def test_preserves_submission_source_from_db(
+        self,
+        isolated_db: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The orchestrator's ``submission_source`` must equal the DB value,
+        not the old hard-coded ``'cli'``.
+        """
+        yaml_path = _write_yaml(tmp_path)
+        sweep_id = _seed_sweep(
+            yaml_path=str(yaml_path),
+            status="running",
+            cell_count=2,
+            cells_pending=1,
+            cells_running=0,
+            cells_completed=1,
+            max_parallel=2,
+            submission_source="web",
+        )
+        _seed_cells(sweep_id, ["completed", "pending"])
+
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_init(self: Any, **kwargs: Any) -> None:
+            captured_kwargs.update(kwargs)
+            raise RuntimeError("abort after construction")
+
+        monkeypatch.setattr(SweepOrchestrator, "__init__", fake_init)
+
+        SweepReconciler.scan_and_resume()
+
+        assert captured_kwargs.get("submission_source") == "web"
+
+    def test_falls_back_to_local_slurm_when_provider_returns_none(
+        self,
+        isolated_db: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Provider returning ``None`` → orchestrator gets ``None`` factory
+        (legacy local-``Slurm`` behaviour preserved for CLI sweeps).
+        """
+        yaml_path = _write_yaml(tmp_path)
+        sweep_id = _seed_sweep(
+            yaml_path=str(yaml_path),
+            status="running",
+            cell_count=2,
+            cells_pending=1,
+            cells_running=0,
+            cells_completed=1,
+            max_parallel=2,
+            submission_source="cli",
+        )
+        _seed_cells(sweep_id, ["completed", "pending"])
+
+        provider_calls: list[Any] = []
+
+        def provider(sweep: Any) -> None:
+            provider_calls.append(sweep)
+            return None
+
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_init(self: Any, **kwargs: Any) -> None:
+            captured_kwargs.update(kwargs)
+            raise RuntimeError("abort after construction")
+
+        monkeypatch.setattr(SweepOrchestrator, "__init__", fake_init)
+
+        SweepReconciler.scan_and_resume(executor_factory_provider=provider)
+
+        assert len(provider_calls) == 1
+        assert captured_kwargs.get("executor_factory") is None
+        assert captured_kwargs.get("submission_context") is None
+        # Audit trail intact: ``submission_source`` still ``cli``.
+        assert captured_kwargs.get("submission_source") == "cli"
+
+    def test_closes_pool_after_resume_completes(
+        self,
+        isolated_db: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``bundle.cleanup`` MUST run after resume returns (success or crash)."""
+        from srunx.sweep.reconciler import ExecutorFactoryBundle
+
+        yaml_path = _write_yaml(tmp_path)
+        sweep_id = _seed_sweep(
+            yaml_path=str(yaml_path),
+            status="running",
+            cell_count=2,
+            cells_pending=1,
+            cells_running=0,
+            cells_completed=1,
+            max_parallel=2,
+            submission_source="web",
+        )
+        _seed_cells(sweep_id, ["completed", "pending"])
+
+        # Drive cells to completion via the same trick used in
+        # test_resume_drives_pending_cells_to_completion.
+        from srunx.sweep.state_service import WorkflowRunStateService
+
+        def _simulate(cell: CellSpec) -> None:
+            conn = open_connection()
+            try:
+                with transaction(conn, "IMMEDIATE"):
+                    WorkflowRunStateService.update(
+                        conn=conn,
+                        workflow_run_id=cell.workflow_run_id,
+                        from_status="pending",
+                        to_status="running",
+                    )
+                with transaction(conn, "IMMEDIATE"):
+                    WorkflowRunStateService.update(
+                        conn=conn,
+                        workflow_run_id=cell.workflow_run_id,
+                        from_status="running",
+                        to_status="completed",
+                        completed_at=now_iso(),
+                    )
+            finally:
+                conn.close()
+
+        monkeypatch.setattr(
+            SweepOrchestrator,
+            "_run_cell_sync",
+            lambda self, cell: _simulate(cell),
+        )
+
+        cleanup_calls: list[int] = []
+        sentinel_factory = MagicMock(name="sentinel_factory")
+
+        def provider(sweep: Any) -> ExecutorFactoryBundle:
+            return ExecutorFactoryBundle(
+                factory=sentinel_factory,
+                cleanup=lambda: cleanup_calls.append(1),
+            )
+
+        SweepReconciler.scan_and_resume(executor_factory_provider=provider)
+
+        assert cleanup_calls == [1], "bundle.cleanup must run exactly once"
+
+    def test_provider_exception_falls_back_to_none(
+        self,
+        isolated_db: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A provider that raises MUST NOT abort the startup pass —
+        the reconciler falls back to ``None`` and continues.
+        """
+        yaml_path = _write_yaml(tmp_path)
+        sweep_id = _seed_sweep(
+            yaml_path=str(yaml_path),
+            status="running",
+            cell_count=2,
+            cells_pending=1,
+            cells_running=0,
+            cells_completed=1,
+            max_parallel=2,
+            submission_source="web",
+        )
+        _seed_cells(sweep_id, ["completed", "pending"])
+
+        def provider(sweep: Any) -> Any:
+            raise RuntimeError("provider boom")
+
+        captured_kwargs: dict[str, Any] = {}
+
+        def fake_init(self: Any, **kwargs: Any) -> None:
+            captured_kwargs.update(kwargs)
+            raise RuntimeError("abort after construction")
+
+        monkeypatch.setattr(SweepOrchestrator, "__init__", fake_init)
+
+        SweepReconciler.scan_and_resume(executor_factory_provider=provider)
+
+        # Orchestrator still instantiated — with ``None`` factory.
+        assert captured_kwargs.get("executor_factory") is None
+        assert captured_kwargs.get("submission_source") == "web"

--- a/tests/web/test_ssh_adapter_parsing.py
+++ b/tests/web/test_ssh_adapter_parsing.py
@@ -539,3 +539,74 @@ class TestClusterSnapshot:
 
         with pytest.raises(RuntimeError, match="ssh dropped"):
             adapter.get_cluster_snapshot()
+
+
+# ── queue_by_ids scontrol fallback (Phase 3 A-1) ──
+
+
+class TestQueueByIdsScontrolFallback:
+    """Phase 3 A-1: on pyxis clusters where sacct is unreachable,
+    queue_by_ids must fall back to scontrol per-id before giving up.
+    """
+
+    def test_scontrol_fills_gap_for_ids_missing_from_sacct_and_squeue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scontrol_out = (
+            "JobId=555 JobName=late JobState=COMPLETED Reason=None ExitCode=0:0"
+        )
+
+        def fake_run(_adapter, cmd: str) -> str:
+            if cmd.startswith("squeue"):
+                # squeue has no record of 555 (already finished)
+                return ""
+            if cmd.startswith("sacct"):
+                # sacct returns empty on pyxis (slurmdbd unreachable)
+                return ""
+            if cmd.startswith("scontrol show job 555"):
+                return scontrol_out
+            return ""
+
+        monkeypatch.setattr("srunx.web.ssh_adapter._run_slurm_cmd", fake_run)
+        adapter = object.__new__(SlurmSSHAdapter)
+
+        result = adapter.queue_by_ids([555])
+
+        assert 555 in result
+        assert result[555].status == "COMPLETED"
+
+    def test_scontrol_completed_with_nonzero_exit_is_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scontrol_out = "JobId=556 JobState=COMPLETED Reason=NonZeroExit ExitCode=2:0"
+
+        def fake_run(_adapter, cmd: str) -> str:
+            if cmd.startswith("scontrol show job 556"):
+                return scontrol_out
+            return ""
+
+        monkeypatch.setattr("srunx.web.ssh_adapter._run_slurm_cmd", fake_run)
+        adapter = object.__new__(SlurmSSHAdapter)
+
+        result = adapter.queue_by_ids([556])
+
+        assert 556 in result
+        # ExitCode=2:0 → disambiguated to FAILED (not COMPLETED)
+        assert result[556].status == "FAILED"
+
+    def test_all_three_empty_omits_id_from_results(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When no source knows about a job, it stays out of the result
+        map (unchanged vs. pre-fix behaviour — the caller treats absence
+        as 'no update')."""
+
+        def fake_run(_adapter, _cmd: str) -> str:
+            return ""
+
+        monkeypatch.setattr("srunx.web.ssh_adapter._run_slurm_cmd", fake_run)
+        adapter = object.__new__(SlurmSSHAdapter)
+
+        result = adapter.queue_by_ids([999])
+
+        assert 999 not in result

--- a/tests/web/test_ssh_adapter_run.py
+++ b/tests/web/test_ssh_adapter_run.py
@@ -568,6 +568,54 @@ class TestSSHAdapterRunSubmissionContext:
 
         assert "#SBATCH --chdir=/mnt/injected" in captured["content"]  # type: ignore[operator]
 
+    def test_original_job_gets_terminal_status_when_context_forces_copy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: ``WorkflowRunner.all_jobs`` holds the caller's ``Job``;
+        when ``normalize_job_for_submission`` returns a ``model_copy``
+        the terminal status must still propagate back to the caller's
+        instance so the runner doesn't declare the cell "incomplete"
+        even after SLURM reports COMPLETED.
+        """
+        from srunx.rendering import SubmissionRenderContext
+
+        ctx = SubmissionRenderContext(default_work_dir="/mnt/forced_copy")
+
+        adapter = _bare_adapter()
+        original = Job(
+            name="propagate",
+            command=["echo", "ok"],
+            work_dir="",  # triggers normalize → model_copy
+            log_dir="",
+        )
+
+        def fake_submit(script_content: str, *, job_name=None, dependency=None):
+            sj = MagicMock()
+            sj.job_id = "4242"
+            sj.name = job_name
+            return sj
+
+        adapter._client.submit_sbatch_job = fake_submit  # type: ignore[method-assign,assignment]
+        monkeypatch.setattr(
+            adapter, "_monitor_until_terminal", lambda _jid: "COMPLETED"
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_job_submission",
+            staticmethod(lambda *a, **k: None),
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_completion_safe",
+            staticmethod(lambda *a, **k: None),
+        )
+
+        returned = adapter.run(original, submission_context=ctx)
+
+        assert returned is original
+        assert original.status == JobStatus.COMPLETED
+        assert original.job_id == 4242
+
 
 class TestAdapterFromSpec:
     def test_from_spec_creates_disconnected_clone(self) -> None:

--- a/tests/web/test_ssh_adapter_run.py
+++ b/tests/web/test_ssh_adapter_run.py
@@ -14,7 +14,11 @@ import pytest
 
 from srunx.callbacks import Callback
 from srunx.models import Job, JobStatus
-from srunx.web.ssh_adapter import SlurmSSHAdapter, SlurmSSHAdapterSpec
+from srunx.web.ssh_adapter import (
+    SlurmSSHAdapter,
+    SlurmSSHAdapterSpec,
+    SSHMonitorTimeoutError,
+)
 
 # --- Helpers ---------------------------------------------------------
 
@@ -264,6 +268,149 @@ class TestSSHAdapterRun:
         job = Job(name="nope", command=["echo"], log_dir="", work_dir="")
         with pytest.raises(RuntimeError, match="Failed to submit"):
             adapter.run(job)
+
+
+class TestSSHAdapterRunUnknownStatus:
+    """Phase 3 A-1: NOT_FOUND / unrecognised states must not silently FAIL.
+
+    Pre-fix behaviour: any non-COMPLETED/FAILED/CANCELLED/TIMEOUT status
+    hit ``JobStatus(terminal_status)`` → ``ValueError`` → silent FAILED,
+    turning successful-but-dropped-from-sacct jobs into false failures
+    on pyxis clusters. The fix maps these to :attr:`JobStatus.UNKNOWN`
+    with a warning log and skips the failure-raise path.
+    """
+
+    def test_not_found_becomes_unknown_not_silent_failed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cb = _RecordingCallback()
+        adapter = _bare_adapter(callbacks=[cb])
+
+        job = Job(name="disappeared", command=["true"], log_dir="", work_dir="")
+
+        sj = MagicMock()
+        sj.job_id = "501"
+        sj.name = "disappeared"
+        adapter._client.submit_sbatch_job = MagicMock(return_value=sj)  # type: ignore[method-assign]
+
+        monkeypatch.setattr(
+            adapter, "_monitor_until_terminal", lambda _jid: "NOT_FOUND"
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_job_submission",
+            staticmethod(lambda *a, **k: None),
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_completion_safe",
+            staticmethod(lambda *a, **k: None),
+        )
+
+        # run() must return without raising — the pre-fix behaviour would
+        # have silently tagged the job FAILED and raised RuntimeError.
+        result = adapter.run(job)
+
+        assert result.status == JobStatus.UNKNOWN
+        # Neither completed nor failed callbacks fired — UNKNOWN is
+        # explicitly outside the terminal-callback set.
+        assert cb.completed == []
+        assert cb.failed == []
+
+    def test_unrecognised_slurm_state_becomes_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _bare_adapter()
+        job = Job(name="weird", command=["true"], log_dir="", work_dir="")
+
+        sj = MagicMock()
+        sj.job_id = "502"
+        sj.name = "weird"
+        adapter._client.submit_sbatch_job = MagicMock(return_value=sj)  # type: ignore[method-assign]
+
+        monkeypatch.setattr(
+            adapter, "_monitor_until_terminal", lambda _jid: "SOME_FUTURE_STATE"
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_job_submission",
+            staticmethod(lambda *a, **k: None),
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_completion_safe",
+            staticmethod(lambda *a, **k: None),
+        )
+
+        result = adapter.run(job)
+        assert result.status == JobStatus.UNKNOWN
+
+
+class TestMonitorTimeout:
+    """Phase 3 A-2: ``_monitor_until_terminal`` must honour a timeout."""
+
+    def test_timeout_raises_ssh_monitor_timeout_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = _bare_adapter()
+
+        # Job is always RUNNING — the loop never escapes on its own.
+        monkeypatch.setattr(adapter, "get_job_status", lambda _jid: "RUNNING")
+
+        with pytest.raises(SSHMonitorTimeoutError, match="Timed out"):
+            adapter._monitor_until_terminal(123, poll_interval=0, timeout=0.1)
+
+    def test_timeout_none_waits_until_terminal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Explicit timeout=None disables the bound even if the env-var default would."""
+        adapter = _bare_adapter()
+
+        # Env var would otherwise force a very short timeout; None overrides.
+        monkeypatch.setenv("SRUNX_SSH_MONITOR_TIMEOUT", "0.01")
+
+        calls = {"n": 0}
+
+        def _status(_jid):
+            calls["n"] += 1
+            return "COMPLETED" if calls["n"] >= 3 else "RUNNING"
+
+        monkeypatch.setattr(adapter, "get_job_status", _status)
+
+        result = adapter._monitor_until_terminal(42, poll_interval=0, timeout=None)
+        assert result == "COMPLETED"
+        assert calls["n"] == 3
+
+    def test_env_var_default_bounds_wait_when_unspecified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unset ``timeout`` kwarg picks up SRUNX_SSH_MONITOR_TIMEOUT."""
+        adapter = _bare_adapter()
+        monkeypatch.setenv("SRUNX_SSH_MONITOR_TIMEOUT", "0.1")
+        monkeypatch.setattr(adapter, "get_job_status", lambda _jid: "RUNNING")
+
+        with pytest.raises(SSHMonitorTimeoutError):
+            # No explicit timeout kwarg; env var should kick in.
+            adapter._monitor_until_terminal(99, poll_interval=0)
+
+    def test_invalid_env_var_falls_back_to_no_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Garbage env var is ignored (warning logged) — no timeout applied."""
+        adapter = _bare_adapter()
+        monkeypatch.setenv("SRUNX_SSH_MONITOR_TIMEOUT", "not-a-number")
+
+        # Terminate quickly to avoid hanging the test on the pass-through path.
+        calls = {"n": 0}
+
+        def _status(_jid):
+            calls["n"] += 1
+            return "COMPLETED" if calls["n"] >= 2 else "RUNNING"
+
+        monkeypatch.setattr(adapter, "get_job_status", _status)
+
+        result = adapter._monitor_until_terminal(1, poll_interval=0)
+        assert result == "COMPLETED"
 
 
 class TestSSHAdapterRunSubmissionContext:

--- a/tests/web/test_sweep_runs_api.py
+++ b/tests/web/test_sweep_runs_api.py
@@ -384,6 +384,164 @@ class TestRunWorkflowWithSweep:
         assert resp.status_code == 422, resp.text
 
 
+class TestDispatchSweepShellJobGuard:
+    """C3: the sweep dispatch path must enforce the ShellJob script-root
+    traversal guard before materializing cells or spawning the orchestrator.
+
+    These tests write a sweep-eligible workflow YAML directly to the
+    mount's workflow directory (bypassing /api/workflows/create so the
+    ``script_path`` isn't validated at creation time) and then submit
+    it via /api/workflows/{name}/run.
+    """
+
+    def _write_sweep_yaml(
+        self,
+        tmp_path: Path,
+        *,
+        name: str,
+        script_path: str,
+    ) -> None:
+        import yaml
+
+        wf_dir = tmp_path / "project" / ".srunx" / "workflows"
+        wf_dir.mkdir(parents=True, exist_ok=True)
+        body = {
+            "name": name,
+            "args": {"lr": "0.01"},
+            "jobs": [
+                {
+                    "name": "train",
+                    "script_path": script_path,
+                }
+            ],
+        }
+        (wf_dir / f"{name}.yaml").write_text(yaml.dump(body))
+
+    def test_rejects_shell_job_traversal_outside_mount(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+    ) -> None:
+        """``script_path`` resolving outside the mount → 403 before
+        materialize."""
+        self._write_sweep_yaml(
+            tmp_path,
+            name="evil-traversal",
+            script_path="../../../etc/passwd",
+        )
+
+        with patch("srunx.web.routers.workflows.SweepOrchestrator") as orch_cls:
+            resp = client.post(
+                "/api/workflows/evil-traversal/run",
+                params={"mount": MOUNT},
+                json={
+                    "sweep": {
+                        "matrix": {"lr": [0.01, 0.1]},
+                        "max_parallel": 2,
+                    }
+                },
+            )
+
+        assert resp.status_code == 403, resp.text
+        assert "outside allowed directories" in resp.text
+        # Orchestrator must NOT have been constructed — guard runs before
+        # materialize.
+        orch_cls.assert_not_called()
+
+    def test_rejects_shell_job_absolute_path_outside_mount_root(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+    ) -> None:
+        """An absolute ``script_path`` outside every mount → 403."""
+        self._write_sweep_yaml(
+            tmp_path,
+            name="abs-outside",
+            script_path="/tmp/attacker.sh",
+        )
+
+        with patch("srunx.web.routers.workflows.SweepOrchestrator") as orch_cls:
+            resp = client.post(
+                "/api/workflows/abs-outside/run",
+                params={"mount": MOUNT},
+                json={
+                    "sweep": {
+                        "matrix": {"lr": [0.01, 0.1]},
+                        "max_parallel": 2,
+                    }
+                },
+            )
+
+        assert resp.status_code == 403, resp.text
+        orch_cls.assert_not_called()
+
+    def test_accepts_shell_job_within_mount(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+    ) -> None:
+        """Legitimate ``script_path`` under the mount passes the guard."""
+        # Place a real script inside the mount's local directory.
+        mount_local = tmp_path / "project"
+        script = mount_local / "train.sh"
+        script.write_text("#!/bin/bash\necho hi\n")
+        self._write_sweep_yaml(
+            tmp_path,
+            name="legit-shell",
+            script_path=str(script),
+        )
+
+        with (
+            patch("srunx.web.routers.workflows.SweepOrchestrator") as orch_cls,
+            patch("srunx.web.routers.workflows.SweepSpec") as spec_cls,
+        ):
+            from srunx.sweep import SweepSpec as _RealSweepSpec
+
+            spec_cls.side_effect = _RealSweepSpec
+
+            from srunx.db.connection import open_connection
+            from srunx.db.repositories.sweep_runs import SweepRunRepository
+
+            conn = open_connection()
+            try:
+                seeded_id = SweepRunRepository(conn).create(
+                    name="legit-shell",
+                    matrix={"lr": [0.01, 0.1]},
+                    args=None,
+                    fail_fast=False,
+                    max_parallel=2,
+                    cell_count=2,
+                    submission_source="web",
+                    status="pending",
+                )
+            finally:
+                conn.close()
+
+            mock_orch = MagicMock()
+            mock_orch.materialize.return_value = seeded_id
+
+            async def _fake_arun(_sweep_run_id: int) -> _FakeSweepRun:
+                return _FakeSweepRun(sweep_id=seeded_id, cell_count=2)
+
+            mock_orch.arun_from_materialized = _fake_arun
+            orch_cls.return_value = mock_orch
+
+            resp = client.post(
+                "/api/workflows/legit-shell/run",
+                params={"mount": MOUNT},
+                json={
+                    "sweep": {
+                        "matrix": {"lr": [0.01, 0.1]},
+                        "max_parallel": 2,
+                    }
+                },
+            )
+
+        # Guard passed → normal sweep dispatch happened.
+        assert resp.status_code == 202, resp.text
+        orch_cls.assert_called_once()
+
+
 class TestSweepRunsReadAPI:
     def _seed_sweep(self, *, name: str = "wf") -> int:
         """Create a minimal sweep_runs row directly in the DB for list tests."""


### PR DESCRIPTION
Phase 3 follow-up to #124. Stacks on top of `feat/workflow-parameter-sweep`; rebase onto `main` once #124 merges.

## Summary
- **α** `fix(ssh)`: scontrol fallback for terminal status when sacct unreachable + typed monitor timeout
- **β** `feat(db)`: V4 migration widens `workflow_runs.triggered_by` to admit `'mcp'`; drops orchestrator workaround
- **γ** `fix(sweep)`: ShellJob path traversal guard applied to sweep dispatch + reconciler restores SSH executor for Web/MCP sweeps on restart
- **δ** `chore(sweep)`: `srunx flow validate` validates every matrix cell + 3 Codex nitpicks (docstring, stale comment, lazy Slurm init)

## Motivation

### α — sacct misclassification (root cause fix)
Pyxis clusters with unreachable slurmdbd return empty `sacct` output and jobs drop from `squeue` within seconds. `SSHSlurmClient.get_job_status` returned the `"NOT_FOUND"` sentinel in that window, which `SlurmSSHAdapter.run` silently coerced to `JobStatus.FAILED` via `ValueError` — completed jobs were reported as failures.

Fix: third probe via `scontrol show job <id>` (keeps record in memory for `MinJobAge`, typically ~5 min, without slurmdbd). `ExitCode=N:M` disambiguates `COMPLETED`-with-nonzero-exit → `FAILED`. Remaining `NOT_FOUND` surfaces as `JobStatus.UNKNOWN` with a warning, not silent FAILED.

Also: `_monitor_until_terminal` gets a keyword-only `timeout` (+ `SRUNX_SSH_MONITOR_TIMEOUT` env default) raising typed `SSHMonitorTimeoutError` so a hung job cannot pin a pooled SSH adapter forever.

### β — MCP audit trail fidelity
Phase 1 persisted MCP-origin sweep cells as `triggered_by='web'` because SQLite cannot `ALTER CHECK` in place. V4 rebuilds `workflow_runs` under `requires_fk_off=True`, preserving V3 columns (`sweep_run_id` + FK + index). `_TRIGGERED_BY_BY_SOURCE` workaround removed.

### γ — Codex critical findings
- **C3 (security)**: `_dispatch_sweep` skipped `_enforce_shell_script_roots`, so sweep YAML with `template: shell` + `script_path: ../../etc/passwd` could read host files into sbatch. Apply the guard on the base workflow (matrix values are scalar, so base-time validation covers every cell).
- **C4 (resilience)**: `SweepReconciler` resumed with `executor_factory=None, submission_source="cli"` — Web/MCP sweeps post-restart silently fell back to local `Slurm`. Inject an optional `ExecutorFactoryProvider` from `web/app.py` that builds a per-sweep `SlurmSSHExecutorPool` for Web/MCP origins; CLI origins still use local.

### δ — Validate UX + cleanup
`srunx flow validate` now iterates the full matrix and reports the first failing cell's args. `rendering.py` docstring accuracy (+ stale Batch 2 comment removed). `WorkflowRunner.slurm` → `cached_property` so SSH-injected paths don't materialize `Slurm` on hosts lacking local sbatch.

## Out of scope (defer / wontfix)
- Codex C1 (drain/fail_fast TOCTOU) — partially valid UX slack, not a correctness bug
- Codex C2 (request_cancel terminal overwrite) — false positive; SQL gates on `status='pending'`
- Codex I1 (lifespan blocking resume) — low risk, defer
- Codex I3 (spec/impl reconciliation) — spec is already correct
- Codex I4 (`mark_workflow_run_status` dead-code deletion) — still exercised by tests as a public helper
- Local `Slurm.retrieve` / `utils.get_job_status` also `sacct`-only (same bug asymptotically); out of scope for this PR — file a separate issue if it surfaces on local clusters

## Test plan
- [x] `uv run pytest` — 1687 passed, 2 skipped, 1 pre-existing flake (`test_apply_migrations_concurrent_callers_do_not_duplicate` — passes 5/5 in isolation; V4 does not touch race-protection code)
- [x] `uv run mypy .` — clean
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [ ] Live pyxis smoke (re-run `/tmp/sweep_pyxis_smoke.yaml` and confirm cells now report COMPLETED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)