### PR TITLE
docs: v1.2 updates for parameter sweeps + MCP mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Instead of stitching together `sbatch`, `squeue`, SSH, and a pipeline runner, sr
 | Web dashboard | ✅ | ❌ | ❌ | ❌ |
 | Workflow DAG with dependencies | ✅ | ❌ | ❌ | ✅ |
 | Inter-job value passing (load-time) | ✅ | ❌ | ❌ | ⚠️ via files |
+| Matrix parameter sweeps | ✅ | ⚠️ manual | ❌ | ⚠️ via wildcards |
 | GPU availability monitoring | ✅ | ❌ | ❌ | ❌ |
 | SSH remote submit + file sync | ✅ | ❌ | ❌ | ❌ |
 | Container support (Pyxis / Apptainer / Singularity) | ✅ | ⚠️ limited | ❌ | ⚠️ via rules |
@@ -97,6 +98,8 @@ If you need full-featured scientific workflow tooling, Snakemake / Nextflow are 
 | `srunx resources` | Display GPU availability |
 | `srunx monitor` | Monitor jobs, resources, or cluster |
 | `srunx flow` | Run / validate YAML workflows |
+| `srunx flow run --arg KEY=VALUE` | Override workflow `args` from the CLI |
+| `srunx flow run --sweep KEY=V1,V2 --max-parallel N` | Ad-hoc matrix parameter sweep |
 | `srunx ssh` | Remote SLURM operations over SSH |
 | `srunx history` | Show job execution history |
 | `srunx report` | Generate job execution report |
@@ -187,6 +190,39 @@ srunx flow run workflow.yaml --from train # resume / partial execution
 
 Retry with `retry: N` and `retry_delay: <seconds>` per job.
 
+### Parameter Sweeps
+
+Run the same workflow across a matrix of hyperparameters without copying YAML. Each cell materializes into its own sbatch submission and is tracked independently.
+
+```yaml
+name: train
+args:
+  lr: 0.01
+  seed: 1
+
+sweep:
+  matrix:
+    lr: [0.001, 0.01, 0.1]
+    seed: [1, 2, 3]
+  fail_fast: false
+  max_parallel: 4
+
+jobs:
+  - name: train
+    command: ["python", "train.py", "--lr", "{{ lr }}", "--seed", "{{ seed }}"]
+    gpus_per_node: 1
+```
+
+Run it — or declare the axes ad-hoc on the command line:
+
+```bash
+srunx flow run train.yaml                                                # YAML-declared sweep
+srunx flow run --sweep lr=0.001,0.01 --max-parallel 2 train.yaml          # ad-hoc
+srunx flow run --sweep lr=0.001,0.01 --max-parallel 2 --dry-run train.yaml
+```
+
+Sweeps are a first-class concept across **CLI, Web UI, and MCP**. Web-triggered sweeps route cells through a bounded `SlurmSSHExecutorPool` against the configured SSH profile, while CLI and MCP runs use the local SLURM client by default. The Web UI surfaces per-cell progress with ETA, filter / sort, and per-cell cancellation.
+
 ## Monitoring
 
 ```bash
@@ -234,6 +270,30 @@ Get notified when jobs finish — set `SLACK_WEBHOOK_URL` (or configure it in th
 export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
 srunx flow run workflow.yaml --slack
 ```
+
+## MCP Server
+
+srunx ships an MCP server so Claude Code (and other MCP clients) can submit jobs, inspect the queue, and drive workflows over stdio. Install the extra and register the server with your client:
+
+```bash
+uv add "srunx[mcp]"
+srunx-mcp                                                              # launch the stdio server directly
+
+# Or register with Claude Code in one shot
+claude mcp add --scope user srunx -- uvx --from 'srunx[mcp]' srunx-mcp
+```
+
+Once connected, the agent can call `run_workflow` with optional sweep and mount parameters:
+
+```python
+run_workflow(
+    yaml_path="train.yaml",
+    sweep={"matrix": {"lr": [0.001, 0.01]}, "max_parallel": 2},
+    mount="my-project",
+)
+```
+
+Passing `mount=<name>` routes the run through the matching SSH profile mount, translating `work_dir` / `log_dir` into remote paths — so the agent can launch mount-aware submissions against a remote cluster without leaving the chat.
 
 ## Python API
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -111,6 +111,180 @@ React + TypeScript with Vite. Pages use a custom `useApi` hook for
 data fetching with automatic polling. React Flow provides DAG
 visualization for workflow dependencies.
 
