### PR TITLE
feat(mcp): SSH+mount support for run_workflow tool (Phase 5a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,18 +376,21 @@ srunx flow run --arg dataset=imagenet train.yaml
 srunx flow run --sweep lr=0.001,0.01 --max-parallel 2 --dry-run train.yaml
 ```
 
-Constraints / Phase 1 limitations:
+Constraints:
 
 - `max_parallel` is required (YAML or `--max-parallel`; Web API defaults to 4).
 - Matrix values must be scalar (str/int/float/bool); nested structures rejected.
 - Cell count capped at 1000 (safety valve; SLURM MaxSubmitJobs is typically ~4096).
 - `fail_fast` defaults to false; one cell failing does not abort peers.
-- Web UI sweep submission routes through the configured SSH adapter via a
-  per-sweep `SlurmSSHExecutorPool` (capped at `min(max_parallel, 8)` pooled
-  connections); the pool is closed when the background sweep task exits.
-  CLI and MCP sweeps still run cells through the local `Slurm` singleton —
-  the orchestrator's default `executor_factory=None` preserves that
-  behaviour bit-for-bit.
+- Web UI + MCP sweep submissions can route through the configured SSH adapter
+  via a per-sweep `SlurmSSHExecutorPool` (capped at `min(max_parallel, 8)`
+  pooled connections); the pool is closed when the orchestrator returns.
+  MCP opts in explicitly with the `mount=` tool arg; when omitted MCP stays
+  on the local `Slurm` singleton (same as CLI). The orchestrator's default
+  `executor_factory=None` preserves local-SLURM behaviour bit-for-bit.
+- MCP `run_workflow(mount=...)` applies the same ShellJob script-root guard
+  as the Web sweep path (paths outside every profile mount's `local` root
+  are rejected before render), so the MCP and Web security surfaces match.
 - MCP-originated sweep cells record `workflow_runs.triggered_by='mcp'`
   (V4 migration widened the CHECK allowlist); parent
   `sweep_runs.submission_source` is `'mcp'` for the same sweep so cell

--- a/src/srunx/mcp/server.py
+++ b/src/srunx/mcp/server.py
@@ -627,6 +627,65 @@ def _reject_python_prefix_mcp(payload: Any, *, source: str) -> None:
         )
 
 
+def _enforce_shell_script_roots_mcp(workflow: Any, profile: Any) -> None:
+    """Guard ShellJob script paths for the MCP transport.
+
+    Mirrors the Web router's ``_enforce_shell_script_roots`` semantics:
+    every ShellJob's ``script_path`` must sit under one of the profile's
+    mount ``local`` roots. Raises ``ValueError`` (caller converts to
+    ``_err(...)``) instead of ``HTTPException`` because MCP has no HTTP
+    layer.
+    """
+    from srunx.security import find_shell_script_violation
+
+    allowed_roots = [Path(m.local).resolve() for m in (profile.mounts or [])]
+    violation = find_shell_script_violation(workflow, allowed_roots)
+    if violation is not None:
+        raise ValueError(
+            f"Script path '{violation.script_path}' is outside allowed directories"
+        )
+
+
+def _resolve_mount_context(
+    mount: str,
+) -> tuple[Any, SubmissionRenderContext, Any]:
+    """Resolve ``(adapter, submission_context, profile)`` for an MCP mount run.
+
+    Returns the :class:`SlurmSSHAdapter` for the active SSH profile, a
+    :class:`SubmissionRenderContext` pinned to ``mount.remote`` as the
+    default work dir, and the profile object itself (needed by the
+    ShellJob guard). Raises ``ValueError`` on any misconfiguration —
+    no current profile, unknown mount name, etc.
+    """
+    from srunx.rendering import SubmissionRenderContext
+    from srunx.ssh.core.config import ConfigManager
+    from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+    cm = ConfigManager()
+    profile = cm.get_current_profile()
+    profile_name = cm.get_current_profile_name()
+    if profile is None:
+        raise ValueError(
+            "mount requires a current SSH profile; configure one via "
+            "`srunx ssh profile add` and select it with `srunx ssh profile use`"
+        )
+
+    mount_found = next(
+        (m for m in (profile.mounts or []) if m.name == mount),
+        None,
+    )
+    if mount_found is None:
+        raise ValueError(f"Mount '{mount}' not found in profile '{profile_name}'")
+
+    adapter = SlurmSSHAdapter(profile_name=profile_name)
+    context = SubmissionRenderContext(
+        mount_name=mount,
+        mounts=tuple(profile.mounts),
+        default_work_dir=mount_found.remote,
+    )
+    return adapter, context, profile
+
+
 @mcp.tool()
 def run_workflow(
     yaml_path: str,
@@ -636,19 +695,12 @@ def run_workflow(
     dry_run: bool = False,
     args: dict[str, Any] | None = None,
     sweep: dict[str, Any] | None = None,
+    mount: str | None = None,
 ) -> dict[str, Any]:
     """Execute a SLURM workflow from a YAML file.
 
     Jobs are executed in dependency order - independent jobs run in parallel,
     dependent jobs wait for their prerequisites to complete.
-
-    Phase 1 limitation: MCP-initiated runs use the local SLURM client — the
-    canonical :class:`~srunx.rendering.SubmissionRenderContext` is always
-    passed as ``None``, so no mount translation is performed on
-    ``work_dir`` / ``log_dir``. Remote cluster submission via SSH + mount
-    translation from MCP is out of scope for this phase; use the Web UI or
-    ``srunx ssh submit`` for that path. Phase 3 may thread a ``mount`` arg
-    through this tool.
 
     Args:
         yaml_path: Path to the YAML workflow file
@@ -662,19 +714,30 @@ def run_workflow(
             "max_parallel": int}``. When present, the request goes through
             :class:`SweepOrchestrator` and the response contains
             ``sweep_run_id``.
+        mount: Optional mount name from the active SSH profile. When
+            provided, the run is routed through the configured cluster
+            adapter with mount-aware path translation for ``work_dir`` /
+            ``log_dir``. When omitted (default), the run stays on the
+            local SLURM client — same behaviour as pre-5a.
     """
     try:
         from srunx.runner import WorkflowRunner
+        from srunx.web.ssh_executor import SlurmSSHExecutorPool
 
         if args is not None:
             _reject_python_prefix_mcp(args, source="args")
 
-        # MCP runs have no mount context: Phase 1 is local-SLURM only.
-        # Passing ``submission_context=None`` explicitly (rather than
-        # relying on the default) documents the intent at the call site
-        # and lets tests pin the contract between MCP and the canonical
-        # render entry.
+        # Resolve the SSH adapter + render context + profile when the caller
+        # opted into mount-aware mode. ``submission_context=None`` keeps the
+        # legacy "local SLURM only" path intact when ``mount`` is omitted.
         submission_context: SubmissionRenderContext | None = None
+        adapter = None
+        profile = None
+        if mount is not None:
+            try:
+                adapter, submission_context, profile = _resolve_mount_context(mount)
+            except ValueError as exc:
+                return _err(str(exc))
 
         if sweep is not None:
             from pathlib import Path as _Path
@@ -704,62 +767,126 @@ def run_workflow(
             if not isinstance(raw, dict):
                 raw = {}
 
+            # Mount-aware branch: apply the same ShellJob script-root guard
+            # the Web sweep path runs, and submit every cell through a
+            # bounded :class:`SlurmSSHExecutorPool` so concurrent cells
+            # share a small set of SSH sessions against the cluster.
+            pool: SlurmSSHExecutorPool | None = None
+            executor_factory = None
+            if adapter is not None and profile is not None:
+                try:
+                    guard_runner = WorkflowRunner.from_yaml(
+                        yaml_file,
+                        args_override=args or None,
+                    )
+                    _enforce_shell_script_roots_mcp(guard_runner.workflow, profile)
+                except ValueError as exc:
+                    return _err(str(exc))
+                pool_size = max(1, min(sweep_spec.max_parallel, 8))
+                pool = SlurmSSHExecutorPool(
+                    adapter.connection_spec,
+                    callbacks=[],
+                    size=pool_size,
+                )
+                executor_factory = pool.lease
+
             orchestrator = SweepOrchestrator(
                 workflow_yaml_path=yaml_file,
                 workflow_data=raw,
                 args_override=args or None,
                 sweep_spec=sweep_spec,
                 submission_source="mcp",
+                executor_factory=executor_factory,
                 submission_context=submission_context,
             )
-            sweep_run = orchestrator.run()
-            return _ok(
-                sweep_run_id=sweep_run.id,
-                status=sweep_run.status,
-                cell_count=sweep_run.cell_count,
-                cells_completed=sweep_run.cells_completed,
-                cells_failed=sweep_run.cells_failed,
-                cells_cancelled=sweep_run.cells_cancelled,
+            try:
+                sweep_run = orchestrator.run()
+                return _ok(
+                    sweep_run_id=sweep_run.id,
+                    status=sweep_run.status,
+                    cell_count=sweep_run.cell_count,
+                    cells_completed=sweep_run.cells_completed,
+                    cells_failed=sweep_run.cells_failed,
+                    cells_cancelled=sweep_run.cells_cancelled,
+                )
+            finally:
+                if pool is not None:
+                    pool.close()
+
+        # Non-sweep path — mount-aware branch routes submission through a
+        # small SSH executor pool so WorkflowRunner's parallel execution
+        # (``ThreadPoolExecutor(max_workers=8)``) can submit concurrently
+        # against the remote cluster. The pool is closed in ``finally``.
+        pool = None
+        executor_factory = None
+        if adapter is not None and profile is not None:
+            try:
+                guard_runner = WorkflowRunner.from_yaml(
+                    yaml_path,
+                    args_override=args or None,
+                )
+                _enforce_shell_script_roots_mcp(guard_runner.workflow, profile)
+            except ValueError as exc:
+                return _err(str(exc))
+            pool = SlurmSSHExecutorPool(
+                adapter.connection_spec,
+                callbacks=[],
+                size=8,
+            )
+            executor_factory = pool.lease
+
+        try:
+            runner = WorkflowRunner.from_yaml(
+                yaml_path,
+                args_override=args or None,
+                executor_factory=executor_factory,
+                submission_context=submission_context,
             )
 
-        runner = WorkflowRunner.from_yaml(
-            yaml_path,
-            args_override=args or None,
-            submission_context=submission_context,
-        )
+            if dry_run:
+                jobs_to_execute = runner._get_jobs_to_execute(
+                    from_job, to_job, single_job
+                )
+                jobs_info = []
+                for job in jobs_to_execute:
+                    info: dict[str, Any] = {
+                        "name": job.name,
+                        "depends_on": job.depends_on,
+                    }
+                    if hasattr(job, "command"):
+                        cmd = job.command
+                        info["command"] = (
+                            cmd if isinstance(cmd, str) else " ".join(cmd or [])
+                        )
+                    if hasattr(job, "script_path"):
+                        info["script_path"] = job.script_path
+                    jobs_info.append(info)
+                return _ok(
+                    dry_run=True,
+                    workflow=runner.workflow.name,
+                    jobs_to_execute=jobs_info,
+                    count=len(jobs_info),
+                )
 
-        if dry_run:
-            jobs_to_execute = runner._get_jobs_to_execute(from_job, to_job, single_job)
-            jobs_info = []
-            for job in jobs_to_execute:
-                info: dict[str, Any] = {"name": job.name, "depends_on": job.depends_on}
-                if hasattr(job, "command"):
-                    cmd = job.command
-                    info["command"] = (
-                        cmd if isinstance(cmd, str) else " ".join(cmd or [])
-                    )
-                if hasattr(job, "script_path"):
-                    info["script_path"] = job.script_path
-                jobs_info.append(info)
+            results = runner.run(
+                from_job=from_job, to_job=to_job, single_job=single_job
+            )
+            completed = {}
+            for job_name, job in results.items():
+                completed[job_name] = {
+                    "job_id": job.job_id,
+                    "status": job._status.value,
+                }
             return _ok(
-                dry_run=True,
                 workflow=runner.workflow.name,
-                jobs_to_execute=jobs_info,
-                count=len(jobs_info),
+                results=completed,
+                all_completed=all(
+                    v["status"] == "COMPLETED" for v in completed.values()
+                ),
             )
-
-        results = runner.run(from_job=from_job, to_job=to_job, single_job=single_job)
-        completed = {}
-        for job_name, job in results.items():
-            completed[job_name] = {
-                "job_id": job.job_id,
-                "status": job._status.value,
-            }
-        return _ok(
-            workflow=runner.workflow.name,
-            results=completed,
-            all_completed=all(v["status"] == "COMPLETED" for v in completed.values()),
-        )
+        finally:
+            if pool is not None:
+                pool.close()
     except Exception as e:
         return _err(str(e))
 

--- a/src/srunx/security/__init__.py
+++ b/src/srunx/security/__init__.py
@@ -1,8 +1,17 @@
 """Security-related helpers shared across transport boundaries (Web, MCP)."""
 
+from srunx.security.mount_paths import (
+    ShellJobScriptViolation,
+    find_shell_script_violation,
+)
 from srunx.security.python_args import (
     PythonPrefixViolation,
     find_python_prefix,
 )
 
-__all__ = ["PythonPrefixViolation", "find_python_prefix"]
+__all__ = [
+    "PythonPrefixViolation",
+    "ShellJobScriptViolation",
+    "find_python_prefix",
+    "find_shell_script_violation",
+]

--- a/src/srunx/security/mount_paths.py
+++ b/src/srunx/security/mount_paths.py
@@ -1,0 +1,56 @@
+"""Mount-root guard for ShellJob script paths.
+
+Both the Web API and the MCP tool surface the same attack shape: a
+workflow YAML can declare ``template: shell`` with an arbitrary
+``script_path`` that ``render_shell_job_script`` then reads verbatim.
+Without a guard, a caller could exfiltrate or inject arbitrary host
+files via e.g. ``script_path: ../../../etc/passwd``.
+
+The helper here returns a structured ``ShellJobScriptViolation`` so
+each transport caller can raise the right exception type (Web →
+``HTTPException(403)``, MCP → ``ValueError``) while the actual
+directory-check logic lives in one place.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from srunx.models import Workflow
+
+
+@dataclass(frozen=True)
+class ShellJobScriptViolation:
+    """First ShellJob whose script path escapes the allowed mount roots."""
+
+    job_name: str
+    script_path: str
+
+
+def find_shell_script_violation(
+    workflow: Workflow,
+    mount_roots: Iterable[Path],
+) -> ShellJobScriptViolation | None:
+    """Return the first ShellJob pointing outside every ``mount_roots`` entry.
+
+    ``mount_roots`` must already be resolved absolute paths (see
+    :meth:`pathlib.Path.resolve`). Non-ShellJob entries are ignored.
+    Returns ``None`` when every ShellJob's ``script_path`` is contained
+    in at least one root.
+    """
+    from srunx.models import ShellJob  # local import to avoid cycles
+
+    roots = list(mount_roots)
+    for job in workflow.jobs:
+        if isinstance(job, ShellJob):
+            resolved = Path(job.script_path).resolve()
+            if not any(resolved.is_relative_to(root) for root in roots):
+                return ShellJobScriptViolation(
+                    job_name=job.name,
+                    script_path=job.script_path,
+                )
+    return None

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -868,17 +868,17 @@ def _enforce_shell_script_roots(
     performed before the file was opened. Called before render so bogus
     paths surface as 403 with no partial render side effects.
     """
+    from srunx.security import find_shell_script_violation
+
     allowed_roots = [_workflow_dir(mount).resolve()]
     if profile:
         allowed_roots.extend(Path(m.local).resolve() for m in profile.mounts)
-    for job in workflow.jobs:
-        if isinstance(job, ShellJob):
-            script_path = Path(job.script_path).resolve()
-            if not any(script_path.is_relative_to(root) for root in allowed_roots):
-                raise HTTPException(
-                    403,
-                    f"Script path '{job.script_path}' is outside allowed directories",
-                )
+    violation = find_shell_script_violation(workflow, allowed_roots)
+    if violation is not None:
+        raise HTTPException(
+            403,
+            f"Script path '{violation.script_path}' is outside allowed directories",
+        )
 
 
 async def _submit_jobs_bfs(

--- a/tests/test_mcp_sweep.py
+++ b/tests/test_mcp_sweep.py
@@ -160,3 +160,194 @@ class TestMCPBackwardCompat:
 
             result = run_workflow(str(yaml_path))
         assert result["success"] is True
+
+
+class TestMCPMountRouting:
+    """Phase 5a: ``mount=...`` threads MCP runs through the SSH adapter."""
+
+    def test_mount_without_profile_returns_error(
+        self, tmp_path: Path, isolated_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No current SSH profile → readable error, no partial execution."""
+        yaml_path = _write_workflow(tmp_path)
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile",
+            lambda self: None,
+        )
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile_name",
+            lambda self: None,
+        )
+        result = run_workflow(str(yaml_path), mount="cookbook2")
+        assert result["success"] is False
+        assert "SSH profile" in result["error"]
+
+    def test_mount_name_not_in_profile_returns_error(
+        self, tmp_path: Path, isolated_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unknown mount name → error, no adapter instantiation."""
+        yaml_path = _write_workflow(tmp_path)
+        fake_profile = MagicMock(
+            mounts=[MagicMock(name="other", local="/l", remote="/r")]
+        )
+        fake_profile.mounts[0].name = "other"
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile",
+            lambda self: fake_profile,
+        )
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile_name",
+            lambda self: "pyxis",
+        )
+        result = run_workflow(str(yaml_path), mount="cookbook2")
+        assert result["success"] is False
+        assert "cookbook2" in result["error"]
+
+    def test_mount_routes_sweep_through_pool(
+        self, tmp_path: Path, isolated_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mount=...`` + sweep constructs a pool and threads executor_factory."""
+        yaml_path = _write_workflow(tmp_path)
+
+        fake_mount = MagicMock()
+        fake_mount.name = "cookbook2"
+        fake_mount.local = str(tmp_path)
+        fake_mount.remote = "/home/remote/cookbook2"
+        fake_profile = MagicMock()
+        fake_profile.mounts = [fake_mount]
+
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile",
+            lambda self: fake_profile,
+        )
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile_name",
+            lambda self: "pyxis",
+        )
+        with (
+            patch(
+                "srunx.web.ssh_adapter.SlurmSSHAdapter.__init__", return_value=None
+            ) as adapter_init,
+            patch(
+                "srunx.web.ssh_adapter.SlurmSSHAdapter.connection_spec",
+                new=MagicMock(),
+            ),
+            patch("srunx.web.ssh_executor.SlurmSSHExecutorPool") as pool_cls,
+            patch("srunx.sweep.orchestrator.SweepOrchestrator") as orch_cls,
+        ):
+            mock_pool = MagicMock()
+            pool_cls.return_value = mock_pool
+            mock_orch = MagicMock()
+            mock_orch.run.return_value = _FakeSweepRun()
+            orch_cls.return_value = mock_orch
+
+            result = run_workflow(
+                str(yaml_path),
+                sweep={"matrix": {"lr": [0.1, 0.01]}, "max_parallel": 2},
+                mount="cookbook2",
+            )
+
+        assert result["success"] is True, result
+        assert result["sweep_run_id"] == 77
+        adapter_init.assert_called_once()  # adapter built from the profile
+        pool_cls.assert_called_once()  # pool built once
+        # Orchestrator received the pool's lease + a populated render context.
+        orch_kwargs = orch_cls.call_args.kwargs
+        assert orch_kwargs["executor_factory"] is mock_pool.lease
+        ctx = orch_kwargs["submission_context"]
+        assert ctx is not None
+        assert ctx.mount_name == "cookbook2"
+        assert ctx.default_work_dir == "/home/remote/cookbook2"
+        # Pool is closed after the orchestrator returns (or raises).
+        mock_pool.close.assert_called_once()
+
+    def test_mount_routes_non_sweep_through_pool(
+        self, tmp_path: Path, isolated_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mount=...`` without sweep still routes the runner through the pool."""
+        yaml_path = _write_workflow(tmp_path)
+
+        fake_mount = MagicMock()
+        fake_mount.name = "cookbook2"
+        fake_mount.local = str(tmp_path)
+        fake_mount.remote = "/home/remote/cookbook2"
+        fake_profile = MagicMock()
+        fake_profile.mounts = [fake_mount]
+
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile",
+            lambda self: fake_profile,
+        )
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile_name",
+            lambda self: "pyxis",
+        )
+        with (
+            patch("srunx.web.ssh_adapter.SlurmSSHAdapter.__init__", return_value=None),
+            patch(
+                "srunx.web.ssh_adapter.SlurmSSHAdapter.connection_spec",
+                new=MagicMock(),
+            ),
+            patch("srunx.web.ssh_executor.SlurmSSHExecutorPool") as pool_cls,
+            patch("srunx.runner.WorkflowRunner.from_yaml") as from_yaml,
+        ):
+            mock_pool = MagicMock()
+            pool_cls.return_value = mock_pool
+            mock_runner = MagicMock()
+            mock_runner.workflow.name = "mcp_wf"
+            mock_runner.run.return_value = {}
+            # Two from_yaml calls: ShellJob guard (bare) + run (with factory).
+            from_yaml.return_value = mock_runner
+
+            result = run_workflow(str(yaml_path), mount="cookbook2")
+
+        assert result["success"] is True, result
+        pool_cls.assert_called_once()
+        # Second from_yaml call receives the executor_factory + context.
+        run_call_kwargs = from_yaml.call_args_list[-1].kwargs
+        assert run_call_kwargs["executor_factory"] is mock_pool.lease
+        assert run_call_kwargs["submission_context"].mount_name == "cookbook2"
+        mock_pool.close.assert_called_once()
+
+    def test_mount_rejects_shell_job_escaping_mount_root(
+        self, tmp_path: Path, isolated_db: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ShellJob ``script_path`` outside mount local root → error."""
+        # Write a ShellJob workflow whose script_path is ../escape.sh
+        mount_root = tmp_path / "proj"
+        mount_root.mkdir()
+        escape = tmp_path / "escape.sh"  # NOT under mount_root
+        escape.write_text("#!/bin/bash\necho hi\n")
+        wf = {
+            "name": "shell_wf",
+            "jobs": [
+                {
+                    "name": "bad",
+                    "template": "shell",
+                    "script_path": str(escape),
+                }
+            ],
+        }
+        yaml_path = tmp_path / "shell_wf.yaml"
+        yaml_path.write_text(yaml.dump(wf))
+
+        fake_mount = MagicMock()
+        fake_mount.name = "cookbook2"
+        fake_mount.local = str(mount_root)
+        fake_mount.remote = "/home/remote/cookbook2"
+        fake_profile = MagicMock()
+        fake_profile.mounts = [fake_mount]
+
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile",
+            lambda self: fake_profile,
+        )
+        monkeypatch.setattr(
+            "srunx.ssh.core.config.ConfigManager.get_current_profile_name",
+            lambda self: "pyxis",
+        )
+        with patch("srunx.web.ssh_adapter.SlurmSSHAdapter.__init__", return_value=None):
+            result = run_workflow(str(yaml_path), mount="cookbook2")
+
+        assert result["success"] is False
+        assert "outside allowed directories" in result["error"]


### PR DESCRIPTION
Phase 3 で defer した 2 件を同時解消：MCP の機能ギャップ（SSH 越しの sweep 不可）+ セキュリティギャップ（ShellJob path traversal guard なし）。

## Summary
- `run_workflow` MCP tool に optional ``mount: str`` を追加。省略時は従来通り local Slurm、指定時は Web と同じ SSH pool + mount-aware canonical render を経由
- ShellJob script-root guard を `srunx.security.find_shell_script_violation` に抽出し、Web と MCP 両方から利用（Phase 4 の python guard と同じパターン）

## 2 コミット

### `4fde15c` refactor(security): extract shell-script-root guard helper
- 新 `src/srunx/security/mount_paths.py` に `find_shell_script_violation(workflow, mount_roots) -> ShellJobScriptViolation | None`
- Web の `_enforce_shell_script_roots` は helper 経由に変更。HTTPException 403 は Web 側で raise（transport 依存を helper に漏らさない）

### `cbee68e` feat(mcp): route run_workflow through SSH adapter when mount= is given
- `_resolve_mount_context(mount)` helper で adapter + SubmissionRenderContext + profile を resolve（misconfig は ValueError → `_err(...)` に変換）
- `_enforce_shell_script_roots_mcp(workflow, profile)` で ShellJob guard を MCP 経路にも適用
- **Sweep 経路**: `SlurmSSHExecutorPool(size=min(max_parallel, 8))` を組立、orchestrator に `executor_factory=pool.lease` + `submission_context` を渡す。pool は `finally` で close
- **非 sweep 経路**: `SlurmSSHExecutorPool(size=8)` で `WorkflowRunner` の `ThreadPoolExecutor(max_workers=8)` と同期。並列 submit を SSH 経由で可能に
- `mount` 省略時は `executor_factory=None, submission_context=None` で Phase 4 以前と bit-for-bit 同一

## Verification

### Static
- `uv run pytest` — **1717 passed / 2 skipped / 0 failed**（+5 new tests in `TestMCPMountRouting`）
- `uv run mypy .` — clean
- `uv run ruff check .` / `format --check` — clean

### Live pyxis (MCP 直接呼出し経由)
| ケース | 結果 |
|---|---|
| 4-cell sweep via ``mount=cookbook2`` | 4/4 COMPLETED（SSH pool, mount translation 有効） |
| 非 sweep workflow via ``mount=cookbook2`` | job 19702 COMPLETED |
| Invalid mount (``mount=does_not_exist``) | `{"success": False, "error": "Mount 'does_not_exist' not found in profile 'pyxis'"}` |

## Breaking changes
なし。``mount`` 引数は optional、既存の MCP 呼出しは全て従来通り local Slurm で動作。

## Docs
- CLAUDE.md の "Phase 1 limitations" → "Constraints" に格下げ、MCP sweep 制限記述を更新
- `_enforce_shell_script_roots_mcp` の security-parity を明示

🤖 Generated with [Claude Code](https://claude.com/claude-code)