### PR TITLE
refactor: DRY/SOLID cleanup (Codex-reviewed, no back-compat)

### DIFF
--- a/src/srunx/db/cli_helpers.py
+++ b/src/srunx/db/cli_helpers.py
@@ -44,16 +44,14 @@ def record_submission_from_job(
         if job.job_id is None:
             return
 
-        from srunx.db.connection import init_db, open_connection
+        from srunx.db.connection import initialized_connection
         from srunx.db.repositories.job_state_transitions import (
             JobStateTransitionRepository,
         )
         from srunx.db.repositories.jobs import JobRepository
         from srunx.models import Job
 
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             resources = getattr(job, "resources", None)
             environment = getattr(job, "environment", None)
             command_val: list[str] | None = None
@@ -101,8 +99,6 @@ def record_submission_from_job(
                     to_status="PENDING",
                     source="webhook",
                 )
-        finally:
-            conn.close()
     except Exception as exc:  # noqa: BLE001 — best-effort
         logger.debug(f"record_submission_from_job failed: {exc}")
 
@@ -125,20 +121,16 @@ def create_cli_workflow_run(
     treats the link as best-effort and keeps submitting.
     """
     try:
-        from srunx.db.connection import init_db, open_connection
+        from srunx.db.connection import initialized_connection
         from srunx.db.repositories.workflow_runs import WorkflowRunRepository
 
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             return WorkflowRunRepository(conn).create(
                 workflow_name=workflow_name,
                 yaml_path=yaml_path,
                 args=args,
                 triggered_by="cli",
             )
-        finally:
-            conn.close()
     except Exception as exc:  # noqa: BLE001 — best-effort
         logger.debug(f"create_cli_workflow_run failed: {exc}")
         return None
@@ -154,15 +146,13 @@ def record_completion(job_id: int, status: JobStatus) -> None:
     poller) can't both append the same terminal state.
     """
     try:
-        from srunx.db.connection import init_db, open_connection, transaction
+        from srunx.db.connection import initialized_connection, transaction
         from srunx.db.repositories.job_state_transitions import (
             JobStateTransitionRepository,
         )
         from srunx.db.repositories.jobs import JobRepository
 
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             repo = JobRepository(conn)
             if repo.get(job_id) is None:
                 return
@@ -178,8 +168,6 @@ def record_completion(job_id: int, status: JobStatus) -> None:
                         source="cli_monitor",
                     )
                 repo.update_completion(job_id, status.value)
-        finally:
-            conn.close()
     except Exception as exc:  # noqa: BLE001 — best-effort
         logger.debug(f"record_completion failed: {exc}")
 
@@ -190,15 +178,11 @@ def list_recent_jobs(limit: int = 100) -> list[dict[str, Any]]:
     Thin wrapper around :meth:`JobRepository.list_recent_as_dict` that
     owns the connection; used by the CLI ``history`` command.
     """
-    from srunx.db.connection import init_db, open_connection
+    from srunx.db.connection import initialized_connection
     from srunx.db.repositories.jobs import JobRepository
 
-    init_db(delete_legacy=True)
-    conn = open_connection()
-    try:
+    with initialized_connection() as conn:
         return JobRepository(conn).list_recent_as_dict(limit=limit)
-    finally:
-        conn.close()
 
 
 def compute_job_stats(
@@ -210,15 +194,11 @@ def compute_job_stats(
     Thin wrapper around :meth:`JobRepository.compute_stats` that owns
     the connection; used by the CLI ``report`` command.
     """
-    from srunx.db.connection import init_db, open_connection
+    from srunx.db.connection import initialized_connection
     from srunx.db.repositories.jobs import JobRepository
 
-    init_db(delete_legacy=True)
-    conn = open_connection()
-    try:
+    with initialized_connection() as conn:
         return JobRepository(conn).compute_stats(from_date=from_date, to_date=to_date)
-    finally:
-        conn.close()
 
 
 def compute_workflow_stats(workflow_name: str) -> dict[str, Any]:
@@ -229,11 +209,9 @@ def compute_workflow_stats(workflow_name: str) -> dict[str, Any]:
     ``avg_duration_seconds``, ``first_submitted``, ``last_submitted``.
     Used by the CLI ``report --workflow`` command.
     """
-    from srunx.db.connection import init_db, open_connection
+    from srunx.db.connection import initialized_connection
 
-    init_db(delete_legacy=True)
-    conn = open_connection()
-    try:
+    with initialized_connection() as conn:
         row = conn.execute(
             """
             SELECT
@@ -247,8 +225,6 @@ def compute_workflow_stats(workflow_name: str) -> dict[str, Any]:
             """,
             (workflow_name,),
         ).fetchone()
-    finally:
-        conn.close()
 
     return {
         "workflow_name": workflow_name,

--- a/src/srunx/db/connection.py
+++ b/src/srunx/db/connection.py
@@ -186,3 +186,25 @@ def init_db(db_path: Path | None = None, *, delete_legacy: bool = True) -> Path:
     if delete_legacy:
         _delete_legacy_history_db()
     return path
+
+
+@contextlib.contextmanager
+def initialized_connection(
+    db_path: Path | None = None,
+    *,
+    delete_legacy: bool = True,
+) -> Iterator[sqlite3.Connection]:
+    """Yield a migration-applied SQLite connection, closed on exit.
+
+    Encapsulates ``init_db(...) + open_connection(path)`` so callers can
+    treat the connection as "ready to query" without knowing about
+    migrations. Idempotent: ``apply_migrations`` early-returns when the
+    schema is already at the target version, so repeated use from hot
+    paths is safe.
+    """
+    path = init_db(db_path, delete_legacy=delete_legacy)
+    conn = open_connection(path)
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/src/srunx/mcp/server.py
+++ b/src/srunx/mcp/server.py
@@ -522,15 +522,12 @@ def create_workflow(
         from srunx.models import Workflow
         from srunx.runner import WorkflowRunner
 
-        # Reject python: args for security (arbitrary code execution)
+        # Reject python: args for security (arbitrary code execution).
         if args:
-            for arg_key, arg_val in args.items():
-                if isinstance(arg_val, str) and "python:" in arg_val.lower():
-                    return _err(
-                        f"Arg '{arg_key}' contains 'python:' prefix which is not "
-                        "allowed for security reasons. Use plain values or Jinja2 "
-                        "templates instead."
-                    )
+            try:
+                _reject_python_prefix_mcp(args, source="args")
+            except ValueError as exc:
+                return _err(str(exc))
 
         # Validate the workflow structure before writing.
         # Skip job parsing validation when args are present (Jinja templates
@@ -612,24 +609,22 @@ def validate_workflow(yaml_path: str) -> dict[str, Any]:
         return _err(str(e))
 
 
-def _reject_python_in_mcp_mapping(mapping: dict[str, Any], *, source: str) -> None:
-    """Reject ``python:`` prefix in MCP args / sweep payloads.
+def _reject_python_prefix_mcp(payload: Any, *, source: str) -> None:
+    """Reject ``python:``-prefixed strings in MCP tool payloads.
 
-    Mirrors the Web API guard. MCP is reachable by any Claude Code
-    session so we apply the same security rule as the Web path.
+    MCP is reachable by any Claude Code session so we apply the same
+    security rule as the Web path. Raises ``ValueError`` on the first
+    violation; callers convert that to the tool's ``{"success": False}``
+    response shape.
     """
-    for key, val in mapping.items():
-        if isinstance(val, str) and "python:" in val.lower():
-            raise ValueError(
-                f"{source} key '{key}' contains 'python:' which is not allowed"
-            )
-        if isinstance(val, list):
-            for i, element in enumerate(val):
-                if isinstance(element, str) and "python:" in element.lower():
-                    raise ValueError(
-                        f"{source} key '{key}' contains 'python:' at index {i} "
-                        "which is not allowed"
-                    )
+    from srunx.security import find_python_prefix
+
+    violation = find_python_prefix(payload, source=source)
+    if violation is not None:
+        raise ValueError(
+            f"{violation.source} at '{violation.path}' contains 'python:' "
+            f"prefix which is not allowed: {violation.value!r}"
+        )
 
 
 @mcp.tool()
@@ -672,7 +667,7 @@ def run_workflow(
         from srunx.runner import WorkflowRunner
 
         if args is not None:
-            _reject_python_in_mcp_mapping(args, source="args")
+            _reject_python_prefix_mcp(args, source="args")
 
         # MCP runs have no mount context: Phase 1 is local-SLURM only.
         # Passing ``submission_context=None`` explicitly (rather than
@@ -692,7 +687,7 @@ def run_workflow(
             matrix = sweep.get("matrix") or {}
             if not isinstance(matrix, dict):
                 return _err("sweep.matrix must be a mapping")
-            _reject_python_in_mcp_mapping(matrix, source="sweep.matrix")
+            _reject_python_prefix_mcp(matrix, source="sweep.matrix")
 
             try:
                 sweep_spec = SweepSpec(

--- a/src/srunx/notifications/presets.py
+++ b/src/srunx/notifications/presets.py
@@ -7,18 +7,7 @@ whether a given subscription should generate a delivery for an event.
 
 from __future__ import annotations
 
-# Terminal job statuses, per SLURM conventions.
-_TERMINAL_JOB_STATUSES: frozenset[str] = frozenset(
-    {
-        "COMPLETED",
-        "FAILED",
-        "CANCELLED",
-        "TIMEOUT",
-        "NODE_FAIL",
-        "PREEMPTED",
-        "OUT_OF_MEMORY",
-    }
-)
+from srunx.slurm.states import SLURM_TERMINAL_JOB_STATES
 
 # Terminal workflow_run statuses, per our own domain model.
 _TERMINAL_WORKFLOW_RUN_STATUSES: frozenset[str] = frozenset(
@@ -70,7 +59,7 @@ def should_deliver(
 
     # From here on: preset is 'terminal' or 'running_and_terminal'.
     if event_kind == "job.status_changed":
-        if to_status in _TERMINAL_JOB_STATUSES:
+        if to_status in SLURM_TERMINAL_JOB_STATES:
             return True
         if preset == "running_and_terminal" and to_status == "RUNNING":
             return True

--- a/src/srunx/pollers/active_watch_poller.py
+++ b/src/srunx/pollers/active_watch_poller.py
@@ -58,25 +58,11 @@ from srunx.db.repositories.workflow_run_jobs import WorkflowRunJobRepository
 from srunx.db.repositories.workflow_runs import WorkflowRunRepository
 from srunx.logging import get_logger
 from srunx.notifications.service import NotificationService
+from srunx.slurm.states import SLURM_TERMINAL_JOB_STATES
 from srunx.sweep.state_service import WorkflowRunStateService
 
 logger = get_logger(__name__)
 
-
-# Terminal job statuses per SLURM conventions. Kept in lock-step with
-# ``srunx.notifications.presets._TERMINAL_JOB_STATUSES`` — the poller
-# uses this set to decide when to close the owning watch.
-_TERMINAL_JOB_STATUSES: frozenset[str] = frozenset(
-    {
-        "COMPLETED",
-        "FAILED",
-        "CANCELLED",
-        "TIMEOUT",
-        "NODE_FAIL",
-        "PREEMPTED",
-        "OUT_OF_MEMORY",
-    }
-)
 
 # Terminal workflow_run statuses per our own domain model.
 _TERMINAL_WORKFLOW_RUN_STATUSES: frozenset[str] = frozenset(
@@ -404,7 +390,7 @@ class ActiveWatchPoller:
                 # Close every matching watch once the job hits a
                 # terminal state — a batch of N watches on the same
                 # job collapses to a single transition + N closes.
-                if current_status in _TERMINAL_JOB_STATUSES:
+                if current_status in SLURM_TERMINAL_JOB_STATES:
                     for closing_watch in watch_repo.list_by_target(
                         kind="job",
                         target_ref=source_ref,
@@ -527,7 +513,7 @@ class ActiveWatchPoller:
         # PREEMPTED / OUT_OF_MEMORY). The design.md wording is
         # "FAILED/TIMEOUT" but the other SLURM terminal failures are
         # semantically identical and already in
-        # ``_TERMINAL_JOB_STATUSES`` minus COMPLETED/CANCELLED.
+        # ``SLURM_TERMINAL_JOB_STATES`` minus COMPLETED/CANCELLED.
         if any(
             s in {"FAILED", "TIMEOUT", "NODE_FAIL", "PREEMPTED", "OUT_OF_MEMORY"}
             for s in child_statuses

--- a/src/srunx/runner.py
+++ b/src/srunx/runner.py
@@ -455,16 +455,14 @@ def _transition_workflow_run(
     DB outage never takes down the primary workflow flow.
     """
     try:
-        from srunx.db.connection import init_db, open_connection, transaction
+        from srunx.db.connection import initialized_connection, transaction
         from srunx.db.repositories.base import now_iso
         from srunx.sweep.state_service import WorkflowRunStateService
 
         completed_at = (
             now_iso() if to_status in {"completed", "failed", "cancelled"} else None
         )
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             with transaction(conn, "IMMEDIATE"):
                 WorkflowRunStateService.update(
                     conn=conn,
@@ -474,8 +472,6 @@ def _transition_workflow_run(
                     error=error,
                     completed_at=completed_at,
                 )
-        finally:
-            conn.close()
     except Exception as exc:  # noqa: BLE001 — best-effort
         logger.debug(f"_transition_workflow_run failed: {exc}")
 

--- a/src/srunx/security/__init__.py
+++ b/src/srunx/security/__init__.py
@@ -1,0 +1,8 @@
+"""Security-related helpers shared across transport boundaries (Web, MCP)."""
+
+from srunx.security.python_args import (
+    PythonPrefixViolation,
+    find_python_prefix,
+)
+
+__all__ = ["PythonPrefixViolation", "find_python_prefix"]

--- a/src/srunx/security/python_args.py
+++ b/src/srunx/security/python_args.py
@@ -1,0 +1,68 @@
+"""Reject ``python:`` prefix in user-supplied args / matrix values.
+
+Runs on Web API submission (YAML + JSON) and MCP tool calls. The
+``python:`` prefix in ``args`` is a server-side evaluation escape hatch
+reserved for CLI-local use; exposing it over transport boundaries is a
+security concern (remote code execution via workflow mutation). See
+:func:`srunx.runner._has_python_prefix` for the CLI-side parser that
+actually evaluates these values — the check here mirrors its matching
+rules (prefix match, leading-whitespace-tolerant, case-insensitive).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PythonPrefixViolation:
+    """Structured violation record. Caller converts to transport-specific error."""
+
+    source: str
+    """Logical origin of the payload (e.g. ``"args"``, ``"sweep.matrix"``)."""
+
+    path: str
+    """Dotted / indexed path to the offending value (e.g. ``"x[2]"``, ``"lr"``)."""
+
+    value: str
+    """The offending value, reproduced for error messaging."""
+
+
+def _has_python_prefix(value: str) -> bool:
+    """Match runner's parser: leading-whitespace-tolerant, case-insensitive prefix."""
+    return value.lstrip().lower().startswith("python:")
+
+
+def find_python_prefix(
+    payload: Any,
+    *,
+    source: str,
+    _path: str = "",
+) -> PythonPrefixViolation | None:
+    """Recursively scan a dict / list / scalar payload; return the first violation.
+
+    Traverses nested dict -> list -> str. Non-string scalars
+    (int / float / bool / None) are ignored. Returns ``None`` when no
+    violation is found.
+    """
+    if isinstance(payload, str):
+        if _has_python_prefix(payload):
+            return PythonPrefixViolation(source=source, path=_path, value=payload)
+        return None
+    if isinstance(payload, Mapping):
+        for key, val in payload.items():
+            child_path = f"{_path}.{key}" if _path else str(key)
+            violation = find_python_prefix(val, source=source, _path=child_path)
+            if violation is not None:
+                return violation
+        return None
+    if isinstance(payload, list):
+        for i, element in enumerate(payload):
+            child_path = f"{_path}[{i}]"
+            violation = find_python_prefix(element, source=source, _path=child_path)
+            if violation is not None:
+                return violation
+        return None
+    return None

--- a/src/srunx/slurm/__init__.py
+++ b/src/srunx/slurm/__init__.py
@@ -1,0 +1,12 @@
+"""SLURM protocol-level constants and helpers.
+
+This subpackage holds values that come straight from SLURM's wire
+vocabulary (state strings, etc.) — distinct from ``srunx.models``,
+which carries the narrower domain enum.
+"""
+
+from __future__ import annotations
+
+from .states import SLURM_TERMINAL_JOB_STATES
+
+__all__ = ["SLURM_TERMINAL_JOB_STATES"]

--- a/src/srunx/slurm/states.py
+++ b/src/srunx/slurm/states.py
@@ -1,0 +1,25 @@
+"""SLURM protocol-level state constants.
+
+Separate from :class:`srunx.models.JobStatus` (the domain-level enum)
+because SLURM's raw state vocabulary is wider than what srunx models:
+SLURM emits ``NODE_FAIL`` / ``PREEMPTED`` / ``OUT_OF_MEMORY`` for
+terminal failures that srunx currently collapses into ``FAILED`` at
+the domain boundary. Keeping these strings in a single module lets
+every caller that speaks SLURM-native states (notification preset
+filter, active-watch poller, web SSH adapter) agree on the set
+without risking drift when a new terminal state is added.
+"""
+
+from __future__ import annotations
+
+SLURM_TERMINAL_JOB_STATES: frozenset[str] = frozenset(
+    {
+        "COMPLETED",
+        "FAILED",
+        "CANCELLED",
+        "TIMEOUT",
+        "NODE_FAIL",
+        "PREEMPTED",
+        "OUT_OF_MEMORY",
+    }
+)

--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -652,8 +652,10 @@ def sync_mount(
             console.print("  [yellow]Dry run — no files will be transferred[/yellow]")
         console.print()
 
-        # Merge mount-level and CLI-level exclude patterns
-        mount_excludes = mount.exclude_patterns or []
+        # Merge mount-level and CLI-level exclude patterns.
+        # mount.exclude_patterns is an immutable tuple; normalize to list
+        # so list concatenation below works.
+        mount_excludes: list[str] = list(mount.exclude_patterns)
         cli_excludes = exclude or []
         all_excludes = mount_excludes + [
             p for p in cli_excludes if p not in mount_excludes

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -39,51 +39,15 @@ from .file_manager import RemoteFileManager
 from .log_reader import RemoteLogReader
 from .slurm import SlurmRemoteClient
 from .utils import (
+    query_slurm_job_state,
     quote_shell_path,
     sanitize_job_id,
 )
 
-# Re-export so ``from srunx.ssh.core.client import SlurmJob`` keeps working
+# Re-export so ``from srunx.ssh.core.client import SlurmJob`` keeps working.
 __all__ = ["SSHSlurmClient", "SlurmJob"]
 
 _logger = get_logger(__name__)
-
-# scontrol prints whitespace-separated ``Key=Value`` tokens; ``JobState=`` is
-# the observed state (e.g. RUNNING, COMPLETED) and ``ExitCode=N:M`` carries
-# the process exit code (N) and terminating signal (M). Match until the next
-# whitespace so multi-word values stop at the token boundary.
-_SCONTROL_JOBSTATE_RE = re.compile(r"JobState=(\S+)")
-_SCONTROL_EXITCODE_RE = re.compile(r"ExitCode=(\d+):(\d+)")
-
-
-def _parse_scontrol_status(output: str) -> str | None:
-    """Extract a SLURM state string from ``scontrol show job`` output.
-
-    Returns ``None`` when the output is empty or lacks a ``JobState=`` token
-    — callers treat that as "scontrol didn't know either" and fall through
-    to the NOT_FOUND sentinel. When ``JobState=COMPLETED`` appears we also
-    consult ``ExitCode`` to disambiguate: a non-zero exit code or signal
-    means the job actually failed (SLURM reports COMPLETED for any clean
-    exit regardless of the process's own status), so we downgrade to
-    FAILED. Other states pass through unchanged so RUNNING / PENDING /
-    CANCELLED / TIMEOUT remain distinguishable.
-    """
-    if not output or not output.strip():
-        return None
-
-    state_match = _SCONTROL_JOBSTATE_RE.search(output)
-    if not state_match:
-        return None
-
-    state = state_match.group(1).strip().upper()
-    if state == "COMPLETED":
-        exit_match = _SCONTROL_EXITCODE_RE.search(output)
-        if exit_match:
-            exit_code = int(exit_match.group(1))
-            signal = int(exit_match.group(2))
-            if exit_code != 0 or signal != 0:
-                return "FAILED"
-    return state
 
 
 class SSHSlurmClient:
@@ -708,43 +672,7 @@ class SSHSlurmClient:
             self.cleanup_file(job.script_path)
 
     def get_job_status(self, job_id: str) -> str:
-        try:
-            if not re.match(r"^[0-9]+([._][A-Za-z0-9_-]+)?$", job_id):
-                self.logger.error(f"Invalid job_id format: {job_id!r}")
-                return "ERROR"
-
-            sacct_cmd = f"sacct -j {job_id} --format=JobID,State --noheader | grep -E '^[0-9]+' | head -1"
-            stdout, stderr, exit_code = self._execute_slurm_command(sacct_cmd)
-
-            if exit_code == 0 and stdout.strip():
-                status = stdout.strip().split()[1].split("+")[0]
-                return status
-
-            squeue_cmd = f"squeue -j {job_id} -h -o %T | head -1"
-            stdout, stderr, exit_code = self._execute_slurm_command(squeue_cmd)
-            if exit_code == 0 and stdout.strip():
-                return stdout.strip().split("\n")[0].strip()
-
-            # scontrol fallback: on pyxis/slurmdbd-unreachable clusters sacct
-            # returns empty for finished jobs, and once a job leaves the
-            # queue squeue returns empty too. scontrol keeps the record in
-            # memory for MinJobAge (~5 min default) and does not depend on
-            # slurmdbd, so it disambiguates COMPLETED vs FAILED via ExitCode
-            # for the critical post-completion window.
-            quoted_id = shlex.quote(job_id)
-            scontrol_out, _, scontrol_rc = self._execute_slurm_command(
-                f"scontrol show job {quoted_id} 2>/dev/null"
-            )
-            if scontrol_rc == 0 and scontrol_out.strip():
-                parsed = _parse_scontrol_status(scontrol_out)
-                if parsed is not None:
-                    return parsed
-
-            return "NOT_FOUND"
-
-        except Exception as e:
-            self.logger.error(f"Failed to get job status for job {job_id}: {e}")
-            return "ERROR"
+        return query_slurm_job_state(job_id, self._execute_slurm_command, self.logger)
 
     def monitor_job(
         self, job: SlurmJob, poll_interval: int = 10, timeout: int | None = None

--- a/src/srunx/ssh/core/config.py
+++ b/src/srunx/ssh/core/config.py
@@ -3,26 +3,51 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class MountConfig(BaseModel):
-    """Local-to-remote path mapping for a project directory."""
+    """Local-to-remote path mapping for a project directory.
+
+    Deeply immutable: ``frozen=True`` locks fields and ``exclude_patterns``
+    is a tuple so nested state cannot be mutated either. This lets the
+    model be safely embedded in ``frozen`` dataclasses (e.g. the SSH
+    adapter pool spec) without a ``list[str]`` escape hatch.
+    """
+
+    model_config = ConfigDict(frozen=True)
 
     name: str
-    local: str  # local path, e.g. "~/projects/ml-project"
-    remote: str  # remote path, e.g. "/home/user/projects/ml-project"
-    exclude_patterns: list[str] = Field(
-        default=[], description="Additional rsync exclude patterns for this mount"
+    local: str  # local path, e.g. "~/projects/ml-project" (resolved absolute after validation)
+    remote: str  # remote path, must be absolute
+    exclude_patterns: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description="Additional rsync exclude patterns for this mount",
     )
 
-    @model_validator(mode="after")
-    def expand_and_validate_paths(self) -> "MountConfig":
-        """Expand ~ in local path. Remote must be absolute."""
-        self.local = str(Path(self.local).expanduser().resolve())
-        if not self.remote.startswith("/"):
-            raise ValueError(f"Mount remote path must be absolute: {self.remote}")
-        return self
+    @field_validator("local", mode="before")
+    @classmethod
+    def _expand_local(cls, v: Any) -> Any:
+        """Expand ``~`` and resolve to an absolute path."""
+        if not isinstance(v, str):
+            return v
+        return str(Path(v).expanduser().resolve())
+
+    @field_validator("remote")
+    @classmethod
+    def _validate_remote(cls, v: str) -> str:
+        if not v.startswith("/"):
+            raise ValueError(f"Mount remote path must be absolute: {v}")
+        return v
+
+    @field_validator("exclude_patterns", mode="before")
+    @classmethod
+    def _coerce_patterns_to_tuple(cls, v: Any) -> Any:
+        # JSON / YAML round-trip produces list[str]; normalize so the stored
+        # field is always a tuple and the model stays hashable-compatible.
+        if isinstance(v, list):
+            return tuple(v)
+        return v
 
 
 class ServerProfile(BaseModel):

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 # Imported at module level so the facade can reference it
 from .client_types import SlurmJob  # noqa: F401  re-exported for convenience
+from .utils import query_slurm_job_state
 
 _logger = get_logger(__name__)
 
@@ -309,43 +310,8 @@ class SlurmRemoteClient:
     # ------------------------------------------------------------------
 
     def get_job_status(self, job_id: str) -> str:
-        """Get job status using SLURM commands."""
-        try:
-            if not re.match(r"^[0-9]+([._][A-Za-z0-9_-]+)?$", job_id):
-                self.logger.error(f"Invalid job_id format: {job_id!r}")
-                return "ERROR"
-
-            sacct_cmd = f"sacct -j {job_id} --format=JobID,State --noheader | grep -E '^[0-9]+' | head -1"
-            stdout, stderr, exit_code = self.execute_slurm_command(sacct_cmd)
-
-            if exit_code == 0 and stdout.strip():
-                status = stdout.strip().split()[1].split("+")[0]
-                return status
-
-            squeue_cmd = f"squeue -j {job_id} -h -o %T | head -1"
-            stdout, stderr, exit_code = self.execute_slurm_command(squeue_cmd)
-            if exit_code == 0 and stdout.strip():
-                return stdout.strip().split("\n")[0].strip()
-
-            # scontrol fallback: pyxis/slurmdbd-unreachable clusters return
-            # empty sacct output, and finished jobs drop out of squeue. See
-            # srunx.ssh.core.client._parse_scontrol_status for the rationale.
-            from .client import _parse_scontrol_status
-
-            quoted_id = shlex.quote(job_id)
-            scontrol_out, _, scontrol_rc = self.execute_slurm_command(
-                f"scontrol show job {quoted_id} 2>/dev/null"
-            )
-            if scontrol_rc == 0 and scontrol_out.strip():
-                parsed = _parse_scontrol_status(scontrol_out)
-                if parsed is not None:
-                    return parsed
-
-            return "NOT_FOUND"
-
-        except Exception as e:
-            self.logger.error(f"Failed to get job status for job {job_id}: {e}")
-            return "ERROR"
+        """Get job status using SLURM commands (sacct -> squeue -> scontrol)."""
+        return query_slurm_job_state(job_id, self.execute_slurm_command, self.logger)
 
     def monitor_job(
         self, job: SlurmJob, poll_interval: int = 10, timeout: int | None = None

--- a/src/srunx/ssh/core/utils.py
+++ b/src/srunx/ssh/core/utils.py
@@ -9,7 +9,21 @@ from __future__ import annotations
 import re
 import shlex
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
+
+# scontrol prints whitespace-separated ``Key=Value`` tokens; ``JobState=`` is
+# the observed state (e.g. RUNNING, COMPLETED) and ``ExitCode=N:M`` carries
+# the process exit code (N) and terminating signal (M). Match until the next
+# whitespace so multi-word values stop at the token boundary.
+_SCONTROL_JOBSTATE_RE = re.compile(r"JobState=(\S+)")
+_SCONTROL_EXITCODE_RE = re.compile(r"ExitCode=(\d+):(\d+)")
+
+# Matches a SLURM job id (optionally with array / step suffix). Shared by
+# the 3-stage status-query helper so both the facade and the component
+# class reject shell-unsafe input identically.
+_JOB_ID_RE = re.compile(r"^[0-9]+([._][A-Za-z0-9_-]+)?$")
 
 
 def quote_shell_path(path: str) -> str:
@@ -49,3 +63,90 @@ def detect_project_root() -> str:
     except FileNotFoundError:
         pass
     return str(Path.cwd())
+
+
+def parse_scontrol_job_state(output: str) -> str | None:
+    """Extract a SLURM state string from ``scontrol show job`` output.
+
+    Returns ``None`` when the output is empty or lacks a ``JobState=`` token
+    — callers treat that as "scontrol didn't know either" and fall through
+    to the NOT_FOUND sentinel. When ``JobState=COMPLETED`` appears we also
+    consult ``ExitCode`` to disambiguate: a non-zero exit code or signal
+    means the job actually failed (SLURM reports COMPLETED for any clean
+    exit regardless of the process's own status), so we downgrade to
+    FAILED. Other states pass through unchanged so RUNNING / PENDING /
+    CANCELLED / TIMEOUT remain distinguishable.
+    """
+    if not output or not output.strip():
+        return None
+
+    state_match = _SCONTROL_JOBSTATE_RE.search(output)
+    if not state_match:
+        return None
+
+    state = state_match.group(1).strip().upper()
+    if state == "COMPLETED":
+        exit_match = _SCONTROL_EXITCODE_RE.search(output)
+        if exit_match:
+            exit_code = int(exit_match.group(1))
+            signal = int(exit_match.group(2))
+            if exit_code != 0 or signal != 0:
+                return "FAILED"
+    return state
+
+
+def query_slurm_job_state(
+    job_id: str,
+    execute: Callable[[str], tuple[str, str, int]],
+    logger: Any,
+) -> str:
+    """Three-stage SLURM job state query: sacct -> squeue -> scontrol.
+
+    Returns the raw SLURM state string (e.g. ``"RUNNING"``) or one of the
+    sentinels ``"NOT_FOUND"`` / ``"ERROR"``. The ``execute`` callable must
+    run a SLURM command with a fully prepared environment and return the
+    ``(stdout, stderr, exit_code)`` tuple — typically
+    ``SSHSlurmClient._execute_slurm_command`` or
+    ``SlurmRemoteClient.execute_slurm_command``.
+
+    The scontrol tier is load-bearing on pyxis / slurmdbd-unreachable
+    clusters: sacct returns empty for finished jobs and once a job
+    leaves the queue squeue returns empty too. scontrol keeps the
+    record in memory for MinJobAge (~5 min default) and does not depend
+    on slurmdbd, so it disambiguates COMPLETED vs FAILED via ExitCode
+    for the critical post-completion window.
+    """
+    try:
+        if not _JOB_ID_RE.match(job_id):
+            logger.error(f"Invalid job_id format: {job_id!r}")
+            return "ERROR"
+
+        sacct_cmd = (
+            f"sacct -j {job_id} --format=JobID,State --noheader | "
+            "grep -E '^[0-9]+' | head -1"
+        )
+        stdout, _, exit_code = execute(sacct_cmd)
+
+        if exit_code == 0 and stdout.strip():
+            status = stdout.strip().split()[1].split("+")[0]
+            return status
+
+        squeue_cmd = f"squeue -j {job_id} -h -o %T | head -1"
+        stdout, _, exit_code = execute(squeue_cmd)
+        if exit_code == 0 and stdout.strip():
+            return stdout.strip().split("\n")[0].strip()
+
+        quoted_id = shlex.quote(job_id)
+        scontrol_out, _, scontrol_rc = execute(
+            f"scontrol show job {quoted_id} 2>/dev/null"
+        )
+        if scontrol_rc == 0 and scontrol_out.strip():
+            parsed = parse_scontrol_job_state(scontrol_out)
+            if parsed is not None:
+                return parsed
+
+        return "NOT_FOUND"
+
+    except Exception as e:
+        logger.error(f"Failed to get job status for job {job_id}: {e}")
+        return "ERROR"

--- a/src/srunx/sweep/orchestrator.py
+++ b/src/srunx/sweep/orchestrator.py
@@ -17,7 +17,7 @@ import anyio
 
 from srunx.callbacks import Callback
 from srunx.client_protocol import WorkflowJobExecutorFactory
-from srunx.db.connection import init_db, open_connection, transaction
+from srunx.db.connection import initialized_connection, transaction
 from srunx.db.models import SweepRun, SweepSubmissionSource, WorkflowRunTriggeredBy
 from srunx.db.repositories.base import now_iso
 from srunx.db.repositories.sweep_runs import SweepRunRepository
@@ -114,9 +114,9 @@ class SweepOrchestrator:
         inserted so the sweep remains visible in the UI (R4.7). Raises
         :class:`SweepExecutionError` after the audit row is written.
         """
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        # init+open via context manager: callers don't need to know about
+        # migrations; apply_migrations is idempotent on the hot path.
+        with initialized_connection() as conn:
             try:
                 sweep_run_id = self._materialize_happy_path(conn, cells)
             except Exception as exc:
@@ -125,8 +125,6 @@ class SweepOrchestrator:
                 # in listings even though none of its cells exist.
                 self._record_materialize_failure(conn, exc)
                 raise SweepExecutionError(f"sweep materialize failed: {exc!r}") from exc
-        finally:
-            conn.close()
 
         self._sweep_run_id = sweep_run_id
         return sweep_run_id
@@ -400,9 +398,7 @@ class SweepOrchestrator:
         concurrent ``_drain`` already cancelled the cell — the caller
         must skip ``_run_cell_sync`` to avoid a wasted SLURM submission.
         """
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             with transaction(conn, "IMMEDIATE"):
                 return WorkflowRunStateService.update(
                     conn=conn,
@@ -410,8 +406,6 @@ class SweepOrchestrator:
                     from_status="pending",
                     to_status="running",
                 )
-        finally:
-            conn.close()
 
     def _record_cell_failure(self, cell: CellSpec, error: str) -> None:
         """Best-effort failed transition for a cell the runner never finalized.
@@ -423,9 +417,7 @@ class SweepOrchestrator:
         cannot mask the original cell failure.
         """
         try:
-            init_db(delete_legacy=True)
-            conn = open_connection()
-            try:
+            with initialized_connection() as conn:
                 for from_status in ("pending", "running"):
                     with transaction(conn, "IMMEDIATE"):
                         transitioned = WorkflowRunStateService.update(
@@ -438,8 +430,6 @@ class SweepOrchestrator:
                         )
                     if transitioned:
                         return
-            finally:
-                conn.close()
         except Exception as exc:  # noqa: BLE001 — never mask the original failure
             logger.warning(
                 f"sweep cell {cell.cell_index} "
@@ -513,14 +503,10 @@ class SweepOrchestrator:
             # flag so an in-progress arun() doesn't start new cells.
             return
 
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             with transaction(conn, "IMMEDIATE"):
                 SweepRunRepository(conn).request_cancel(sweep_run_id)
             self._drain(sweep_run_id)
-        finally:
-            conn.close()
 
     def _drain(self, sweep_run_id: int) -> None:
         """Atomically cancel every still-pending cell and adjust counters.
@@ -537,12 +523,8 @@ class SweepOrchestrator:
 
     def _load_sweep(self, sweep_run_id: int) -> SweepRun:
         """Return the current ``SweepRun`` row, raising if it vanished."""
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             sweep = SweepRunRepository(conn).get(sweep_run_id)
-        finally:
-            conn.close()
         if sweep is None:
             raise SweepExecutionError(
                 f"sweep_run_id={sweep_run_id} disappeared from DB after materialize"
@@ -563,9 +545,7 @@ def drain_sweep_pending_cells(sweep_run_id: int) -> int:
     no in-process orchestrator is registered (crash-recovery path) and
     by :class:`SweepOrchestrator` itself via :meth:`SweepOrchestrator._drain`.
     """
-    init_db(delete_legacy=True)
-    conn = open_connection()
-    try:
+    with initialized_connection() as conn:
         with transaction(conn, "IMMEDIATE"):
             cur = conn.execute(
                 "UPDATE workflow_runs "
@@ -589,8 +569,6 @@ def drain_sweep_pending_cells(sweep_run_id: int) -> int:
             from srunx.sweep.aggregator import evaluate_and_fire_sweep_status_event
 
             evaluate_and_fire_sweep_status_event(conn=conn, sweep_run_id=sweep_run_id)
-    finally:
-        conn.close()
     return k
 
 

--- a/src/srunx/sweep/reconciler.py
+++ b/src/srunx/sweep/reconciler.py
@@ -21,7 +21,7 @@ from typing import Any
 import anyio
 
 from srunx.client_protocol import WorkflowJobExecutorFactory
-from srunx.db.connection import init_db, open_connection, transaction
+from srunx.db.connection import initialized_connection, transaction
 from srunx.db.models import SweepRun
 from srunx.db.repositories.sweep_runs import SweepRunRepository
 from srunx.logging import get_logger
@@ -149,12 +149,8 @@ class SweepReconciler:
     @classmethod
     def _load_incomplete_sweeps(cls) -> list[SweepRun]:
         """Load every sweep still in an incomplete status (pending/running/draining)."""
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             return SweepRunRepository(conn).list_incomplete()
-        finally:
-            conn.close()
 
     # ------------------------------------------------------------------
     # Internals
@@ -211,9 +207,7 @@ class SweepReconciler:
         cases (aggregator evaluate, info logs) are handled inline so the
         caller only has to act on the happy path.
         """
-        init_db(delete_legacy=True)
-        conn = open_connection()
-        try:
+        with initialized_connection() as conn:
             running = _count_cells(conn, sweep_run_id, "running")
             pending = _list_pending_cells(conn, sweep_run_id)
             sweep_row = conn.execute(
@@ -248,8 +242,6 @@ class SweepReconciler:
                 f"reconciler: sweep {sweep_run_id} resuming with "
                 f"{len(pending)} pending cells, headroom={headroom}"
             )
-        finally:
-            conn.close()
 
         return sweep_row, pending
 

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import shutil
 import subprocess
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar
@@ -58,7 +59,7 @@ class RsyncClient:
         key_filename: str | None = None,
         proxy_jump: str | None = None,
         ssh_config_path: str | None = None,
-        exclude_patterns: list[str] | None = None,
+        exclude_patterns: Sequence[str] | None = None,
     ) -> None:
         rsync_path = shutil.which("rsync")
         if rsync_path is None:
@@ -113,7 +114,7 @@ class RsyncClient:
         *,
         delete: bool = True,
         dry_run: bool = False,
-        exclude_patterns: list[str] | None = None,
+        exclude_patterns: Sequence[str] | None = None,
     ) -> RsyncResult:
         """Sync a local directory/file to the remote server.
 
@@ -157,7 +158,7 @@ class RsyncClient:
         *,
         delete: bool = False,
         dry_run: bool = False,
-        exclude_patterns: list[str] | None = None,
+        exclude_patterns: Sequence[str] | None = None,
     ) -> RsyncResult:
         """Sync a remote directory/file to the local machine.
 
@@ -266,7 +267,7 @@ class RsyncClient:
         logger.debug("Ensuring remote dir: {}", shlex.join(mkdir_cmd))
         subprocess.run(mkdir_cmd, capture_output=True, text=True)  # noqa: S603
 
-    def _merge_excludes(self, extra: list[str] | None) -> list[str]:
+    def _merge_excludes(self, extra: Sequence[str] | None) -> list[str]:
         """Merge per-call exclude patterns with instance patterns."""
         if not extra:
             return self.exclude_patterns

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -47,6 +47,7 @@ from srunx.rendering import (
     render_workflow_for_submission,
 )
 from srunx.runner import WorkflowRunner
+from srunx.security import find_python_prefix
 from srunx.sweep import SweepSpec
 from srunx.sweep.orchestrator import SweepOrchestrator
 from srunx.sweep.state_service import WorkflowRunStateService
@@ -263,16 +264,34 @@ def _find_yaml(name: str, mount_name: str) -> Path:
     raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
 
 
-def _reject_python_args(yaml_content: str) -> None:
-    """Reject YAML whose args section contains python: values (case-insensitive).
+def _reject_python_prefix_web(payload: Any, *, source: str) -> None:
+    """Reject ``python:``-prefixed strings in Web API payloads.
 
-    Parses the YAML first so legitimate uses of "python:" in commands or
-    comments are not blocked.
+    Centralizes the guard applied to both YAML args (pre-parsed by the
+    caller) and JSON ``args_override`` / ``sweep.matrix`` payloads.
+    Raises ``HTTPException(422)`` on the first violation.
+    """
+    violation = find_python_prefix(payload, source=source)
+    if violation is not None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{violation.source} at '{violation.path}' contains 'python:' "
+                "prefix which is not allowed via web for security reasons"
+            ),
+        )
+
+
+def _reject_python_prefix_in_yaml_args(yaml_content: str) -> None:
+    """Parse YAML text and apply the ``python:`` guard to its ``args`` section.
+
+    Uses ``yaml.safe_load`` so legitimate uses of ``python:`` in commands
+    or comments are not blocked. Malformed YAML is left to downstream
+    validation to report.
     """
     try:
         data = yaml.safe_load(yaml_content)
     except Exception:
-        # Let downstream validation handle malformed YAML
         return
 
     if not isinstance(data, dict):
@@ -282,40 +301,7 @@ def _reject_python_args(yaml_content: str) -> None:
     if not isinstance(args, dict):
         return
 
-    for key, val in args.items():
-        if isinstance(val, str) and "python:" in val.lower():
-            raise HTTPException(
-                status_code=422,
-                detail=f"Arg '{key}' contains 'python:' prefix which is not allowed via web for security reasons",
-            )
-
-
-def _reject_python_in_mapping(mapping: dict[str, Any], *, source: str) -> None:
-    """Reject ``python:`` values in structured request payloads.
-
-    Used by the Web API sweep path where ``args_override`` and
-    ``sweep.matrix`` come in as JSON (not YAML text). The YAML path
-    uses :func:`_reject_python_args`.
-    """
-    for key, val in mapping.items():
-        if isinstance(val, str) and "python:" in val.lower():
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f"{source} key '{key}' contains 'python:' which is not "
-                    "allowed via web for security reasons"
-                ),
-            )
-        if isinstance(val, list):
-            for i, element in enumerate(val):
-                if isinstance(element, str) and "python:" in element.lower():
-                    raise HTTPException(
-                        status_code=422,
-                        detail=(
-                            f"{source} key '{key}' contains 'python:' at index "
-                            f"{i} which is not allowed via web for security reasons"
-                        ),
-                    )
+    _reject_python_prefix_web(args, source="args")
 
 
 def _serialize_workflow(
@@ -568,7 +554,7 @@ async def validate_workflow(body: dict[str, str]) -> dict[str, Any]:
     if not yaml_content:
         return {"valid": False, "errors": ["Empty YAML content"]}
 
-    _reject_python_args(yaml_content)
+    _reject_python_prefix_in_yaml_args(yaml_content)
 
     with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
         f.write(yaml_content)
@@ -599,7 +585,7 @@ async def upload_workflow(body: dict[str, str]) -> dict[str, Any]:
             status_code=422, detail="'yaml', 'filename', and 'mount' are required"
         )
 
-    _reject_python_args(yaml_content)
+    _reject_python_prefix_in_yaml_args(yaml_content)
 
     if len(yaml_content) > 1_000_000:
         raise HTTPException(status_code=413, detail="YAML content exceeds 1MB limit")
@@ -657,13 +643,8 @@ async def create_workflow(body: WorkflowCreateRequest) -> dict[str, Any]:
                     detail=f"Workflow '{name}' already exists",
                 )
 
-    # Reject python: args from web for security (case-insensitive)
-    for val in body.args.values():
-        if isinstance(val, str) and "python:" in val.lower():
-            raise HTTPException(
-                status_code=422,
-                detail="Args with 'python:' values are not allowed via web for security reasons",
-            )
+    # Reject python: args from web for security (shared guard).
+    _reject_python_prefix_web(body.args, source="args")
 
     # Build the raw dict list from the request for validation + serialization
     jobs_raw: list[dict[str, Any]] = [
@@ -1315,9 +1296,9 @@ async def run_workflow(
     # R7: sanitize structured sweep / args_override payloads. YAML-level
     # guard still runs on upload; this catches requests that bypass it.
     if run_opts.args_override:
-        _reject_python_in_mapping(run_opts.args_override, source="args_override")
+        _reject_python_prefix_web(run_opts.args_override, source="args_override")
     if run_opts.sweep is not None:
-        _reject_python_in_mapping(run_opts.sweep.matrix, source="sweep.matrix")
+        _reject_python_prefix_web(run_opts.sweep.matrix, source="sweep.matrix")
 
     yaml_path = _find_yaml(name, mount)
 

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -21,6 +21,7 @@ from srunx.client_protocol import (
     parse_slurm_duration,
 )
 from srunx.logging import get_logger
+from srunx.slurm.states import SLURM_TERMINAL_JOB_STATES
 from srunx.ssh.core.client import SSHSlurmClient
 from srunx.ssh.core.config import ConfigManager, MountConfig
 from srunx.ssh.core.ssh_config import SSHConfigParser  # noqa: F811
@@ -37,17 +38,6 @@ _SAFE_IDENTIFIER = re.compile(r"^[a-zA-Z0-9_.\-]+$")
 
 # Node states that should be excluded from available counts
 _UNAVAILABLE_STATES = {"down", "drain", "maint", "reserved"}
-
-# SLURM terminal job states (used to filter sacct output)
-_TERMINAL_STATES = {
-    "COMPLETED",
-    "FAILED",
-    "CANCELLED",
-    "TIMEOUT",
-    "NODE_FAIL",
-    "PREEMPTED",
-    "OUT_OF_MEMORY",
-}
 
 
 class SSHMonitorTimeoutError(RuntimeError):
@@ -95,9 +85,8 @@ class SlurmSSHAdapterSpec:
     channels, or in-flight state. Used by Step 4's pool factory to mint
     per-cell adapter clones off a shared singleton template.
 
-    ``mounts`` is a tuple so the spec itself is immutable; the contained
-    :class:`MountConfig` instances are Pydantic models and may not be
-    hashable, so do not rely on ``hash(spec)``.
+    ``mounts`` is a tuple of frozen :class:`MountConfig` instances so the
+    spec is deeply immutable and hashable end-to-end.
     """
 
     profile_name: str | None
@@ -461,7 +450,7 @@ class SlurmSSHAdapter:
                 # Skip non-terminal states (already covered by squeue)
                 raw_state = parts[2].strip()
                 status = raw_state.split()[0] if raw_state else "UNKNOWN"
-                if status not in _TERMINAL_STATES:
+                if status not in SLURM_TERMINAL_JOB_STATES:
                     continue
 
                 gpus = 0
@@ -586,7 +575,7 @@ class SlurmSSHAdapter:
         # per-missing-id. Per-id cost is acceptable because the poller
         # runs every 15s and the missing set is only the final-transition
         # tail, not the full active set.
-        from srunx.ssh.core.client import _parse_scontrol_status
+        from srunx.ssh.core.utils import parse_scontrol_job_state
 
         still_missing = [j for j in job_ids if j not in results]
         for jid in still_missing:
@@ -596,7 +585,7 @@ class SlurmSSHAdapter:
                 )
             except RuntimeError:
                 continue
-            parsed = _parse_scontrol_status(scontrol_out)
+            parsed = parse_scontrol_job_state(scontrol_out)
             if parsed is None:
                 continue
             results[jid] = JobStatusInfo(status=parsed)

--- a/tests/db/test_connection.py
+++ b/tests/db/test_connection.py
@@ -14,6 +14,7 @@ from srunx.db.connection import (
     get_config_dir,
     get_db_path,
     init_db,
+    initialized_connection,
     open_connection,
     transaction,
 )
@@ -211,3 +212,85 @@ def test_connection_usable_from_another_thread(tmp_path: Path) -> None:
         assert result == [1]
     finally:
         conn.close()
+
+
+# ---- initialized_connection() ----
+
+
+def test_initialized_connection_applies_migrations_on_first_call(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(conn_mod, "LEGACY_HISTORY_DB_PATH", tmp_path / "nope.db")
+
+    with initialized_connection() as conn:
+        names = {
+            r[0] for r in conn.execute("SELECT name FROM schema_version").fetchall()
+        }
+
+    assert "v1_initial" in names
+
+
+def test_initialized_connection_is_idempotent_across_multiple_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(conn_mod, "LEGACY_HISTORY_DB_PATH", tmp_path / "nope.db")
+
+    with initialized_connection():
+        pass
+    with initialized_connection():
+        pass
+
+    conn = sqlite3.connect(tmp_path / "srunx" / "srunx.db")
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM schema_version WHERE name = 'v1_initial'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1
+
+
+def test_initialized_connection_closes_on_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.setattr(conn_mod, "LEGACY_HISTORY_DB_PATH", tmp_path / "nope.db")
+
+    leaked: list[sqlite3.Connection] = []
+    with pytest.raises(RuntimeError):
+        with initialized_connection() as conn:
+            leaked.append(conn)
+            raise RuntimeError("boom")
+
+    # Using a closed sqlite3.Connection raises ProgrammingError.
+    assert leaked, "context manager did not yield a connection"
+    with pytest.raises(sqlite3.ProgrammingError):
+        leaked[0].execute("SELECT 1")
+
+
+def test_initialized_connection_honors_delete_legacy_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    # Legacy DB seeded in two fake homes so we can test both branches
+    # without cross-talk.
+    legacy_keep = tmp_path / "keep" / "history.db"
+    legacy_keep.parent.mkdir(parents=True)
+    legacy_keep.touch()
+    monkeypatch.setattr(conn_mod, "LEGACY_HISTORY_DB_PATH", legacy_keep)
+
+    with initialized_connection(delete_legacy=False):
+        pass
+    assert legacy_keep.exists(), "delete_legacy=False must preserve legacy DB"
+
+    legacy_gone = tmp_path / "gone" / "history.db"
+    legacy_gone.parent.mkdir(parents=True)
+    legacy_gone.touch()
+    monkeypatch.setattr(conn_mod, "LEGACY_HISTORY_DB_PATH", legacy_gone)
+
+    with initialized_connection(delete_legacy=True):
+        pass
+    assert not legacy_gone.exists(), "delete_legacy=True must remove legacy DB"

--- a/tests/security/test_python_args.py
+++ b/tests/security/test_python_args.py
@@ -1,0 +1,97 @@
+"""Tests for the shared ``python:`` prefix guard.
+
+Pins the matching rules to runner's CLI-side ``_has_python_prefix``
+(prefix match, leading-whitespace-tolerant, case-insensitive) and the
+recursive traversal semantics (dict -> list -> str).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from srunx.security.python_args import (
+    PythonPrefixViolation,
+    find_python_prefix,
+)
+
+
+class TestFindPythonPrefix:
+    def test_scalar_string_with_prefix_returns_violation(self) -> None:
+        result = find_python_prefix("python: 1 + 1", source="args")
+        assert isinstance(result, PythonPrefixViolation)
+        assert result.source == "args"
+        assert result.path == ""
+        assert result.value == "python: 1 + 1"
+
+    def test_scalar_string_without_prefix_returns_none(self) -> None:
+        assert find_python_prefix("safe value", source="args") is None
+
+    def test_leading_whitespace_tolerance(self) -> None:
+        """Matches runner parser: leading whitespace does not bypass the guard."""
+        assert find_python_prefix("  python: x", source="args") is not None
+        assert find_python_prefix("\tpython: x", source="args") is not None
+
+    def test_case_insensitive_prefix(self) -> None:
+        for variant in ("Python: x", "PYTHON: x", "pYtHoN: x"):
+            assert find_python_prefix(variant, source="args") is not None
+
+    def test_substring_not_at_start_passes(self) -> None:
+        # Prefix match, not substring: legitimate values containing
+        # the token ``python:`` elsewhere must NOT be flagged.
+        assert find_python_prefix("my_python_arg value", source="args") is None
+        assert find_python_prefix("run with python: flag", source="args") is None
+
+    def test_nested_dict_finds_violation(self) -> None:
+        result = find_python_prefix(
+            {"lr": "0.1", "cmd": "python: evil"},
+            source="args",
+        )
+        assert result is not None
+        assert result.path == "cmd"
+        assert result.value == "python: evil"
+
+    def test_list_element_finds_violation(self) -> None:
+        # Bug-fix coverage: YAML list elements were previously not checked
+        # by the Web path. The unified helper scans recursively.
+        result = find_python_prefix(
+            {"x": ["safe", "python: evil"]},
+            source="sweep.matrix",
+        )
+        assert result is not None
+        assert result.source == "sweep.matrix"
+        assert result.path == "x[1]"
+        assert result.value == "python: evil"
+
+    def test_non_string_scalars_are_ignored(self) -> None:
+        assert find_python_prefix(42, source="args") is None
+        assert find_python_prefix(3.14, source="args") is None
+        assert find_python_prefix(True, source="args") is None
+        assert find_python_prefix(None, source="args") is None
+        assert find_python_prefix({"a": 1, "b": 2.0, "c": False}, source="args") is None
+
+    def test_deeply_nested_mapping_list_mapping(self) -> None:
+        payload = {
+            "matrix": {
+                "group_a": [
+                    {"safe": "ok", "inner": ["literal", "python: boom"]},
+                ],
+            },
+        }
+        result = find_python_prefix(payload, source="sweep")
+        assert result is not None
+        assert result.path == "matrix.group_a[0].inner[1]"
+
+    def test_empty_mapping_and_list_return_none(self) -> None:
+        assert find_python_prefix({}, source="args") is None
+        assert find_python_prefix([], source="args") is None
+
+    def test_violation_dataclass_is_frozen(self) -> None:
+        violation = PythonPrefixViolation(source="args", path="x", value="python:")
+
+        assert dataclasses.is_dataclass(violation)
+        # frozen=True -> attribute assignment must fail
+        try:
+            violation.source = "other"  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            return
+        raise AssertionError("PythonPrefixViolation must be frozen")

--- a/tests/ssh/test_status_fallback.py
+++ b/tests/ssh/test_status_fallback.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from srunx.ssh.core.client import SSHSlurmClient, _parse_scontrol_status
+from srunx.ssh.core.client import SSHSlurmClient
+from srunx.ssh.core.utils import parse_scontrol_job_state
 
 # ── Pure parser ──────────────────────────────────────────────────────
 
@@ -18,41 +19,41 @@ from srunx.ssh.core.client import SSHSlurmClient, _parse_scontrol_status
 class TestParseScontrolStatus:
     def test_parses_running(self) -> None:
         out = "JobId=123 JobName=foo JobState=RUNNING Reason=None ExitCode=0:0"
-        assert _parse_scontrol_status(out) == "RUNNING"
+        assert parse_scontrol_job_state(out) == "RUNNING"
 
     def test_parses_pending(self) -> None:
         out = "JobId=1 JobState=PENDING Reason=Resources ExitCode=0:0"
-        assert _parse_scontrol_status(out) == "PENDING"
+        assert parse_scontrol_job_state(out) == "PENDING"
 
     def test_completed_with_clean_exit_is_completed(self) -> None:
         out = "JobId=1 JobState=COMPLETED Reason=None ExitCode=0:0"
-        assert _parse_scontrol_status(out) == "COMPLETED"
+        assert parse_scontrol_job_state(out) == "COMPLETED"
 
     def test_completed_with_nonzero_exit_downgrades_to_failed(self) -> None:
         out = "JobId=1 JobState=COMPLETED Reason=None ExitCode=1:0"
-        assert _parse_scontrol_status(out) == "FAILED"
+        assert parse_scontrol_job_state(out) == "FAILED"
 
     def test_completed_with_signal_downgrades_to_failed(self) -> None:
         out = "JobId=1 JobState=COMPLETED Reason=None ExitCode=0:9"
-        assert _parse_scontrol_status(out) == "FAILED"
+        assert parse_scontrol_job_state(out) == "FAILED"
 
     def test_failed_state_passes_through(self) -> None:
         out = "JobId=1 JobState=FAILED Reason=NonZeroExit ExitCode=1:0"
-        assert _parse_scontrol_status(out) == "FAILED"
+        assert parse_scontrol_job_state(out) == "FAILED"
 
     def test_cancelled_state_passes_through(self) -> None:
         out = "JobId=1 JobState=CANCELLED Reason=None ExitCode=0:15"
-        assert _parse_scontrol_status(out) == "CANCELLED"
+        assert parse_scontrol_job_state(out) == "CANCELLED"
 
     def test_empty_input_returns_none(self) -> None:
-        assert _parse_scontrol_status("") is None
+        assert parse_scontrol_job_state("") is None
 
     def test_whitespace_only_returns_none(self) -> None:
-        assert _parse_scontrol_status("   \n  \t  \n") is None
+        assert parse_scontrol_job_state("   \n  \t  \n") is None
 
     def test_missing_jobstate_returns_none(self) -> None:
         out = "JobId=1 JobName=foo Reason=None"
-        assert _parse_scontrol_status(out) is None
+        assert parse_scontrol_job_state(out) is None
 
     def test_multiline_output(self) -> None:
         out = (
@@ -61,7 +62,7 @@ class TestParseScontrolStatus:
             "   Priority=1 JobState=COMPLETED Reason=None ExitCode=0:0\n"
             "   RunTime=00:05:12 TimeLimit=01:00:00\n"
         )
-        assert _parse_scontrol_status(out) == "COMPLETED"
+        assert parse_scontrol_job_state(out) == "COMPLETED"
 
 
 # ── get_job_status three-tier fallback ───────────────────────────────

--- a/tests/test_ssh_components.py
+++ b/tests/test_ssh_components.py
@@ -140,6 +140,33 @@ class TestSlurmRemoteClient:
         # Should not raise — only logs error details
         slurm._handle_slurm_error("sbatch", "command not found", 127)
 
+    def test_get_job_status_uses_shared_three_stage_fallback(self):
+        """sacct empty + squeue empty -> scontrol parses COMPLETED."""
+        conn = MagicMock(spec=SSHConnection)
+        fm = MagicMock(spec=RemoteFileManager)
+        slurm = SlurmRemoteClient(conn, fm)
+        scontrol_out = (
+            "JobId=42 JobName=train JobState=COMPLETED Reason=None ExitCode=0:0"
+        )
+        responses = iter(
+            [
+                ("", "", 0),  # sacct empty
+                ("", "", 0),  # squeue empty
+                (scontrol_out, "", 0),  # scontrol hit
+            ]
+        )
+        # Bypass the real execute path — the helper only needs the callable.
+        slurm.execute_slurm_command = lambda cmd: next(responses)  # type: ignore[method-assign]
+        assert slurm.get_job_status("42") == "COMPLETED"
+
+    def test_get_job_status_rejects_invalid_job_id(self):
+        conn = MagicMock(spec=SSHConnection)
+        fm = MagicMock(spec=RemoteFileManager)
+        slurm = SlurmRemoteClient(conn, fm)
+        # If the helper touched execute_slurm_command it would raise since
+        # we never stubbed it — asserting "ERROR" confirms the regex guard.
+        assert slurm.get_job_status("not; an id") == "ERROR"
+
 
 class TestRemoteLogReader:
     """Test RemoteLogReader standalone instantiation."""

--- a/tests/test_ssh_profiles_config.py
+++ b/tests/test_ssh_profiles_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from srunx.ssh.core.config import ConfigManager, MountConfig, ServerProfile
 
@@ -171,11 +172,18 @@ class TestConfigManager:
 
 
 class TestMountConfigExcludePatterns:
-    """Tests for MountConfig.exclude_patterns field."""
+    """Tests for MountConfig.exclude_patterns field.
+
+    Post-refactor: ``exclude_patterns`` is stored as ``tuple[str, ...]``
+    (deep immutability). JSON/YAML ``list[str]`` input is coerced to a
+    tuple by a ``mode='before'`` validator; ``model_dump(mode='json')``
+    round-trips back to a list.
+    """
 
     def test_default_exclude_patterns_is_empty(self, tmp_path):
         mount = MountConfig(name="proj", local=str(tmp_path), remote="/remote/proj")
-        assert mount.exclude_patterns == []
+        assert mount.exclude_patterns == ()
+        assert isinstance(mount.exclude_patterns, tuple)
 
     def test_exclude_patterns_set_on_creation(self, tmp_path):
         patterns = ["data/", "*.bin", "logs/"]
@@ -185,7 +193,10 @@ class TestMountConfigExcludePatterns:
             remote="/remote/proj",
             exclude_patterns=patterns,
         )
-        assert mount.exclude_patterns == patterns
+        # list input is coerced to tuple (deep-immutability guarantee)
+        assert mount.exclude_patterns == tuple(patterns)
+        assert isinstance(mount.exclude_patterns, tuple)
+        assert list(mount.exclude_patterns) == patterns
 
     def test_exclude_patterns_serialized_in_model_dump(self, tmp_path):
         patterns = ["data/", "*.log"]
@@ -195,8 +206,12 @@ class TestMountConfigExcludePatterns:
             remote="/remote/proj",
             exclude_patterns=patterns,
         )
+        # Native dump preserves the tuple
         dumped = mount.model_dump()
-        assert dumped["exclude_patterns"] == patterns
+        assert dumped["exclude_patterns"] == tuple(patterns)
+        # JSON mode converts tuple → list for JSON compatibility
+        dumped_json = mount.model_dump(mode="json")
+        assert dumped_json["exclude_patterns"] == patterns
 
     def test_exclude_patterns_deserialized_from_dict(self, tmp_path):
         data = {
@@ -206,17 +221,17 @@ class TestMountConfigExcludePatterns:
             "exclude_patterns": ["weights/", "*.ckpt"],
         }
         mount = MountConfig.model_validate(data)
-        assert mount.exclude_patterns == ["weights/", "*.ckpt"]
+        assert mount.exclude_patterns == ("weights/", "*.ckpt")
 
     def test_backward_compat_missing_exclude_patterns(self, tmp_path):
-        """Old config without exclude_patterns should deserialize with default []."""
+        """Old config without exclude_patterns should deserialize with default ()."""
         data = {
             "name": "proj",
             "local": str(tmp_path),
             "remote": "/remote/proj",
         }
         mount = MountConfig.model_validate(data)
-        assert mount.exclude_patterns == []
+        assert mount.exclude_patterns == ()
 
     def test_mount_with_excludes_persisted_via_config_manager(self, temp_config_file):
         cm = ConfigManager(temp_config_file)
@@ -231,12 +246,13 @@ class TestMountConfigExcludePatterns:
         )
         cm.add_profile_mount("p", mount)
 
-        # Reload from disk
+        # Reload from disk — JSON round-trip (tuple → list → tuple)
         cm2 = ConfigManager(temp_config_file)
         loaded_profile = cm2.get_profile("p")
         assert loaded_profile is not None
         assert len(loaded_profile.mounts) == 1
-        assert loaded_profile.mounts[0].exclude_patterns == ["data/", "*.bin"]
+        assert loaded_profile.mounts[0].exclude_patterns == ("data/", "*.bin")
+        assert isinstance(loaded_profile.mounts[0].exclude_patterns, tuple)
 
     def test_mount_without_excludes_persisted_via_config_manager(
         self, temp_config_file
@@ -251,7 +267,68 @@ class TestMountConfigExcludePatterns:
         cm2 = ConfigManager(temp_config_file)
         loaded_profile = cm2.get_profile("p")
         assert loaded_profile is not None
-        assert loaded_profile.mounts[0].exclude_patterns == []
+        assert loaded_profile.mounts[0].exclude_patterns == ()
+
+
+class TestMountConfigImmutability:
+    """Verify frozen=True + tuple exclude_patterns cannot be mutated.
+
+    A frozen MountConfig is required so the SSH adapter's frozen
+    SlurmSSHAdapterSpec genuinely has deep immutability (and stays
+    hashable end-to-end).
+    """
+
+    def test_field_assignment_is_blocked(self, tmp_path):
+        mount = MountConfig(name="proj", local=str(tmp_path), remote="/remote/proj")
+        with pytest.raises(ValidationError):
+            mount.local = "/other"  # type: ignore[misc]
+
+    def test_exclude_patterns_assignment_is_blocked(self, tmp_path):
+        mount = MountConfig(
+            name="proj",
+            local=str(tmp_path),
+            remote="/remote/proj",
+            exclude_patterns=["a/"],
+        )
+        with pytest.raises(ValidationError):
+            mount.exclude_patterns = ("b/",)  # type: ignore[misc]
+
+    def test_exclude_patterns_inplace_concat_is_blocked(self, tmp_path):
+        mount = MountConfig(
+            name="proj",
+            local=str(tmp_path),
+            remote="/remote/proj",
+            exclude_patterns=["a/"],
+        )
+        # tuple doesn't support __iadd__ on a field, but frozen would also
+        # block the rebinding that += would attempt.
+        with pytest.raises((ValidationError, TypeError)):
+            mount.exclude_patterns += ("b/",)  # type: ignore[misc]
+
+    def test_exclude_patterns_tuple_has_no_mutation_methods(self, tmp_path):
+        mount = MountConfig(
+            name="proj",
+            local=str(tmp_path),
+            remote="/remote/proj",
+            exclude_patterns=["a/"],
+        )
+        # Proves the contained sequence is a tuple, so list-style
+        # mutation methods simply don't exist.
+        assert not hasattr(mount.exclude_patterns, "append")
+        assert not hasattr(mount.exclude_patterns, "extend")
+
+    def test_frozen_mount_is_hashable(self, tmp_path):
+        mount = MountConfig(
+            name="proj",
+            local=str(tmp_path),
+            remote="/remote/proj",
+            exclude_patterns=["a/", "b/"],
+        )
+        # A hashable MountConfig lets SlurmSSHAdapterSpec (frozen dataclass
+        # containing tuple[MountConfig, ...]) be used as a dict key / set
+        # member, which is the whole point of deep immutability.
+        assert hash(mount) == hash(mount)
+        assert {mount} == {mount}
 
 
 class TestServerProfileKeyFilenameExpansion:

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -258,6 +258,15 @@ class TestWorkflowsRouter:
         )
         assert resp.status_code == 422
 
+    def test_validate_rejects_python_args_in_list_element(
+        self, client: TestClient
+    ) -> None:
+        # Regression: YAML path previously skipped list elements inside
+        # ``args``. The unified guard scans recursively.
+        yaml_text = "name: test\nargs:\n  x:\n    - safe\n    - 'python: evil'\n"
+        resp = client.post("/api/workflows/validate", json={"yaml": yaml_text})
+        assert resp.status_code == 422, resp.text
+
     def test_upload_rejects_path_traversal(self, client: TestClient) -> None:
         resp = client.post(
             "/api/workflows/upload",

--- a/tests/web/test_ssh_adapter_run.py
+++ b/tests/web/test_ssh_adapter_run.py
@@ -651,6 +651,33 @@ class TestAdapterFromSpec:
         adapter = SlurmSSHAdapter.from_spec(spec, callbacks=[cb])
         assert adapter.callbacks == [cb]
 
+    def test_spec_with_mounts_is_hashable(self, tmp_path) -> None:
+        """MountConfig is frozen → the entire spec is hashable end-to-end.
+
+        Regression lock: before Phase 4 refactor, ``MountConfig`` held a
+        mutable ``list[str]`` so embedding one in a frozen dataclass gave
+        a non-hashable spec despite the ``@dataclass(frozen=True)`` decorator.
+        """
+        from srunx.ssh.core.config import MountConfig
+
+        mount = MountConfig(
+            name="proj",
+            local=str(tmp_path),
+            remote="/remote/proj",
+            exclude_patterns=["data/", "*.bin"],
+        )
+        spec = SlurmSSHAdapterSpec(
+            profile_name=None,
+            hostname="h",
+            username="u",
+            key_filename=None,
+            port=22,
+            mounts=(mount,),
+        )
+        # Must not raise — proves deep immutability of the mount chain.
+        assert hash(spec) == hash(spec)
+        assert {spec} == {spec}
+
 
 class TestIsConnected:
     def test_is_connected_true_with_active_transport(self) -> None:


### PR DESCRIPTION
v1.1.1 → main レビュー (#126 merged) で検出した DRY/SOLID 違反を、Codex の精査プランに沿って修正。後方互換は要件外として全エイリアスを削除。

## 4 コミット

### `a9f6aa5` refactor(slurm): centralize state helpers and terminal-state constants (M1 + LOW)
- 3 段 SLURM 状態問い合わせ (sacct → squeue → scontrol) を ``ssh/core/utils.py`` に ``query_slurm_job_state()`` として集約。``SSHSlurmClient.get_job_status`` / ``SlurmRemoteClient.get_job_status`` は 1 行委譲へ
- ``_parse_scontrol_status`` → ``parse_scontrol_job_state`` に改名（旧名 alias 削除）
- ``SLURM_TERMINAL_JOB_STATES`` を新 ``srunx.slurm.states`` に集約し ``web/ssh_adapter.py`` / ``notifications/presets.py`` / ``pollers/active_watch_poller.py`` の重複定数を撤去
- ``models.JobStatus`` と意図的に分離（SLURM プロトコル vocabulary は JobStatus より広い）

### `1337774` refactor(db): route callers through initialized_connection() provider (M2)
- ``db/connection.py`` に ``initialized_connection()`` コンテキストマネージャ追加（``init_db`` + ``open_connection`` + close を 1 単位化）
- ``sweep/orchestrator.py`` (6 箇所) / ``sweep/reconciler.py`` / ``runner.py`` / ``db/cli_helpers.py`` の ``init_db(delete_legacy=True); open_connection(path); try/finally close`` パターンを全置換
- Web lifespan / CLI entry / MCP bootstrap の eager init は意図的に維持（touch しない）
- SRP: 「caller が init を知る」→「DB 層が init 済み session を提供」

### `bfb044d` refactor(ssh): make MountConfig deeply immutable (M3)
- ``ConfigDict(frozen=True)`` + ``exclude_patterns: tuple[str, ...]``
- ``model_validator(mode='after')`` → per-field ``field_validator`` (frozen と両立)
- ``list[str]`` JSON 入力は coerce-to-tuple validator で吸収、``model_dump(mode='json')`` で list 出力が維持され round-trip 健全
- ``RsyncClient`` の型を ``list[str] | None`` → ``Sequence[str] | None`` に拡張、無駄な copy 不要
- ``SlurmSSHAdapterSpec`` (frozen) と内包 ``MountConfig`` の immutability 一貫性が達成（hashable 主張と整合）

### `e7de109` refactor(security): unify python: prefix guard across Web and MCP (M4)
- 5 箇所に散在していた guard を ``srunx.security.find_python_prefix()`` に集約（``PythonPrefixViolation`` dataclass + recursive scan）
- **Bug fix 1**: substring match (``"python:" in val.lower()``) → prefix match (``val.lstrip().lower().startswith("python:")``) に修正。``"my_python_arg=foo"`` のような正規値を誤 reject しなくなる
- **Bug fix 2**: YAML 経路だけ list element を検査していなかった問題を修正 (``args: {x: ["python:evil"]}`` が YAML submit で passes していた)。JSON Web / MCP と挙動統一
- transport 依存の例外変換 (``HTTPException`` / ``ValueError``) は caller 側に留める → helper に FastAPI 依存無し

## Verification

### Static
- ``uv run pytest`` — **1712 passed / 2 skipped / 0 failed** (v1.1.1 基準から +24 tests)
- ``uv run mypy .`` — clean
- ``uv run ruff check .`` / ``uv run ruff format --check .`` — clean

### Live pyxis smoke
| ケース | 結果 |
|---|---|
| 4-cell sweep (normal) | 4/4 COMPLETED |
| ``args_override: {x: "python:evil"}`` | **422** ✅ reject |
| ``args_override: {x: "my_python_arg value"}`` | **202** ✅ accept (bug fix 効果) |
| ``sweep.matrix: {x: ["python:bad"]}`` | **422** ✅ reject (bug fix 効果) |

## Scope 明示

- 後方互換は要件外のため、``_parse_scontrol_status`` / ``_TERMINAL_STATES`` / ``_TERMINAL_JOB_STATUSES`` など全 alias を削除し、正式名称に一本化
- Codex 精査後に skip 判定した項目はゼロ — 5 項目すべて対応
- 隣接コードの "ついで改善" は行っていない（surgical 原則維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)