+## Sweep Architecture
+
+Parameter sweeps extend the single-workflow execution model into a bounded
+fan-out of "cells" -- each cell is an ordinary workflow run, but the
+whole set is tracked and orchestrated as one unit. The design deliberately
+reuses the workflow runner rather than inventing a parallel execution
+mechanism: a sweep is "one sweep_run, N workflow_runs", not "one
+workflow_run with N internal branches".
+
+### Load-time matrix materialization
+
+A sweep is expanded at **load time**, before any job is submitted to
+SLURM. `expand_matrix` takes the `sweep.matrix` block and produces the
+scalar cross-product, rejecting nested structures and capping the total
+cell count at 1000 (SLURM's `MaxSubmitJobs` is typically ~4096, so this
+is a safety valve and not a hard ceiling).
+
+Each resulting cell becomes its own `workflow_runs` row that is persisted
+up front, with the child's `sweep_run_id` pointing back to the parent
+`sweep_runs` row. Rendering substitutes the cell's args into every job
+field using Jinja2 with `StrictUndefined`, so a missing key fails loudly
+at expansion time instead of producing an empty arg inside `sbatch`.
+
+This is the same design judgement that underlies `exports` / `deps`:
+inter-job values are resolved at workflow load time rather than through
+a runtime env-file mechanism. Load-time resolution gives sweeps three
+properties that runtime expansion could not: the full plan is inspectable
+before submission (enabling `--dry-run`), every cell's args are stable
+and auditable in the DB, and reconciliation after a crash is purely a
+function of the persisted rows.
+
+### Orchestration and concurrency control
+
+The `SweepOrchestrator` runs cells under an `anyio.Semaphore` whose
+capacity is `min(max_parallel, cell_count)`. When `max_parallel` is
+larger than the actual cell count the semaphore is silently clamped
+(with a warning log) instead of erroring, keeping the CLI / Web /
+MCP surfaces tolerant of "over-provisioned" sweeps.
+
+Cell failures interact with `fail_fast` in one direction only: when
+`fail_fast=true` and a cell reaches a terminal failure state, the
+orchestrator transitions the sweep into `draining` and cancels not-yet-
+running cells. Cells already running are allowed to finish -- draining
+is cooperative, not pre-emptive. With the default `fail_fast=false` a
+single failure has no effect on peers, which matches how hyperparameter
+sweeps are typically run in practice.
+
+### Per-cell execution paths
+
+The orchestrator constructs each cell's `WorkflowRunner` with two
+injected dependencies:
+
+- **`executor_factory`** -- `None` for local execution (`Slurm`
+  singleton, `subprocess`-based), or a callable that leases a
+  `SlurmSSHExecutor` from a pool for remote execution.
+- **`submission_context`** -- a `SubmissionRenderContext` that
+  encapsulates the per-cell render concerns: mount-aware translation of
+  `work_dir` and `log_dir` from local paths to their remote equivalents,
+  and the canonical rendering step for `ShellJob` scripts that are
+  staged via SFTP.
+
+This keeps the local path and the SSH path on the **same code path**:
+the runner does not branch on execution mode. CLI and MCP sweeps
+without a `mount=` argument pass `executor_factory=None`, which
+preserves the pre-sweep behaviour bit-for-bit -- cells go through the
+`Slurm` singleton exactly as a non-swept workflow would. Web UI
+sweeps, and MCP sweeps with `mount=<profile>`, pass an
+`executor_factory` backed by a per-sweep `SlurmSSHExecutorPool`.
+
+### SSH pool and mount-aware rendering
+
+`SlurmSSHExecutorPool` is a bounded pool of pre-built SSH executors,
+sized at `max(1, min(max_parallel, 8))`. The floor at 1 guards against
+a zero-sized pool when `max_parallel=0` would otherwise be pathological;
+the ceiling at 8 avoids drowning the remote SSH server in long-lived
+control sessions even when the sweep's nominal parallelism is higher.
+The pool's lifecycle is strictly **per sweep**: the Web UI's
+`_run_sweep_background` closes it in a `finally` block, and the MCP
+`run_workflow` tool closes it in its own `finally` -- there is no
+process-wide pool.
+
+`SubmissionRenderContext` is the responsibility boundary for
+path translation. Where the local `Slurm` client can use absolute local
+paths verbatim, the SSH path must convert a job's `work_dir` /
+`log_dir` from the developer's machine into the matching remote path
+under the SSH mount. The render context owns that conversion (plus
+`ShellJob` script rendering), so the runner itself stays agnostic
+about whether it is submitting locally or through SSH.
+
+A related SSH-path subtlety is the **scontrol fallback** in the status
+query: the lookup chain is `sacct` → `squeue` → `scontrol`. The third
+stage exists specifically for Pyxis-style environments where
+`slurmdbd` is unreachable and `sacct` returns empty, which previously
+surfaced as silent `FAILED` statuses. If even `scontrol` cannot find
+the job we return `JobStatus.UNKNOWN` rather than coercing it to
+`FAILED` -- the ambiguity is preserved for the caller.
+
+### Aggregation via the sweep_runs counters
+
+Every cell transition goes through `WorkflowRunStateService`, which
+performs an optimistic-lock `UPDATE` on the cell's `workflow_runs` row
+and, in the same transaction, increments or decrements the parent
+sweep's `cells_*` counters. The counters on `sweep_runs`
+(`cells_pending` / `cells_running` / `cells_completed` /
+`cells_failed` / `cells_cancelled`) converge atomically with each cell
+transition rather than being re-derived from a scan, so the parent
+status is always a consistent snapshot of its children.
+
+Notifications follow a parent-only rule: only the `sweep_run` gets a
+`watch` + `subscription`, and only the parent fires a
+`sweep_run.status_changed` event (at first-cell-start and at the final
+terminal transition). Individual cells do not produce Slack messages.
+This is the opposite of the workflow-run default, and is a deliberate
+choice -- a 9-cell sweep would otherwise produce 18+ Slack messages
+for a single intent.
+
+### Crash recovery
+
+The `SweepReconciler` runs during Web lifespan startup and scans for
+sweeps in non-terminal states whose pending cells have no active
+orchestrator. For each such sweep it resumes execution from the DB
+snapshot -- the cells' args are already persisted, so reconciliation
+is a matter of rebuilding the orchestrator with the right
+`executor_factory` and letting it pick up the pending cells.
+
+The executor factory is reconstructed via an
+`executor_factory_provider` callback that the Web lifespan injects.
+The provider inspects the persisted sweep (submission source, mount
+profile) and returns either `None` (local path) or a fresh SSH pool
+lease factory. This indirection exists because the reconciler itself
+must stay pure with respect to transport choice: it does not know about
+SSH profiles, and it should not have to.
+
+## DB schema migrations
+
+The SQLite schema at `$XDG_CONFIG_HOME/srunx/srunx.db` evolves through
+numbered migrations. Each migration is applied idempotently and leaves a
+row in a `schema_migrations` table; the runtime refuses to start against
+a DB whose latest migration is unknown to the current binary.
+
+**V1 -- initial persistence layer.** Introduces the five core concepts
+for notification and state (`jobs`, `workflow_runs`, `workflow_run_jobs`,
+`job_state_transitions`, `resource_snapshots`, plus
+`endpoints` / `watches` / `subscriptions` / `events` / `deliveries`).
+The original allowlists are conservative: `workflow_runs.triggered_by`
+is `('cli', 'web', 'schedule')` and `events.kind` / `watches.kind`
+do not yet know about sweeps.
+
+**V3 -- sweep tables and widened allowlists.** Adds the `sweep_runs`
+table with the per-cell counters described above, and adds
+`workflow_runs.sweep_run_id` as a nullable FK that links each cell
+back to its parent. The `events.kind` CHECK is widened via a table
+rebuild to admit `sweep_run.status_changed`, and `watches.kind` is
+widened to admit `sweep_run`. The rebuild is required because SQLite
+cannot `ALTER CHECK` in place. (V2 is reserved for dashboard indexes
+and does not change the schema shape.)
+
+**V4 -- widen `workflow_runs.triggered_by` to include `'mcp'`.** V3
+shipped with MCP-originated cells marked `triggered_by='web'` as a
+workaround, because the V1 CHECK allowlist did not admit `'mcp'`
+and the CHECK can only be widened by rebuilding the table. V4 does
+exactly that: the migration is flagged `requires_fk_off=True` so
+SQLite can temporarily disable foreign-key enforcement while the old
+table is renamed, the new table is created, rows are copied with
+their preserved `sweep_run_id`, and the old table is dropped.
+`'schedule'` is kept in the widened allowlist as a reserved value
+for planned scheduled-workflow triggers even though no writer emits
+it yet.
+
+After V4, MCP-originated sweeps record their true provenance end-to-end:
+the parent `sweep_runs.submission_source` is `'mcp'` and each cell's
+`workflow_runs.triggered_by` is also `'mcp'`, which the notification
+fan-out and audit queries consume verbatim.
+
 ## DAG Builder Architecture
 
 The DAG builder is an interactive workflow editor that lets users construct

