### PR TITLE
feat(web): sweep detail UX (Phase 5b)

### DIFF
--- a/src/srunx/web/frontend/e2e/sweep-detail-ux.spec.ts
+++ b/src/srunx/web/frontend/e2e/sweep-detail-ux.spec.ts
@@ -1,0 +1,274 @@
+import { expect, test } from "@playwright/test";
+import { setupMockRoutes } from "./fixtures/mock-routes.ts";
+
+/**
+ * Phase 5b: sweep detail UX — status filter, column sort, per-cell cancel,
+ * progress bar + ETA.
+ *
+ * The backend fixture is a running sweep with a deliberately mixed cell
+ * set so each feature has something meaningful to exercise:
+ *   - 1 pending, 1 running, 2 completed, 1 failed, 1 cancelled
+ */
+
+const SWEEP_ID = 555;
+const SWEEP_STARTED_AT = new Date(Date.now() - 120_000).toISOString();
+
+type CellStatus = "pending" | "running" | "completed" | "failed" | "cancelled";
+
+type Cell = {
+  id: number;
+  workflow_name: string;
+  status: CellStatus;
+  started_at: string | null;
+  completed_at: string | null;
+  args: Record<string, unknown>;
+  error: string | null;
+  triggered_by: "web" | "mcp" | "cli";
+};
+
+const INITIAL_CELLS: Cell[] = [
+  {
+    id: 701,
+    workflow_name: "ml-pipeline",
+    status: "completed",
+    started_at: new Date(Date.now() - 100_000).toISOString(),
+    completed_at: new Date(Date.now() - 70_000).toISOString(),
+    args: { lr: "0.001", seed: 1 },
+    error: null,
+    triggered_by: "web",
+  },
+  {
+    id: 702,
+    workflow_name: "ml-pipeline",
+    status: "completed",
+    started_at: new Date(Date.now() - 95_000).toISOString(),
+    completed_at: new Date(Date.now() - 30_000).toISOString(),
+    args: { lr: "0.01", seed: 1 },
+    error: null,
+    triggered_by: "web",
+  },
+  {
+    id: 703,
+    workflow_name: "ml-pipeline",
+    status: "failed",
+    started_at: new Date(Date.now() - 90_000).toISOString(),
+    completed_at: new Date(Date.now() - 40_000).toISOString(),
+    args: { lr: "0.1", seed: 1 },
+    error: "diverged at step 3",
+    triggered_by: "web",
+  },
+  {
+    id: 704,
+    workflow_name: "ml-pipeline",
+    status: "running",
+    started_at: new Date(Date.now() - 30_000).toISOString(),
+    completed_at: null,
+    args: { lr: "0.001", seed: 2 },
+    error: null,
+    triggered_by: "web",
+  },
+  {
+    id: 705,
+    workflow_name: "ml-pipeline",
+    status: "cancelled",
+    started_at: new Date(Date.now() - 80_000).toISOString(),
+    completed_at: new Date(Date.now() - 50_000).toISOString(),
+    args: { lr: "0.01", seed: 2 },
+    error: null,
+    triggered_by: "web",
+  },
+  {
+    id: 706,
+    workflow_name: "ml-pipeline",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    args: { lr: "0.1", seed: 2 },
+    error: null,
+    triggered_by: "web",
+  },
+];
+
+function buildSweep(cells: Cell[]) {
+  const count = (s: CellStatus) => cells.filter((c) => c.status === s).length;
+  return {
+    id: SWEEP_ID,
+    name: "ml-pipeline",
+    workflow_yaml_path: null,
+    status: "running" as const,
+    matrix: { lr: ["0.001", "0.01", "0.1"], seed: [1, 2] },
+    args: null,
+    fail_fast: false,
+    max_parallel: 2,
+    cell_count: cells.length,
+    cells_pending: count("pending"),
+    cells_running: count("running"),
+    cells_completed: count("completed"),
+    cells_failed: count("failed"),
+    cells_cancelled: count("cancelled"),
+    submission_source: "web" as const,
+    started_at: SWEEP_STARTED_AT,
+    completed_at: null,
+    cancel_requested_at: null,
+    error: null,
+  };
+}
+
+test.beforeEach(async ({ page }) => {
+  await setupMockRoutes(page);
+});
+
+test.describe("Sweep Detail UX (Phase 5b)", () => {
+  test("status filter narrows cells to the failed subset only", async ({
+    page,
+  }) => {
+    const cells: Cell[] = JSON.parse(JSON.stringify(INITIAL_CELLS));
+
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}`, (route) =>
+      route.fulfill({ json: buildSweep(cells) }),
+    );
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}/cells`, (route) =>
+      route.fulfill({ json: cells }),
+    );
+
+    await page.goto(`/sweep_runs/${SWEEP_ID}`);
+
+    // All cells visible initially.
+    await expect(page.getByTestId("sweep-cell-row-701")).toBeVisible();
+    await expect(page.getByTestId("sweep-cell-row-703")).toBeVisible();
+    await expect(page.getByTestId("sweep-cell-row-705")).toBeVisible();
+
+    // Apply "failed" filter → only cell 703 remains.
+    await page.getByTestId("sweep-cell-status-filter").selectOption("failed");
+
+    await expect(page.getByTestId("sweep-cell-row-703")).toBeVisible();
+    await expect(page.getByTestId("sweep-cell-row-701")).not.toBeVisible();
+    await expect(page.getByTestId("sweep-cell-row-702")).not.toBeVisible();
+    await expect(page.getByTestId("sweep-cell-row-705")).not.toBeVisible();
+  });
+
+  test("sort by started toggles ascending → descending", async ({ page }) => {
+    const cells: Cell[] = JSON.parse(JSON.stringify(INITIAL_CELLS));
+
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}`, (route) =>
+      route.fulfill({ json: buildSweep(cells) }),
+    );
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}/cells`, (route) =>
+      route.fulfill({ json: cells }),
+    );
+
+    await page.goto(`/sweep_runs/${SWEEP_ID}`);
+
+    // Default: # index order == insertion order (cells 701..706).
+    const firstRowInitial = page
+      .locator('tr[data-testid^="sweep-cell-row-"]')
+      .first();
+    await expect(firstRowInitial).toHaveAttribute(
+      "data-testid",
+      "sweep-cell-row-701",
+    );
+
+    // Sort by Started asc → oldest-started cell first. 706 has null
+    // started_at (pending) and its Date.parse falls back to 0, so it
+    // should sort to the top in ascending.
+    await page.getByTestId("sort-started").click();
+
+    const firstRowAsc = page
+      .locator('tr[data-testid^="sweep-cell-row-"]')
+      .first();
+    await expect(firstRowAsc).toHaveAttribute(
+      "data-testid",
+      "sweep-cell-row-706",
+    );
+
+    // Toggle: second click on the same header flips to descending.
+    // 704 (most recent started) should be first.
+    await page.getByTestId("sort-started").click();
+
+    const firstRowDesc = page
+      .locator('tr[data-testid^="sweep-cell-row-"]')
+      .first();
+    await expect(firstRowDesc).toHaveAttribute(
+      "data-testid",
+      "sweep-cell-row-704",
+    );
+  });
+
+  test("per-cell cancel button posts to workflow runs cancel", async ({
+    page,
+  }) => {
+    const cells: Cell[] = JSON.parse(JSON.stringify(INITIAL_CELLS));
+    const cancelRequests: string[] = [];
+
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}`, (route) =>
+      route.fulfill({ json: buildSweep(cells) }),
+    );
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}/cells`, (route) =>
+      route.fulfill({ json: cells }),
+    );
+    await page.route("**/api/workflows/runs/*/cancel", (route) => {
+      const match = route
+        .request()
+        .url()
+        .match(/\/runs\/(\d+)\/cancel/);
+      if (match) {
+        cancelRequests.push(match[1]);
+        // Flip the matching cell to cancelled so the reload sees the
+        // action took effect.
+        const cancelledId = Number(match[1]);
+        const idx = cells.findIndex((c) => c.id === cancelledId);
+        if (idx >= 0) {
+          cells[idx].status = "cancelled";
+          cells[idx].completed_at = new Date().toISOString();
+        }
+      }
+      return route.fulfill({
+        json: { status: "cancelled", run_id: match?.[1] ?? "0" },
+      });
+    });
+
+    await page.goto(`/sweep_runs/${SWEEP_ID}`);
+
+    // Cancel button shown for running cell 704, not shown for terminal 701.
+    await expect(page.getByTestId("sweep-cell-cancel-704")).toBeVisible();
+    await expect(page.getByTestId("sweep-cell-cancel-701")).toHaveCount(0);
+
+    await page.getByTestId("sweep-cell-cancel-704").click();
+
+    // Expect the cancel endpoint to be hit for the active cell only.
+    await expect.poll(() => cancelRequests).toContain("704");
+  });
+
+  test("progress bar + ETA render and draining indicator appears on draining sweeps", async ({
+    page,
+  }) => {
+    const cells: Cell[] = JSON.parse(JSON.stringify(INITIAL_CELLS));
+
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}`, (route) =>
+      route.fulfill({ json: buildSweep(cells) }),
+    );
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}/cells`, (route) =>
+      route.fulfill({ json: cells }),
+    );
+
+    await page.goto(`/sweep_runs/${SWEEP_ID}`);
+
+    await expect(page.getByTestId("sweep-progress-bar")).toBeVisible();
+    // ETA label only shown while the sweep is active and at least one
+    // cell has terminated (we have 2 completed / 1 failed / 1 cancelled).
+    await expect(page.getByTestId("sweep-eta")).toBeVisible();
+    await expect(page.getByTestId("sweep-draining-indicator")).toHaveCount(0);
+
+    // Switch the sweep to draining and re-load to trigger the indicator.
+    const drainingSweep = {
+      ...buildSweep(cells),
+      status: "draining" as const,
+    };
+    await page.route(`**/api/sweep_runs/${SWEEP_ID}`, (route) =>
+      route.fulfill({ json: drainingSweep }),
+    );
+    await page.reload();
+
+    await expect(page.getByTestId("sweep-draining-indicator")).toBeVisible();
+  });
+});