--- a/docs/explanation/mcp-architecture.md
+++ b/docs/explanation/mcp-architecture.md
@@ -141,6 +141,61 @@ flowchart TD
 For SSH mode, the `work_dir` parameter is required on `submit_job` because
 the local working directory has no meaning on the remote cluster.
 
+## Parameter Sweeps Through MCP
+
+`run_workflow` accepts an optional `sweep={...}` argument that expands a
+matrix at load time into N independent `workflow_runs` under one
+`sweep_run` parent. From the MCP server's perspective this is a single
+blocking tool call: the tool only returns once the whole sweep has
+converged (all cells terminal, or a `fail_fast` drain has completed).
+This is the opposite of the Web UI, which returns `202 Accepted` the
+moment the background task is scheduled.
+
+```mermaid
+flowchart LR
+  subgraph mcp["MCP tool: run_workflow(sweep=..., mount=...)"]
+    Expand["expand_matrix\n(load-time)"]
+    Orchestrator["SweepOrchestrator\nanyio.Semaphore"]
+    Factory["executor_factory\n= pool.lease"]
+    Pool["SlurmSSHExecutorPool\nsize=min(max_parallel, 8)"]
+    Expand --> Orchestrator
+    Orchestrator --> Factory --> Pool
+  end
+  subgraph cluster["SLURM (via SSH)"]
+    sbatch["sbatch"]
+    squeue["squeue / sacct"]
+  end
+  Pool -- "leased SSH exec" --> sbatch
+  Pool -- "leased SSH exec" --> squeue
+```
+
+**Shared code path with the Web UI.** The SSH-backed execution path is
+not reimplemented inside the MCP server. Both `srunx ui` and
+`srunx-mcp` build their sweep executor factories on top of
+`srunx.web.ssh_adapter` + `srunx.web.ssh_executor`. The MCP server is a
+side-effect-free caller that borrows the Web UI's abstractions; all
+reconciliation, pool lifecycle, and mount-aware render logic live in
+one place. The Web UI's `_run_sweep_background` closes the pool in a
+`finally` block; the MCP `run_workflow` tool closes its own pool in a
+matching `finally`. There is no process-wide pool.
+
+**Provenance: `submission_source='mcp'`.** A sweep triggered through
+MCP writes `sweep_runs.submission_source='mcp'` for audit. After the V4
+schema migration (see the architecture guide), each child cell also
+writes `workflow_runs.triggered_by='mcp'`, so notification fan-out and
+sweep listings can tell MCP-originated cells apart from Web and CLI
+cells without guessing. Before V4, MCP cells were recorded as
+`triggered_by='web'` because the V1 CHECK allowlist did not admit
+`'mcp'`; the V4 rebuild removed that workaround.
+
+**CLI-style sweeps without `mount=`.** When `run_workflow` is called
+with a `sweep` argument but **without** `mount=<profile>`, execution
+stays on the local `Slurm` singleton path -- exactly as if the user
+had run `srunx flow run --sweep ...` on a login node. Passing
+`mount=<profile>` switches the tool to the SSH + pool path above. This
+mirrors the CLI / Web split: the same tool call, the same blocking
+semantics, but a different transport determined by one argument.
+
 ## Security
 
 **Input validation.**  
@@ -159,6 +214,15 @@ The MCP server exposes only read and submit operations. It cannot modify
 SLURM configuration, access other users' jobs, or execute arbitrary
 commands on the cluster. File sync is constrained to configured mount
 points or explicit paths.