--- a/src/srunx/web/frontend/src/components/WorkflowRunDialog.tsx
+++ b/src/srunx/web/frontend/src/components/WorkflowRunDialog.tsx
@@ -35,7 +35,10 @@ type WorkflowRunDialogProps = {
    * can add new keys on top of these — the dialog stays usable when
    * the workflow defines no args at all.
    */
-  args?: Record<string, string>;
+  /** YAML-declared workflow args. Values may be non-string (int / bool /
+   *  float) so the dialog coerces them via ``String(...)`` at seed time;
+   *  the matrix / args_override payloads are string-only. */
+  args?: Record<string, unknown>;
   onClose: () => void;
   onRunStarted: (run: Record<string, unknown>) => void;
   /**
@@ -82,15 +85,22 @@ function parseListValues(raw: string): string[] {
 
 /** Seed the editor with existing workflow-level ``args`` in ``single``
  * mode. When the workflow defines no args we start with a single
- * blank row so the user has a visible target to edit. */
-function seedArgEntries(args: Record<string, string> | undefined): ArgEntry[] {
+ * blank row so the user has a visible target to edit.
+ *
+ * The YAML parser preserves scalar types, so ``value`` arrives as
+ * ``string | number | boolean | null``. The editor operates on strings
+ * (``<input type="text">`` + comma split for list mode), so coerce
+ * here — otherwise toggling to list mode on an int arg blows up with
+ * ``e.split is not a function``. ``null`` / ``undefined`` seed as the
+ * empty string; everything else runs through ``String(...)``. */
+function seedArgEntries(args: Record<string, unknown> | undefined): ArgEntry[] {
   const entries = Object.entries(args ?? {});
   if (entries.length === 0) return [];
   return entries.map<ArgEntry>(([name, value], i) => ({
     id: i,
     name,
     mode: "single",
-    value,
+    value: value == null ? "" : String(value),
   }));
 }
 
@@ -123,11 +133,17 @@ export function WorkflowRunDialog({
   // keys to ``args_override`` at submit time (UI-FIX-2). The backend is
   // idempotent w.r.t. unchanged values, but always sending them makes
   // the Web access log noisy and makes it impossible to tell a deliberate
-  // override from a passthrough.
-  const initialArgs = useMemo<Record<string, string>>(
-    () => ({ ...(args ?? {}) }),
-    [args],
-  );
+  // override from a passthrough. Coerce each value to its string shape
+  // so the diff check at submit time can equality-compare against the
+  // editor's string state without triggering spurious overrides for
+  // workflows whose YAML args are numeric / boolean.
+  const initialArgs = useMemo<Record<string, string>>(() => {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(args ?? {})) {
+      out[k] = v == null ? "" : String(v);
+    }
+    return out;
+  }, [args]);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [failFast, setFailFast] = useState(false);
   const [maxParallel, setMaxParallel] = useState(4);

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -52,7 +52,11 @@ export type RunnableJob = CommandJob | ShellJob;
 
 export type Workflow = {
   name: string;
-  args?: Record<string, string>;
+  /** YAML-declared ``args`` — values are whatever YAML parsed to
+   *  (string / number / boolean / null), mirroring the backend's
+   *  ``Record[str, Any]`` wire shape. Consumers must coerce to string
+   *  before string-only operations. */
+  args?: Record<string, unknown>;
   jobs: RunnableJob[];
   default_project?: string | null;
 };

--- a/src/srunx/web/frontend/src/pages/SweepRunDetailPage.tsx
+++ b/src/srunx/web/frontend/src/pages/SweepRunDetailPage.tsx
@@ -1,8 +1,19 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { motion } from "framer-motion";
-import { ArrowLeft, XCircle, ExternalLink } from "lucide-react";
-import { sweepRuns as sweepRunsApi } from "../lib/api.ts";
+import {
+  ArrowLeft,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+  Filter,
+  XCircle,
+  ExternalLink,
+} from "lucide-react";
+import {
+  sweepRuns as sweepRunsApi,
+  workflows as workflowsApi,
+} from "../lib/api.ts";
 import type {
   SweepCellRow,
   SweepRun,
@@ -18,6 +29,12 @@ const TERMINAL_SWEEP_STATUSES: ReadonlySet<SweepStatus> = new Set([
   "cancelled",
 ]);
 
+const TERMINAL_CELL_STATUSES: ReadonlySet<WorkflowRunStatus> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
 const SWEEP_STATUS_COLOR: Record<SweepStatus, string> = {
   pending: "var(--st-pending)",
   running: "var(--st-running)",
@@ -26,6 +43,18 @@ const SWEEP_STATUS_COLOR: Record<SweepStatus, string> = {
   failed: "var(--st-failed)",
   cancelled: "var(--text-muted)",
 };
+
+const CELL_STATUS_OPTIONS: readonly (WorkflowRunStatus | "all")[] = [
+  "all",
+  "pending",
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+];
+
+type SortKey = "index" | "status" | "started" | "completed" | "duration";
+type SortDir = "asc" | "desc";
 
 /** Map the lowercase workflow_run status returned by
  *  ``/api/sweep_runs/{id}/cells`` onto the uppercase ``JobStatus`` that
@@ -77,6 +106,50 @@ function formatTs(ts: string | null): string {
   }
 }
 
+function durationSeconds(
+  startedAt: string | null,
+  completedAt: string | null,
+): number | null {
+  if (!startedAt) return null;
+  const start = Date.parse(startedAt);
+  if (Number.isNaN(start)) return null;
+  const end = completedAt ? Date.parse(completedAt) : Date.now();
+  if (Number.isNaN(end) || end < start) return null;
+  return (end - start) / 1000;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null) return "—";
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds - mins * 60);
+  if (mins < 60) return `${mins}m ${secs}s`;
+  const hours = Math.floor(mins / 60);
+  const remMins = mins - hours * 60;
+  return `${hours}h ${remMins}m`;
+}
+
+/** Naive linear-throughput ETA: remaining ÷ throughput.
+ *
+ *  ``throughput`` is computed from the elapsed wall-clock since the
+ *  sweep's ``started_at`` divided by the number of cells that have
+ *  already reached a terminal state. The estimate is noisy in the
+ *  very first seconds (zero completions) and towards the tail (fewer
+ *  cells left to average), but for a multi-minute sweep it gives
+ *  operators a useful upper-bound glance. */
+function computeEta(sweep: SweepRun): number | null {
+  const completedTerminal =
+    sweep.cells_completed + sweep.cells_failed + sweep.cells_cancelled;
+  if (completedTerminal <= 0) return null;
+  const remaining = sweep.cell_count - completedTerminal;
+  if (remaining <= 0) return 0;
+  const elapsed = durationSeconds(sweep.started_at, null);
+  if (elapsed === null || elapsed <= 0) return null;
+  const throughput = completedTerminal / elapsed;
+  if (throughput <= 0) return null;
+  return remaining / throughput;
+}
+
 function MetaCell({
   label,
   children,
@@ -117,6 +190,136 @@ function MetaCell({
   );
 }
 
+function ProgressBar({ sweep }: { sweep: SweepRun }) {
+  const completed = sweep.cells_completed;
+  const failed = sweep.cells_failed;
+  const cancelled = sweep.cells_cancelled;
+  const running = sweep.cells_running;
+  const total = Math.max(sweep.cell_count, 1);
+
+  const segments: Array<{ key: string; value: number; color: string }> = [
+    { key: "completed", value: completed, color: "var(--st-completed)" },
+    { key: "failed", value: failed, color: "var(--st-failed)" },
+    { key: "cancelled", value: cancelled, color: "var(--text-muted)" },
+    { key: "running", value: running, color: "var(--st-running)" },
+  ];
+
+  const eta = computeEta(sweep);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      <div
+        style={{
+          position: "relative",
+          height: 10,
+          background: "var(--bg-base)",
+          borderRadius: 5,
+          overflow: "hidden",
+          border: "1px solid var(--border-ghost)",
+          display: "flex",
+        }}
+        data-testid="sweep-progress-bar"
+      >
+        {segments.map((s) => (
+          <div
+            key={s.key}
+            style={{
+              width: `${(s.value / total) * 100}%`,
+              background: s.color,
+              transition: "width 0.3s ease",
+            }}
+            title={`${s.key}: ${s.value}`}
+          />
+        ))}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          gap: 16,
+          fontSize: "0.72rem",
+          fontFamily: "var(--font-mono)",
+          color: "var(--text-muted)",
+        }}
+      >
+        <span>
+          {completed + failed + cancelled}/{sweep.cell_count} terminal
+        </span>
+        {eta !== null && !TERMINAL_SWEEP_STATUSES.has(sweep.status) && (
+          <span data-testid="sweep-eta">ETA ≈ {formatDuration(eta)}</span>
+        )}
+        {sweep.status === "draining" && (
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              color: "var(--st-pending)",
+            }}
+            data-testid="sweep-draining-indicator"
+          >
+            <motion.span
+              animate={{ rotate: 360 }}
+              transition={{ repeat: Infinity, duration: 1.2, ease: "linear" }}
+              style={{ display: "inline-block", width: 10, height: 10 }}
+            >
+              ◐
+            </motion.span>
+            draining pending cells
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  direction,
+  onToggle,
+  width,
+}: {
+  label: string;
+  sortKey: SortKey;
+  activeKey: SortKey;
+  direction: SortDir;
+  onToggle: (key: SortKey) => void;
+  width?: number;
+}) {
+  const isActive = activeKey === sortKey;
+  const Icon = isActive
+    ? direction === "asc"
+      ? ArrowUp
+      : ArrowDown
+    : ArrowUpDown;
+  return (
+    <th style={width ? { width } : undefined}>
+      <button
+        type="button"
+        onClick={() => onToggle(sortKey)}
+        data-testid={`sort-${sortKey}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          background: "transparent",
+          border: "none",
+          color: isActive ? "var(--text-primary)" : "inherit",
+          font: "inherit",
+          cursor: "pointer",
+          padding: 0,
+          textTransform: "inherit",
+          letterSpacing: "inherit",
+        }}
+      >
+        {label}
+        <Icon size={12} style={{ opacity: isActive ? 1 : 0.4 }} />
+      </button>
+    </th>
+  );
+}
+
 export function SweepRunDetailPage() {
   const { id: idParam } = useParams<{ id: string }>();
   const id = Number(idParam);
@@ -125,6 +328,14 @@ export function SweepRunDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [cancelError, setCancelError] = useState<string | null>(null);
+  const [pendingCellCancels, setPendingCellCancels] = useState<Set<number>>(
+    new Set(),
+  );
+  const [statusFilter, setStatusFilter] = useState<WorkflowRunStatus | "all">(
+    "all",
+  );
+  const [sortKey, setSortKey] = useState<SortKey>("index");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
 
   const load = useCallback(async () => {
     if (!Number.isFinite(id)) {
@@ -165,6 +376,62 @@ export function SweepRunDetailPage() {
     [sweep],
   );
 
+  const toggleSort = useCallback((key: SortKey) => {
+    setSortKey((prev) => {
+      if (prev === key) {
+        setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+        return key;
+      }
+      setSortDir("asc");
+      return key;
+    });
+  }, []);
+
+  const visibleCells = useMemo(() => {
+    if (!cells) return [];
+    const filtered =
+      statusFilter === "all"
+        ? cells
+        : cells.filter((c) => c.status === statusFilter);
+
+    const indexed = filtered.map((cell) => {
+      // Stable "insertion" index anchored on the original cells array so
+      // the leftmost column stays stable regardless of sort direction.
+      const originalIndex = cells.indexOf(cell);
+      return { cell, originalIndex };
+    });
+
+    const mul = sortDir === "asc" ? 1 : -1;
+    indexed.sort((a, b) => {
+      const A = a.cell;
+      const B = b.cell;
+      switch (sortKey) {
+        case "status":
+          return mul * A.status.localeCompare(B.status);
+        case "started": {
+          const aT = A.started_at ? Date.parse(A.started_at) : 0;
+          const bT = B.started_at ? Date.parse(B.started_at) : 0;
+          return mul * (aT - bT);
+        }
+        case "completed": {
+          const aT = A.completed_at ? Date.parse(A.completed_at) : 0;
+          const bT = B.completed_at ? Date.parse(B.completed_at) : 0;
+          return mul * (aT - bT);
+        }
+        case "duration": {
+          const aD = durationSeconds(A.started_at, A.completed_at) ?? -1;
+          const bD = durationSeconds(B.started_at, B.completed_at) ?? -1;
+          return mul * (aD - bD);
+        }
+        case "index":
+        default:
+          return mul * (a.originalIndex - b.originalIndex);
+      }
+    });
+
+    return indexed;
+  }, [cells, statusFilter, sortKey, sortDir]);
+
   const handleCancel = async () => {
     if (!sweep) return;
     try {
@@ -175,6 +442,28 @@ export function SweepRunDetailPage() {
       setCancelError(e instanceof Error ? e.message : "Failed to cancel sweep");
     }
   };
+
+  const handleCancelCell = useCallback(
+    async (cellId: number) => {
+      try {
+        setCancelError(null);
+        setPendingCellCancels((s) => new Set(s).add(cellId));
+        await workflowsApi.cancelRun(String(cellId));
+        void load();
+      } catch (e) {
+        setCancelError(
+          e instanceof Error ? e.message : `Failed to cancel cell ${cellId}`,
+        );
+      } finally {
+        setPendingCellCancels((s) => {
+          const next = new Set(s);
+          next.delete(cellId);
+          return next;
+        });
+      }
+    },
+    [load],
+  );
 
   if (loading) {
     return (
@@ -297,6 +586,10 @@ export function SweepRunDetailPage() {
         className="panel"
         style={{ padding: "var(--sp-4)" }}
       >
+        <div style={{ marginBottom: "var(--sp-4)" }}>
+          <ProgressBar sweep={sweep} />
+        </div>
+
         <div
           style={{
             display: "grid",
@@ -355,33 +648,107 @@ export function SweepRunDetailPage() {
         className="panel"
         style={{ overflow: "hidden" }}
       >
-        <div className="panel-header">
+        <div
+          className="panel-header"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
           <h3 style={{ textTransform: "none", letterSpacing: 0 }}>
-            Cells ({cells?.length ?? 0})
+            Cells ({visibleCells.length}
+            {cells && visibleCells.length !== cells.length
+              ? ` of ${cells.length}`
+              : ""}
+            )
           </h3>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <Filter size={14} color="var(--text-muted)" />
+            <select
+              className="select"
+              value={statusFilter}
+              onChange={(e) =>
+                setStatusFilter(e.target.value as WorkflowRunStatus | "all")
+              }
+              data-testid="sweep-cell-status-filter"
+            >
+              {CELL_STATUS_OPTIONS.map((s) => (
+                <option key={s} value={s}>
+                  {s === "all" ? "All statuses" : s}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
         <div style={{ overflow: "auto", maxHeight: "50vh" }}>
           <table className="data-table">
             <thead>
               <tr>
-                <th style={{ width: 60 }}>#</th>
+                <SortHeader
+                  label="#"
+                  sortKey="index"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onToggle={toggleSort}
+                  width={60}
+                />
                 {axisNames.map((axis) => (
                   <th key={axis}>{axis}</th>
                 ))}
-                <th style={{ width: 120 }}>Status</th>
-                <th style={{ width: 180 }}>Started</th>
-                <th style={{ width: 180 }}>Completed</th>
+                <SortHeader
+                  label="Status"
+                  sortKey="status"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onToggle={toggleSort}
+                  width={120}
+                />
+                <SortHeader
+                  label="Started"
+                  sortKey="started"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onToggle={toggleSort}
+                  width={180}
+                />
+                <SortHeader
+                  label="Completed"
+                  sortKey="completed"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onToggle={toggleSort}
+                  width={180}
+                />
+                <SortHeader
+                  label="Duration"
+                  sortKey="duration"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onToggle={toggleSort}
+                  width={100}
+                />
                 <th>Error</th>
-                <th style={{ width: 60 }}>Run</th>
+                <th style={{ width: 110 }}>Actions</th>
               </tr>
             </thead>
             <tbody>
-              {cells && cells.length > 0 ? (
-                cells.map((cell, i) => {
+              {visibleCells.length > 0 ? (
+                visibleCells.map(({ cell, originalIndex }) => {
                   const a = cell.args ?? {};
+                  const duration = durationSeconds(
+                    cell.started_at,
+                    cell.completed_at,
+                  );
+                  const cellIsActive = !TERMINAL_CELL_STATUSES.has(cell.status);
+                  const isCancelling = pendingCellCancels.has(cell.id);
                   return (
                     <tr key={cell.id} data-testid={`sweep-cell-row-${cell.id}`}>
-                      <td className="col-mono col-muted">{i + 1}</td>
+                      <td className="col-mono col-muted">
+                        {originalIndex + 1}
+                      </td>
                       {axisNames.map((axis) => (
                         <td key={axis} className="col-mono">
                           {formatAxisValue(a[axis])}
@@ -399,6 +766,9 @@ export function SweepRunDetailPage() {
                       <td className="col-mono col-muted">
                         {formatTs(cell.completed_at)}
                       </td>
+                      <td className="col-mono col-muted">
+                        {formatDuration(duration)}
+                      </td>
                       <td
                         className="col-mono truncate"
                         style={{
@@ -412,14 +782,32 @@ export function SweepRunDetailPage() {
                         {cell.error ?? "—"}
                       </td>
                       <td>
-                        <Link
-                          to={`/workflow_runs/${cell.id}`}
-                          className="btn btn-ghost"
-                          style={{ padding: "4px 8px" }}
-                          title="Open workflow run"
-                        >
-                          <ExternalLink size={13} />
-                        </Link>
+                        <div style={{ display: "flex", gap: 4 }}>
+                          {cellIsActive && (
+                            <button
+                              type="button"
+                              className="btn btn-ghost"
+                              style={{
+                                padding: "4px 8px",
+                                color: "var(--st-failed)",
+                              }}
+                              disabled={isCancelling}
+                              onClick={() => void handleCancelCell(cell.id)}
+                              data-testid={`sweep-cell-cancel-${cell.id}`}
+                              title="Cancel this cell"
+                            >
+                              <XCircle size={13} />
+                            </button>
+                          )}
+                          <Link
+                            to={`/workflow_runs/${cell.id}`}
+                            className="btn btn-ghost"
+                            style={{ padding: "4px 8px" }}
+                            title="Open workflow run"
+                          >
+                            <ExternalLink size={13} />
+                          </Link>
+                        </div>
                       </td>
                     </tr>
                   );
@@ -427,14 +815,16 @@ export function SweepRunDetailPage() {
               ) : (
                 <tr>
                   <td
-                    colSpan={axisNames.length + 6}
+                    colSpan={axisNames.length + 7}
                     style={{
                       textAlign: "center",
                       color: "var(--text-muted)",
                       padding: 32,
                     }}
                   >
-                    No cells materialized for this sweep.
+                    {cells && cells.length > 0
+                      ? `No cells match the "${statusFilter}" filter.`
+                      : "No cells materialized for this sweep."}
                   </td>
                 </tr>
               )}

--- a/src/srunx/web/frontend/src/pages/WorkflowBuilder.tsx
+++ b/src/srunx/web/frontend/src/pages/WorkflowBuilder.tsx
@@ -387,10 +387,13 @@ export function WorkflowBuilder() {
         setOriginalName(workflow.name);
         setDefaultProject(workflow.default_project ?? null);
         if (workflow.args && Object.keys(workflow.args).length > 0) {
+          // ``Workflow.args`` values are ``unknown`` because YAML scalars
+          // (int / bool / float) may arrive non-string; the builder edits
+          // them as plain strings, so coerce at the boundary.
           setArgsEntries(
             Object.entries(workflow.args).map(([key, value]) => ({
               key,
-              value,
+              value: value == null ? "" : String(value),
             })),
           );
         }


### PR DESCRIPTION
SweepRunDetailPage に 4 項目の UX 改善を surgical に追加。全て frontend-only、既存の `POST /api/workflows/runs/{id}/cancel` を流用するため backend 変更なし。

## 改善内容

### 1. Status filter on cells table
- `<select>` ドロップダウン（`Jobs.tsx` の `statusFilter` パターン踏襲）
- `all / pending / running / completed / failed / cancelled`
- 失敗 cell だけを即座に絞り込める

### 2. Sortable columns
- `#`, `Status`, `Started`, `Completed`, `Duration` でソート可能
- カラムヘッダクリックで asc ⇄ desc 切り替え（arrow icon で現在の direction 視認）
- `#` (index) が default、stable sort 維持

### 3. Per-cell cancel ボタン
- 非 terminal cell の行に `<XCircle>` ボタン表示
- `POST /api/workflows/runs/{id}/cancel` を call（cell.id == workflow_run_id）
- `WorkflowRunStateService` 経由で sweep aggregator が counters を converge、既存の atomic claim / drain 挙動と整合

### 4. Progress bar + ETA + draining indicator
- Sweep header 直下に segmented progress bar（completed / failed / cancelled / running）
- ETA 計算: `elapsed / completed_terminal * remaining`（naive linear throughput）
- 最低 1 cell が terminal に到達するまで ETA 非表示（初期ノイズ回避）
- `status='draining'` の sweep には回転 indicator + "draining pending cells" ラベル

## Verification
- **Playwright**: `sweep-detail-ux.spec.ts` に 4 新規テスト、全 pass
  1. Status filter: failed のみ絞り込み
  2. Sort by Started: asc → desc toggle
  3. Per-cell cancel: `/api/workflows/runs/704/cancel` が叩かれる
  4. Progress bar + ETA 表示 + draining indicator
- **既存 E2E regression**: `sweep-builder.spec.ts`, `workflow-run.spec.ts` (14 tests) 全 pass
- **Frontend static**: `tsc --noEmit` + `vite build` clean
- **Python**: 1712 passed / 2 skipped / 1 pre-existing flake（frontend-only 変更なので Python 側は無改変）

## Defer
明示的に本 PR のスコープ外（次 PR 候補）:
- **Re-run failed cells**: 意味論議論（新 workflow_run 起こす vs 既存 cell pending 戻す）
- **Cell log preview modal**: cell → job_id → logs の API 形状要決定
- **Live log streaming**: SSE/WS インフラ未整備
- **Tag / axis value 部分一致 filter**: 現状の status filter で十分な要件カバー、将来の追加機能として

## Breaking changes
なし。既存の URL スキーム・API 契約・CSS 変数は unchanged。

🤖 Generated with [Claude Code](https://claude.com/claude-code)