+
+**Shared security guards.**  
+The argument inspection that rejects dangerous Python invocations
+(`find_python_prefix`) and dangerous shell-script patterns
+(`find_shell_script_violation`) lives in `srunx.security` and is
+imported by both the Web UI router and the MCP tool surface. Keeping
+these checks in one module avoids drift between the two entry points:
+a pattern blocked in the Web UI is necessarily blocked in MCP, and
+vice versa.
 
 ## Relationship to Other Interfaces
 

--- a/docs/how-to/mcp-usage.md
+++ b/docs/how-to/mcp-usage.md
@@ -131,6 +131,93 @@ Execute specific portions of a workflow:
 Claude Code uses the `single_job`, `from_job`, `to_job`, and
 `dry_run` parameters of `run_workflow`.
 
+## Parameter Sweeps
+
+Run the same workflow over a cross-product of hyperparameters by passing
+a `sweep=` argument to `run_workflow`. Each cell executes as an
+independent `workflow_run` under one parent `sweep_run`.
+
+### Basic sweep (local Slurm)
+
+``` text
+> Run the train workflow at /projects/train.yaml with seed 1/2/3 and
+> lr 0.001/0.01, max 2 in parallel
+```
+
+Claude Code calls:
+
+``` python
+run_workflow(
+    yaml_path="/projects/train.yaml",
+    sweep={
+        "matrix": {"seed": [1, 2, 3], "lr": [0.001, 0.01]},
+        "max_parallel": 2,
+    },
+)
+```
+
+Without `mount=`, cells run through the local `Slurm` singleton.
+
+### Sweep over SSH (``mount=``)
+
+``` text
+> Submit the train workflow on the cookbook2 project with seed 1-3,
+> max 2 parallel
+```
+
+Claude Code calls:
+
+``` python
+run_workflow(
+    yaml_path="/projects/cookbook2/train.yaml",
+    sweep={
+        "matrix": {"seed": [1, 2, 3]},
+        "max_parallel": 2,
+    },
+    mount="cookbook2",
+)
+```
+
+With `mount=<profile>`, cells route through a per-sweep SSH executor
+pool. The named mount must exist on the active SSH profile -- unknown
+names return an error envelope.
+
+### Combine ``args`` and ``sweep``
+
+`args` overrides base workflow args for every cell; `sweep` defines
+the matrix axes. They can be used together:
+
+``` python
+run_workflow(
+    yaml_path="/projects/train.yaml",
+    args={"dataset": "imagenet"},
+    sweep={
+        "matrix": {"lr": [0.001, 0.01, 0.1]},
+        "max_parallel": 3,
+    },
+)
+```
+
+### Return value
+
+``` json
+{
+  "success": true,
+  "sweep_run_id": "sr_abc123",
+  "status": "running",
+  "cell_count": 6,
+  "cells_completed": 0,
+  "cells_failed": 0,
+  "cells_cancelled": 0
+}
+```
+
+!!! warning
+    `python:` arg prefixes and `ShellJob.script_path` values outside the
+    mount root are rejected for security.
+
+See also: [Parameter Sweeps in workflows how-to](workflows.md#parameter-sweeps).
+
 ## Combine Multiple Operations
 
 Claude Code can chain tools in a single conversation turn:

--- a/docs/how-to/webui.md
+++ b/docs/how-to/webui.md
@@ -188,6 +188,58 @@ By default, edges use `afterok` (run only if the upstream job completes successf
 !!! note
     The run transitions through these phases: `syncing` (pushing files), `submitting` (sending sbatch commands), `running` (polling job statuses), then a terminal state (`completed`, `failed`, or `cancelled`).
 
+## Run a Parameter Sweep
+
+Launch the same workflow over a cross-product of arg values without
+duplicating YAML files. Every cell runs as an independent `workflow_run`
+under one parent `sweep_run`.
+
+**Open the Run dialog:**
+
+1.  Navigate to **Workflows**
+2.  On the target workflow card, click the **Run** button (triangle icon)
+
+**Toggle LIST mode on args:**
+
+1.  Each arg row has a **SINGLE | LIST** toggle on the right
+2.  Switch the arg you want to sweep to **LIST**
+3.  Enter comma-separated values (for example `0.001, 0.01, 0.1`)
+4.  Repeat for any additional sweep axes -- the cell count is the
+    cross-product of all LIST args
+5.  A `Sweep: N cells . lr[3] . seed[3]` badge appears above the submit
+    button, showing the total cell count and the cardinality of each axis
+
+**Configure Advanced options:**
+
+1.  Expand the **Advanced** section below the args
+2.  Toggle **fail_fast** to cancel peers on first failure (default: off)
+3.  Set **max_parallel** (default: 4; required for sweeps)
+
+**Submit:**
+
+1.  Click **RUN SWEEP (N)** where N is the cell count
+2.  The UI navigates to `/sweep_runs/{id}` for the new sweep
+
+**Track progress on the sweep detail page:**
+
+- **Progress bar** -- segmented by cell status
+  (completed / failed / cancelled / running)
+- **ETA** -- linear estimate based on completed cells; hidden until at
+  least one cell reaches a terminal state
+- **Draining indicator** -- spinner plus "draining pending cells" label
+  while a cancelled sweep finishes up active cells
+- **Cells table** with:
+    - **Status filter** dropdown (all / pending / running / completed / failed / cancelled)
+    - **Sortable columns**: #, Status, Started, Completed, Duration
+    - Per-cell **cancel x** button (shown only for non-terminal cells)
+- Click any cell row to drill into `/workflow_runs/{cell_id}` for the
+  per-cell DAG view and logs
+
+!!! note
+    Sweep submissions always route through the configured SSH adapter via
+    a per-sweep pool. If no SSH profile is configured, the `RUN SWEEP`
+    button is disabled.
+
 ## Cancel a Running Workflow
 
 1.  While a workflow is running, click **Cancel** in the toolbar on the workflow detail page

--- a/docs/how-to/workflows.md
+++ b/docs/how-to/workflows.md
@@ -383,3 +383,95 @@ jobs:
       EPOCHS: 100
       LR: 0.001
 ```
+
+## Parameter Sweeps
+
+Run the same workflow over a cross-product of hyperparameters without
+copying YAML files. srunx expands the matrix into N independent
+``workflow_runs`` (cells), so a cell failure does not abort peers unless
+``fail_fast: true``.
+
+### YAML declaration
+
+Declare the matrix in a `sweep` block at the workflow root. Matrix keys
+reference values via ordinary `{{ arg }}` substitution in job fields.
+
+``` yaml
+name: train
+args:
+  lr: 0.01
+  seed: 1
+
+sweep:
+  matrix:
+    lr: [0.001, 0.01, 0.1]
+    seed: [1, 2, 3]
+  fail_fast: false
+  max_parallel: 4
+
+jobs:
+  - name: train
+    command: ["python", "train.py", "--lr", "{{ lr }}", "--seed", "{{ seed }}"]
+    gpus_per_node: 1
+```
+
+The example above produces a 3 x 3 cross-product (9 cells). Each cell
+runs with its own `lr` / `seed` pair and is tracked as a separate
+`workflow_run` under one parent `sweep_run`.
+
+### CLI usage
+
+Run a YAML-declared sweep:
+
+``` bash
+srunx flow run train.yaml
+```
+
+Override a single arg without triggering a sweep:
+
+``` bash
+srunx flow run --arg dataset=imagenet train.yaml
+```
+
+Launch an ad-hoc sweep from the CLI (takes precedence over, or augments,
+any YAML `sweep` block):
+
+``` bash
+srunx flow run --sweep lr=0.001,0.01,0.1 --max-parallel 2 train.yaml
+```
+
+### Constraints
+
+- ``max_parallel`` is required (YAML or ``--max-parallel``; Web UI defaults to 4).
+- Matrix values must be scalar (str/int/float/bool) -- nested structures are rejected at validation.
+- Total cell count is capped at 1000 (safety valve; SLURM ``MaxSubmitJobs`` is typically ~4096).
+- ``fail_fast`` defaults to ``false`` -- one cell failing does not cancel peers.
+
+### Ad-hoc overrides (``--arg`` / ``--sweep``)
+
+- ``--arg key=value`` overrides a single workflow arg for every cell (no sweep triggered on its own).
+- ``--sweep key=v1,v2,v3`` adds or replaces a matrix axis. Repeat the flag to sweep multiple keys.
+- CLI sweep axes merge with the YAML `sweep.matrix`: CLI wins on conflicting keys.
+- ``--max-parallel N`` is required when a sweep is active via CLI.
+
+### Dry-run preview
+
+Preview the expanded matrix without submitting any jobs:
+
+``` bash
+srunx flow run --sweep lr=0.001,0.01 --max-parallel 2 --dry-run train.yaml
+```
+
+The dry-run prints the resolved args for each cell so you can sanity-check
+the cross-product before launching.
+
+### Execution paths
+
+CLI and MCP sweeps (without a `mount=` argument) run cells through the
+local `Slurm` singleton. Web UI sweeps, and MCP sweeps that specify
+`mount=<profile>`, route every cell through a per-sweep
+`SlurmSSHExecutorPool` (capped at `min(max_parallel, 8)` pooled SSH
+connections) which is closed when the background sweep task exits.
+
+See also: [MCP sweep recipes](mcp-usage.md#parameter-sweeps) and
+[Web UI sweep recipes](webui.md#run-a-parameter-sweep).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ hide:
 
 <div class="srunx-hero" markdown>
 
-<p class="srunx-status">v1.1 · SLURM · Apache-2.0</p>
+<p class="srunx-status">v1.2 · SLURM · Apache-2.0</p>
 
 # Orchestrate SLURM jobs<br>like <span class="accent">code</span>.
 
@@ -39,6 +39,14 @@ hide:
 
     Typed jobs with `depends_on`, retry, and Jinja-templated args.
 
+-   :material-tune-variant:{ .lg .middle } __Parameter sweeps__
+
+    ---
+
+    Matrix cross-product over hyperparameters. Per-cell tracking, bounded SSH pool, Web UI progress.
+
+    [:octicons-arrow-right-24: Parameter sweeps](how-to/workflows.md#parameter-sweeps)
+
 -   :material-pulse:{ .lg .middle } __Live monitoring__
 
     ---
@@ -55,13 +63,13 @@ hide:
 
     ---
 
-    Browser dashboard for queue, DAG visualization, and run history.
+    Browser dashboard for queue, DAG visualization, run history, and sweep detail pages.
 
 -   :material-robot-outline:{ .lg .middle } __MCP server__
 
     ---
 
-    14 tools exposed to Claude Code and other MCP clients over stdio.
+    Claude Code and other MCP clients drive srunx over stdio — including `run_workflow(sweep=..., mount=...)`.
 
 -   :material-file-code-outline:{ .lg .middle } __Jinja templates__
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,3 +8,30 @@
       members: true
       inherited_members: false
       show_submodules: true
+
+## Sweep orchestration
+
+::: srunx.sweep.expand
+    options:
+      show_source: false
+
+::: srunx.sweep.orchestrator
+    options:
+      show_source: false
+      members_order: source
+
+## Security helpers
+
+::: srunx.security.python_args
+    options:
+      show_source: false
+
+::: srunx.security.mount_paths
+    options:
+      show_source: false
+
+## SLURM protocol constants
+
+::: srunx.slurm.states
+    options:
+      show_source: false

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -287,8 +287,19 @@ prerequisites to complete.
 | `to_job` | str \| null | No | `null` | Stop execution at this job (skip later jobs) |
 | `single_job` | str \| null | No | `null` | Execute only this specific job, ignoring dependencies |
 | `dry_run` | bool | No | `false` | Show what would be executed without running |
+| `args` | dict \| null | No | `null` | Mapping merged over the YAML `args` section before Jinja rendering. `python:`-prefixed values are rejected |
+| `sweep` | dict \| null | No | `null` | Sweep spec (see schema below). When present, the workflow is routed through `SweepOrchestrator` and the return shape changes |
+| `mount` | str \| null | No | `null` | Active-SSH-profile mount name. When set, the run is routed through the configured cluster adapter with mount-aware path translation for `work_dir` / `log_dir`. Default (null) keeps execution on the local SLURM client |
 
-**Return value (execution):**
+**`sweep` schema:**
+
+| Field | Type | Required | Default | Description |
+|----|----|----|----|----|
+| `matrix` | dict\[str, list\[scalar\]\] | Yes |  | Axis name → list of scalar values (str, int, float, bool). Nested structures are rejected |
+| `fail_fast` | bool | No | `false` | Stop launching new cells on first failure (peers already launched continue to terminal state) |
+| `max_parallel` | int | No | `4` | Maximum concurrent cells. Required in YAML; MCP defaults to 4 |
+
+**Return value (normal execution):**
 
 ``` json
 {
@@ -300,6 +311,24 @@ prerequisites to complete.
     "evaluate": {"job_id": "12347", "status": "COMPLETED"}
   },
   "all_completed": true
+}
+```
+
+**Return value (sweep execution):**
+
+When `sweep` is provided, the tool blocks until every cell reaches a
+terminal state and returns the aggregate counters instead of the
+per-job `results` map:
+
+``` json
+{
+  "success": true,
+  "sweep_run_id": 42,
+  "status": "completed",
+  "cell_count": 9,
+  "cells_completed": 8,
+  "cells_failed": 1,
+  "cells_cancelled": 0
 }
 ```
 
@@ -317,6 +346,46 @@ prerequisites to complete.
   "count": 2
 }
 ```
+
+!!! note
+    `sweep` and `dry_run` are mutually distinct code paths: `dry_run`
+    previews a non-sweep workflow, while `sweep` always executes. The
+    sweep's parent `workflow_runs` rows record `submission_source="mcp"`
+    (automatically stamped) and cells record `triggered_by="mcp"` after
+    the V4 migration widens the `workflow_runs.triggered_by` CHECK
+    allowlist.
+
+**Error responses:**
+
+Errors are returned with `{"success": false, "error": "..."}`:
+
+- Mount not present in the active SSH profile →
+  `"Mount '<name>' not found in profile '<profile_name>'"`
+- No current SSH profile selected but `mount=` was passed →
+  `"mount requires a current SSH profile; configure one via `srunx ssh profile add` and select it with `srunx ssh profile use`"`
+- A `ShellJob`'s `script_path` resolves outside every mount's `local`
+  root →
+  `"Script path '<path>' is outside allowed directories"`
+- Any `python:` prefix in `args` or `sweep.matrix` →
+  `"<source> at '<path>' contains 'python:' prefix which is not allowed: '<value>'"`
+- Invalid sweep spec (non-dict matrix, bad types) →
+  `"invalid sweep spec: <detail>"` or `"sweep.matrix must be a mapping"`
+
+**Constraints:**
+
+- MCP sweeps are **blocking** — the tool call returns only after every
+  cell reaches a terminal state. This differs from the Web UI's
+  `POST /api/workflows/{name}/run`, which returns `202` immediately and
+  exposes progress through `GET /api/sweep_runs/{id}`.
+- `max_parallel` is required in YAML and defaults to `4` when the MCP
+  caller omits it.
+- When `mount=` is combined with `sweep`, every cell is submitted
+  through a shared `SlurmSSHExecutorPool(size=min(max_parallel, 8))` so
+  concurrent cells reuse a small set of SSH sessions against the
+  cluster. The pool is closed when the tool call returns.
+- Matrix values must be scalar (`str`, `int`, `float`, `bool`); nested
+  lists or dicts are rejected at load time.
+- The total cell count is capped at 1000 as a safety valve.
 
 ### list_workflows
 

--- a/docs/reference/webui-api.md
+++ b/docs/reference/webui-api.md
@@ -347,6 +347,207 @@ If some jobs fail to cancel (e.g., already completed), the response includes a `
 - `404` — Run not found
 - `422` — Run is already in a terminal state (completed, failed, or cancelled)
 
+## Sweep Runs
+
+Parameter sweeps expand a workflow into N independent cells across a
+matrix of axes. Each cell is a regular `workflow_runs` row that inherits
+the parent sweep's `sweep_run_id`; the parent `sweep_runs` row tracks
+aggregate counters (`cells_pending`, `cells_running`, `cells_completed`,
+`cells_failed`, `cells_cancelled`) that are updated atomically on every
+cell state transition.
+
+| Method | Endpoint                          | Description                                                     |
+|--------|-----------------------------------|-----------------------------------------------------------------|
+| GET    | `/api/sweep_runs`                 | List all sweep runs (most recent first, capped at 200)          |
+| GET    | `/api/sweep_runs/{id}`            | Get one sweep run with counters and matrix spec                 |
+| GET    | `/api/sweep_runs/{id}/cells`      | List every cell (workflow_run) linked to the sweep              |
+| POST   | `/api/sweep_runs/{id}/cancel`     | Request sweep cancellation (drain pending + scancel running)    |
+
+**Sweep status enum:** `pending | running | draining | completed | failed | cancelled`.
+`draining` is entered after a cancel request while running cells are
+still being stopped; the sweep advances to `cancelled` once every cell
+reaches a terminal state.
+
+Per-cell cancellation reuses the existing workflow-run endpoint —
+`POST /api/workflows/runs/{cell_id}/cancel`, where `cell_id` is the
+`workflow_runs.id` returned by `GET /api/sweep_runs/{id}/cells`.
+
+### GET /api/sweep_runs
+
+List every sweep run. Returns an array ordered by `started_at`
+descending, bounded to 200 rows.
+
+**Response (200):**
+
+``` json
+[
+  {
+    "id": 42,
+    "name": "train-lr-seed-sweep",
+    "workflow_yaml_path": "/workflows/train.yaml",
+    "status": "running",
+    "matrix": {"lr": [0.001, 0.01, 0.1], "seed": [1, 2, 3]},
+    "args": {"dataset": "cifar10"},
+    "fail_fast": false,
+    "max_parallel": 4,
+    "cell_count": 9,
+    "cells_pending": 3,
+    "cells_running": 2,
+    "cells_completed": 4,
+    "cells_failed": 0,
+    "cells_cancelled": 0,
+    "submission_source": "web",
+    "started_at": "2026-04-22T09:00:00+00:00",
+    "completed_at": null,
+    "cancel_requested_at": null,
+    "error": null
+  }
+]
+```
+
+### GET /api/sweep_runs/{id}
+
+Get the full row for a single sweep run. Fields mirror the list
+response.
+
+**Path parameters:**
+
+- `id` — Sweep run ID (integer)
+
+**Example:**
+
+``` http
+GET /api/sweep_runs/42
+```
+
+**Response (200):**
+
+``` json
+{
+  "id": 42,
+  "name": "train-lr-seed-sweep",
+  "workflow_yaml_path": "/workflows/train.yaml",
+  "status": "completed",
+  "matrix": {"lr": [0.001, 0.01, 0.1], "seed": [1, 2, 3]},
+  "args": {"dataset": "cifar10"},
+  "fail_fast": false,
+  "max_parallel": 4,
+  "cell_count": 9,
+  "cells_pending": 0,
+  "cells_running": 0,
+  "cells_completed": 9,
+  "cells_failed": 0,
+  "cells_cancelled": 0,
+  "submission_source": "web",
+  "started_at": "2026-04-22T09:00:00+00:00",
+  "completed_at": "2026-04-22T10:15:00+00:00",
+  "cancel_requested_at": null,
+  "error": null
+}
+```
+
+**Error responses:**
+
+- `404` — Sweep run not found
+
+### GET /api/sweep_runs/{id}/cells
+
+List every cell belonging to the sweep. Each cell is a `workflow_runs`
+row and carries the resolved `args` used for its Jinja render. Ordering
+is `(status, started_at ASC, id ASC)` — grouped by status so callers see
+running/pending cells together.
+
+**Path parameters:**
+
+- `id` — Sweep run ID
+
+**Response (200):**
+
+``` json
+[
+  {
+    "id": "c1f2e3d4-0001-4e00-a000-000000000001",
+    "workflow_name": "train",
+    "status": "completed",
+    "started_at": "2026-04-22T09:00:00+00:00",
+    "completed_at": "2026-04-22T09:20:00+00:00",
+    "args": {"lr": 0.001, "seed": 1, "dataset": "cifar10"},
+    "error": null,
+    "triggered_by": "web"
+  },
+  {
+    "id": "c1f2e3d4-0002-4e00-a000-000000000002",
+    "workflow_name": "train",
+    "status": "running",
+    "started_at": "2026-04-22T09:05:00+00:00",
+    "completed_at": null,
+    "args": {"lr": 0.01, "seed": 1, "dataset": "cifar10"},
+    "error": null,
+    "triggered_by": "web"
+  }
+]
+```
+
+`triggered_by` is `web`, `cli`, `mcp`, or `schedule` (post-V4 migration).
+To cancel a single cell, use `POST /api/workflows/runs/{cell_id}/cancel`
+with the cell's `id` as `cell_id`.
+
+**Error responses:**
+
+- `404` — Sweep run not found
+
+### POST /api/sweep_runs/{id}/cancel
+
+Request sweep cancellation. Stamps `cancel_requested_at` on the sweep
+row, drains all `pending` cells, and fires `scancel` for any `running`
+cells. The sweep transitions to `draining` until every cell reaches a
+terminal state, then to `cancelled` via the aggregator. A
+`sweep_run.status_changed` event is emitted for any subscriber watches.
+
+Calling this endpoint a second time on the same sweep is a no-op: the
+existing `cancel_requested_at` timestamp is preserved and the current
+row is returned.
+
+**Path parameters:**
+
+- `id` — Sweep run ID
+
+**Example:**
+
+``` http
+POST /api/sweep_runs/42/cancel
+```
+
+**Response (202):**
+
+``` json
+{
+  "id": 42,
+  "name": "train-lr-seed-sweep",
+  "workflow_yaml_path": "/workflows/train.yaml",
+  "status": "draining",
+  "matrix": {"lr": [0.001, 0.01, 0.1], "seed": [1, 2, 3]},
+  "args": {"dataset": "cifar10"},
+  "fail_fast": false,
+  "max_parallel": 4,
+  "cell_count": 9,
+  "cells_pending": 0,
+  "cells_running": 2,
+  "cells_completed": 4,
+  "cells_failed": 0,
+  "cells_cancelled": 3,
+  "submission_source": "web",
+  "started_at": "2026-04-22T09:00:00+00:00",
+  "completed_at": null,
+  "cancel_requested_at": "2026-04-22T09:30:00+00:00",
+  "error": null
+}
+```
+
+**Error responses:**
+
+- `404` — Sweep run not found
+
 ## Files
 
 | Method | Endpoint | Description |

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -128,6 +128,78 @@ srunx submit python script.py \
   --conda ml_env
 ```
 
+## Parameter Sweep
+
+So far you have run a single workflow. In this last part of the tutorial you
+will run the *same* workflow several times with different parameters -- a
+**parameter sweep** -- without copying YAML files.
+
+You will:
+
+1. Write a tiny workflow that just echoes the parameters it received.
+2. Launch a sweep over three values from the command line.
+3. Watch the three cells run and inspect the aggregated result.
+
+The example uses only `echo`, so no GPU, conda, or cluster-specific setup
+is required.
+
+### 1. Write the workflow
+
+Save the following as `sweep_demo.yaml`:
+
+``` yaml
+name: sweep_demo
+args:
+  seed: 1
+
+jobs:
+  - name: echo
+    command: ["bash", "-lc", "echo 'seed={{ seed }}'"]
+```
+
+Notice the `{{ seed }}` placeholder. The workflow already runs on its own
+(it will just use `seed=1`, the default), but it is ready to be swept.
+
+### 2. Launch the sweep
+
+Ask srunx to run the workflow three times, once per seed, with at most two
+cells running at the same time:
+
+``` bash
+srunx flow run --sweep seed=1,2,3 --max-parallel 2 sweep_demo.yaml
+```
+
+srunx expands the matrix at load time into **three independent cells**,
+each with its own `seed` value. The command prints a sweep ID and the IDs
+of the three child workflow runs, then streams their progress.
+
+### 3. Observe the cells
+
+While the sweep is running, list your jobs in another terminal:
+
+``` bash
+srunx list
+```
+
+You should see up to two `echo` jobs in `RUNNING` state at a time, with
+the third one queued until a slot frees up. When everything is done, the
+sweep converges to `completed` and each cell reports its own result.
+
+Because `fail_fast` defaults to `false`, one misbehaving cell would **not**
+cancel the others -- the sweep would simply end with a mix of
+`completed` and `failed` cells.
+
+### 4. You made it work
+
+You just ran the same workflow three times under a single sweep parent,
+with automatic concurrency control. From here:
+
+- To re-run only the cells that failed, or to learn the full sweep
+  surface (ad-hoc overrides, dry-run previews, Web UI / MCP sweeps),
+  read the how-to guide: [Parameter Sweeps](../how-to/workflows.md#parameter-sweeps).
+- To drive sweeps from an AI agent via Claude Code, see the
+  [MCP tools reference](../reference/mcp-tools.md).
+
 ## Next Steps
 
 - Read the [User Guide](../how-to/user_guide.md) for detailed usage instructions


### PR DESCRIPTION
v1.2.0 で追加された機能の Diátaxis ドキュメントをゼロから書き足した（全て既存ファイルへの追記、新規ファイル無し）。

## 4 コミット / 11 ファイル

### entry docs
- `6b9395c` — `README.md` (Parameter Sweeps subsection + MCP section + comparison table + CLI table rows)、`docs/index.md` (v1.1 → v1.2 + sweep capability card)

### how-to (problem-oriented)
- `fe22e78` — `docs/how-to/workflows.md` (Parameter Sweeps: YAML schema / CLI / constraints / --arg / dry-run / execution paths)、`docs/how-to/webui.md` (Run dialog LIST mode / Advanced / sweep detail page UX)、`docs/how-to/mcp-usage.md` (sweep recipes, mount= for SSH)

### reference (information-oriented)
- `f80498c` — `docs/reference/webui-api.md` (`/api/sweep_runs*` endpoints)、`docs/reference/mcp-tools.md` (`run_workflow` signature: args/sweep/mount + error shapes + constraints)、`docs/reference/api.md` (mkdocstrings autodoc: srunx.sweep / srunx.security / srunx.slurm.states)

### tutorials + explanation
- `ad62a18` — `docs/tutorials/quickstart.md` (sweep walkthrough, learning-oriented)、`docs/explanation/architecture.md` (Sweep architecture + V3/V4 DB migrations)、`docs/explanation/mcp-architecture.md` (MCP sweep fan-out + security guard sharing)

## Diátaxis coverage matrix (v1.2.0 features × 4 quadrants)
Before: 0/11 sweep 記述。After: tutorials / how-to / reference / explanation すべての象限でカバー。

## Verification
- `uv run --group docs mkdocs build --strict` → clean (only the upstream mkdocs-material team's benign MkDocs 2.0 advisory note)
- 全 anchor (`#parameter-sweeps` 他) が自動生成されリンク整合
- mkdocstrings target (``srunx.sweep.expand``, ``srunx.sweep.orchestrator``, ``srunx.security.python_args``, ``srunx.security.mount_paths``, ``srunx.slurm.states``) は全て実在、import OK

## Scope boundary
- No code change (pure docs)
- CHANGELOG / release notes は GitHub Release #v1.2.0 に既存、docs repo には持ち込まない
- P3 screenshot 追加は後続タスク（現状の文章は image なしで自己完結）

🤖 Generated with [Claude Code](https://claude.com/claude-code)