### PR TITLE
feat(cli): unify local/SSH transport behind JobOperationsProtocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -476,3 +476,4 @@ playwright-report/
 
 # Serena
 .serena/
+specs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,12 +12,28 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### CLI Usage
 
 #### Job Management
-- `uv run srunx submit <command>` - Submit SLURM job
+- `uv run srunx submit <command>` - Submit SLURM job (local)
+- `uv run srunx submit --script <path>` - Submit a pre-authored sbatch script (ShellJob)
+- `uv run srunx submit --profile <name> <command>` - Submit over SSH to a configured profile
 - `uv run srunx status <job_id>` - Check job status
 - `uv run srunx list` - List jobs
 - `uv run srunx list --show-gpus` - List jobs with GPU allocation
 - `uv run srunx list --format json` - List jobs in JSON format
 - `uv run srunx cancel <job_id>` - Cancel job
+- `uv run srunx logs <job_id> --follow` - Stream job logs (local / `--profile` for SSH)
+
+##### Transport Selection (Phase 1 unified CLI)
+Most commands above accept `--profile <name>` / `--local` / `--quiet`. Resolution order:
+1. `--profile <name>` (explicit)
+2. `--local` (mutually exclusive with `--profile`)
+3. `$SRUNX_SSH_PROFILE` environment variable
+4. local SLURM fallback (no banner, preserves legacy CLI behaviour)
+
+When a non-default transport is selected, a 1-line banner is emitted on stderr
+(`→ transport: ssh:<profile> (from --profile)`). `--quiet` suppresses it.
+
+`srunx ssh submit` / `srunx ssh logs` still work but now print a deprecation
+warning pointing to the unified commands above.
 
 #### Monitoring
 - `uv run srunx monitor jobs <job_id>` - Monitor job until completion

--- a/specs/cli-transport-unification/plan.md
+++ b/specs/cli-transport-unification/plan.md
@@ -1,0 +1,734 @@
+# Plan: CLI Transport 統一リファクタリング
+
+## Spec Reference
+
+`specs/cli-transport-unification/spec.md` を参照。
+
+本 plan は spec の REQ-1 〜 REQ-10 と Known Pitfalls (P-1 〜 P-14) を
+実装ロードマップに落とし込んだものであり、再設計はしない。spec の決定
+(3 本 Protocol / transport 解決順序 / Migration V5 = Option A / `ssh`
+サブツリー deprecation 温存) をそのまま施工計画として具体化する。
+
+核となる実装ストーリは以下の 1 行:
+
+> CLI 起動 → `resolve_transport()` が `ResolvedTransport` を返す → CLI は
+> `JobOperationsProtocol` と `WorkflowJobExecutorFactory` のみを介して
+> `Slurm` と `SlurmSSHAdapter` を等価に扱う。DB は `scheduler_key` 軸
+> (Migration V5) で多クラスタ `job_id` 衝突に耐える。Poller は
+> `TransportRegistry` 経由で scheduler_key ごとに group-by 問い合わせる。
+
+## Approach
+
+### 選択したアプローチ: Phase 分割 + 前方互換優先 + Option A (FK retarget)
+
+- **Phase 分割**: spec の Known Pitfalls と整合するよう、下位レイヤ
+  (protocol 定義 → adapter 整流 → migration → repository) から順に積み上げ、
+  CLI の書き換えは後半にまとめる。各 phase は「CLI の挙動が変わらない」
+  状態で commit 可能になるように組む (reviewer gate が回りやすい)。
+- **前方互換優先**: フラグなし・env なしの `srunx submit python foo.py` の
+  stdout / stderr / exit code を Phase 終了時点で常に守る (AC-10.2)。
+  transport banner は「明示指定時のみ」出すという spec 決定がこれを支える。
+- **Option A (FK retarget)**: `jobs.id` (AUTOINCREMENT PK) を子テーブル FK の
+  ターゲットにし、`UNIQUE(scheduler_key, job_id)` を自由にする。SQLite の
+  FK 後付け不能制約を受け入れて、3 テーブル rebuild migration で一気に入れる。
+
+### Trade-offs Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **[Chosen] Phase 分割 + Option A FK retarget** | 各 phase で CLI 挙動が壊れない中間地点を作れる / reviewer gate が回しやすい / FK 健全性を永続的に維持 | migration が 3 テーブル rebuild で重い / repository 層の signature 変更が広範 (`job_id` → `(scheduler_key, job_id)` or `jobs_row_id`) |
+| Big-bang 書き換え (Protocol + CLI + DB 同時) | PR が 1 本で済む | 中間状態が動かず reviewer gate が使えない / 後方互換テストが migration と CLI 変更のどちらで壊れたか切り分けづらい |
+| Option B (子テーブル FK を `(scheduler_key, job_id)` 複合 FK) | 概念上は自然 | SQLite は複合 FK を rebuild でしか追加できず、child 側も列追加が要る / 既存 query の `WHERE job_id=?` が scheduler_key を知らない場所で壊れる |
+| CLI のみ書き換え、DB は据え置き (`scheduler_key` 軸なし) | PR 小さい | P-1 (クラスタ間 `job_id` 衝突) を解決できない / `target_ref` の legacy 2 セグメントと新 3 セグメントが共存し poller parser が複雑化 |
+
+## Architecture
+
+### High-Level Component Map
+
+```mermaid
+flowchart TB
+    subgraph CLI_Layer[CLI レイヤ]
+        MAIN[cli/main.py<br/>submit/cancel/status/list]
+        MON[cli/monitor.py<br/>monitor jobs]
+        WF[cli/workflow.py<br/>flow run _execute_workflow]
+        OPTS[cli/transport_options.py<br/>Annotated 型エイリアス]
+    end
+
+    subgraph Resolve_Layer[Transport 解決レイヤ]
+        RESOLVE[transport/registry.py<br/>resolve_transport ResolvedTransport]
+        REG[TransportRegistry<br/>scheduler_key → client]
+    end
+
+    subgraph Protocol_Layer[Protocol 抽象]
+        JOP[JobOperationsProtocol<br/>submit/cancel/status/queue/tail]
+        SCP[SlurmClientProtocol<br/>queue_by_ids]
+        WJE[WorkflowJobExecutorProtocol<br/>run/get_job_output_detailed]
+    end
+
+    subgraph Impl_Layer[実装]
+        LOCAL[Slurm 既存]
+        SSH[SlurmSSHAdapter 既存<br/>API 整流]
+        POOL[SlurmSSHExecutorPool<br/>sweep/flow 用]
+    end
+
+    subgraph Persist_Layer[永続化 Migration V5]
+        DB[(SQLite<br/>jobs/watches/events<br/>+ scheduler_key 軸)]
+    end
+
+    subgraph Poller_Layer[Poller]
+        AWP[ActiveWatchPoller<br/>group-by scheduler_key]
+    end
+
+    MAIN --> OPTS
+    MON --> OPTS
+    WF --> OPTS
+    MAIN --> RESOLVE
+    MON --> RESOLVE
+    WF --> RESOLVE
+    RESOLVE --> REG
+    REG --> JOP
+    REG --> SCP
+    JOP -.implements.-> LOCAL
+    JOP -.implements.-> SSH
+    SCP -.implements.-> LOCAL
+    SCP -.implements.-> SSH
+    WJE -.implements.-> LOCAL
+    WJE -.implements.-> POOL
+    WF --> POOL
+    AWP --> REG
+    AWP --> DB
+    LOCAL --> DB
+    SSH --> DB
+```
+
+### Components
+
+| # | Component | File Path | 責務 | 対応 REQ |
+|---|-----------|-----------|------|----------|
+| 1 | `JobOperationsProtocol` | `src/srunx/client_protocol.py` (追記) | CLI 向け 5 メソッド (submit/cancel/status/queue/tail_log_incremental) の型契約 | REQ-2, REQ-3 |
+| 2 | `LogChunk` | `src/srunx/client_protocol.py` (追記) | `tail_log_incremental` の戻り型 (Pydantic v2)。フィールド名は WebUI wire に合わせ `stdout_offset` / `stderr_offset` | REQ-3 |
+| 3 | `ResolvedTransport` + `resolve_transport()` | `src/srunx/transport/registry.py` (新規) | CLI が 1 コマンドで使う transport を確定。context manager で close を持つ | REQ-1, REQ-7 |
+| 4 | `TransportRegistry` | `src/srunx/transport/registry.py` (新規) | scheduler_key → `SlurmClientProtocol` / `JobOperationsProtocol` の解決。CLI は 1 コマンド 1 instance、lifespan は 1 プロセス 1 instance | REQ-8 |
+| 5 | Transport 例外階層 | `src/srunx/exceptions.py` (追記) | `TransportError` / `TransportConnectionError` / `TransportAuthError` / `TransportTimeoutError` / `JobNotFound` / `SubmissionError` / `RemoteCommandError` | REQ-4 |
+| 6 | `SlurmSSHAdapter` API 整流 | `src/srunx/web/ssh_adapter.py` | `submit(Job) -> Job` / `cancel` / `status(BaseJob)` / `queue(list[BaseJob])` / `tail_log_incremental`。paramiko 例外を transport 例外にラップ。旧メソッド名は backcompat alias で温存 | REQ-4 |
+| 7 | `Slurm` に `tail_log_incremental` 追加 | `src/srunx/client.py` | SSH 側と等価な offset ベース incremental tail (local file の `tell`/`seek`) | REQ-3 |
+| 8 | Migration V5 | `src/srunx/db/migrations.py` | `jobs` / `workflow_run_jobs` / `job_state_transitions` rebuild + `watches.target_ref` / `events.source_ref` 一括 UPDATE。`_apply_fk_off_migration` template 再利用 | REQ-5 |
+| 9 | Repository 書き換え | `src/srunx/db/repositories/{jobs,job_state_transitions,workflow_run_jobs}.py` | `job_id` 単独 → `(scheduler_key, job_id)` or `jobs_row_id` | REQ-5 |
+| 10 | `cli_helpers.record_submission_from_job` 拡張 | `src/srunx/db/cli_helpers.py` | `transport_type` / `profile_name` / `scheduler_key` を kwargs で受ける | REQ-5 |
+| 11 | CLI 共通オプション | `src/srunx/cli/transport_options.py` (新規) | `ProfileOpt` / `LocalOpt` / `ScriptOpt` / `QuietOpt` Annotated エイリアス | REQ-6 |
+| 12 | CLI コマンド書き換え | `src/srunx/cli/main.py` / `cli/monitor.py` / `cli/workflow.py` | `Slurm()` 直接 new を `resolve_transport()` に置換。`submit --script`, `flow run --profile` (mount translation + script_path guard) | REQ-1, REQ-6 |
+| 13 | Transport banner | `src/srunx/cli/transport_options.py` (emit helper) | `Console(stderr=True)` で 1 行出力。default は無出力 (AC-10.2) | REQ-7 |
+| 14 | `ActiveWatchPoller` transport-aware 化 | `src/srunx/pollers/active_watch_poller.py` | `__init__(registry=...)` / `run_cycle` で scheduler_key group-by / `_parse_target_ref` 実装 / source_ref ライタを 3+ セグメントに | REQ-8 |
+| 15 | `target_ref` / `source_ref` パーサ | `src/srunx/pollers/active_watch_poller.py`, `src/srunx/db/repositories/events.py`, `src/srunx/notifications/adapters/slack_webhook.py` | 3 セグメント (`job:local:N`) / 4 セグメント (`job:ssh:profile:N`) 対応、2 セグメントは `None` | REQ-8 |
+| 16 | `NotificationWatchCallback` 拡張 | `src/srunx/callbacks.py`, `src/srunx/notifications/service.py` | `attach_notification_watch(..., scheduler_key, profile_name)` を受ける | REQ-8 |
+| 17 | `ssh submit` / `ssh logs` deprecation | `src/srunx/ssh/cli/commands.py` | stderr に 1 行 warning、ロジック温存 | REQ-9 |
+| 18 | Web app lifespan 更新 | `src/srunx/web/app.py` | `ActiveWatchPoller(slurm_client=adapter)` を `ActiveWatchPoller(registry=registry)` に置換 | REQ-8 |
+
+### Directory Tree (new / modified)
+
+```
+src/srunx/
+├── client_protocol.py              # +JobOperationsProtocol, +LogChunk
+├── client.py                       # +tail_log_incremental
+├── exceptions.py                   # +TransportError 階層, +JobNotFound, +SubmissionError, +RemoteCommandError
+├── transport/                      # NEW
+│   ├── __init__.py
+│   └── registry.py                 # NEW: resolve_transport, ResolvedTransport, TransportRegistry
+├── cli/
+│   ├── main.py                     # rewrite Slurm() direct instantiation → resolve_transport()
+│   ├── monitor.py                  # same
+│   ├── workflow.py                 # _execute_workflow: mount translation + executor_factory
+│   └── transport_options.py        # NEW: ProfileOpt/LocalOpt/ScriptOpt/QuietOpt + banner emitter
+├── db/
+│   ├── migrations.py               # +SCHEMA_V5
+│   ├── cli_helpers.py              # record_submission_from_job signature 拡張
+│   └── repositories/
+│       ├── jobs.py                 # signature 書き換え (job_id → (scheduler_key, job_id) or jobs_row_id)
+│       ├── workflow_run_jobs.py
+│       ├── job_state_transitions.py
+│       └── events.py               # _extract_source_id を 3+ セグメント対応
+├── pollers/
+│   └── active_watch_poller.py      # registry-based group-by, _parse_target_ref
+├── notifications/
+│   ├── service.py                  # target_ref/source_ref ライタを 3+ セグメントに
+│   └── adapters/
+│       └── slack_webhook.py        # _id_from_source_ref を 3+ セグメント対応
+├── callbacks.py                    # NotificationWatchCallback: scheduler_key/profile_name 受領
+├── ssh/
+│   ├── cli/commands.py             # ssh submit/logs に deprecation warning
+│   └── core/client.py              # 変更なし (ロジック温存)
+├── web/
+│   ├── app.py                      # lifespan: ActiveWatchPoller(registry=...)
+│   ├── ssh_adapter.py              # SlurmSSHAdapter API 整流 (Phase 2)
+│   ├── ssh_executor.py             # SlurmSSHExecutorPool (Phase 1 触らない、参照のみ)
+│   └── routers/*.py                # repository signature 変更の追従 (Phase 3)
+└── web/frontend/                   # 触らない
+```
+
+### Interfaces
+
+#### `JobOperationsProtocol` (新規)
+
+```python
+# src/srunx/client_protocol.py
+
+from typing import Protocol, runtime_checkable
+from pydantic import BaseModel
+
+class LogChunk(BaseModel):
+    """Incremental tail chunk for WebUI wire-compat field names."""
+    stdout: str
+    stderr: str
+    stdout_offset: int = Field(ge=0)  # 負値は reject (未読状態を表す値ではない)
+    stderr_offset: int = Field(ge=0)
+
+
+@runtime_checkable
+class JobOperationsProtocol(Protocol):
+    """CLI-facing job operations. Pure (no stdout side-effects, no blocking)."""
+
+    def submit(self, job: "RunnableJobType") -> "RunnableJobType": ...
+    def cancel(self, job_id: int) -> None: ...
+    def status(self, job_id: int) -> "BaseJob": ...
+    def queue(self, user: str | None = None) -> list["BaseJob"]: ...
+    def tail_log_incremental(
+        self,
+        job_id: int,
+        stdout_offset: int,
+        stderr_offset: int,
+    ) -> LogChunk: ...
+```
+
+契約:
+- `cancel(未知_id)` / `status(未知_id)` は `JobNotFound` を raise。
+- `queue(None)` は transport の current user を使う。`queue(user)` は明示。
+- 戻り値は常に Pydantic モデル。stdout / TTY 操作は CLI レイヤの責務。
+
+#### `ResolvedTransport` + `resolve_transport()` (新規)
+
+```python
+# src/srunx/transport/registry.py
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Literal
+
+@dataclass(frozen=True)
+class ResolvedTransport:
+    """CLI 1 コマンドで確定した transport (TransportHandle + 銘板)."""
+    label: str                        # banner 表示用: "local" / "ssh:dgx"
+    source: Literal["--profile", "--local", "env", "default"]
+    handle: TransportHandle           # scheduler_key / job_ops / queue_client / executor_factory / submission_context
+
+    # convenience properties (handle へのショートカット)
+    @property
+    def scheduler_key(self) -> str: return self.handle.scheduler_key
+    @property
+    def job_ops(self) -> "JobOperationsProtocol": return self.handle.job_ops
+    # ...以下同じパターン
+
+
+@contextmanager
+def resolve_transport(
+    *,
+    profile: str | None,
+    local: bool,
+    quiet: bool = False,
+) -> Iterator[ResolvedTransport]:
+    """Resolve once per CLI invocation; close SSH on exit.
+
+    優先順: --profile > --local > SRUNX_SSH_PROFILE > local fallback.
+    Conflict (--profile + --local) は ClickException で起動時拒否。
+    """
+```
+
+#### `TransportRegistry` (新規)
+
+```python
+@dataclass(frozen=True)
+class TransportHandle:
+    """scheduler_key → client 解決結果の統一型."""
+    scheduler_key: str
+    profile_name: str | None
+    transport_type: Literal["local", "ssh"]
+    job_ops: "JobOperationsProtocol"
+    queue_client: "SlurmClientProtocol"
+    executor_factory: "WorkflowJobExecutorFactory"
+    submission_context: "SubmissionRenderContext | None"
+
+
+class TransportRegistry:
+    """scheduler_key → TransportHandle の解決."""
+
+    def __init__(
+        self,
+        *,
+        local_client: "Slurm",
+        profile_loader: "Callable[[str], SSHProfile | None]",
+        db_connection_factory: "Callable[[], sqlite3.Connection]",
+    ) -> None: ...
+
+    def resolve(self, scheduler_key: str) -> "TransportHandle | None":
+        """'local' / 'ssh:<profile>' を解決。
+        未知 profile の場合は None。caller は warning + skip。
+        `ResolvedTransport` は本メソッドが返す `TransportHandle` を
+        銘板 (label / source) でラップしたもの。"""
+
+    def known_scheduler_keys(self) -> set[str]:
+        """DB の jobs.scheduler_key DISTINCT を返す。Poller の group-by 起点.
+        db_connection_factory を経由して都度 DISTINCT を問い合わせる."""
+
+    def close(self) -> None:
+        """プロセス終了時に全 SSH 接続を close."""
+```
+
+### Data Flow
+
+#### Flow 1: `srunx submit --profile foo echo hi` (単発 submit)
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as cli/main.py submit
+    participant R as resolve_transport
+    participant REG as TransportRegistry
+    participant SSH as SlurmSSHAdapter
+    participant REM as Remote SLURM
+    participant DB as SQLite
+
+    U->>CLI: srunx submit --profile foo echo hi
+    CLI->>R: resolve_transport(profile="foo", local=False)
+    R->>REG: resolve("ssh:foo")
+    REG-->>R: SlurmSSHAdapter (cached)
+    R-->>CLI: ResolvedTransport(label="ssh:foo", source="--profile", ...)
+    CLI->>CLI: emit banner to stderr (not quiet)
+    CLI->>SSH: submit(Job(command=["echo","hi"]))
+    SSH->>SSH: render Jinja template
+    SSH->>REM: sftp upload script.sbatch
+    SSH->>REM: sbatch script.sbatch
+    REM-->>SSH: Submitted batch job 12345
+    SSH-->>CLI: Job(job_id=12345, status=PENDING)
+    CLI->>DB: record_submission_from_job(<br/>  scheduler_key="ssh:foo",<br/>  profile_name="foo",<br/>  transport_type="ssh",<br/>  job_id=12345,<br/>  submission_source="cli")
+    CLI->>CLI: attach_notification_watch(<br/>  scheduler_key="ssh:foo", job_id=12345)
+    CLI-->>U: stdout: "Job ID 12345"
+```
+
+#### Flow 2: `ActiveWatchPoller.run_cycle` (group-by)
+
+```mermaid
+sequenceDiagram
+    participant P as ActiveWatchPoller
+    participant WR as WatchRepository
+    participant REG as TransportRegistry
+    participant L as Slurm (local)
+    participant S1 as SlurmSSHAdapter (foo)
+    participant DB as SQLite
+
+    P->>WR: list_active_job_watches()
+    WR-->>P: [w1(local:100), w2(local:101), w3(ssh:foo:100)]
+    P->>P: group by scheduler_key<br/>→ {local: [100,101], ssh:foo: [100]}
+    P->>REG: resolve("local")
+    REG-->>P: Slurm (singleton)
+    P->>L: queue_by_ids([100, 101])
+    L-->>P: {100: JobStatusInfo, 101: JobStatusInfo}
+    P->>REG: resolve("ssh:foo")
+    REG-->>P: SlurmSSHAdapter (cached)
+    alt SSH connection OK
+        P->>S1: queue_by_ids([100])
+        S1-->>P: {100: JobStatusInfo}
+    else SSH down
+        S1--xP: TransportConnectionError
+        P->>P: warning log, skip this group
+    end
+    P->>P: merge results + process_job_watches
+    P->>DB: events/deliveries/state_transitions
+```
+
+#### Flow 3: `srunx flow run --profile foo workflow.yaml`
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as cli/workflow.py
+    participant R as resolve_transport
+    participant REG as TransportRegistry
+    participant WR as WorkflowRunner
+    participant POOL as SlurmSSHExecutorPool
+    participant SSH as SlurmSSHAdapter lease
+    participant DB as SQLite
+
+    U->>CLI: srunx flow run --profile foo wf.yaml
+    CLI->>R: resolve_transport(profile="foo", local=False)
+    R->>REG: resolve("ssh:foo") + build SubmissionRenderContext
+    R-->>CLI: ResolvedTransport(<br/>  executor_factory=SlurmSSHExecutorPool.lease,<br/>  submission_context=<with mounts>)
+    CLI->>CLI: script_path guard (ShellJob.script_path ⊆ mount.local?)
+    alt script outside mount
+        CLI--xU: exit ≠ 0, guard failure
+    end
+    CLI->>WR: WorkflowRunner.from_yaml(<br/>  executor_factory=pool.lease,<br/>  submission_context=ctx)
+    WR->>WR: load + substitute deps.X.Y
+    loop each independent job
+        WR->>POOL: lease()
+        POOL-->>WR: SlurmSSHAdapter
+        WR->>SSH: run(job, submission_context=ctx)
+        SSH->>SSH: translate work_dir/log_dir via mounts
+        SSH-->>WR: Job(completed)
+    end
+    WR-->>CLI: workflow done
+    CLI->>DB: workflow_run status + cleanup
+```
+
+## Build Sequence
+
+phase は依存関係順。各 phase の末尾で CLI 挙動の後方互換テストを pass
+させる (AC-10.2)。
+
+### Phase 1: Protocol と例外階層 (足場)
+
+- **Inputs**: なし (clean start)
+- **Outputs**:
+  - `src/srunx/client_protocol.py` に `JobOperationsProtocol` / `LogChunk` 追加
+  - `src/srunx/exceptions.py` に `TransportError` / `TransportConnectionError` / `TransportAuthError` / `TransportTimeoutError` / `JobNotFound` / `SubmissionError` / `RemoteCommandError` 追加
+- **検証**:
+  - `mypy` / `ruff` が通る
+  - `isinstance(Slurm(), JobOperationsProtocol)` が False (未実装なのでこの時点では)
+  - 既存テストが全部通る (純追加のみ)
+
+### Phase 2: `Slurm` と `SlurmSSHAdapter` の Protocol 準拠 (LSP 整流)
+
+- **Inputs**: Phase 1 の Protocol 定義
+- **Outputs**:
+  - `src/srunx/client.py:Slurm` に以下を追加:
+    - `tail_log_incremental(job_id, stdout_offset, stderr_offset)` 新規実装 (local log file の `open` / `seek` / `read`)
+    - `status(job_id) -> BaseJob` を **既存の `retrieve` への thin alias** として追加 (`status = retrieve` あるいは `def status(self, ...): return self.retrieve(...)`)。既存 `retrieve` は caller 互換のため残す。
+    - `cancel` / `queue` は既存メソッド名と `JobOperationsProtocol` の名前が一致するので変更不要。
+    - `submit` は Protocol シグネチャと一致するので変更不要。
+  - `src/srunx/web/ssh_adapter.py` の `SlurmSSHAdapter`:
+    - `submit_job(script_content)` を呼ぶ内部実装はそのままに、**新メソッド** `submit(job: RunnableJobType) -> RunnableJobType` を追加 (Jinja render → sftp upload → sbatch → `job.job_id` セット)。
+    - `cancel_job` → `cancel` に改名 (旧メソッドは `cancel_job = cancel` で alias 温存)。
+    - `get_job_status(str)` の上に `status(int) -> BaseJob` を実装。
+    - `list_jobs` の上に `queue(user: str | None) -> list[BaseJob]` を実装 (LSP: `user=None` で profile の username 使用)。
+    - `tail_log_incremental(job_id, stdout_offset, stderr_offset)` 新規実装 (SSH 越しの `wc -c` + `tail -c +offset`)。
+    - paramiko の `AuthenticationException` / `SSHException` / `socket.timeout` 等を `TransportAuthError` / `TransportConnectionError` / `TransportTimeoutError` にラップ。
+- **検証**:
+  - 単体テスト:
+    - `isinstance(Slurm(), JobOperationsProtocol)` が True (AC-2.1)
+    - `isinstance(SlurmSSHAdapter(...), JobOperationsProtocol)` が True
+    - `SlurmSSHAdapter.submit(Job)` が `Job(job_id=int)` を返す (AC-4.1)
+    - `SlurmSSHAdapter.status(未知)` が `JobNotFound` を raise (AC-4.2)
+    - `SlurmSSHAdapter.queue(user="alice")` が `list[BaseJob]` (AC-4.3)
+    - `SlurmSSHAdapter.tail_log_incremental(id, 0, 0)` の戻りが `LogChunk` (AC-4.4)
+    - paramiko.AuthenticationException → `TransportAuthError` (AC-4.5)
+  - 既存 CLI テストは無修正で pass (新メソッド追加のみなので非破壊)
+
+### Phase 3: Migration V5 + Repository 書き換え + 全 caller 修正
+
+**PR 粒度の制約**: Phase 3 は **単一 PR で出す**。schema 変更と repository API 変更と全 caller 修正 (Web routers / poller / cli_helpers / notifications / tests) を同じ PR に収めないと、途中 commit で `job_id` 参照がビルドエラーになる。個別 PR に分けてはいけない。
+
+**レガシー open watch 対応**: pre-V5 時点で WebUI 経由で投入された SSH ジョブ (`submission_source='web'` + `mount=` ルート) は `transport_type` カラムが無かったため、backfill で全て `'local'` に記録される。これは historical record (閉じた jobs) には無害だが、**open watch には誤作動リスク**がある (poller が local SLURM に remote job を問い合わせる)。対策として V5 migration の最後に `UPDATE watches SET status='closed', closed_at=now(), closed_reason='v5_migration' WHERE status='open'` で全 open watch を強制クローズする。user は migration 後に必要なら watch を再張する想定。これは本 migration の documented breaking behavior として README / release note に明記する。
+
+- **Inputs**: Phase 1-2
+- **Outputs**:
+  - `src/srunx/db/migrations.py` に `SCHEMA_V5` Migration を追加 (`requires_fk_off=True`)。内容は spec REQ-5 の通り:
+    1. `jobs` rebuild: +`transport_type` / `profile_name` / `scheduler_key` / CHECK 制約 / `UNIQUE(scheduler_key, job_id)` に変更
+    2. `workflow_run_jobs` rebuild: `job_id` → `jobs_row_id`, FK 先を `jobs.id` へ
+    3. `job_state_transitions` rebuild: 同上
+    4. `watches.target_ref` / `events.source_ref` を一括 UPDATE (`job:N` → `job:local:N`)
+    5. **open watch 強制クローズ** (レガシー SSH ジョブ誤作動対策): `UPDATE watches SET status='closed', closed_at=now(), closed_reason='v5_migration' WHERE status='open'`
+  - `src/srunx/db/repositories/jobs.py`: `record_submission` / `get` / `update_status` / `update_completion` / `delete` の引数を `(scheduler_key, job_id)` or `jobs_row_id` に変更 + `transport_type` / `profile_name` を保存
+  - `src/srunx/db/repositories/workflow_run_jobs.py` / `job_state_transitions.py`: 同上
+  - `src/srunx/db/cli_helpers.py:record_submission_from_job`: `scheduler_key` / `transport_type` / `profile_name` kwargs 追加 (default は local)
+  - `src/srunx/db/models.py` の Pydantic row モデルに新列追加
+  - **全 caller 修正 (同一 PR)**:
+    - `src/srunx/web/routers/jobs.py` / `workflows.py` / `sweep_runs.py`: `JobRepository.get(job_id)` 等の呼出を新 signature に追従 (wire API は unchanged、persistence call site のみ変更)
+    - `src/srunx/pollers/active_watch_poller.py`: `job_repo.get(...)` 等の呼出を追従 (Phase 6 の本格 transport-aware 化より前に、signature 互換を Phase 3 で完了)
+    - `src/srunx/cli/notification_setup.py`: 同上
+    - `src/srunx/notifications/service.py`: 同上
+    - `tests/` 配下の repository / CLI helper テスト: signature 変更に追従
+  - **DB 記録責務の一元化**: `Slurm.submit()` / `SlurmSSHAdapter.submit()` の**内部で** `record_submission_from_job(transport_type=..., profile_name=..., scheduler_key=...)` を呼ぶ。CLI レイヤでは再度呼ばない (double-record 防止)。Phase 2 の adapter 整流時に `SlurmSSHAdapter.submit()` にもこの責務を持たせる。
+- **検証**:
+  - in-memory SQLite で V4 fixture → V5 migration 適用 → assert:
+    - `PRAGMA table_info(jobs)` に新列あり (AC-5.1)
+    - `scheduler_key IS NULL` の行数が 0 (AC-5.2)
+    - `watches.target_ref` に 2 セグメント残存なし (AC-5.3)
+    - `(scheduler_key='local', job_id=12345)` と `(scheduler_key='ssh:dgx', job_id=12345)` が同時挿入可能 (AC-5.4)
+    - `PRAGMA foreign_key_list(workflow_run_jobs)` / `PRAGMA foreign_key_list(job_state_transitions)` の FK 先が `jobs.id` (AC-5.5)
+    - `submission_source` カラム値 diff なし (AC-5.6)
+  - DB row モデルテスト (`tests/.../test_repositories_*.py`) は signature 変更に追従して修正込みで pass (AC-10.1 の repository レベル)
+
+### Phase 4: Transport 解決レイヤ (`resolve_transport` / `TransportRegistry`)
+
+- **Inputs**: Phase 1-3
+- **Outputs**:
+  - `src/srunx/transport/__init__.py` (新規)
+  - `src/srunx/transport/registry.py` (新規):
+    - `ResolvedTransport` dataclass
+    - `resolve_transport()` context manager (conflict 検査 → 優先順で resolve → banner emit → close 保証)
+    - `TransportRegistry` (DB の scheduler_key DISTINCT + profile loader)
+  - `src/srunx/cli/transport_options.py` (新規):
+    - Annotated 型エイリアス (`ProfileOpt` / `LocalOpt` / `ScriptOpt` / `QuietOpt`)
+    - `emit_transport_banner(resolved: ResolvedTransport, quiet: bool)` 補助関数 (stderr に 1 行、default ソースは無出力)
+- **検証**:
+  - 単体テスト (table-driven):
+    - `resolve_transport(profile="foo", local=True)` → `ClickException`
+    - `resolve_transport(profile="foo", local=False)` → `source="--profile"`, `scheduler_key="ssh:foo"`
+    - `resolve_transport(profile=None, local=True)` → `source="--local"`, `scheduler_key="local"`
+    - env `SRUNX_SSH_PROFILE=foo` のみ → `source="env"`, `scheduler_key="ssh:foo"`
+    - 何もなし → `source="default"`, `scheduler_key="local"`, banner 無出力
+    - `--local` が env を上書き (AC-1.4)
+  - `TransportRegistry.resolve("ssh:nonexistent")` が `None` (AC-8.5)
+
+### Phase 5a: CLI コマンド書き換え — main.py コア (submit / cancel / status / list / logs)
+
+- **Inputs**: Phase 1-4
+- **Outputs**:
+  - `src/srunx/cli/main.py`:
+    - `Slurm()` 直接 new 箇所のうち、CLI コマンドスコープの 6 箇所 (line 564 submit, 613 status, 655 list, 734 cancel, 830 logs, 1276 template_apply) を `with resolve_transport(...) as rt: ops = rt.job_ops` に置換
+    - **line 57 の特殊ケース** (`DebugCallback.on_job_submitted` 内の `Slurm().default_template`): これは callback コンテキストで template パス取得のみ用途。`resolve_transport()` は使わず、module-level 定数または `Slurm._get_default_template()` class method への書き換えで対応。通常の CLI transport 解決経路ではない。
+    - `submit` に `--profile` / `--local` / `--quiet` / `--script` 追加。`--script` と command list は排他 (Typer の callback で検査)。`--script` 指定時は `ShellJob` を構築
+    - `cancel` / `status` / `list` / `logs` に `--profile` / `--local` / `--quiet` 追加
+    - line 660 の "No jobs in queue" 出力を `format == "json"` 判定後に移す (pre-existing bug の incidental fix — **別コミットで分離**、PR 記述に "incidental fix" と明記)
+    - `list` で `--format json` のとき banner が stdout に絶対出ないことを `quiet` 判定 + stderr 出力で担保
+- **検証**:
+  - CLI E2E:
+    - `srunx submit echo hi` (フラグなし) の stdout / stderr / exit code が V4/V5 前後で完全一致 (AC-1.1, AC-10.2) — golden test
+    - `srunx submit --profile foo --local echo hi` が exit ≠ 0 (AC-1.2)
+    - `SRUNX_SSH_PROFILE=foo srunx list` が SSH 経由 (AC-1.3)
+    - `SRUNX_SSH_PROFILE=foo srunx list --local` が local (AC-1.4)
+    - `srunx list --format json --quiet` の stdout が `jq .` を通る (AC-7.1)
+    - `srunx list --format json` (quiet なし) の stdout が純粋 JSON、stderr に banner (AC-7.2)
+    - `srunx submit --profile foo echo hi` の stderr 1 行 banner (AC-7.3)
+    - `srunx cancel --profile foo 12345` が SSH `scancel` (AC-6.1, mock)
+    - **`srunx status --profile foo 12345` が SSH 経由で BaseJob 取得 (AC-6.2)**
+    - `srunx submit --script train.sh --profile foo` (AC-6.4)
+    - `srunx submit --script train.sh python foo.py` exit ≠ 0 (AC-6.5)
+
+### Phase 5b: CLI コマンド書き換え — monitor + workflow
+
+- **Inputs**: Phase 5a
+- **Outputs**:
+  - `src/srunx/cli/monitor.py`:
+    - `Slurm()` 2 箇所 (line 116, 369) を `resolve_transport()` に置換
+    - `monitor jobs` に `--profile` / `--local` / `--quiet` 追加
+    - `JobMonitor(client=rt.queue_client)` を明示注入 (内部 `client or Slurm()` の default 生成パスを使わない)
+  - `src/srunx/cli/workflow.py:_execute_workflow`:
+    - `--profile` / `--local` / `--quiet` 追加
+    - `resolve_transport()` で `executor_factory` と `submission_context` を取得
+    - sweep / 非 sweep の注入点 (line 376, 483, 495) を両方 `executor_factory=rt.executor_factory, submission_context=rt.submission_context` に書き換え
+    - ShellJob.script_path guard: `rt.submission_context.mounts` の `local` root 配下にない場合 `ClickException` で exit ≠ 0 (WebUI / MCP sweep と同じガード)
+- **検証**:
+  - `srunx monitor jobs --profile foo 12345` (AC-6 延伸、mock)
+  - `srunx flow run --profile foo wf.yaml` (AC-6.3, dry-run mock)
+  - `srunx flow run --profile foo wf.yaml` で ShellJob.script_path が mount 外の場合 exit ≠ 0 (REQ-6 guard)
+
+### Phase 6: Poller transport-aware 化
+
+- **Inputs**: Phase 1-5
+- **Outputs**:
+  - `src/srunx/pollers/active_watch_poller.py`:
+    - `__init__(registry: TransportRegistry, ...)` に変更 (既存 `slurm_client` 引数は Phase 6 で置換、lifespan の互換は Web app 側で吸収)
+    - `run_cycle` で watches を `scheduler_key` で group-by、各 group ごとに `registry.resolve(scheduler_key).queue_by_ids(ids)` を呼ぶ
+    - 未知 scheduler_key は warning + skip (AC-8.5)
+    - `_parse_target_id` → `_parse_target_ref` に改名、3+ セグメント rsplit 実装
+    - `source_ref` ライタを `f"job:{scheduler_key}:{job_id}"` に変更。`scheduler_key` は `local` または `ssh:<profile>` (ser/des で直接使えるよう `f"job:{scheduler_key}:{job_id}"` にすると `job:ssh:foo:N` になる)
+  - `src/srunx/db/repositories/events.py`:
+    - `_extract_source_id` を 3+ セグメント対応 (legacy 2 セグメントは None)
+  - `src/srunx/notifications/adapters/slack_webhook.py`:
+    - `_id_from_source_ref` を同様に 3+ セグメント対応
+  - `src/srunx/notifications/service.py:126`:
+    - `source_ref` 書込を新文法に
+  - `src/srunx/web/routers/jobs.py:173,177` と `src/srunx/cli/notification_setup.py:133,151`:
+    - `target_ref` 書込を新文法に (呼出側に `scheduler_key` を伝搬)
+  - `src/srunx/callbacks.py:NotificationWatchCallback` と `attach_notification_watch`:
+    - `scheduler_key` / `profile_name` kwargs 追加、watches.target_ref 構築に使う
+  - `src/srunx/web/app.py` lifespan:
+    - `ActiveWatchPoller(slurm_client=adapter)` を `ActiveWatchPoller(registry=registry)` に置換
+    - `TransportRegistry` を lifespan で 1 instance 構築、app.state に保持、shutdown で close
+- **検証**:
+  - `_parse_target_ref("job:local:12345")` → `("local", 12345)` (AC-8.2)
+  - `_parse_target_ref("job:ssh:dgx:12345")` → `("ssh:dgx", 12345)` (AC-8.3)
+  - `_parse_target_ref("job:12345")` → `None` (AC-8.4)
+  - mock で scheduler_key=local と scheduler_key=ssh:dgx の両方を含む watch セットを作り、1 cycle で両 transport に `queue_by_ids` が呼ばれる (AC-8.1)
+  - 既存 poller テスト (`test_active_watch_poller.py`) が修正込みで pass (AC-2.2)
+
+### Phase 7: `srunx ssh submit` / `ssh logs` deprecation + Web 整合
+
+- **Inputs**: Phase 1-6
+- **Outputs**:
+  - `src/srunx/ssh/cli/commands.py`:
+    - `submit` / `logs` の最初に `typer.echo("WARNING: ...", err=True)` を 1 行追加
+    - 推奨コマンド名を示す (`srunx submit --script <path> --profile <name>` / `srunx logs --profile <name> <job_id>`)
+    - ロジックは一切変更しない (ssh test / ssh sync / ssh profile * も変更なし)
+  - `src/srunx/web/app.py` の lifespan が Phase 6 で変わっているので、dev reload mode (`SRUNX_DISABLE_POLLER=1`) 経路の回帰確認
+  - MCP (`src/srunx/mcp/server.py`): 変更なし (既に transport 抽象に乗っている。確認のみ)
+  - WebUI (`/api/jobs/{id}/logs`): `tail_log_incremental` の Protocol 化により Phase 2 で SlurmSSHAdapter / Slurm の両方が同じ wire 型を返すようになる。ルータ側の変更は不要 (確認のみ)
+- **検証**:
+  - `srunx ssh submit foo.sh` の stderr に deprecation warning、exit 0 (AC-9.1)
+  - `srunx ssh profile list` に warning なし (AC-9.2)
+  - `srunx ssh sync` に warning なし (AC-9.3)
+
+### Nice to Have (REQ-N1 / REQ-N2): Phase 1 では扱わない
+
+spec REQ-N1 (`SRUNX_DEBUG_TRANSPORT=1` 詳細出力) と REQ-N2 (`srunx config show` に transport 候補表示) は**本 Phase 1 スコープ外として明示的に延期**する。コア transport 統一が安定した後の Phase 2 で単独 issue として扱う。
+
+### Phase 8: 後方互換検証 + ドキュメント微修正
+
+- **Inputs**: Phase 1-7
+- **Outputs**:
+  - 手動検証手順の runbook (docstring コメント、`.md` ファイルは新規作成しない)
+  - V4 DB の fixture を `tests/fixtures/v4_db/` に配置 → V5 migration 自動適用 → CLI が動作の integration test
+- **検証**:
+  - AC-10.1 (既存 CLI behavioral テスト全 pass + repo テスト修正込み pass)
+  - AC-10.2 (フラグなし submit の stdout / stderr / exit code golden 一致)
+  - AC-10.3 (V4 → V5 auto migration → CLI 動作、手動検証の pass 確認)
+  - `uv run pytest && uv run mypy . && uv run ruff check .` が全部通る
+
+## Integration Points
+
+| 接続先 | 場所 | Phase 1 での扱い |
+|---|---|---|
+| WebUI `/api/jobs/{id}/logs` + 他 routers | `src/srunx/web/routers/*` | **wire API は触らない**。ただし Phase 3 で `JobRepository.get` 等の signature が変わるため、persistence call site (routers 内の repository 呼出) は追従修正。frontend / API 契約は unchanged |
+| MCP `run_workflow(mount=...)` | `src/srunx/mcp/server.py` | **ツール API は触らない**。ただし Phase 3 で repository signature が変わるため、MCP 経由の job 記録箇所も追従修正。tool 契約は unchanged |
+| Web app lifespan poller | `src/srunx/web/app.py:300-445` | `ActiveWatchPoller(slurm_client=adapter)` を `ActiveWatchPoller(registry=registry)` に差し替え (Phase 6)。`TransportRegistry` を lifespan で 1 instance 構築 |
+| `WorkflowRunner` | `src/srunx/runner.py:486-495` | 既に `executor_factory` + `submission_context` を受ける。CLI 側で `resolve_transport()` 結果を渡すだけ |
+| `SlurmSSHExecutorPool` | `src/srunx/web/ssh_executor.py:128-134` | 既に `WorkflowJobExecutorFactory` 互換。CLI `flow run --profile` で直接流用 |
+| `JobMonitor` | `src/srunx/monitor/job_monitor.py:57` | `__init__(client=None)` default 生成を廃止せず、CLI 側から明示的に `rt.queue_client` を渡す。internal fallback は残してよい (他 caller の互換維持) |
+
+## Dependencies
+
+### Internal
+
+- `src/srunx/models.py` の `Job` / `BaseJob` / `RunnableJobType` / `JobStatus`
+- `src/srunx/rendering.py` の `SubmissionRenderContext`
+- `src/srunx/client_protocol.py` の既存 `SlurmClientProtocol` / `WorkflowJobExecutorProtocol` / `JobStatusInfo`
+- `src/srunx/db/connection.py` の `open_connection` / `transaction`
+- `src/srunx/db/migrations.py` の `_apply_fk_off_migration` template
+- `src/srunx/web/ssh_executor.py` の `SlurmSSHExecutorPool`
+- `src/srunx/ssh/core/client.py` の `SSHSlurmClient` (adapter が内部で利用)
+- `src/srunx/pollers/supervisor.py` の `PollerSupervisor` (lifespan で registry を渡す)
+
+### External
+
+追加依存ゼロ。既存の `paramiko` / `pydantic` / `typer` / `rich` / `sqlite3` (stdlib) / `loguru` / `anyio` の範囲で実装する。
+
+## Error Handling
+
+### CLI 起動時エラー (exit ≠ 0)
+
+| 状況 | 例外 / 挙動 | ユーザーへの出力 |
+|---|---|---|
+| `--profile foo --local` 併用 | `typer.BadParameter` (ClickException) | stderr: `"--profile と --local は同時指定できません"` |
+| `--profile foo` で `foo` が profile 未登録 | `TransportError` | stderr: `"SSH profile 'foo' が見つかりません。'srunx ssh profile list' で確認してください"` |
+| SSH 接続確立失敗 (`resolve_transport()` 内で health check) | `TransportConnectionError` | stderr: `"SSH profile 'foo' への接続に失敗しました: <reason>"` |
+| SSH 認証失敗 | `TransportAuthError` | stderr: `"SSH 認証失敗 (profile='foo'): <reason>"` |
+| `flow run --profile` で `ShellJob.script_path` が mount.local 配下外 | `ClickException` | stderr: `"script_path <path> は profile 'foo' の mount (<local_root>) の配下にありません"` |
+
+### CLI 実行中エラー (submit / cancel / status / queue)
+
+| 状況 | 例外 | CLI 出力 |
+|---|---|---|
+| `cancel 未知_id` | `JobNotFound` | stderr: `"Job <id> not found on <transport>"`, exit 1 |
+| `status 未知_id` | `JobNotFound` | 同上 |
+| SSH 切断 (mid-operation) | `TransportConnectionError` | stderr: `"Transport error: <reason>"`, exit 1 |
+| `sbatch` 非 0 exit | `SubmissionError` | stderr: `"Submission failed: <sbatch stderr>"`, exit 1 |
+
+### Poller cycle 中エラー
+
+| 状況 | 挙動 |
+|---|---|
+| `registry.resolve("ssh:foo")` が `None` (profile 削除済み) | warning log + 当該 scheduler_key group skip、次 group へ進む (AC-8.5) |
+| SSH 接続失敗 (`queue_by_ids` 中) | `TransportConnectionError` を catch、当該 group の watches を skip、次 cycle で retry |
+| DB エラー | 既存の `PollerSupervisor` の crash/grace 機構に委譲 (spec 外、変更なし) |
+
+### Migration エラー
+
+- `_apply_fk_off_migration` template が transaction rollback を保証。部分適用は不可。
+- migration 失敗時は app 起動失敗として propagation。user には stderr に migration name + 詳細 error。
+- `~/.config/srunx/srunx.db` はユーザー判断でバックアップ推奨 (README に一文追加案件だが Phase 1 スコープ外、必要なら別 issue)。
+
+## Performance Considerations
+
+### CLI latency
+
+- `srunx submit --profile foo echo hi` は SSH 1 round-trip (sftp upload + sbatch) で ~2-3 秒遅延増 (local の ~200ms 比)。user facing UX として WARNING ではなく、初回接続時のみ paramiko handshake の約 500ms を追加負担。2 回目以降 (同一プロセス内) は connection reuse で高速化。
+- `TransportRegistry` は lazy init。local fallback のみ使うユーザーには SSH module の import すら起きないよう、`SlurmSSHAdapter` import を `resolve_transport()` 内の conditional import にする (起動時間回帰を防ぐ)。
+- 「2 回目以降 connection reuse で高速化」は `flow run --profile` など**同一プロセス内で複数回 submit が発生するケース限定**。単発 `srunx submit` / `srunx status` のような短命 CLI では毎回 SSH handshake が走る (想定通り)。
+
+### Poller cycle
+
+- 既存 interval 15 秒を維持。
+- scheduler_key group は Phase 1 では**直列処理** (spec REQ-8)。SSH connect timeout を**既存 adapter の 30s から 10s に短縮** (`SSHSlurmClient.connect_timeout` の既存オプション経由、poller 起動時に設定)。これで最悪 `local (<1s) + ssh:A (10s) + ssh:B (10s) = ~20s` となり 15s interval を少し超える程度に収まる。
+- 実用想定: local + 1-2 profile までなら合計 15s 以内に収まる。3 profile 以上や頻繁な SSH タイムアウトが発生する環境は Phase 2 の profile-per-poller 並列化まで待つ。
+- cycle 時間が interval を超えた場合でも `leased_until` + `worker_id` のリース機構が保護するため、重複処理や crash loop は発生しない。
+- DB 読み書きは単一 SQLite 接続の transaction で完結。
+
+### Migration V5
+
+- 3 テーブル rebuild (`jobs` / `workflow_run_jobs` / `job_state_transitions`) + 2 テーブル UPDATE (`watches` / `events`)。
+- `jobs` 1 万行規模でも SQLite の rebuild は index 再構築込みで 1 秒未満 (経験則)。10 万行規模でも 10 秒以内。
+- app 起動時の block time は運用上許容範囲 (CLI の初回起動は元々 ~200ms → 最悪 10s 程度の遅延、migration は 1 回限り)。
+
+## Risks & Mitigations
+
+| # | Risk | Impact | Mitigation |
+|---|---|---|---|
+| R-1 | V5 migration が途中で失敗し DB が中途半端な状態になる | High | `_apply_fk_off_migration` の BEGIN IMMEDIATE + rollback template を必ず使う。FK OFF → ON は finally で保証。3 テーブル rebuild を 1 migration 内にまとめ、全体 atomic |
+| R-2 | `SlurmSSHAdapter` の API 改名で既存 WebUI / MCP 経路が壊れる | High | 旧メソッド (`submit_job`, `cancel_job`, `get_job_status`, `list_jobs`) を alias として残す。新メソッドは追加のみ、削除は Phase 2 以降で別 spec |
+| R-3 | `resolve_transport()` の SSH health check が遅く CLI 起動が体感悪化 | Med | health check は `ssh profile list` 相当の cheap call (e.g. `true` を越える必要なし)。`--local` や default path ではそもそも SSH import しない (conditional import) |
+| R-4 | poller が SSH 切断時に cycle 全体を巻き込んで落ちる | High | `run_cycle` で `TransportConnectionError` / `TransportError` を scheduler_key group 単位で catch + warning log + skip。次 cycle で retry |
+| R-5 | `target_ref` parser の 3+ セグメント化で legacy 2 セグメントに遭遇 | Med | Migration V5 で全行 backfill 済みが前提。parser は `None` を返して caller が skip する防御。migration 未適用 DB を拒否する check を Web app startup に追加 (既存 schema_version 機構) |
+| R-6 | `flow run --profile` の mount translation が WebUI / MCP 実装と微妙に乖離 | Med | `SubmissionRenderContext` を共通経路として使う。sweep / single-run ともに同じ context を `WorkflowRunner` に注入するので、ロジックは 1 箇所 (web/sweep 既存実装) に集約 |
+| R-7 | profile_name に `:` が含まれると scheduler_key が壊れる | High | Phase 3 の Migration V5 で `jobs.profile_name` / `scheduler_key` に CHECK 制約追加。また profile CRUD (`ssh profile add`) 側でも `:` を含む名前を reject する validation を追加 (P-12) |
+| R-8 | `--profile foo --local` の conflict を CLI callback で検出しそこねて silently wins 動作になる | Low | Typer の命令形 validator で起動時に必ず raise。unit test で table-driven に網羅 |
+| R-9 | MCP / Web から投入されたジョブが CLI の V5 書式 (`job:ssh:X:N`) ではなく旧書式で target_ref を書いて、poller parser が swallow する | Med | MCP / Web ルータの書込箇所 (`web/routers/jobs.py:173,177`) も Phase 6 で新文法に合わせる。parser が `None` 返したら warning + skip (debuggability) |
+| R-10 | legacy CLI の golden test (AC-10.2) が transport banner の stderr 変化で壊れる | Med | default path (フラグなし・env なし) では banner を出さないと spec 決定。golden test は stderr 完全一致で書く |
+| R-11 | `main.py:660` の pre-existing bug (json 出力前の print) を直すと既存テストが壊れる | Low | 既存テストが当該 print に依存していれば修正。Phase 5a で commit を分離 (別 commit、PR description に incidental fix と明記) |
+| R-12 | `events.payload_hash` が V5 backfill 後に stale になる (P-6) | Low | documented, acceptable。backfill 直後の初回 event は dedup ヒットせず 1 件余分に記録される可能性があるが、以降は正常 dedup。影響範囲は migration 直後のごく短期間のみ |
+| R-13 | profile 名同じで hostname を変えると別クラスタが同じ `scheduler_key` 衝突 (P-13) | Med | Phase 1 は「profile 名 = scheduler identity」と仮定。profile 編集時に既存 `jobs.scheduler_key='ssh:<profile>'` 行との整合は保証しない。README に運用上の注意として明記 |
+| R-14 | `BaseJob.status` lazy refresh で SSH adapter が返した BaseJob を CLI が触ると local sacct fallback (P-14) | Med | Phase 2 で `SlurmSSHAdapter.status()` が返す BaseJob は lazy refresh を disable にする (frozen snapshot として返す)、または `JobStatusInfo` を返すよう spec Open Question を決着させる |
+| R-15 | Pre-V5 の WebUI SSH ジョブが backfill で `'local'` 扱いになり、open watch が local SLURM を問い合わせて誤状態検知 | High | Phase 3 の V5 migration 最後に `UPDATE watches SET status='closed'` で全 open watch を強制クローズ。documented breaking behavior として release note 明記 |
+
+## Testing Strategy
+
+### Unit
+
+- **`resolve_transport()` の優先順序** (table-driven): flag / env / default / conflict の 5 パターン
+- **`_parse_target_ref`**: `job:local:N` / `job:ssh:foo:N` / `job:N` / malformed の 4 パターン
+- **`TransportRegistry.resolve`**: known scheduler_key / unknown profile / local
+- **`SlurmSSHAdapter.submit` / `status` / `cancel` / `queue` / `tail_log_incremental`**: paramiko を mock、メソッド呼出 sequence を assert
+- **例外ラッピング**: `paramiko.AuthenticationException` → `TransportAuthError`, `socket.timeout` → `TransportTimeoutError`, `SSHException` → `TransportConnectionError`
+- **`LogChunk` Pydantic v2 validation**: stdout_offset / stderr_offset が int、負値を reject
+- **`isinstance` 検査**: `Slurm()` / `SlurmSSHAdapter(...)` 双方が 3 Protocol 全部を満たす
+
+### Integration
+
+- **Migration V5 (happy path)**: in-memory SQLite に V4 schema + fixture data を流し込み、`apply_migrations` → schema assert (AC-5.1 〜 AC-5.6)
+- **Migration V5 (rollback)**: `jobs_v5` 作成後の `INSERT...SELECT` で意図的に例外注入 → 元 schema / rows / indexes / FK が完全に残っていることを assert (atomicity)
+- **Migration V5 (open watch close)**: V4 DB に open watch を 2 件含めた fixture を適用 → V5 migration 後に全 open watch が closed + reason='v5_migration' になっていることを assert
+- **Poller transport-aware**: 2 scheduler_key を含む watches を DB に insert → `run_cycle` mock で両 transport に `queue_by_ids` が呼ばれることを assert (AC-8.1)
+- **TransportRegistry failure policy**: `ssh:foo` watch を残したまま profile 削除 → cycle 全体 crash せず、warning log 出力 + 次 group 進行 (AC-8.5)
+- **Web app lifespan**: `SRUNX_DISABLE_POLLER=1` / `SRUNX_DISABLE_ACTIVE_WATCH_POLLER=1` / `UVICORN_RELOAD=1` の各経路で startup / shutdown が regression していない
+
+### E2E (CLI, subprocess ベース)
+
+- **Golden test**: `srunx submit python foo.py` (フラグなし) の stdout / stderr / exit code の bytewise 一致 (AC-10.2)
+- **JSON 整合**: `srunx list --format json --quiet` / `srunx list --format json` の両方で stdout が純粋 JSON (`jq .` 通過) (AC-7.1, AC-7.2)
+- **Banner**: `srunx submit --profile foo echo hi` の stderr に `→ transport: ssh:foo (from --profile)` 1 行 (AC-7.3)
+- **Conflict**: `srunx submit --profile foo --local echo hi` が exit ≠ 0 (AC-1.2)
+- **Env**: `SRUNX_SSH_PROFILE=foo srunx list` / `SRUNX_SSH_PROFILE=foo srunx list --local` (AC-1.3, AC-1.4)
+- **Script mode**: `srunx submit --script train.sh --profile foo` / `srunx submit --script train.sh python foo.py` (AC-6.4, AC-6.5)
+- **flow run**: `srunx flow run --profile foo wf.yaml` (mock SSH、AC-6.3)
+- **Deprecation**: `srunx ssh submit foo.sh` / `srunx ssh profile list` / `srunx ssh sync` (AC-9.1 〜 AC-9.3)
+
+### Manual Verification (推奨)
+
+- 実 SSH 環境 (dgx サーバー等) で `srunx submit --profile dgx python train.py` → 投入 → `srunx status --profile dgx <id>` → `srunx logs --profile dgx <id>` の end-to-end 確認
+- V4 DB (Migration V5 未適用) を `~/.config/srunx/srunx.db` に置き、srunx 起動で auto-migration が走って既存 CLI が動くことを確認 (AC-10.3)
+- `srunx ssh submit` を実行して deprecation warning が表示されることを目視確認
+
+### Quality Gate
+
+- `uv run pytest` 全通過
+- `uv run mypy .` 全通過 (新 Protocol / dataclass の型整合含む)
+- `uv run ruff check .` 全通過
+- 全 Phase 終了後、reviewer subagent (CLAUDE.md "Review Gate") に回して second opinion 取得

--- a/specs/cli-transport-unification/spec.md
+++ b/specs/cli-transport-unification/spec.md
@@ -1,0 +1,460 @@
+# Spec: CLI Transport 統一リファクタリング
+
+## User Intent
+
+- **Goal**: `srunx submit` / `cancel` / `status` / `list` / `logs` / `flow run` / `monitor jobs` などの top-level CLI を、WebUI と MCP sweep で既に稼働している transport 抽象 (local SLURM / SSH アダプタ) に統一的に載せる。「どのクラスタに投げるか」を transport 選択として直交化し、ユーザーは同一 CLI で local にも remote にも投入できるようにする。
+- **Why**: 現状の CLI はローカル `Slurm` シングルトンに直結しており、remote SLURM 向けに `srunx ssh submit` という並行 CLI ツリーが存在する。両者は submit / cancel / status / list / logs ですべて別実装・別引数・別例外型を持ち、機能差 (例: logs の incremental 化、JSON 出力、workflow 連携) が SSH 側で後手に回っている。この二重化が修正コストを毎リリース 2 倍にし、ユーザーにも「どっちを使えばよいか分からない」混乱を生んでいる。
+- **Why this approach**: WebUI と MCP sweep は既に `SlurmSSHExecutorPool` と transport 抽象を経由しているため、CLI もその同じ抽象に乗せれば 3 経路 (CLI/Web/MCP) がひとつの Protocol 系で揃う。`srunx ssh` サブツリーを即削除せず deprecation に留めるのは、profile 管理コマンド (`ssh profile *`) や `ssh sync` が transport 非依存で現役のため。
+
+## Overview
+
+CLI が使う実行基盤を `JobOperationsProtocol` 経由の抽象に切り替え、`--profile <name>` / `--local` フラグと `$SRUNX_SSH_PROFILE` 環境変数で local / SSH を選択できるようにする。併せて `SlurmSSHAdapter` のメソッド名・引数・戻り型を既存の `Slurm` クライアントに揃え (LSP 準拠)、DB スキーマに `scheduler_key` 軸を導入してクラスタ間の `job_id` 衝突に耐える構造へ移行する。
+
+## Background
+
+### 現状の二重化
+
+| 側面 | top-level CLI (`srunx submit` 等) | `srunx ssh *` サブツリー |
+|---|---|---|
+| 実装起点 | `Slurm` シングルトン (`client.py`) | `SSHSlurmClient` (`ssh/core/client.py`) |
+| submit API | `submit(job: RunnableJobType) -> RunnableJobType` | `submit_sbatch_job(script_content: str) -> dict` |
+| status API | `retrieve(job_id) -> BaseJob` | `get_job_status(job_id) -> str` |
+| cancel API | `cancel(job_id)` | `cancel_job(job_id)` |
+| logs | なし (都度実装) | 都度 `cat`、offset なし |
+| 例外型 | `srunx.exceptions.*` | SSH 固有の例外クラス |
+| workflow 連携 | `WorkflowRunner` が直結 | なし (単発投入のみ) |
+
+WebUI / MCP sweep は既に `SlurmSSHExecutorPool` を介して `SlurmSSHAdapter` を利用しており、adapter 側の protocol 準拠はそこでは部分的に達成されている。しかし CLI は一切その抽象を通らない。
+
+### 既に確定済みの設計判断
+
+本 spec は conversation で合意済みの以下の判断を前提にする:
+
+1. Protocol は 3 本立て (ISP 準拠)。`JobOperationsProtocol` を新設し、既存の `SlurmClientProtocol` (poller 用) と `WorkflowJobExecutorProtocol` (runner 用) はそのまま残す。`Slurm` と `SlurmSSHAdapter` は 3 本すべてを実装する (LSP)。
+2. Protocol メソッドは純粋関数。stdout 出力や follow-blocking を含めない。follow / streaming は CLI レイヤの責務。
+3. transport 解決は「明示フラグ → env → local fallback」。active profile config fallback は Phase 1 ではやらない。
+4. DB 側は migration V5 で `scheduler_key` 軸を追加。子テーブル FK は `jobs.id` (内部 AUTOINCREMENT PK) への retarget (exploration で合意した Option A)。
+5. `submission_source` (`cli`/`web`/`workflow`/`mcp`) は transport とは独立な軸。ここに `ssh:*` を混ぜない。
+6. `srunx ssh submit` / `srunx ssh logs` は deprecation warning のみ。ロジックは温存する。`ssh profile *` / `ssh sync` / `ssh test` は変更しない。
+
+## Requirements
+
+### Must Have
+
+#### REQ-1: Transport 解決順序
+
+CLI は以下の優先順で transport を選択する。複数指定時のコンフリクトは起動時エラー (exit code ≠ 0) で即座に拒否する。
+
+| 優先度 | 指定方法 | 備考 |
+|---|---|---|
+| 1 | `--profile <name>` | SSH profile を明示 |
+| 2 | `--local` | ローカル SLURM を明示。`--profile` との併用は禁止 |
+| 3 | `$SRUNX_SSH_PROFILE` 環境変数 | 既存変数を再利用。`SRUNX_PROFILE` は新設しない |
+| 4 | fallback | local `Slurm` シングルトン |
+
+- 「`srunx ssh profile set` で設定した active profile」は Phase 1 では読まない。既存 `srunx ssh` サブツリー用のセマンティクスを温存する。
+
+#### REQ-2: Protocol 3 本立て (ISP)
+
+- `JobOperationsProtocol` (新規): CLI 用。`submit` / `cancel` / `status` / `queue` / `tail_log_incremental` を定義。
+- `SlurmClientProtocol` (既存、維持): poller 用の `queue_by_ids` を定義。
+- `WorkflowJobExecutorProtocol` (既存、維持): runner 用の `run` / `get_job_output_detailed` を定義。
+- `Slurm` と `SlurmSSHAdapter` は 3 本すべてを実装する。CLI・poller・runner のいずれからも両実装が差し替え可能でなければならない (LSP)。
+
+```mermaid
+classDiagram
+    class JobOperationsProtocol {
+        <<Protocol>>
+        +submit(job) RunnableJobType
+        +cancel(job_id) None
+        +status(job_id) BaseJob
+        +queue(user) list~BaseJob~
+        +tail_log_incremental(job_id, stdout_offset, stderr_offset) LogChunk
+    }
+    class SlurmClientProtocol {
+        <<Protocol>>
+        +queue_by_ids(job_ids) dict~int, JobStatusInfo~
+    }
+    class WorkflowJobExecutorProtocol {
+        <<Protocol>>
+        +run(job) RunnableJobType
+        +get_job_output_detailed(job_id) JobOutput
+    }
+    class Slurm
+    class SlurmSSHAdapter
+
+    JobOperationsProtocol <|.. Slurm
+    JobOperationsProtocol <|.. SlurmSSHAdapter
+    SlurmClientProtocol <|.. Slurm
+    SlurmClientProtocol <|.. SlurmSSHAdapter
+    WorkflowJobExecutorProtocol <|.. Slurm
+    WorkflowJobExecutorProtocol <|.. SlurmSSHAdapter
+```
+
+#### REQ-3: Protocol メソッドは純粋関数
+
+- 戻り型は既存 Pydantic モデル (`Job` / `BaseJob` / `JobStatusInfo`) を再利用し、新しい tuple / dict 型を作らない。例外として `tail_log_incremental` のみ以下の新規 Pydantic モデル `LogChunk` を返す:
+
+  ```python
+  # src/srunx/client_protocol.py
+  class LogChunk(BaseModel):
+      stdout: str
+      stderr: str
+      stdout_offset: int  # 次回呼出で渡すべき新オフセット (WebUI wire 名と一致)
+      stderr_offset: int
+  ```
+  WebUI の `/api/jobs/{id}/logs` が返す JSON (`web/routers/jobs.py:352-357`) のフィールド名と揃える (`stdout_offset` / `stderr_offset`)。Python 内部変数 `new_stdout_offset` は実装ディテールで、公開名は `stdout_offset`。
+- Protocol メソッドは副作用 (stdout への出力・ブロッキングストリーム・TTY 操作) を持たない。
+- follow / polling / live-tail は CLI レイヤ (`src/srunx/cli/*.py`) で protocol を呼び出すループとして実装する。
+- 返却モデル (`BaseJob` 等) は呼出後に追加の SLURM 問い合わせ (lazy refresh) を起こさないこと。SSH adapter が返した `BaseJob` を CLI が触って local `sacct` にフォールバックする事故を防ぐため、ステータス系は原則 `JobStatusInfo` を使う。`BaseJob` を使う箇所は refresh をトリガしない path に限定する。
+
+#### REQ-4: SlurmSSHAdapter の API 乖離解消
+
+`SlurmSSHAdapter` のメソッドを `Slurm` の API 形に揃える。
+
+| Before | After | 備考 |
+|---|---|---|
+| `submit_job(script_content: str) -> dict` | `submit(job: RunnableJobType) -> RunnableJobType` | Jinja レンダと sftp upload は adapter 内部に閉じる |
+| `cancel_job(job_id)` | `cancel(job_id)` | 改名のみ |
+| `get_job_status(job_id) -> str` | `status(job_id) -> BaseJob` | 戻り型を Pydantic モデルへ |
+| `list_jobs(...) -> list[dict]` | `queue(user: str \| None) -> list[BaseJob]` | 戻り型を統一 |
+| (都度 `cat` 実装) | `tail_log_incremental(job_id, stdout_offset, stderr_offset) -> LogChunk` | WebUI 準拠の offset incremental 方式 |
+
+**`queue(user=None)` のセマンティクス** (LSP 制約上重要):
+- `user=None` は「transport が認識する current user」を意味する。
+- local `Slurm.queue(None)` は `$USER` (または `getpass.getuser()`) を使う (既存挙動)。
+- SSH `SlurmSSHAdapter.queue(None)` は接続プロファイルの `username` (= `squeue -u $USER_ON_REMOTE`) を使う。
+- 明示的に `user="alice"` を渡したら local / SSH ともに同じ意味 (その user のキュー)。
+
+**`cancel(job_id)` / `status(job_id)` の契約**:
+- `cancel(未知_id)` は `JobNotFound` を raise する。黙って通さない。
+- `status(未知_id)` は `JobNotFound` を raise する。
+- `queue(user)` はジョブゼロ件でも空 list を返す。例外にはしない。
+
+**例外階層** (`srunx.exceptions` で transport-agnostic に定義):
+
+```
+TransportError                    # base (SSH / local どちらでも起き得る)
+├─ TransportConnectionError       # SSH 接続失敗 / local sbatch FileNotFoundError
+├─ TransportAuthError             # SSH 認証失敗
+└─ TransportTimeoutError          # SSH / scontrol タイムアウト
+JobNotFound                       # job_id が SLURM 側に存在しない
+SubmissionError                   # sbatch 自体が非0 exit (構文エラー等)
+RemoteCommandError                # SSH 越しの任意コマンドが失敗 (scontrol show job 等)
+```
+
+- SSH 固有の例外 (paramiko.AuthenticationException 等) は上記にラップして送出する。CLI レイヤは transport を問わず同じ except 節で処理できる。
+- `SubmissionError` と `TransportError` は排他: sbatch プロセスは起動したが sbatch が非0 exit → `SubmissionError`。sbatch まで到達できない (SSH 切断・認証失敗) → `TransportError`。
+
+#### REQ-5: DB スキーマ Migration V5
+
+**実装方式**: `requires_fk_off=True` のテーブル rebuild migration (既存 V3/V4 の template を踏襲)。SQLite は後付けで UNIQUE 変更や FK 追加ができないため、`jobs` / `workflow_run_jobs` / `job_state_transitions` の 3 テーブルすべて `*_v5` を CREATE → `INSERT...SELECT` → `DROP` → `RENAME` で差し替える。1 トランザクション内で完遂し、途中失敗時はロールバック。
+
+**`jobs` テーブル**:
+- 新規カラム:
+  - `transport_type` TEXT NOT NULL DEFAULT `'local'` CHECK IN (`'local'`, `'ssh'`)
+  - `profile_name` TEXT NULL (transport_type = 'ssh' のときのみ意味を持つ)
+  - `scheduler_key` TEXT NOT NULL DEFAULT `'local'` (`'local'` または `'ssh:<profile_name>'`)
+- CHECK 制約で不整合行を生成不能にする:
+  ```sql
+  CHECK (
+      (transport_type = 'local' AND profile_name IS NULL AND scheduler_key = 'local')
+      OR
+      (transport_type = 'ssh'   AND profile_name IS NOT NULL AND scheduler_key = 'ssh:' || profile_name)
+  )
+  ```
+- `UNIQUE(jobs.job_id)` を `UNIQUE(jobs.scheduler_key, jobs.job_id)` に変更。
+- 既存行は全て `transport_type='local'`, `profile_name=NULL`, `scheduler_key='local'` で backfill。
+
+**子テーブル FK retarget (Option A)**:
+- `workflow_run_jobs.job_id` → `workflow_run_jobs.jobs_row_id` に改名、FK を `jobs(id)` (内部 AUTOINCREMENT PK) へ変更。
+- `job_state_transitions.job_id` → `job_state_transitions.jobs_row_id`、同上。
+- backfill は `LEFT JOIN jobs ON old.job_id = jobs.job_id` で `jobs.id` を取得してセット。
+
+**`watches.target_ref` / `events.source_ref`**:
+- 文法: `job:local:<job_id>` または `job:ssh:<profile_name>:<job_id>` (REQ-8 で詳細)。
+- 既存行は一括 UPDATE で `job:<id>` → `job:local:<id>` に backfill。
+- migration 中は poller を停止させる運用前提 (Web app lifespan の起動順で、migration 完了後に poller を起動)。
+
+**Repository / CLI helpers の API 変更** (この migration に伴って必須):
+- `JobRepository.record_submission` / `get` / `update_status` / `update_completion` / `delete`: `job_id` 単独引数を `(scheduler_key, job_id)` 複合、または `jobs_row_id` に変更。
+- `JobStateTransitionRepository.latest_for_job` / `history_for_job`: 同上。
+- `WorkflowRunJobRepository.upsert` / `get`: 同上。
+- `cli_helpers.record_submission_from_job`: `transport_type` / `profile_name` / `scheduler_key` を受け取る kwargs を追加。
+- すべての `WHERE job_id = ?` クエリが `WHERE scheduler_key = ? AND job_id = ?` か `WHERE id = ?` (jobs_row_id) に書き換わる。
+
+**submission_source は一切変更しない**。transport と submission_source は別軸 (CLI から SSH 経由で投入したジョブは `submission_source='cli'` かつ `transport_type='ssh'`)。
+
+```mermaid
+erDiagram
+    JOBS_V4 {
+        int id PK
+        string job_id UK
+        string submission_source
+    }
+    JOBS_V5 {
+        int id PK
+        string job_id
+        string transport_type
+        string profile_name
+        string scheduler_key
+        string submission_source
+    }
+    WATCHES_V4 {
+        string target_ref "job:123"
+    }
+    WATCHES_V5 {
+        string target_ref "job:local:123 または job:ssh:dgx:123"
+    }
+    JOBS_V5 ||..|| WATCHES_V5 : "scheduler_key 経由"
+```
+
+#### REQ-6: CLI 横断統合
+
+- `submit` / `cancel` / `status` / `list` / `logs` / `flow run` / `monitor jobs` に以下のオプションを追加する:
+  - `--profile <name>`
+  - `--local`
+- `submit` に `--script <path>` を追加する。command list と排他。`--script` 指定時は ShellJob 経由で投入する。これは既存 `ssh submit` の script 投入パスを top-level に橋渡しする役割を担う。
+- 共通オプションは `src/srunx/cli/transport_options.py` (新規) に Annotated 型エイリアスで集約する (DRY)。
+- `-p` の短縮形は `--profile` には割り当てない。`resources` / `monitor resources` で既に `-p` が `--partition` に使われているため、同一 CLI 内で意味が衝突する。
+- `flow run --profile` は remote path 問題を抱える (workflow YAML の `work_dir` / `log_dir` / `ShellJob.script_path` は local path 前提)。Phase 1 では:
+  - `flow run --profile <name>` を使うとき、**profile に `mounts` 設定があれば自動的に mount translation を適用** (WebUI / MCP sweep と同じロジック = `SubmissionRenderContext`)。
+  - profile に `mounts` が無ければ、workflow YAML 内の path が remote 上に既に存在する前提で render される (warning 出力)。
+  - `ShellJob.script_path` が mount の `local` 配下にない場合は**起動時エラー**で拒否する (WebUI / MCP と同じ security guard)。
+
+#### REQ-7: Transport 可視化
+
+- コマンド開始時に解決された transport を 1 行表示する (**明示指定時のみ**):
+  - `--profile foo` → `→ transport: ssh:foo (from --profile)`
+  - `$SRUNX_SSH_PROFILE=foo` → `→ transport: ssh:foo (from env)`
+  - `--local` → `→ transport: local (from --local)`
+  - **default (何も指定なし・env なし) は banner を出さない** — AC-10.2 (後方互換) を破らないため、かつ従来 CLI との stderr 出力の完全一致を維持するため。
+- 出力先は **stderr** 固定。`--format json` の stdout を汚染しない。
+- `Console(stderr=True)` または loguru (既に stderr 出力) を使用する。
+- `--quiet` フラグで明示指定時の banner も抑制可能 (全 CLI 共通のフラグとして追加する)。
+
+#### REQ-8: Poller transport-aware 化
+
+**`target_ref` / `source_ref` の文法** (precise grammar):
+- `job:local:<job_id>` (local transport)
+- `job:ssh:<profile_name>:<job_id>` (SSH transport)
+- `workflow_run:<run_id>` (transport 非依存、既存のまま)
+- `sweep_run:<sweep_run_id>` (同上)
+
+**パーサ契約** (`_parse_target_ref(ref: str) -> tuple[scheduler_key: str, job_id: int] | None`):
+```python
+# 擬似コード
+parts = ref.split(":")
+if parts[0] != "job":
+    return None
+if len(parts) < 3:
+    return None  # legacy 2-segment は migration で消える前提。防御的対応は AC には含めない
+job_id = int(parts[-1])                  # 末尾は必ず数値
+scheduler_tokens = parts[1:-1]           # 中間トークン
+if scheduler_tokens == ["local"]:
+    scheduler_key = "local"
+elif scheduler_tokens[0] == "ssh" and len(scheduler_tokens) == 2:
+    scheduler_key = f"ssh:{scheduler_tokens[1]}"  # profile_name は `:` を含まない前提
+else:
+    return None
+return (scheduler_key, job_id)
+```
+
+- **profile_name に `:` を含めることは禁止** (CHECK 制約で追加、または `add_profile` 段階で reject)。これが崩れると parser が破綻するため、REQ-5 の CHECK 制約に併せて profile name validation も実装する。
+- legacy 2-segment (`job:<id>`) は V5 migration で全行 backfill されるので、パーサは 3+ セグメントのみ受ける。migration 中のレースは「migration 完了後に poller を起動」の運用 (Web app lifespan) で回避する。
+
+**`ActiveWatchPoller` の group-by**:
+- watches を `scheduler_key` で group-by し、transport ごとに該当する `SlurmClientProtocol.queue_by_ids()` を呼ぶ。
+- 戻り値 `dict[int, JobStatusInfo]` を scheduler_key ごとに merge して後段の `_process_job_watches` に渡す。
+
+**`TransportRegistry`**:
+- 新規、薄い解決レイヤ。`src/srunx/transport/registry.py` (新規 module) に配置。
+- DB の `jobs.scheduler_key` DISTINCT から既知キーを列挙、`SlurmClientProtocol` 実装を解決。
+- ライフサイクル:
+  - **CLI 経路**: コマンドごとに構築、`close()` で SSH 接続を閉じる (context manager)。
+  - **Web app lifespan / poller**: lifespan で 1 インスタンス保持、プロセス終了まで再利用。
+- Failure policy: DB に `scheduler_key='ssh:foo'` の watch があるが profile `foo` が削除済みの場合、**当該 scheduler_key group の処理を skip し、warning をログ**する (poller cycle 全体を落とさない)。該当 watch の自動 close はしない (Phase 2)。
+
+**Phase 2 スコープ** (今回は扱わない):
+- profile-per-poller (ssh profile ごとに専用 poller を起動) — 現行の group-by で遅い SSH が fast local を巻き込む問題は Phase 1 では許容。
+- SSH `queue_by_ids` のバッチ並列化 — Phase 1 は直列。
+
+**性能ガイドライン** (Phase 1 の目安):
+- poller cycle の interval は既存の 15 秒を維持。
+- 1 cycle 内で scheduler_key group は直列に処理。SSH timeout は既存 adapter の値 (通常 30 秒) を継承。
+- 1 cycle 内の scheduler_key group 数は実用上 1-3 程度 (local + 2-3 profile) を想定。それ以上増えたら Phase 2 の並列化を検討。
+
+#### REQ-9: `srunx ssh` サブツリーの deprecation
+
+- `srunx ssh submit` / `srunx ssh logs` に deprecation warning を追加する。stderr への 1 行で、新 CLI (`srunx submit --script ... --profile` / `srunx logs --profile`) を案内する。ロジックは温存し、Phase 1 では削除しない。
+- `srunx ssh test` / `srunx ssh sync` / `srunx ssh profile *` は transport 非依存なので変更しない。保守用として残す。
+
+#### REQ-10: 後方互換
+
+- フラグなしの `srunx submit python foo.py` (従来 CLI) は挙動を完全に変えない。local fallback で従来通り動く。stderr banner も出さない (REQ-7)。
+- 既存 DB は migration V5 により自動的に:
+  - `jobs.scheduler_key = 'local'`、`jobs.transport_type = 'local'`、`jobs.profile_name = NULL`
+  - `workflow_run_jobs.jobs_row_id` / `job_state_transitions.jobs_row_id` に既存の `jobs.id` を backfill
+  - `watches.target_ref`, `events.source_ref` を `job:local:<id>` に backfill
+- SQLite + 単一マシン運用前提のため、V5 のロールバックは想定しない。DB は常に CLI / Web を実行している control machine の local SQLite で、remote host 側の `~/.config/srunx/srunx.db` は触らない。
+- 既存テスト:
+  - **CLI レベルの behavioral テスト**は全て無修正で pass する。
+  - **DB row モデル・repository レベルのテスト**は `job_id` → `jobs_row_id` / `(scheduler_key, job_id)` のキー変更に伴い修正が入る (REQ-5 の repository API 変更に比例)。これは migration 本体と 1 つの PR に収める。
+- プラットフォーム: **macOS / Linux のみ Phase 1 サポート**。Windows は local SLURM が動かない前提のため、`--profile` 指定時の SSH transport のみ best-effort で動く想定 (公式サポート外)。
+
+### Nice to Have
+
+- REQ-N1: transport 解決のトレースを `SRUNX_DEBUG_TRANSPORT=1` で詳細出力 (どのステップで解決したか)。
+- REQ-N2: `srunx config show` に現在の active transport 候補 (env / default) を表示。
+
+## Acceptance Criteria
+
+以下の AC は各 REQ と 1:N で対応する。すべて pytest もしくは CLI 手動検証で verifiable。
+
+### REQ-1 対応
+
+- AC-1.1: `srunx submit echo hi` (フラグなし・env なし) がローカル SLURM を呼び、従来 CLI と同じ exit code / stdout を返す。
+- AC-1.2: `srunx submit --profile foo --local echo hi` は exit code ≠ 0 で起動時エラー終了し、stderr に「`--profile` と `--local` は同時指定できません」旨のメッセージを出力する。
+- AC-1.3: `SRUNX_SSH_PROFILE=foo srunx list` が SSH profile `foo` 経由で `squeue` を実行し、結果を表示する。
+- AC-1.4: `SRUNX_SSH_PROFILE=foo srunx list --local` は env を上書きして local SLURM を呼ぶ。
+
+### REQ-2 / REQ-3 対応
+
+- AC-2.1: `isinstance(Slurm(), JobOperationsProtocol)` と `isinstance(SlurmSSHAdapter(...), JobOperationsProtocol)` の両方が True (runtime_checkable または構造的検査で確認)。
+- AC-2.2: 既存 poller テスト (`tests/.../test_active_watch_poller.py`) が `Slurm` / `SlurmSSHAdapter` の双方を `SlurmClientProtocol` として注入しても pass する。
+- AC-3.1: `JobOperationsProtocol.tail_log_incremental` は stdout / stderr に直接書き出さず、構造化された戻り値のみ返す (単体テスト: mock した `run_remote_command` の呼出が `print` / `sys.stdout.write` と結び付いていないことを保証)。
+- AC-3.2: follow 付きログ表示は `src/srunx/cli/` 配下のループ実装で行われ、protocol 自体には follow 引数がない。
+
+### REQ-4 対応
+
+- AC-4.1: `SlurmSSHAdapter.submit(Job(...))` が `RunnableJobType` を返し、戻り値の `job_id` が設定されている。
+- AC-4.2: `SlurmSSHAdapter.status(existing_job_id)` が `BaseJob` を返し、存在しない ID は `JobNotFound` を raise する。
+- AC-4.3: `SlurmSSHAdapter.queue(user="alice")` が `list[BaseJob]` を返し、要素の Pydantic 検証が通る。
+- AC-4.4: `SlurmSSHAdapter.tail_log_incremental(job_id, 0, 0)` が `stdout / stderr / new_stdout_offset / new_stderr_offset` を返し、同 API が `Slurm` 実装でも同一シグネチャで呼べる。
+- AC-4.5: SSH 接続失敗時に `TransportError` が raise され、既存の paramiko 固有例外は外部に漏れない。
+
+### REQ-5 対応
+
+- AC-5.1: Migration V5 適用後、`PRAGMA table_info(jobs)` に `transport_type` / `profile_name` / `scheduler_key` が含まれ、`scheduler_key` は NOT NULL である。
+- AC-5.2: V5 適用後に `SELECT COUNT(*) FROM jobs WHERE scheduler_key IS NULL` が 0 を返す。
+- AC-5.3: V5 適用後に `SELECT COUNT(*) FROM watches WHERE kind = 'job' AND (target_ref NOT LIKE 'job:local:%' AND target_ref NOT LIKE 'job:ssh:%:%')` が 0 を返す (legacy 2 セグメント形式が完全に消えている)。
+- AC-5.4: 同一 `job_id=12345` が `scheduler_key='local'` と `scheduler_key='ssh:dgx'` で同時に存在できる (UNIQUE 制約が複合キーになっている)。
+- AC-5.5: `PRAGMA foreign_key_list(workflow_run_jobs)` および `PRAGMA foreign_key_list(job_state_transitions)` の結果が `jobs.id` を FK 先として返す (structural assertion)。
+- AC-5.6: `submission_source` の CHECK 制約とカラム値が V4 から変化していない (diff で確認)。
+
+### REQ-6 対応
+
+- AC-6.1: `srunx cancel --profile foo 12345` が SSH 経由で `scancel 12345` を実行する。
+- AC-6.2: `srunx status --profile foo 12345` が SSH 経由で該当 job の `BaseJob` を表示する。
+- AC-6.3: `srunx flow run --profile foo workflow.yaml` が workflow 全体を SSH 経由で実行する。
+- AC-6.4: `srunx submit --script train.sh --profile foo` が ShellJob として SSH 経由で投入される。
+- AC-6.5: `srunx submit --script train.sh python foo.py` は command list と排他のため起動時エラー。
+
+### REQ-7 対応
+
+- AC-7.1: `srunx list --format json --quiet` の stdout が純粋な JSON であり、transport 表示行が混ざらない (`jq .` が成功する)。
+- AC-7.2: `srunx list --format json` (quiet なし) の stderr に `→ transport:` 行が出力され、stdout は依然として純粋 JSON である。
+- AC-7.3: `srunx submit --profile foo echo hi` の stderr に `→ transport: ssh:foo (from --profile)` が 1 行だけ表示される。
+
+### REQ-8 対応
+
+- AC-8.1: V5 適用後、active watches が `scheduler_key='local'` と `scheduler_key='ssh:dgx'` の両方を含む場合、`ActiveWatchPoller` 1 サイクルで両方の transport に対して `queue_by_ids` が呼ばれる (mock で検証)。
+- AC-8.2: `_parse_target_ref("job:local:12345")` が `("local", 12345)` を返す。
+- AC-8.3: `_parse_target_ref("job:ssh:dgx:12345")` が `("ssh:dgx", 12345)` を返す。
+- AC-8.4: `_parse_target_ref("job:12345")` (legacy 2 セグメント) は `None` を返す (migration 後は存在しないため)。
+- AC-8.5: `TransportRegistry.resolve("ssh:nonexistent_profile")` が `None` を返し、poller は cycle 全体を落とさず warning ログを出して次の scheduler_key group へ進む (mock で検証)。
+
+### REQ-9 対応
+
+- AC-9.1: `srunx ssh submit foo.sh` が stderr に deprecation warning を出し、exit code 0 で従来通り動作する。
+- AC-9.2: `srunx ssh profile list` は warning なしで従来通り動作する (保守コマンドとして温存)。
+- AC-9.3: `srunx ssh sync` は warning なしで従来通り動作する。
+
+### REQ-10 対応
+
+- AC-10.1: CLI レベルの behavioral テストスイートが pass する。DB row モデル・repository テストは `job_id` → `jobs_row_id` キー変更に追従した修正込みで pass する。
+- AC-10.2: 既存の `srunx submit python foo.py` (フラグなし・env なし) の stdout / stderr / exit code が V4 / V5 前後で完全一致する (golden test)。transport banner は default では出ないので stderr も同一。
+- AC-10.3: V4 DB を用意して srunx 起動 → V5 migration 自動適用 → 既存 CLI が動作、という一連のフローが手動検証で通る。
+
+## Out of Scope
+
+以下は本 spec のスコープ外 (Phase 2 以降 or 採用しない):
+
+- **active profile config fallback** (`srunx ssh profile set` の設定を CLI の default transport に使う): Phase 2 以降。既存 `srunx ssh` サブツリーのセマンティクスを変えないため Phase 1 では見ない。
+- **profile-per-poller**: Phase 2 以降。今回は `ActiveWatchPoller` 内で `scheduler_key` group-by する単一 poller 方式。
+- **cwd ベース transport 自動判定** (profile の `local_root` と cwd を突き合わせる): 採用しない。暗黙挙動が多すぎて混乱のもと。
+- **`srunx ssh submit` の即時削除**: Phase 1 は deprecation warning のみ。削除は未来の breaking release で実施。
+- **WebUI の変更**: 既に transport 抽象化済み。触らない。
+- **MCP の変更**: 既に `mount=` 引数で transport 選択に対応済み。触らない。
+- **`submission_source` に transport 軸を混ぜる変更**: 意味論違反として拒否 (CLI から SSH 経由で投入したジョブは `submission_source='cli'` かつ `transport_type='ssh'` として記録する)。
+
+## Constraints
+
+### Technical Constraints
+
+- SQLite + `sqlite3` 標準ライブラリのみ使用 (既存方針踏襲)。V5 migration は `requires_fk_off=True` の rebuild migration (V3/V4 の template 踏襲) として実装する。UNIQUE 制約変更と子 FK retarget が SQLite では table rebuild でしか達成できないため。
+- Python 3.11+ (既存プロジェクトは 3.12)。
+- `JobOperationsProtocol` は `typing.Protocol` で定義し、`runtime_checkable` を付与するかは実装時判断 (テストで `isinstance` 検査をするなら必須)。
+- `SlurmSSHAdapter` の内部実装 (paramiko, sftp upload, Jinja render) は変更しない。外向き API のみ adapt する。
+
+### Design Constraints
+
+- LSP: 3 本の Protocol それぞれについて、`Slurm` と `SlurmSSHAdapter` のどちらを渡しても呼出側のテストが pass すること。
+- ISP: CLI コマンドが poller 用 API (`queue_by_ids`) に依存してはいけない。poller が CLI 用 API (`tail_log_incremental`) に依存してはいけない。
+- 純粋関数原則: Protocol の戻り値は Pydantic モデル。stdout / stderr への出力は CLI レイヤのみ。
+- 既存 `submission_source` 軸に transport 情報を混ぜない。`transport_type` / `profile_name` / `scheduler_key` は別カラムで表現する。
+
+### Business Constraints
+
+- 後方互換を破らない。既存ユーザーの `srunx submit python foo.py` が動かなくなるのは不可。
+- deprecation は段階的に。`srunx ssh submit` を使っているユーザーに移行期間を与える。
+
+## Known Pitfalls
+
+codex review と exploration で明らかになった、実装時に必ず考慮すべき落とし穴:
+
+| # | Pitfall | 対策 |
+|---|---|---|
+| P-1 | SLURM `job_id` はクラスタ間で衝突する (別クラスタが同じ数字を返す) | `UNIQUE(job_id)` 単体を廃止し `UNIQUE(scheduler_key, job_id)` へ (REQ-5) |
+| P-2 | `submission_source` に `ssh:*` を混ぜると意味論が壊れる (誰がトリガしたか vs どこに投げたかを混同) | 別カラム `transport_type` / `profile_name` を使う (REQ-5) |
+| P-3 | active profile の暗黙 fallback を Phase 1 で入れると既存 `srunx ssh profile set` の意味が変わる | Phase 1 では読まない (REQ-1、Out of Scope) |
+| P-4 | transport 表示を stdout に出すと `--format json` がパース不能になる | stderr 固定 + `--quiet` 対応 (REQ-7) |
+| P-5 | `_parse_target_id` は `:` split を partition 前提で書かれており 3 セグメント化で破綻する | `_parse_target_ref` に改名、`rsplit` ベースの末尾 job_id 切り出しで実装 (REQ-8) |
+| P-6 | `events.payload_hash` は過去行が stale になる (target_ref の backfill で hash が再計算されない) | documented, acceptable。backfill 直後の初回 event は dedup ヒットせず 1 件余分に記録される可能性があるが、以降の dedup には影響しない |
+| P-7 | SSH adapter の `submit_job(script_content)` と top-level `submit` (command list) の引数形が違い、直接差し替えが効かない | `--script` フラグ + ShellJob 経路を top-level に追加して橋渡し (REQ-4, REQ-6) |
+| P-8 | `-p` 短縮形を `--profile` に割り当てると `resources` / `monitor resources` の `--partition` と衝突 | 短縮形なし。long form `--profile` のみ (REQ-6) |
+| P-9 | SSH 固有例外 (paramiko.AuthenticationException 等) が CLI レイヤに漏れると transport 抽象が意味をなさない | `srunx.exceptions` で `TransportError` 階層にラップ (REQ-4) |
+| P-10 | 子テーブル FK を `jobs.job_id` 参照のままにすると `UNIQUE(scheduler_key, job_id)` に変更した瞬間に FK 制約が壊れる | Option A で `jobs.id` (AUTOINCREMENT PK) への retarget。SQLite は後付け FK 追加できないので rebuild migration 必須 (REQ-5) |
+| P-11 | `flow run --profile` で workflow YAML の `work_dir` / `log_dir` / `ShellJob.script_path` が remote path として解決できない | profile の `mounts` 設定を使って translation。`script_path` が mount の `local` 配下外なら起動時エラー (REQ-6、WebUI / MCP と同じ guard) |
+| P-12 | profile_name に `:` を含めると `scheduler_key='ssh:<profile>'` のパースが破綻する | profile_name のバリデーションで `:` を禁止。DB CHECK 制約で追加 (REQ-5, REQ-8) |
+| P-13 | 同じ profile_name で hostname を変えると別クラスタが同じ `scheduler_key` になり cross-cluster 衝突保護が崩れる | Phase 1 は「profile 名 = scheduler identity」と仮定。profile 更新時に DB の既存 `jobs` 行との整合は保証しない (運用上の注意として documented) |
+| P-14 | `BaseJob.status` が lazy refresh を持つため、SSH adapter が返した `BaseJob` を CLI が触ると local `sacct` に fallback する可能性 | ステータス系は原則 `JobStatusInfo` (refresh しない純粋 DTO) を使う (REQ-3) |
+
+## Transport 解決フロー
+
+```mermaid
+flowchart TD
+    Start([CLI 起動]) --> CheckFlags{--profile と --local<br/>同時指定?}
+    CheckFlags -->|Yes| Error1[exit ≠ 0<br/>conflict error]
+    CheckFlags -->|No| CheckProfile{--profile 指定?}
+    CheckProfile -->|Yes| UseProfile[transport = ssh:profile<br/>source = --profile]
+    CheckProfile -->|No| CheckLocal{--local 指定?}
+    CheckLocal -->|Yes| UseLocal1[transport = local<br/>source = --local]
+    CheckLocal -->|No| CheckEnv{SRUNX_SSH_PROFILE<br/>set?}
+    CheckEnv -->|Yes| UseEnv[transport = ssh:SRUNX_SSH_PROFILE の値<br/>source = env]
+    CheckEnv -->|No| UseLocal2[transport = local<br/>source = default]
+    UseProfile --> Emit[stderr に<br/>→ transport: ... を出力]
+    UseLocal1 --> Emit
+    UseEnv --> Emit
+    UseLocal2 --> SkipEmit[banner なし<br/>後方互換優先]
+    Emit --> Resolve[TransportRegistry 経由で<br/>JobOperationsProtocol 取得]
+    SkipEmit --> Resolve
+    Resolve --> Exec([CLI コマンド実行])
+```
+
+## Open Questions
+
+以下は実装着手後に決めてよい細部 (spec を blocker にしない):
+
+- deprecation warning の具体的文言 (例: `"srunx ssh submit is deprecated; use 'srunx submit --script <path> --profile <name>' instead"`) と、将来の削除時期 (`# removed in v2.0` のようなコメント) の明記有無。
+- `JobStatusInfo` を CLI `status` / `queue` の戻り型として再利用するか、`BaseJob` から `JobStatusInfo` を派生させる新モデルを設けるか (REQ-3 P-14 の対応詳細)。

--- a/specs/cli-transport-unification/tasks.md
+++ b/specs/cli-transport-unification/tasks.md
@@ -1,0 +1,594 @@
+# Tasks: CLI Transport 統一リファクタリング
+
+## Prerequisites
+- [ ] Spec approved: `specs/cli-transport-unification/spec.md`
+- [ ] Plan approved: `specs/cli-transport-unification/plan.md`
+- [ ] 作業は Phase 1 → Phase 8 の順序で進める (各 Phase の Gate を満たしてから次へ)
+- [ ] Nice to Have (REQ-N1 / REQ-N2) は本イテレーションでは**実装しない** (明示的に out of scope)
+
+## Phase 1: Protocol / 例外階層 (足場)
+
+後続 phase が依存する型・例外を純追加する。既存 CLI 挙動は一切変わらない。
+
+- [ ] T-1.1: `LogChunk` Pydantic モデルを `src/srunx/client_protocol.py` に追加 (REQ-3)
+      Files: `src/srunx/client_protocol.py`
+      完了条件: `stdout: str`, `stderr: str`, `stdout_offset: int = Field(ge=0)`, `stderr_offset: int = Field(ge=0)` を持ち、負値を reject する unit test が pass。フィールド名は WebUI wire と一致 (`stdout_offset` / `stderr_offset`)。
+
+- [ ] T-1.2: `JobOperationsProtocol` を `src/srunx/client_protocol.py` に追加 (REQ-2, REQ-3)
+      Files: `src/srunx/client_protocol.py`
+      完了条件: `submit` / `cancel` / `status` / `queue` / `tail_log_incremental` の 5 メソッドを持つ `typing.Protocol`、`@runtime_checkable` 付与。戻り値は全て Pydantic モデル (`RunnableJobType` / `BaseJob` / `LogChunk`)。stdout / TTY 操作はシグネチャに含めない。
+
+- [ ] T-1.3: Transport 例外階層を `src/srunx/exceptions.py` に追加 (REQ-4)
+      Files: `src/srunx/exceptions.py`
+      完了条件: `TransportError` (base) / `TransportConnectionError` / `TransportAuthError` / `TransportTimeoutError` / `JobNotFound` / `SubmissionError` / `RemoteCommandError` の 7 クラスを追加。`SubmissionError` と `TransportError` の排他セマンティクスを docstring に明記。
+
+- [ ] T-1.4: `runtime_checkable` 付与後の既存テスト回帰確認 (REQ-2)
+      Files: `tests/`
+      完了条件: `uv run pytest` が全 pass。この時点で `isinstance(Slurm(), JobOperationsProtocol)` は False (未実装) で良い。
+
+### Phase 1 Gate
+- [ ] `uv run mypy .` / `uv run ruff check .` / `uv run pytest` が全 pass
+- [ ] CLI 挙動は未変化 (`srunx submit echo hi` が従来通り動く)
+
+---
+
+## Phase 2: `Slurm` / `SlurmSSHAdapter` LSP 整流
+
+Protocol に準拠させる。既存メソッド名は alias で温存し、WebUI / MCP 経路を壊さない。
+
+### `Slurm` 側
+
+- [ ] T-2.1: `Slurm.status(job_id) -> BaseJob` を `retrieve` への thin alias として追加 (REQ-2)
+      Files: `src/srunx/client.py`
+      完了条件: `status = retrieve` または `def status(self, job_id): return self.retrieve(job_id)`。既存 `retrieve` は caller 互換のため残す。
+
+- [ ] T-2.2: `Slurm.tail_log_incremental(job_id, stdout_offset, stderr_offset) -> LogChunk` を実装 (REQ-3)
+      Files: `src/srunx/client.py`
+      完了条件: local log file を `open` / `seek(offset)` / `read` して `LogChunk` を返す。未読ファイルは空 stdout/stderr + 同一 offset を返す。
+
+- [ ] T-2.3: `Slurm` が 3 Protocol (`JobOperationsProtocol` / `SlurmClientProtocol` / `WorkflowJobExecutorProtocol`) を満たすことを assert する unit test (REQ-2, AC-2.1)
+      Files: `tests/test_client.py` (既存) もしくは新規
+      完了条件: `assert isinstance(Slurm(), JobOperationsProtocol)` 等が True。
+
+### `SlurmSSHAdapter` 側
+
+- [ ] T-2.4: `SlurmSSHAdapter.submit(job: RunnableJobType) -> RunnableJobType` を新規実装 (REQ-4, AC-4.1)
+      Files: `src/srunx/web/ssh_adapter.py`
+      完了条件: Jinja render → sftp upload → sbatch → `job.job_id` をセットして返す。既存 `submit_job(script_content)` は温存。
+
+- [ ] T-2.5: `SlurmSSHAdapter.cancel(job_id)` を新規実装、`cancel_job = cancel` alias を温存 (REQ-4)
+      Files: `src/srunx/web/ssh_adapter.py`
+      完了条件: `cancel(未知_id)` で `JobNotFound` を raise (AC 互換)。旧名 `cancel_job` は backcompat alias として残す。
+
+- [ ] T-2.6: `SlurmSSHAdapter.status(job_id: int) -> BaseJob` を新規実装、`get_job_status` alias を温存 (REQ-4, AC-4.2)
+      Files: `src/srunx/web/ssh_adapter.py`
+      完了条件: 戻り値が `BaseJob`。未知 ID は `JobNotFound`。`BaseJob.status` の lazy refresh が SSH で local sacct に fallback しないよう対処 (P-14, frozen snapshot もしくは後続 T-2.11 で対処)。
+
+- [ ] T-2.7: `SlurmSSHAdapter.queue(user: str | None) -> list[BaseJob]` を新規実装、`list_jobs` alias を温存 (REQ-4, AC-4.3)
+      Files: `src/srunx/web/ssh_adapter.py`
+      完了条件: `user=None` は profile の username を使う。`user="alice"` は明示指定。ゼロ件は空 list を返し例外にしない。
+
+- [ ] T-2.8: `SlurmSSHAdapter.tail_log_incremental(job_id, stdout_offset, stderr_offset) -> LogChunk` を新規実装 (REQ-3, AC-4.4)
+      Files: `src/srunx/web/ssh_adapter.py`
+      完了条件: SSH 越しの `wc -c` + `tail -c +offset` で incremental 取得。stdout 直接出力はしない (pure function)。
+
+- [ ] T-2.9: paramiko 系例外を transport 例外にラップ (REQ-4, AC-4.5)
+      Files: `src/srunx/web/ssh_adapter.py`
+      完了条件: `paramiko.AuthenticationException` → `TransportAuthError`、`paramiko.SSHException` / 接続失敗 → `TransportConnectionError`、`socket.timeout` → `TransportTimeoutError`。paramiko 固有例外が adapter 外部に漏れない。
+
+- [ ] T-2.10: `SlurmSSHAdapter` が 3 Protocol を満たすことを assert する unit test (REQ-2, AC-2.1)
+      Files: `tests/test_ssh_adapter.py` 等
+      完了条件: `assert isinstance(SlurmSSHAdapter(...), JobOperationsProtocol)` 等が True。
+
+- [ ] T-2.11: `BaseJob.status` lazy refresh の SSH fallback 防止対応 (REQ-3, P-14)
+      Files: `src/srunx/models.py` or `src/srunx/web/ssh_adapter.py`
+      完了条件: SSH adapter が返す `BaseJob` に対して CLI が属性アクセスしても local `sacct` 呼出が発生しないこと。`JobStatusInfo` 使用 or `model_config = ConfigDict(frozen=True)` 等の選択肢から実装方針を決めて docstring に明記。
+
+### Phase 2 Gate
+- [ ] AC-2.1 / AC-4.1 / AC-4.2 / AC-4.3 / AC-4.4 / AC-4.5 の unit test が全 pass
+- [ ] 既存 CLI テストが**無修正で** pass (新メソッド追加 + alias 温存のみなので非破壊)
+- [ ] `uv run pytest && uv run mypy . && uv run ruff check .` が通る
+
+---
+
+## Phase 3: Migration V5 + Repository + 全 caller 修正 (単一 PR)
+
+**重要制約**: 本 Phase 全体を**単一 PR** で出す。schema 変更と repository API 変更と全 caller 修正を同じ PR にまとめないと、途中 commit で `job_id` 参照がビルドエラーになる。
+
+### Schema
+
+- [ ] T-3.1: `SCHEMA_V5` を `src/srunx/db/migrations.py` に追加 — `jobs` rebuild (REQ-5, AC-5.1, AC-5.2, AC-5.4)
+      Files: `src/srunx/db/migrations.py`
+      完了条件: `_apply_fk_off_migration` template (`requires_fk_off=True`) を用いて `jobs_v5` CREATE → `INSERT...SELECT` → `DROP` → `RENAME`。新規カラム `transport_type` (NOT NULL DEFAULT `'local'` CHECK IN local/ssh) / `profile_name` (NULL) / `scheduler_key` (NOT NULL DEFAULT `'local'`) + 三項 CHECK 制約 + `UNIQUE(scheduler_key, job_id)`。既存行は全て `('local', NULL, 'local')` backfill。
+
+- [ ] T-3.2: `SCHEMA_V5` に `workflow_run_jobs` rebuild を追加 (REQ-5, AC-5.5)
+      Files: `src/srunx/db/migrations.py`
+      完了条件: `job_id` カラムを `jobs_row_id` に改名、FK を `jobs(id)` (AUTOINCREMENT PK) へ retarget。backfill は `LEFT JOIN jobs ON old.job_id = jobs.job_id` で `jobs.id` を取得。
+
+- [ ] T-3.3: `SCHEMA_V5` に `job_state_transitions` rebuild を追加 (REQ-5, AC-5.5)
+      Files: `src/srunx/db/migrations.py`
+      完了条件: `workflow_run_jobs` と同じパターンで FK 先を `jobs.id` に retarget。
+
+- [ ] T-3.4: `watches.target_ref` / `events.source_ref` を `job:N` → `job:local:N` に一括 UPDATE (REQ-5, REQ-8, AC-5.3)
+      Files: `src/srunx/db/migrations.py`
+      完了条件: 同一 migration transaction 内で UPDATE。適用後に `target_ref NOT LIKE 'job:local:%' AND NOT LIKE 'job:ssh:%:%'` が 0 件。
+
+- [ ] T-3.5: pre-V5 open watch の強制クローズ (REQ-5, P-15 相当)
+      Files: `src/srunx/db/migrations.py`
+      完了条件: migration 最後に `UPDATE watches SET status='closed', closed_at=<now>, closed_reason='v5_migration' WHERE status='open'`。pre-V5 の WebUI 経由 SSH ジョブが backfill で `'local'` 扱いされて poller が local SLURM に誤問い合わせする事故を防ぐ。
+
+- [ ] T-3.6: profile_name CHECK 制約の追加 (REQ-5, P-12)
+      Files: `src/srunx/db/migrations.py`
+      完了条件: `jobs.profile_name` に `:` を含まない CHECK 制約、または migration と同時に `add_profile` 側で `:` を reject する validation を実装。
+
+### Repository / Models
+
+- [ ] T-3.7: `src/srunx/db/models.py` の Pydantic row モデルに新列反映 (REQ-5)
+      Files: `src/srunx/db/models.py`
+      完了条件: `JobRow` に `transport_type` / `profile_name` / `scheduler_key` 追加。`WorkflowRunJobRow` / `JobStateTransitionRow` は `job_id` → `jobs_row_id`。
+
+- [ ] T-3.8: `JobRepository` の signature 書き換え (REQ-5)
+      Files: `src/srunx/db/repositories/jobs.py`
+      完了条件: `record_submission` / `get` / `update_status` / `update_completion` / `delete` を `(scheduler_key, job_id)` 複合キーまたは `jobs_row_id` ベースに変更。`transport_type` / `profile_name` を保存。
+
+- [ ] T-3.9: `WorkflowRunJobRepository.upsert` / `get` の signature 書き換え (REQ-5)
+      Files: `src/srunx/db/repositories/workflow_run_jobs.py`
+      完了条件: `job_id` → `jobs_row_id` へ追従。全 `WHERE job_id = ?` → `WHERE jobs_row_id = ?`。
+
+- [ ] T-3.10: `JobStateTransitionRepository.latest_for_job` / `history_for_job` の signature 書き換え (REQ-5)
+      Files: `src/srunx/db/repositories/job_state_transitions.py`
+      完了条件: 同上。
+
+- [ ] T-3.11: `cli_helpers.record_submission_from_job` に `transport_type` / `profile_name` / `scheduler_key` kwargs 追加 (REQ-5)
+      Files: `src/srunx/db/cli_helpers.py`
+      完了条件: default は local (既存挙動と互換)。明示指定で SSH 経路の記録が可能。
+
+- [ ] T-3.12: `Slurm.submit()` / `SlurmSSHAdapter.submit()` 内部で `record_submission_from_job` を呼ぶ (REQ-5, DB 記録責務の一元化)
+      Files: `src/srunx/client.py`, `src/srunx/web/ssh_adapter.py`
+      完了条件: CLI 側での double-record を防止。adapter は自分の `transport_type='ssh'` / `profile_name` / `scheduler_key='ssh:<profile>'` を認識して渡す。
+
+### Caller 修正 (同一 PR 内)
+
+- [ ] T-3.13: Web routers の repository call site を新 signature に追従 (REQ-5)
+      Files: `src/srunx/web/routers/jobs.py`, `src/srunx/web/routers/workflows.py`, `src/srunx/web/routers/sweep_runs.py`
+      完了条件: 全ての `JobRepository.get(job_id)` 等の呼出が新 signature に合う。wire API は unchanged。
+
+- [ ] T-3.14: Poller の repository call site 追従 (REQ-5)
+      Files: `src/srunx/pollers/active_watch_poller.py`
+      完了条件: signature 互換を Phase 3 で完了。本格 transport-aware 化は Phase 6。
+
+- [ ] T-3.15: Notifications / CLI notification_setup の追従 (REQ-5)
+      Files: `src/srunx/cli/notification_setup.py`, `src/srunx/notifications/service.py`
+      完了条件: repository 呼出を新 signature へ。
+
+- [ ] T-3.16: Repository / cli_helper テストの修正 (REQ-10, AC-10.1)
+      Files: `tests/` 配下の該当ファイル
+      完了条件: signature 変更に追従して全 pass。新列の assertion も追加。
+
+### Migration 検証
+
+- [ ] T-3.17: Migration V5 happy path の integration test (REQ-5, AC-5.1〜5.6)
+      Files: `tests/db/test_migrations.py` 等
+      完了条件: in-memory SQLite に V4 schema + fixture data → `apply_migrations` → 以下を assert:
+      - `PRAGMA table_info(jobs)` に `transport_type` / `profile_name` / `scheduler_key` が含まれ NOT NULL (AC-5.1)
+      - `SELECT COUNT(*) FROM jobs WHERE scheduler_key IS NULL` = 0 (AC-5.2)
+      - `watches` の legacy 2 セグメント形式が 0 件 (AC-5.3)
+      - 同じ `job_id=12345` が `scheduler_key='local'` と `'ssh:dgx'` で同時挿入可能 (AC-5.4)
+      - `PRAGMA foreign_key_list` の FK 先が `jobs.id` (AC-5.5)
+      - `submission_source` カラム diff なし (AC-5.6)
+
+- [ ] T-3.18: Migration V5 rollback atomicity test (REQ-5, R-1)
+      Files: `tests/db/test_migrations.py`
+      完了条件: `jobs_v5` 作成後の `INSERT...SELECT` に例外注入 → 元 schema / rows / indexes / FK が完全に残ることを assert。
+
+- [ ] T-3.19: Migration V5 の open watch 強制クローズ test (REQ-5)
+      Files: `tests/db/test_migrations.py`
+      完了条件: V4 DB に open watch 2 件を含む fixture → V5 migration 後に全 open watch が `status='closed'`, `closed_reason='v5_migration'` であることを assert。
+
+### Phase 3 Gate
+- [ ] AC-5.1 / AC-5.2 / AC-5.3 / AC-5.4 / AC-5.5 / AC-5.6 の integration test が全 pass
+- [ ] Repository / CLI helper テストが修正込みで pass (AC-10.1)
+- [ ] Web routers / poller / notifications の既存機能が無修正 wire API で動く
+- [ ] 単一 PR として commit が完結 (途中 commit で `job_id` 参照エラー出ない)
+
+---
+
+## Phase 4: `resolve_transport` / `TransportRegistry`
+
+CLI が使う transport 解決レイヤを新設。この時点では CLI 側はまだ呼ばない。
+
+- [ ] T-4.1: `src/srunx/transport/__init__.py` 新規作成 (REQ-1)
+      Files: `src/srunx/transport/__init__.py`
+      完了条件: module を成立させる。公開 API (`resolve_transport`, `ResolvedTransport`, `TransportHandle`, `TransportRegistry`) を re-export。
+
+- [ ] T-4.2: `TransportHandle` dataclass を新規実装 (REQ-1, REQ-8)
+      Files: `src/srunx/transport/registry.py`
+      完了条件: `scheduler_key` / `profile_name` / `transport_type` / `job_ops` / `queue_client` / `executor_factory` / `submission_context` フィールドを持つ `@dataclass(frozen=True)`。
+
+- [ ] T-4.3: `ResolvedTransport` dataclass を新規実装 (REQ-1, REQ-7)
+      Files: `src/srunx/transport/registry.py`
+      完了条件: `label` / `source` (Literal) / `handle` フィールド + `handle` へのショートカット property。
+
+- [ ] T-4.4: `resolve_transport()` context manager を新規実装 (REQ-1, REQ-7)
+      Files: `src/srunx/transport/registry.py`
+      完了条件: 優先順 (`--profile` > `--local` > `$SRUNX_SSH_PROFILE` > local fallback)。`--profile` + `--local` 併用を `ClickException` で起動時拒否 (AC-1.2)。`__exit__` で SSH 接続を close。
+
+- [ ] T-4.5: `resolve_transport()` の SSH import を conditional に (R-3)
+      Files: `src/srunx/transport/registry.py`
+      完了条件: local fallback のみ使う経路で `SlurmSSHAdapter` / paramiko の import が発生しない (CLI 起動時間回帰防止)。
+
+- [ ] T-4.6: `TransportRegistry` 新規実装 (REQ-8)
+      Files: `src/srunx/transport/registry.py`
+      完了条件: `__init__(local_client, profile_loader, db_connection_factory)` / `resolve(scheduler_key) -> TransportHandle | None` / `known_scheduler_keys() -> set[str]` / `close()` を持つ。`resolve("ssh:nonexistent")` は `None` を返す (AC-8.5)。
+
+- [ ] T-4.7: `resolve_transport` 優先順序の table-driven unit test (REQ-1, AC-1.1〜1.4)
+      Files: `tests/transport/test_registry.py`
+      完了条件: 5 パターン (flag/env/default/conflict/local 上書き) を網羅。
+
+- [ ] T-4.8: `TransportRegistry.resolve` failure policy の unit test (REQ-8, AC-8.5)
+      Files: `tests/transport/test_registry.py`
+      完了条件: 未知 profile で `None` 返却、caller が cycle 全体を落とさず warning + skip できることを mock で検証。
+
+### CLI 共通オプション
+
+- [ ] T-4.9: `src/srunx/cli/transport_options.py` 新規作成 (REQ-6)
+      Files: `src/srunx/cli/transport_options.py`
+      完了条件: `ProfileOpt` / `LocalOpt` / `ScriptOpt` / `QuietOpt` を Annotated 型エイリアスで定義。`--profile` に `-p` 短縮形は割り当てない (P-8)。
+
+- [ ] T-4.10: `emit_transport_banner(resolved, quiet)` 補助関数を実装 (REQ-7, AC-7.3)
+      Files: `src/srunx/cli/transport_options.py`
+      完了条件: `Console(stderr=True)` で 1 行出力。`source == "default"` では無出力 (AC-10.2 対応)。`quiet=True` で常に無出力。
+
+### Phase 4 Gate
+- [ ] AC-1.2 / AC-8.5 の unit test が pass
+- [ ] `resolve_transport` table-driven test 全 pass
+- [ ] 既存 CLI 挙動未変化 (この phase ではまだ CLI 側から呼ばない)
+
+---
+
+## Phase 5a: CLI 書き換え — main.py コア
+
+`submit` / `cancel` / `status` / `list` / `logs` / `template_apply` を transport 対応に。
+
+- [ ] T-5a.1: `submit` コマンドに `--profile` / `--local` / `--quiet` / `--script` オプション追加 (REQ-1, REQ-6, AC-6.4, AC-6.5)
+      Files: `src/srunx/cli/main.py`
+      完了条件: `ProfileOpt` / `LocalOpt` / `QuietOpt` / `ScriptOpt` を import して適用。`--script` と command list は Typer callback で排他検査 (AC-6.5)。
+
+- [ ] T-5a.2: `submit` を `resolve_transport()` 経由に書き換え (REQ-1, REQ-6)
+      Files: `src/srunx/cli/main.py`
+      完了条件: `main.py:564` 付近の `Slurm()` 直接 new を `with resolve_transport(...) as rt:` に置換。`rt.job_ops.submit(job)` を呼ぶ。`--script` 指定時は `ShellJob` を構築。
+
+- [ ] T-5a.3: `status` コマンドに transport オプション追加 + 書き換え (REQ-1, REQ-6, AC-6.2)
+      Files: `src/srunx/cli/main.py`
+      完了条件: `main.py:613` 付近を `resolve_transport()` 経由に。`srunx status --profile foo 12345` が SSH 経由で `BaseJob` 表示 (AC-6.2)。
+
+- [ ] T-5a.4: `list` コマンドに transport オプション追加 + 書き換え (REQ-1, REQ-6, REQ-7, AC-1.3, AC-1.4, AC-7.1, AC-7.2)
+      Files: `src/srunx/cli/main.py`
+      完了条件: `main.py:655` 付近を `resolve_transport()` 経由に。`--format json` のとき banner を stdout に絶対に出さない (stderr のみ)。`SRUNX_SSH_PROFILE=foo srunx list` が SSH 経由 (AC-1.3)、`--local` で env を上書き (AC-1.4)。
+
+- [ ] T-5a.5: `cancel` コマンドに transport オプション追加 + 書き換え (REQ-1, REQ-6, AC-6.1)
+      Files: `src/srunx/cli/main.py`
+      完了条件: `main.py:734` 付近を `resolve_transport()` 経由に。`srunx cancel --profile foo 12345` が SSH 経由で `scancel` (AC-6.1)。
+
+- [ ] T-5a.6: `logs` コマンドに transport オプション追加 + 書き換え (REQ-1, REQ-6)
+      Files: `src/srunx/cli/main.py`
+      完了条件: `main.py:830` 付近を `resolve_transport()` 経由に。follow 実装は `rt.job_ops.tail_log_incremental` を CLI レイヤでループ呼出 (REQ-3、Protocol は pure)。
+
+- [ ] T-5a.7: `template_apply` を `resolve_transport()` 経由に書き換え (REQ-1)
+      Files: `src/srunx/cli/main.py`
+      完了条件: `main.py:1276` 付近の `Slurm()` 直接 new を置換。
+
+- [ ] T-5a.8: `DebugCallback.on_job_submitted` (line 57) の特殊ケース対応 (REQ-1)
+      Files: `src/srunx/cli/main.py`
+      完了条件: callback コンテキストの `Slurm().default_template` は `resolve_transport()` 経由ではなく、module-level 定数 or `Slurm._get_default_template()` class method に書き換え。通常 CLI transport 解決経路ではないことを docstring で明記。
+
+- [ ] T-5a.9: **(別 commit)** `main.py:660` の "No jobs in queue" 出力を `format == "json"` 判定後に移す (R-11)
+      Files: `src/srunx/cli/main.py`
+      完了条件: **Phase 5a 本体とは別 commit**。PR description に "incidental fix" と明記。JSON 出力に pre-print が混ざらなくなる。
+
+- [ ] T-5a.10: CLI E2E — default path golden test (REQ-10, AC-1.1, AC-10.2)
+      Files: `tests/cli/test_main_golden.py`
+      完了条件: `srunx submit python foo.py` (フラグなし・env なし) の stdout / stderr / exit code が V4/V5 前後で **bytewise 完全一致** (banner が出ないこと含む)。
+
+- [ ] T-5a.11: CLI E2E — conflict test (REQ-1, AC-1.2)
+      Files: `tests/cli/test_main_transport.py`
+      完了条件: `srunx submit --profile foo --local echo hi` が exit ≠ 0、stderr に「`--profile` と `--local` は同時指定できません」メッセージ。
+
+- [ ] T-5a.12: CLI E2E — env priority test (REQ-1, AC-1.3, AC-1.4)
+      Files: `tests/cli/test_main_transport.py`
+      完了条件: `SRUNX_SSH_PROFILE=foo srunx list` が SSH mock 経由、`--local` で env を上書きして local 経由。
+
+- [ ] T-5a.13: CLI E2E — JSON purity test (REQ-7, AC-7.1, AC-7.2)
+      Files: `tests/cli/test_main_transport.py`
+      完了条件: `srunx list --format json --quiet` / `srunx list --format json` の stdout が `jq .` を通る。後者は stderr に banner。
+
+- [ ] T-5a.14: CLI E2E — banner test (REQ-7, AC-7.3)
+      Files: `tests/cli/test_main_transport.py`
+      完了条件: `srunx submit --profile foo echo hi` の stderr に `→ transport: ssh:foo (from --profile)` が 1 行だけ。
+
+- [ ] T-5a.15: CLI E2E — script mode test (REQ-6, AC-6.4, AC-6.5)
+      Files: `tests/cli/test_main_transport.py`
+      完了条件: `srunx submit --script train.sh --profile foo` が ShellJob として SSH 投入 (mock)。`srunx submit --script train.sh python foo.py` は exit ≠ 0。
+
+- [ ] T-5a.16: CLI E2E — cancel / status via SSH (REQ-6, AC-6.1, AC-6.2)
+      Files: `tests/cli/test_main_transport.py`
+      完了条件: `srunx cancel --profile foo 12345` / `srunx status --profile foo 12345` が SSH mock 経由で動く。
+
+### Phase 5a Gate
+- [ ] AC-1.1〜1.4 / AC-6.1 / AC-6.2 / AC-6.4 / AC-6.5 / AC-7.1〜7.3 / AC-10.2 の test が pass
+- [ ] Golden test (T-5a.10) が完全一致で pass
+- [ ] `srunx ssh` サブツリーはこの時点では未変更 (Phase 7 で deprecation)
+
+---
+
+## Phase 5b: CLI 書き換え — monitor + workflow
+
+- [ ] T-5b.1: `monitor jobs` コマンドに transport オプション追加 (REQ-1, REQ-6)
+      Files: `src/srunx/cli/monitor.py`
+      完了条件: `ProfileOpt` / `LocalOpt` / `QuietOpt` を適用。`monitor.py:116` / `monitor.py:369` の `Slurm()` 2 箇所を `resolve_transport()` 経由に置換。`JobMonitor(client=rt.queue_client)` で明示注入。
+
+- [ ] T-5b.2: `flow run` コマンドに transport オプション追加 (REQ-1, REQ-6)
+      Files: `src/srunx/cli/workflow.py`
+      完了条件: `--profile` / `--local` / `--quiet` を `_execute_workflow` に追加。
+
+- [ ] T-5b.3: `flow run` で `resolve_transport()` から `executor_factory` / `submission_context` を取得 (REQ-6, AC-6.3)
+      Files: `src/srunx/cli/workflow.py`
+      完了条件: sweep / 非 sweep の注入点 (line 376, 483, 495) を両方 `executor_factory=rt.executor_factory, submission_context=rt.submission_context` に書き換え。`srunx flow run --profile foo wf.yaml` が SSH 経由で workflow 実行 (AC-6.3, mock)。
+
+- [ ] T-5b.4: `flow run --profile` の `ShellJob.script_path` guard 実装 (REQ-6, P-11, R-6)
+      Files: `src/srunx/cli/workflow.py`
+      完了条件: `rt.submission_context.mounts` の `local` root 配下にない場合 `ClickException` で exit ≠ 0。WebUI / MCP sweep と同じガード。
+
+- [ ] T-5b.5: `flow run --profile` で mounts なしの場合の warning 出力 (REQ-6)
+      Files: `src/srunx/cli/workflow.py`
+      完了条件: profile に `mounts` 設定なし → warning を stderr に出す (path は remote 前提)。
+
+- [ ] T-5b.6: CLI E2E — `monitor jobs --profile` (REQ-6)
+      Files: `tests/cli/test_monitor_transport.py`
+      完了条件: `srunx monitor jobs --profile foo 12345` が SSH mock 経由で動く。
+
+- [ ] T-5b.7: CLI E2E — `flow run --profile` dry-run (REQ-6, AC-6.3)
+      Files: `tests/cli/test_workflow_transport.py`
+      完了条件: mock SSH で `srunx flow run --profile foo wf.yaml` が executor_factory 経由で動く。
+
+- [ ] T-5b.8: CLI E2E — `flow run` script_path guard (REQ-6)
+      Files: `tests/cli/test_workflow_transport.py`
+      完了条件: `ShellJob.script_path` が mount 外の場合 exit ≠ 0。
+
+### Phase 5b Gate
+- [ ] AC-6.3 の test が pass
+- [ ] Phase 5a の golden test が依然 pass (回帰なし)
+
+---
+
+## Phase 6: Poller transport-aware 化
+
+- [ ] T-6.1: `_parse_target_ref(ref)` 実装 (REQ-8, AC-8.2, AC-8.3, AC-8.4)
+      Files: `src/srunx/pollers/active_watch_poller.py`
+      完了条件: `rsplit` ベースの末尾 job_id 切り出し実装 (P-5)。
+      - `"job:local:12345"` → `("local", 12345)` (AC-8.2)
+      - `"job:ssh:dgx:12345"` → `("ssh:dgx", 12345)` (AC-8.3)
+      - `"job:12345"` (legacy 2 セグメント) → `None` (AC-8.4)
+      - malformed → `None`
+
+- [ ] T-6.2: `ActiveWatchPoller.__init__` に `registry: TransportRegistry` を導入 (REQ-8)
+      Files: `src/srunx/pollers/active_watch_poller.py`
+      完了条件: 既存 `slurm_client` 引数を `registry` に置換。`AWP(registry=registry)` で構築できる。
+
+- [ ] T-6.3: `run_cycle` で watches を `scheduler_key` で group-by (REQ-8, AC-8.1)
+      Files: `src/srunx/pollers/active_watch_poller.py`
+      完了条件: 各 group ごとに `registry.resolve(scheduler_key).queue_by_ids(ids)` を呼ぶ。戻り値を merge して後段の `_process_job_watches` に渡す。
+
+- [ ] T-6.4: poller の failure isolation (REQ-8, AC-8.5, R-4)
+      Files: `src/srunx/pollers/active_watch_poller.py`
+      完了条件: 未知 scheduler_key (`registry.resolve()` が `None`) は warning log + skip、次 group へ進む。`TransportConnectionError` catch も同様に group 単位で skip。
+
+- [ ] T-6.5: SSH connect_timeout を 10s に短縮 (Performance)
+      Files: `src/srunx/pollers/active_watch_poller.py` or registry
+      完了条件: poller 起動時に `SSHSlurmClient.connect_timeout=10` を設定。最悪 1 cycle 時間を ~20s 以内に抑える。
+
+- [ ] T-6.6: `events._extract_source_id` を 3+ セグメント対応 (REQ-8)
+      Files: `src/srunx/db/repositories/events.py`
+      完了条件: 新文法 `job:local:N` / `job:ssh:profile:N` をパース、legacy 2 セグメントは `None`。
+
+- [ ] T-6.7: Slack webhook adapter の `_id_from_source_ref` を 3+ セグメント対応 (REQ-8)
+      Files: `src/srunx/notifications/adapters/slack_webhook.py`
+      完了条件: 同上パーサ。
+
+- [ ] T-6.8: `notifications/service.py` の `source_ref` 書込を新文法に (REQ-8)
+      Files: `src/srunx/notifications/service.py`
+      完了条件: `source_ref = f"job:{scheduler_key}:{job_id}"` 形式。
+
+- [ ] T-6.9: Web routers の `target_ref` 書込を新文法に (REQ-8, R-9)
+      Files: `src/srunx/web/routers/jobs.py` (L173, L177)
+      完了条件: 呼出側に `scheduler_key` を伝搬して `job:local:N` / `job:ssh:profile:N` を書く。
+
+- [ ] T-6.10: CLI notification_setup の `target_ref` 書込を新文法に (REQ-8)
+      Files: `src/srunx/cli/notification_setup.py` (L133, L151)
+      完了条件: 同上。
+
+- [ ] T-6.11: `NotificationWatchCallback` / `attach_notification_watch` に `scheduler_key` / `profile_name` kwargs 追加 (REQ-8)
+      Files: `src/srunx/callbacks.py`, `src/srunx/notifications/service.py`
+      完了条件: watches.target_ref 構築時に scheduler_key を伝搬。
+
+- [ ] T-6.12: Web app lifespan の `ActiveWatchPoller` 構築変更 (REQ-8)
+      Files: `src/srunx/web/app.py` (lifespan)
+      完了条件: `ActiveWatchPoller(slurm_client=adapter)` を `ActiveWatchPoller(registry=registry)` に置換。`TransportRegistry` を lifespan で 1 instance 構築、`app.state` に保持、shutdown で `registry.close()`。
+
+- [ ] T-6.13: `_parse_target_ref` の unit test (REQ-8, AC-8.2, AC-8.3, AC-8.4)
+      Files: `tests/pollers/test_active_watch_poller.py`
+      完了条件: 4 パターン (`job:local:N` / `job:ssh:foo:N` / `job:N` / malformed) 全 pass。
+
+- [ ] T-6.14: Poller 1 cycle で複数 scheduler_key に `queue_by_ids` が呼ばれる integration test (REQ-8, AC-8.1)
+      Files: `tests/pollers/test_active_watch_poller.py`
+      完了条件: `scheduler_key='local'` と `scheduler_key='ssh:dgx'` の両方を含む watches を DB に insert、`run_cycle` mock で両 transport に呼出が入ることを assert。
+
+- [ ] T-6.15: Poller failure policy test (REQ-8, AC-8.5)
+      Files: `tests/pollers/test_active_watch_poller.py`
+      完了条件: `ssh:foo` watch を残したまま profile 削除 → cycle 全体 crash せず、warning log + 次 group 進行。
+
+- [ ] T-6.16: 既存 poller テスト (`test_active_watch_poller.py`) の修正 + pass 確認 (REQ-2, AC-2.2)
+      Files: `tests/pollers/test_active_watch_poller.py`
+      完了条件: `Slurm` / `SlurmSSHAdapter` のどちらを `SlurmClientProtocol` として注入しても pass。
+
+### Phase 6 Gate
+- [ ] AC-2.2 / AC-8.1〜8.5 の test が pass
+- [ ] Web app lifespan が `SRUNX_DISABLE_POLLER=1` / `UVICORN_RELOAD=1` 経路で regression なし
+
+---
+
+## Phase 7: `srunx ssh` deprecation + Web 整合確認
+
+- [ ] T-7.1: `srunx ssh submit` に deprecation warning 追加 (REQ-9, AC-9.1)
+      Files: `src/srunx/ssh/cli/commands.py`
+      完了条件: コマンド最初で `typer.echo("WARNING: ...", err=True)` を 1 行追加。新 CLI (`srunx submit --script <path> --profile <name>`) を案内。ロジック温存。exit code 0 で従来通り動作 (AC-9.1)。
+
+- [ ] T-7.2: `srunx ssh logs` に deprecation warning 追加 (REQ-9)
+      Files: `src/srunx/ssh/cli/commands.py`
+      完了条件: 同上パターン。新 CLI (`srunx logs --profile <name> <job_id>`) を案内。
+
+- [ ] T-7.3: `srunx ssh test` / `ssh sync` / `ssh profile *` は変更しない確認 (REQ-9, AC-9.2, AC-9.3)
+      Files: `src/srunx/ssh/cli/commands.py`
+      完了条件: これらのコマンドに warning を追加しないことを docstring / code review で確認。保守用として残る。
+
+- [ ] T-7.4: Web app dev reload 経路の回帰確認 (REQ-8)
+      Files: `src/srunx/web/app.py`
+      完了条件: `SRUNX_DISABLE_POLLER=1` / `SRUNX_DISABLE_ACTIVE_WATCH_POLLER=1` / `UVICORN_RELOAD=1` で startup / shutdown が通る (手動確認 or integration test)。
+
+- [ ] T-7.5: MCP サーバー (`src/srunx/mcp/server.py`) 変更なし確認 (REQ-8)
+      Files: `src/srunx/mcp/server.py`
+      完了条件: 既に transport 抽象に乗っているため Phase 1 では触らない。tool 契約 unchanged を code review で確認。
+
+- [ ] T-7.6: WebUI `/api/jobs/{id}/logs` の wire 契約 unchanged 確認 (REQ-3)
+      Files: `src/srunx/web/routers/jobs.py`
+      完了条件: Phase 2 で `tail_log_incremental` が Protocol 化されたことで `Slurm` / `SlurmSSHAdapter` 両方が同じ wire 型 (`LogChunk`) を返す。router 側は無変更で OK。
+
+- [ ] T-7.7: Deprecation warning の CLI E2E test (REQ-9, AC-9.1, AC-9.2, AC-9.3)
+      Files: `tests/ssh/test_commands_deprecation.py`
+      完了条件:
+      - `srunx ssh submit foo.sh` の stderr に warning、exit 0 (AC-9.1)
+      - `srunx ssh profile list` に warning なし (AC-9.2)
+      - `srunx ssh sync` に warning なし (AC-9.3)
+
+### Phase 7 Gate
+- [ ] AC-9.1 / AC-9.2 / AC-9.3 の test が pass
+- [ ] Web / MCP / WebUI の wire 契約が unchanged
+
+---
+
+## Phase 8: 後方互換検証 + ドキュメント微修正
+
+- [ ] T-8.1: V4 DB fixture 作成 (REQ-10, AC-10.3)
+      Files: `tests/fixtures/v4_db/`
+      完了条件: V4 schema + 代表的行 (jobs / workflow_runs / watches 等) を含む SQLite fixture。
+
+- [ ] T-8.2: V4 → V5 auto migration integration test (REQ-10, AC-10.3)
+      Files: `tests/db/test_migrations.py`
+      完了条件: V4 DB fixture を配置 → srunx 起動 → V5 migration 自動適用 → 既存 CLI (`srunx list`) が動作することを assert。
+
+- [ ] T-8.3: 全 AC の verification matrix 最終確認 (REQ-10, AC-10.1)
+      Files: (test suite 全体)
+      完了条件: Phase 1〜7 の全 AC test が最終 green。`uv run pytest` で全 pass。
+
+- [ ] T-8.4: Quality gate 通過 (REQ-10)
+      Files: N/A
+      完了条件: `uv run pytest && uv run mypy . && uv run ruff check .` が全 pass。
+
+- [ ] T-8.5: Runbook docstring の整備 (Phase 1 では md ファイル新規作成しない)
+      Files: 該当する module の docstring (`src/srunx/transport/registry.py` / `src/srunx/cli/transport_options.py` 等)
+      完了条件: manual verification 手順 (実 SSH 環境、V4 DB 自動 migration、deprecation warning 目視) を docstring コメントとして記述。**新規 `.md` は作成しない** (CLAUDE.md の "never create docs" ルール遵守)。
+
+- [ ] T-8.6: 手動検証 (実 SSH 環境、推奨)
+      Files: N/A
+      完了条件: 実 SSH (dgx サーバー等) で以下を目視確認:
+      - `srunx submit --profile dgx python train.py` → 投入成功
+      - `srunx status --profile dgx <id>` → 状態表示
+      - `srunx logs --profile dgx <id>` → ログ取得
+      - V4 DB を `~/.config/srunx/srunx.db` に置いて srunx 起動 → auto-migration
+      - `srunx ssh submit` で deprecation warning 表示確認
+
+- [ ] T-8.7: Reviewer subagent による second opinion (CLAUDE.md Review Gate)
+      Files: N/A
+      完了条件: 全 Phase 終了後、reviewer subagent に回して second opinion を取得、合意形成。
+
+### Phase 8 Gate
+- [ ] AC-10.1 / AC-10.2 / AC-10.3 が全 pass
+- [ ] Quality gate (`pytest` / `mypy` / `ruff`) 通過
+- [ ] Reviewer second opinion 完了
+
+---
+
+## Verification Checklist
+
+### Acceptance Criteria (全 AC)
+
+#### REQ-1
+- [ ] AC-1.1: `srunx submit echo hi` (フラグなし) が従来 CLI 互換 (T-5a.10)
+- [ ] AC-1.2: `srunx submit --profile foo --local` が起動時エラー (T-5a.11, T-4.7)
+- [ ] AC-1.3: `SRUNX_SSH_PROFILE=foo srunx list` が SSH 経由 (T-5a.12)
+- [ ] AC-1.4: `--local` が env を上書き (T-5a.12, T-4.7)
+
+#### REQ-2 / REQ-3
+- [ ] AC-2.1: `Slurm` / `SlurmSSHAdapter` が `JobOperationsProtocol` を満たす (T-2.3, T-2.10)
+- [ ] AC-2.2: poller テストで両実装が `SlurmClientProtocol` として注入可能 (T-6.16)
+- [ ] AC-3.1: `tail_log_incremental` が純粋関数 (T-2.2, T-2.8)
+- [ ] AC-3.2: follow loop が CLI レイヤにある (T-5a.6)
+
+#### REQ-4
+- [ ] AC-4.1: `SlurmSSHAdapter.submit(Job)` が `RunnableJobType` 返却 (T-2.4)
+- [ ] AC-4.2: `status(未知)` が `JobNotFound` (T-2.6)
+- [ ] AC-4.3: `queue(user="alice")` が `list[BaseJob]` (T-2.7)
+- [ ] AC-4.4: `tail_log_incremental` が `LogChunk` (T-2.8)
+- [ ] AC-4.5: paramiko 例外が transport 例外にラップ (T-2.9)
+
+#### REQ-5
+- [ ] AC-5.1: V5 後の jobs table_info に新列 (T-3.17)
+- [ ] AC-5.2: `scheduler_key IS NULL` = 0 (T-3.17)
+- [ ] AC-5.3: legacy 2 セグメント残存なし (T-3.17)
+- [ ] AC-5.4: 同一 job_id を複数 scheduler_key で保持可能 (T-3.17)
+- [ ] AC-5.5: FK 先が `jobs.id` (T-3.17)
+- [ ] AC-5.6: `submission_source` diff なし (T-3.17)
+
+#### REQ-6
+- [ ] AC-6.1: `srunx cancel --profile foo` が SSH 経由 (T-5a.16)
+- [ ] AC-6.2: `srunx status --profile foo` が SSH 経由 (T-5a.16)
+- [ ] AC-6.3: `srunx flow run --profile foo` が SSH 経由 (T-5b.7)
+- [ ] AC-6.4: `--script --profile foo` が ShellJob/SSH (T-5a.15)
+- [ ] AC-6.5: `--script` + command list が起動時エラー (T-5a.15)
+
+#### REQ-7
+- [ ] AC-7.1: `--format json --quiet` が純粋 JSON (T-5a.13)
+- [ ] AC-7.2: `--format json` (quiet なし) の stdout が純粋 JSON、stderr に banner (T-5a.13)
+- [ ] AC-7.3: `--profile foo` の stderr に banner 1 行 (T-5a.14)
+
+#### REQ-8
+- [ ] AC-8.1: 複数 scheduler_key group-by (T-6.14)
+- [ ] AC-8.2: `_parse_target_ref("job:local:12345")` (T-6.13)
+- [ ] AC-8.3: `_parse_target_ref("job:ssh:dgx:12345")` (T-6.13)
+- [ ] AC-8.4: `_parse_target_ref("job:12345")` が None (T-6.13)
+- [ ] AC-8.5: 未知 profile で registry が None 返却、poller skip (T-4.8, T-6.15)
+
+#### REQ-9
+- [ ] AC-9.1: `ssh submit` に warning + exit 0 (T-7.7)
+- [ ] AC-9.2: `ssh profile list` に warning なし (T-7.7)
+- [ ] AC-9.3: `ssh sync` に warning なし (T-7.7)
+
+#### REQ-10
+- [ ] AC-10.1: CLI behavioral + repository テスト全 pass (T-8.3)
+- [ ] AC-10.2: default path の golden 一致 (T-5a.10)
+- [ ] AC-10.3: V4 → V5 auto migration → CLI 動作 (T-8.2, T-8.6)
+
+### Quality Gates
+- [ ] `uv run pytest` 全通過
+- [ ] `uv run mypy .` 全通過
+- [ ] `uv run ruff check .` 全通過
+- [ ] Reviewer subagent second opinion 完了 (T-8.7)
+
+### Out of Scope 確認
+- [ ] REQ-N1 (`SRUNX_DEBUG_TRANSPORT=1` トレース) は実装していない (Phase 2+)
+- [ ] REQ-N2 (`srunx config show` に transport 候補表示) は実装していない (Phase 2+)
+- [ ] active profile config fallback は実装していない (Phase 2+)
+- [ ] profile-per-poller は実装していない (Phase 2+)
+- [ ] `srunx ssh submit` の即時削除はしていない (deprecation のみ)
+- [ ] WebUI / MCP の wire 契約変更なし
+- [ ] `submission_source` に transport 軸を混ぜていない

--- a/src/srunx/callbacks.py
+++ b/src/srunx/callbacks.py
@@ -331,6 +331,12 @@ class NotificationWatchCallback(Callback):
     Failures are swallowed with a warning: a missing/disabled endpoint
     must never break the submit (matches ``attach_notification_watch``'s
     own best-effort contract).
+
+    ``scheduler_key`` (default ``"local"``) controls which transport
+    axis the watch is created under. Callers driving SSH-backed
+    transports must pass ``f"ssh:{profile_name}"`` so the poller can
+    resolve the watch via the matching :class:`SlurmClientProtocol`
+    implementation.
     """
 
     def __init__(
@@ -338,10 +344,13 @@ class NotificationWatchCallback(Callback):
         endpoint_name: str,
         preset: str = "terminal",
         endpoint_kind: str = "slack_webhook",
+        *,
+        scheduler_key: str = "local",
     ) -> None:
         self.endpoint_name = endpoint_name
         self.preset = preset
         self.endpoint_kind = endpoint_kind
+        self.scheduler_key = scheduler_key
 
     def on_job_submitted(self, job: JobType) -> None:
         if job.job_id is None:
@@ -354,6 +363,7 @@ class NotificationWatchCallback(Callback):
                 endpoint_name=self.endpoint_name,
                 preset=self.preset,
                 endpoint_kind=self.endpoint_kind,
+                scheduler_key=self.scheduler_key,
             )
         except Exception as exc:
             _logger.warning(

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -697,7 +697,7 @@ def submit(
                         console.print(
                             f"❌ Job failed with status: {final_job.status.name}"
                         )
-                        sys.exit(1)
+                        raise typer.Exit(code=1)
                 except KeyboardInterrupt:
                     console.print("\n⚠️  Monitoring interrupted by user")
                     console.print(
@@ -749,8 +749,10 @@ def status(
         typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from None
     except Exception as e:
-        logger.error(f"Error retrieving job {job_id}: {e}")
-        sys.exit(1)
+        typer.secho(
+            f"Error retrieving job {job_id}: {e}", err=True, fg=typer.colors.RED
+        )
+        raise typer.Exit(code=1) from e
 
 
 @app.command("list")
@@ -861,8 +863,8 @@ def list_jobs(
         typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from None
     except Exception as e:
-        logger.error(f"Error retrieving job queue: {e}")
-        sys.exit(1)
+        typer.secho(f"Error retrieving job queue: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from e
 
 
 @app.command("cancel")
@@ -898,8 +900,10 @@ def cancel(
         typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from None
     except Exception as e:
-        logger.error(f"Error cancelling job {job_id}: {e}")
-        sys.exit(1)
+        typer.secho(
+            f"Error cancelling job {job_id}: {e}", err=True, fg=typer.colors.RED
+        )
+        raise typer.Exit(code=1) from e
 
 
 @app.command("resources")
@@ -1049,8 +1053,12 @@ def logs(
         typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from None
     except Exception as e:
-        logger.error(f"Error retrieving logs for job {job_id}: {e}")
-        sys.exit(1)
+        typer.secho(
+            f"Error retrieving logs for job {job_id}: {e}",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=1) from e
 
 
 @flow_app.command("run")
@@ -1549,7 +1557,7 @@ def template_apply(
                             console.print(
                                 f"❌ Job failed with status: {final_job.status.name}"
                             )
-                            sys.exit(1)
+                            raise typer.Exit(code=1)
                     except KeyboardInterrupt:
                         console.print("\n⚠️  Monitoring interrupted by user")
                         console.print(
@@ -1557,14 +1565,14 @@ def template_apply(
                         )
 
     except ValueError as e:
-        logger.error(str(e))
-        sys.exit(1)
+        typer.secho(str(e), err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from e
     except TransportError as exc:
         typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from None
     except Exception as e:
-        logger.error(f"Error applying template: {e}")
-        sys.exit(1)
+        typer.secho(f"Error applying template: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from e
 
 
 @app.command("history")

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -653,9 +653,10 @@ def submit(
 
         if wait:
             if client is None:
-                # Protocol has no blocking monitor yet; SSH wait is out of
-                # scope for Phase 5a and will land with the SSH monitor
-                # wiring in Phase 5b.
+                # JobOperationsProtocol does not define a blocking
+                # monitor method, so --wait on SSH transports is a
+                # no-op until the Protocol grows one (tracked by the
+                # SSH monitor wiring follow-up).
                 console.print(
                     "⚠️  --wait is not yet supported for SSH transports; "
                     "submitted job continues to run."

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -825,7 +825,16 @@ def list_jobs(
             console.print("No jobs in queue")
             return
 
-        # Table format output
+        # Table format output.
+        #
+        # Columns read from ``BaseJob`` top-level fields populated by
+        # both the local and SSH ``queue()`` implementations (squeue
+        # ``%.6D`` / ``%.10M`` / ``%.9l``). Pre-Phase-2 code reached for
+        # ``job.resources.nodes`` etc. but ``BaseJob`` has no
+        # ``resources`` attribute, so every row came back as ``N/A`` —
+        # regardless of transport. Two distinct time columns are shown
+        # because users care about both "how long has this been running"
+        # (Elapsed) and "when will SLURM kill it" (Limit).
         table = Table(title="Job Queue")
         table.add_column("Job ID", style="cyan")
         table.add_column("Name", style="magenta")
@@ -833,27 +842,22 @@ def list_jobs(
         table.add_column("Nodes", justify="right")
         if show_gpus:
             table.add_column("GPUs", justify="right", style="yellow")
-        table.add_column("Time", justify="right")
+        table.add_column("Elapsed", justify="right")
+        table.add_column("Limit", justify="right")
 
         for job in jobs:
             row = [
                 str(job.job_id) if job.job_id else "N/A",
                 job.name,
                 job.status.name if hasattr(job, "status") else "UNKNOWN",
-                str(getattr(getattr(job, "resources", None), "nodes", "N/A") or "N/A"),
+                str(getattr(job, "nodes", None) or "N/A"),
             ]
 
             if show_gpus:
-                resources = getattr(job, "resources", None)
-                if resources:
-                    total_gpus = resources.nodes * resources.gpus_per_node
-                    row.append(str(total_gpus))
-                else:
-                    row.append("0")
+                row.append(str(getattr(job, "gpus", 0) or 0))
 
-            row.append(
-                getattr(getattr(job, "resources", None), "time_limit", None) or "N/A"
-            )
+            row.append(getattr(job, "elapsed_time", None) or "N/A")
+            row.append(getattr(job, "time_limit", None) or "N/A")
             table.add_row(*row)
 
         console = Console()

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -14,7 +14,7 @@ from rich.table import Table
 
 from srunx.callbacks import Callback, NotificationWatchCallback, SlackCallback
 from srunx.cli.monitor import monitor_app
-from srunx.cli.transport_options import LocalOpt, ProfileOpt, QuietOpt, ScriptOpt
+from srunx.cli.transport_options import LocalOpt, ProfileOpt, QuietOpt
 from srunx.client import Slurm
 from srunx.config import (
     create_example_config,
@@ -39,9 +39,24 @@ from srunx.models import (
 from srunx.runner import WorkflowRunner
 from srunx.ssh.cli.commands import ssh_app
 from srunx.template import get_template_info, get_template_path, list_templates
-from srunx.transport import resolve_transport
+from srunx.transport import peek_scheduler_key, resolve_transport
 
 logger = get_logger(__name__)
+
+
+# Module-local option alias: ``--script`` is only used by the ``submit``
+# subcommand so it does not belong in ``transport_options.py`` (which
+# holds the cross-command transport flags).
+ScriptOpt = Annotated[
+    Path | None,
+    typer.Option(
+        "--script",
+        help=(
+            "Submit a pre-authored sbatch script file instead of a command. "
+            "Mutually exclusive with the positional COMMAND argument."
+        ),
+    ),
+]
 
 
 class DebugCallback(Callback):
@@ -616,13 +631,25 @@ def submit(
     # callbacks + template_path + verbose) which the Protocol does not
     # yet expose; SSH path uses the Protocol method, and the adapter
     # owns its own DB recording + callbacks lifecycle.
-    with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+    with resolve_transport(
+        profile=profile,
+        local=local,
+        quiet=quiet,
+        callbacks=callbacks,
+        submission_source="cli",
+    ) as rt:
         client: Slurm | None
         if rt.transport_type == "local":
             client = Slurm(callbacks=callbacks)
             submitted_job = client.submit(job, template_path=template, verbose=verbose)
         else:
-            submitted_job = rt.job_ops.submit(job)
+            # SSH path: callbacks + submission_source were threaded into
+            # ``resolve_transport`` so the adapter + pool fire callbacks
+            # and tag the jobs row correctly. The submission render
+            # context handles ``--work-dir`` / path translation.
+            submitted_job = rt.job_ops.submit(
+                job, submission_context=rt.submission_context
+            )
             client = None
 
         # Attach a durable notification watch if the user asked for one.
@@ -981,10 +1008,29 @@ def logs(
                 # Phase 5b+ concern (loop belongs in the CLI layer, but
                 # the SSH adapter does not yet stream logs).
                 chunk = rt.job_ops.tail_log_incremental(job_id, 0, 0)
-                if chunk.stdout:
-                    sys.stdout.write(chunk.stdout)
-                if chunk.stderr and chunk.stderr != chunk.stdout:
-                    sys.stderr.write(chunk.stderr)
+                # ``--last N`` is applied client-side on the SSH path:
+                # the adapter returns the full log content and we slice
+                # here so the flag isn't silently dropped (SF6). The
+                # local path above already honours ``last_n`` via
+                # ``Slurm.tail_log``.
+                stdout_text = chunk.stdout or ""
+                stderr_text = chunk.stderr or ""
+                if last is not None:
+                    if stdout_text:
+                        stdout_text = "\n".join(stdout_text.splitlines()[-last:])
+                        # Preserve the trailing newline if the original
+                        # chunk ended with one so terminal output stays
+                        # unambiguous.
+                        if chunk.stdout and chunk.stdout.endswith("\n"):
+                            stdout_text += "\n"
+                    if stderr_text and stderr_text != chunk.stdout:
+                        stderr_text = "\n".join(stderr_text.splitlines()[-last:])
+                        if chunk.stderr and chunk.stderr.endswith("\n"):
+                            stderr_text += "\n"
+                if stdout_text:
+                    sys.stdout.write(stdout_text)
+                if stderr_text and stderr_text != (chunk.stdout or ""):
+                    sys.stderr.write(stderr_text)
                 if follow:
                     typer.secho(
                         "--follow is not yet supported for SSH transports.",
@@ -1431,11 +1477,16 @@ def template_apply(
         # lookup failures don't silently drop the user's opt-in.
         callbacks: list[Callback] = []
         effective_preset = preset or get_config().notifications.default_preset
+        # Bind the notification watch to the exact scheduler_key the
+        # transport will resolve to so SSH submissions don't silently
+        # register their watch under the wrong axis (Bug 5).
+        resolved_scheduler_key = peek_scheduler_key(profile=profile, local=local)
         if endpoint:
             callbacks.append(
                 NotificationWatchCallback(
                     endpoint_name=endpoint,
                     preset=effective_preset,
+                    scheduler_key=resolved_scheduler_key,
                 )
             )
         if slack:
@@ -1449,13 +1500,25 @@ def template_apply(
             callbacks.append(SlackCallback(webhook_url=webhook_url))
 
         # Submit job with the specified template.
-        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+        with resolve_transport(
+            profile=profile,
+            local=local,
+            quiet=quiet,
+            callbacks=callbacks,
+            submission_source="cli",
+        ) as rt:
             client: Slurm | None
             if rt.transport_type == "local":
                 client = Slurm(callbacks=callbacks)
                 submitted_job = client.submit(job, template_path=template_path)
             else:
-                submitted_job = rt.job_ops.submit(job)
+                # SSH path: callbacks + submission_source were threaded
+                # into ``resolve_transport`` so the adapter fires callbacks
+                # and tags the jobs row with ``'cli'``. The submission
+                # render context translates ``--work-dir`` / mount paths.
+                submitted_job = rt.job_ops.submit(
+                    job, submission_context=rt.submission_context
+                )
                 client = None
 
             console = Console()

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -14,12 +14,14 @@ from rich.table import Table
 
 from srunx.callbacks import Callback, NotificationWatchCallback, SlackCallback
 from srunx.cli.monitor import monitor_app
+from srunx.cli.transport_options import LocalOpt, ProfileOpt, QuietOpt, ScriptOpt
 from srunx.client import Slurm
 from srunx.config import (
     create_example_config,
     get_config,
     get_config_paths,
 )
+from srunx.exceptions import JobNotFound, TransportError
 from srunx.logging import (
     configure_cli_logging,
     get_logger,
@@ -37,6 +39,7 @@ from srunx.models import (
 from srunx.runner import WorkflowRunner
 from srunx.ssh.cli.commands import ssh_app
 from srunx.template import get_template_info, get_template_path, list_templates
+from srunx.transport import resolve_transport
 
 logger = get_logger(__name__)
 
@@ -53,9 +56,15 @@ class DebugCallback(Callback):
             # Render the script to get the content
             with tempfile.TemporaryDirectory() as temp_dir:
                 if isinstance(job, Job):
-                    # Get the default template path
-                    client = Slurm()
-                    template_path = client.default_template
+                    # Debug render: we just need the default template path.
+                    # Use ``get_template_path("base")`` instead of constructing a
+                    # full ``Slurm()`` instance — this callback fires from
+                    # inside the submit pipeline, and ``resolve_transport()``
+                    # has already done its job by the time we land here.
+                    # Spinning a second Slurm would risk a nested transport
+                    # resolution and also bypass the test fixture patch of
+                    # ``srunx.cli.main.Slurm``.
+                    template_path = get_template_path("base")
                     script_path = render_job_script(
                         template_path, job, temp_dir, verbose=False
                     )
@@ -328,8 +337,17 @@ def _parse_container_args(container_arg: str | None) -> ContainerResource | None
 @app.command("submit")
 def submit(
     command: Annotated[
-        list[str], typer.Argument(help="Command to execute in the SLURM job")
-    ],
+        list[str] | None,
+        typer.Argument(
+            help=(
+                "Command to execute in the SLURM job. Mutually exclusive with --script."
+            ),
+        ),
+    ] = None,
+    script: ScriptOpt = None,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
     name: Annotated[str, typer.Option("--name", "--job-name", help="Job name")] = "job",
     log_dir: Annotated[
         str | None, typer.Option("--log-dir", help="Log directory")
@@ -439,6 +457,25 @@ def submit(
     ] = False,
 ) -> None:
     """Submit a SLURM job."""
+    # --script and positional command are mutually exclusive (AC-6.5).
+    # Enforce the mutex here so resolve_transport does not run for
+    # pathologically-constructed invocations.
+    if script is not None and command:
+        raise typer.BadParameter(
+            "--script and command arguments are mutually exclusive.",
+            param_hint="--script / COMMAND",
+        )
+    if script is None and not command:
+        # Match the historical Typer message so existing CLI tests that
+        # grep stderr for "Missing argument" keep passing. The
+        # ``command`` argument used to be strictly required; we relaxed
+        # it to allow ``--script`` but want the UX for the unconfigured
+        # case to feel identical.
+        raise typer.BadParameter(
+            "Missing argument 'COMMAND'. Provide a command or use --script <path>.",
+            param_hint="--script / COMMAND",
+        )
+
     config = get_config()
 
     # Use defaults from config if not specified
@@ -503,18 +540,30 @@ def submit(
 
     environment = JobEnvironment.model_validate(env_config)
 
-    job_data = {
-        "name": name,
-        "command": command,
-        "resources": resources,
-        "environment": environment,
-        "log_dir": log_dir,
-    }
-
-    if work_dir is not None:
-        job_data["work_dir"] = work_dir
-
-    job = Job.model_validate(job_data)
+    job: Job | ShellJob
+    if script is not None:
+        # ShellJob's schema is intentionally thin: it only records the
+        # script path + script_vars. Resource / environment configuration
+        # travels with the script itself rather than the model, so we do
+        # not forward ``resources`` / ``environment`` / ``log_dir`` /
+        # ``work_dir`` here. Those CLI flags are accepted for UX symmetry
+        # with command-mode submits but are no-ops under ``--script``.
+        shell_data: dict[str, Any] = {
+            "name": name,
+            "script_path": str(script),
+        }
+        job = ShellJob.model_validate(shell_data)
+    else:
+        job_data: dict[str, Any] = {
+            "name": name,
+            "command": command,
+            "resources": resources,
+            "environment": environment,
+            "log_dir": log_dir,
+        }
+        if work_dir is not None:
+            job_data["work_dir"] = work_dir
+        job = Job.model_validate(job_data)
 
     # Resolve the endpoint for the new watch+subscription pipeline.
     #
@@ -525,6 +574,7 @@ def submit(
     effective_endpoint: str | None = endpoint
     effective_preset: str = preset or config.notifications.default_preset
 
+    callbacks: list[Callback]
     if slack:
         # Legacy in-process callback path — kept as a fallback even when
         # --endpoint is also set so users who ask for notifications
@@ -554,77 +604,122 @@ def submit(
                 else " ".join(job.command or [])
             )
             console.print(f"  Command: {command_str}")
+            console.print(f"  Nodes: {job.resources.nodes}")
+            console.print(f"  GPUs: {job.resources.gpus_per_node}")
         elif isinstance(job, ShellJob):
             console.print(f"  Script: {job.script_path}")
-        console.print(f"  Nodes: {job.resources.nodes}")
-        console.print(f"  GPUs: {job.resources.gpus_per_node}")
         return
 
-    # Submit job
-    client = Slurm(callbacks=callbacks)
-    submitted_job = client.submit(job, template_path=template, verbose=verbose)
+    # Submit job through the resolved transport.
+    #
+    # Local path keeps the richer ``Slurm.submit`` signature (accepts
+    # callbacks + template_path + verbose) which the Protocol does not
+    # yet expose; SSH path uses the Protocol method, and the adapter
+    # owns its own DB recording + callbacks lifecycle.
+    with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+        client: Slurm | None
+        if rt.transport_type == "local":
+            client = Slurm(callbacks=callbacks)
+            submitted_job = client.submit(job, template_path=template, verbose=verbose)
+        else:
+            submitted_job = rt.job_ops.submit(job)
+            client = None
 
-    # Attach a durable notification watch if the user asked for one.
-    if effective_endpoint and submitted_job.job_id is not None:
-        from srunx.cli.notification_setup import attach_notification_watch
+        # Attach a durable notification watch if the user asked for one.
+        if effective_endpoint and submitted_job.job_id is not None:
+            from srunx.cli.notification_setup import attach_notification_watch
 
-        attach_notification_watch(
-            job_id=int(submitted_job.job_id),
-            endpoint_name=effective_endpoint,
-            preset=effective_preset,
-        )
-
-    console = Console()
-    console.print(
-        f"✅ Job submitted successfully: [bold green]{submitted_job.job_id}[/bold green]"
-    )
-    console.print(f"   Job name: {submitted_job.name}")
-    if isinstance(submitted_job, Job) and submitted_job.command:
-        command_str = (
-            submitted_job.command
-            if isinstance(submitted_job.command, str)
-            else " ".join(submitted_job.command)
-        )
-        console.print(f"   Command: {command_str}")
-    elif isinstance(submitted_job, ShellJob):
-        console.print(f"   Script: {submitted_job.script_path}")
-
-    if wait:
-        try:
-            final_job = client.monitor(submitted_job)
-            if final_job.status.name == "COMPLETED":
-                console.print("✅ Job completed successfully")
-            else:
-                console.print(f"❌ Job failed with status: {final_job.status.name}")
-                sys.exit(1)
-        except KeyboardInterrupt:
-            console.print("\n⚠️  Monitoring interrupted by user")
-            console.print(
-                f"Job {submitted_job.job_id} is still running in the background"
+            attach_notification_watch(
+                job_id=int(submitted_job.job_id),
+                endpoint_name=effective_endpoint,
+                preset=effective_preset,
+                scheduler_key=rt.scheduler_key,
             )
+
+        console = Console()
+        console.print(
+            f"✅ Job submitted successfully: [bold green]{submitted_job.job_id}[/bold green]"
+        )
+        console.print(f"   Job name: {submitted_job.name}")
+        if isinstance(submitted_job, Job) and submitted_job.command:
+            command_str = (
+                submitted_job.command
+                if isinstance(submitted_job.command, str)
+                else " ".join(submitted_job.command)
+            )
+            console.print(f"   Command: {command_str}")
+        elif isinstance(submitted_job, ShellJob):
+            console.print(f"   Script: {submitted_job.script_path}")
+
+        if wait:
+            if client is None:
+                # Protocol has no blocking monitor yet; SSH wait is out of
+                # scope for Phase 5a and will land with the SSH monitor
+                # wiring in Phase 5b.
+                console.print(
+                    "⚠️  --wait is not yet supported for SSH transports; "
+                    "submitted job continues to run."
+                )
+            else:
+                try:
+                    final_job = client.monitor(submitted_job)
+                    if final_job.status.name == "COMPLETED":
+                        console.print("✅ Job completed successfully")
+                    else:
+                        console.print(
+                            f"❌ Job failed with status: {final_job.status.name}"
+                        )
+                        sys.exit(1)
+                except KeyboardInterrupt:
+                    console.print("\n⚠️  Monitoring interrupted by user")
+                    console.print(
+                        f"Job {submitted_job.job_id} is still running in the background"
+                    )
 
 
 @app.command("status")
 def status(
     job_id: Annotated[int, typer.Argument(help="Job ID to check")],
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Check job status."""
     try:
-        client = Slurm()
-        job = client.retrieve(job_id)
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            # Local ``Slurm.retrieve`` is preserved for the existing
+            # ``mock_slurm.retrieve.assert_called_once_with(...)`` tests.
+            # Remote transports go through the Protocol's ``status``.
+            if rt.transport_type == "local":
+                client = Slurm()
+                job = client.retrieve(job_id)
+            else:
+                job = rt.job_ops.status(job_id)
 
-        console = Console()
-        console.print(f"Job ID: [bold]{job.job_id}[/bold]")
-        console.print(f"Status: {job.status.name}")
-        console.print(f"Name: {job.name}")
-        if isinstance(job, Job) and job.command:
-            command_str = (
-                job.command if isinstance(job.command, str) else " ".join(job.command)
-            )
-            console.print(f"Command: {command_str}")
-        elif isinstance(job, ShellJob):
-            console.print(f"Script: {job.script_path}")
+            console = Console()
+            console.print(f"Job ID: [bold]{job.job_id}[/bold]")
+            console.print(f"Status: {job.status.name}")
+            console.print(f"Name: {job.name}")
+            if isinstance(job, Job) and job.command:
+                command_str = (
+                    job.command
+                    if isinstance(job.command, str)
+                    else " ".join(job.command)
+                )
+                console.print(f"Command: {command_str}")
+            elif isinstance(job, ShellJob):
+                console.print(f"Script: {job.script_path}")
 
+    except JobNotFound:
+        typer.secho(
+            f"Job {job_id} not found",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=1) from None
+    except TransportError as exc:
+        typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
     except Exception as e:
         logger.error(f"Error retrieving job {job_id}: {e}")
         sys.exit(1)
@@ -640,6 +735,9 @@ def list_jobs(
         str,
         typer.Option("--format", "-f", help="Output format: table or json"),
     ] = "table",
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """List user's jobs in the queue.
 
@@ -652,15 +750,17 @@ def list_jobs(
     import json
 
     try:
-        client = Slurm()
-        jobs = client.queue()
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            # Local keeps the ``Slurm.queue()`` direct call to preserve
+            # existing test fixtures that patch ``srunx.cli.main.Slurm``.
+            if rt.transport_type == "local":
+                client = Slurm()
+                jobs = client.queue()
+            else:
+                jobs = rt.job_ops.queue()
 
-        if not jobs:
-            console = Console()
-            console.print("No jobs in queue")
-            return
-
-        # JSON format output
+        # JSON format output (emit before the "empty queue" banner so
+        # --format json stdout stays pure JSON — AC-7.1 / AC-7.2).
         if format == "json":
             job_data = []
             for job in jobs:
@@ -684,6 +784,15 @@ def list_jobs(
 
             console = Console()
             console.print(json.dumps(job_data, indent=2))
+            return
+
+        # Empty-queue sentinel only for human-facing table format.
+        # Moved past the json branch to fix the pre-existing bug where
+        # ``srunx list --format json`` on an empty queue emitted the
+        # human-readable line instead of ``[]`` (AC-7.1 prerequisite).
+        if not jobs:
+            console = Console()
+            console.print("No jobs in queue")
             return
 
         # Table format output
@@ -720,6 +829,9 @@ def list_jobs(
         console = Console()
         console.print(table)
 
+    except TransportError as exc:
+        typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
     except Exception as e:
         logger.error(f"Error retrieving job queue: {e}")
         sys.exit(1)
@@ -728,15 +840,35 @@ def list_jobs(
 @app.command("cancel")
 def cancel(
     job_id: Annotated[int, typer.Argument(help="Job ID to cancel")],
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Cancel a running job."""
     try:
-        client = Slurm()
-        client.cancel(job_id)
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            # Local keeps the direct ``Slurm`` call so existing tests that
+            # patch ``srunx.cli.main.Slurm`` keep working; SSH goes
+            # through the Protocol.
+            if rt.transport_type == "local":
+                client = Slurm()
+                client.cancel(job_id)
+            else:
+                rt.job_ops.cancel(job_id)
 
         console = Console()
         console.print(f"✅ Job {job_id} cancelled successfully")
 
+    except JobNotFound:
+        typer.secho(
+            f"Job {job_id} not found",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=1) from None
+    except TransportError as exc:
+        typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
     except Exception as e:
         logger.error(f"Error cancelling job {job_id}: {e}")
         sys.exit(1)
@@ -824,17 +956,51 @@ def logs(
         str | None,
         typer.Option("--name", help="Job name for better log file detection"),
     ] = None,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Display job logs with optional real-time streaming."""
     try:
-        client = Slurm()
-        client.tail_log(
-            job_id=job_id,
-            job_name=job_name,
-            follow=follow,
-            last_n=last,
-        )
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            if rt.transport_type == "local":
+                # Local keeps the interactive ``Slurm.tail_log`` path for
+                # follow + last_n + file-discovery behaviour the Protocol
+                # does not yet expose.
+                client = Slurm()
+                client.tail_log(
+                    job_id=job_id,
+                    job_name=job_name,
+                    follow=follow,
+                    last_n=last,
+                )
+            else:
+                # SSH path: use the pure Protocol tail_log_incremental
+                # once for non-follow retrieval. --follow over SSH is a
+                # Phase 5b+ concern (loop belongs in the CLI layer, but
+                # the SSH adapter does not yet stream logs).
+                chunk = rt.job_ops.tail_log_incremental(job_id, 0, 0)
+                if chunk.stdout:
+                    sys.stdout.write(chunk.stdout)
+                if chunk.stderr and chunk.stderr != chunk.stdout:
+                    sys.stderr.write(chunk.stderr)
+                if follow:
+                    typer.secho(
+                        "--follow is not yet supported for SSH transports.",
+                        err=True,
+                        fg=typer.colors.YELLOW,
+                    )
 
+    except JobNotFound:
+        typer.secho(
+            f"Job {job_id} not found",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=1) from None
+    except TransportError as exc:
+        typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
     except Exception as e:
         logger.error(f"Error retrieving logs for job {job_id}: {e}")
         sys.exit(1)
@@ -916,6 +1082,9 @@ def flow_run(
             help="Maximum concurrent sweep cells (overrides YAML sweep.max_parallel)",
         ),
     ] = None,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Execute workflow from YAML file."""
     # Delegate to the shared implementation in srunx.cli.workflow which
@@ -939,6 +1108,9 @@ def flow_run(
         fail_fast=fail_fast,
         max_parallel=max_parallel,
         debug=debug,
+        profile=profile,
+        local=local,
+        quiet=quiet,
     )
 
 
@@ -1185,6 +1357,9 @@ def template_apply(
             ),
         ),
     ] = None,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Apply a template and submit a job."""
     try:
@@ -1272,40 +1447,57 @@ def template_apply(
                 raise ValueError("SLACK_WEBHOOK_URL is not set")
             callbacks.append(SlackCallback(webhook_url=webhook_url))
 
-        # Submit job with the specified template
-        client = Slurm(callbacks=callbacks)
-        submitted_job = client.submit(job, template_path=template_path)
+        # Submit job with the specified template.
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            client: Slurm | None
+            if rt.transport_type == "local":
+                client = Slurm(callbacks=callbacks)
+                submitted_job = client.submit(job, template_path=template_path)
+            else:
+                submitted_job = rt.job_ops.submit(job)
+                client = None
 
-        console = Console()
-        console.print(
-            f"✅ Job submitted successfully with template '[cyan]{name}[/cyan]': [bold green]{submitted_job.job_id}[/bold green]"
-        )
-        console.print(f"   Job name: {submitted_job.name}")
-        if isinstance(submitted_job, Job) and submitted_job.command:
-            command_str = (
-                submitted_job.command
-                if isinstance(submitted_job.command, str)
-                else " ".join(submitted_job.command)
+            console = Console()
+            console.print(
+                f"✅ Job submitted successfully with template '[cyan]{name}[/cyan]': [bold green]{submitted_job.job_id}[/bold green]"
             )
-            console.print(f"   Command: {command_str}")
-
-        if wait:
-            try:
-                final_job = client.monitor(submitted_job)
-                if final_job.status.name == "COMPLETED":
-                    console.print("✅ Job completed successfully")
-                else:
-                    console.print(f"❌ Job failed with status: {final_job.status.name}")
-                    sys.exit(1)
-            except KeyboardInterrupt:
-                console.print("\n⚠️  Monitoring interrupted by user")
-                console.print(
-                    f"Job {submitted_job.job_id} is still running in the background"
+            console.print(f"   Job name: {submitted_job.name}")
+            if isinstance(submitted_job, Job) and submitted_job.command:
+                command_str = (
+                    submitted_job.command
+                    if isinstance(submitted_job.command, str)
+                    else " ".join(submitted_job.command)
                 )
+                console.print(f"   Command: {command_str}")
+
+            if wait:
+                if client is None:
+                    console.print(
+                        "⚠️  --wait is not yet supported for SSH transports; "
+                        "submitted job continues to run."
+                    )
+                else:
+                    try:
+                        final_job = client.monitor(submitted_job)
+                        if final_job.status.name == "COMPLETED":
+                            console.print("✅ Job completed successfully")
+                        else:
+                            console.print(
+                                f"❌ Job failed with status: {final_job.status.name}"
+                            )
+                            sys.exit(1)
+                    except KeyboardInterrupt:
+                        console.print("\n⚠️  Monitoring interrupted by user")
+                        console.print(
+                            f"Job {submitted_job.job_id} is still running in the background"
+                        )
 
     except ValueError as e:
         logger.error(str(e))
         sys.exit(1)
+    except TransportError as exc:
+        typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1) from None
     except Exception as e:
         logger.error(f"Error applying template: {e}")
         sys.exit(1)

--- a/src/srunx/cli/monitor.py
+++ b/src/srunx/cli/monitor.py
@@ -196,30 +196,32 @@ def monitor_jobs(
         )
 
         try:
+            jobs_str = ", ".join(f"[bold cyan]{jid}[/bold cyan]" for jid in job_ids)
             if continuous:
                 console.print(
-                    f"🔄 Continuously monitoring jobs {job_ids} "
-                    f"(interval={interval}s, press Ctrl+C to stop)"
+                    f"[yellow]🔄[/yellow] Continuously monitoring {jobs_str} "
+                    f"[dim](interval={interval}s · Ctrl+C to stop)[/dim]"
                 )
                 job_monitor.watch_continuous()
-                console.print("✅ Monitoring stopped")
+                console.print("[green]✅[/green] Monitoring stopped")
             else:
+                timeout_display = f"{timeout}s" if timeout else "no timeout"
                 console.print(
-                    f"🔍 Monitoring jobs {job_ids} "
-                    f"(interval={interval}s, timeout={timeout or 'None'}s)"
+                    f"[yellow]🔍[/yellow] Monitoring {jobs_str} "
+                    f"[dim](interval={interval}s · timeout={timeout_display})[/dim]"
                 )
-                console.print("Press Ctrl+C to stop monitoring")
+                console.print("[dim]Press Ctrl+C to stop monitoring[/dim]")
                 job_monitor.watch_until()
-                console.print("✅ All jobs reached terminal status")
+                console.print("[green]✅[/green] All jobs reached terminal status")
         except TimeoutError as e:
             console.print(f"[red]⏱️  {e}[/red]")
-            sys.exit(1)
+            raise typer.Exit(code=1) from e
         except KeyboardInterrupt:
-            console.print("\n[yellow]Monitoring stopped by user[/yellow]")
-            sys.exit(0)
+            console.print("\n[yellow]⚠[/yellow]  [dim]Monitoring stopped by user[/dim]")
+            raise typer.Exit(code=0) from None
         except Exception as e:
-            console.print(f"[red]Error: {e}[/red]")
-            sys.exit(1)
+            console.print(f"[red]✗ {e}[/red]")
+            raise typer.Exit(code=1) from e
 
 
 @monitor_app.command("resources")

--- a/src/srunx/cli/monitor.py
+++ b/src/srunx/cli/monitor.py
@@ -14,7 +14,12 @@ from srunx.monitor.report_types import ReportConfig
 from srunx.monitor.resource_monitor import ResourceMonitor
 from srunx.monitor.scheduler import ScheduledReporter
 from srunx.monitor.types import MonitorConfig, WatchMode
-from srunx.transport import resolve_transport
+from srunx.transport import (
+    emit_transport_banner,
+    peek_scheduler_key,
+    resolve_transport,
+    resolve_transport_source,
+)
 
 # Create monitor subcommand app
 monitor_app = typer.Typer(
@@ -153,6 +158,7 @@ def monitor_jobs(
                     job_id=int(_jid),
                     endpoint_name=endpoint,
                     preset=effective_preset,
+                    scheduler_key=rt.scheduler_key,
                 )
         if notify:
             console.print(
@@ -186,6 +192,7 @@ def monitor_jobs(
             config=config,
             callbacks=callbacks,
             client=cast(Slurm, rt.job_ops),
+            scheduler_key=rt.scheduler_key,
         )
 
         try:
@@ -269,65 +276,70 @@ def monitor_resources(
         console.print("Usage: srunx monitor resources --min-gpus N")
         sys.exit(1)
 
-    # Call resolve_transport purely for conflict detection + banner
-    # emission. ResourceMonitor still queries local SLURM in Phase 5b;
-    # the SSH-aware refactor belongs to a later phase. ``_`` marks the
-    # resolved handle as intentionally unused for now.
-    with resolve_transport(profile=profile, local=local, quiet=quiet) as _:
-        if profile:
-            console.print(
-                "[yellow]⚠️  ResourceMonitor ignores --profile in this release; "
-                "resource queries still run against the local cluster.[/yellow]"
-            )
+    # SF7: ResourceMonitor is local-only, so skip the full
+    # resolve_transport() path (which would build an SSH handle + open
+    # a pool) and call the pure helpers instead. ``peek_scheduler_key``
+    # still raises on the ``--profile`` + ``--local`` conflict, and
+    # ``emit_transport_banner`` reproduces the same stderr line
+    # ``resolve_transport`` would emit so diffing scripts see no change.
+    scheduler_key = peek_scheduler_key(profile=profile, local=local)
+    source = resolve_transport_source(profile=profile, local=local)
+    emit_transport_banner(label=scheduler_key, source=source, quiet=quiet)
 
-        # Setup callbacks
-        callbacks: list[Callback] = []
-        if notify:
-            try:
-                callbacks.append(SlackCallback(notify))
-            except ValueError as e:
-                console.print(f"[red]Invalid webhook URL: {e}[/red]")
-                sys.exit(1)
-
-        # Create monitor config
-        config = MonitorConfig(
-            poll_interval=interval,
-            timeout=timeout if not continuous else None,
-            mode=WatchMode.CONTINUOUS if continuous else WatchMode.UNTIL_CONDITION,
-            notify_on_change=continuous or bool(notify),
+    if profile:
+        console.print(
+            "[yellow]⚠️  ResourceMonitor ignores --profile in this release; "
+            "resource queries still run against the local cluster.[/yellow]"
         )
 
-        # Create and run resource monitor
-        resource_monitor = ResourceMonitor(
-            min_gpus=min_gpus,
-            partition=partition,
-            config=config,
-            callbacks=callbacks,
-        )
-
+    # Setup callbacks
+    callbacks: list[Callback] = []
+    if notify:
         try:
-            if continuous:
-                console.print(
-                    f"🔄 Continuously monitoring GPU resources "
-                    f"(min={min_gpus}, interval={interval}s)"
-                )
-                resource_monitor.watch_continuous()
-            else:
-                console.print(
-                    f"🎮 Waiting for {min_gpus} GPUs to become available "
-                    f"(partition={partition or 'all'})"
-                )
-                resource_monitor.watch_until()
-                console.print(f"✅ {min_gpus} GPUs now available!")
-        except TimeoutError as e:
-            console.print(f"[red]⏱️  {e}[/red]")
+            callbacks.append(SlackCallback(notify))
+        except ValueError as e:
+            console.print(f"[red]Invalid webhook URL: {e}[/red]")
             sys.exit(1)
-        except KeyboardInterrupt:
-            console.print("\n[yellow]Monitoring stopped by user[/yellow]")
-            sys.exit(0)
-        except Exception as e:
-            console.print(f"[red]Error: {e}[/red]")
-            sys.exit(1)
+
+    # Create monitor config
+    config = MonitorConfig(
+        poll_interval=interval,
+        timeout=timeout if not continuous else None,
+        mode=WatchMode.CONTINUOUS if continuous else WatchMode.UNTIL_CONDITION,
+        notify_on_change=continuous or bool(notify),
+    )
+
+    # Create and run resource monitor
+    resource_monitor = ResourceMonitor(
+        min_gpus=min_gpus,
+        partition=partition,
+        config=config,
+        callbacks=callbacks,
+    )
+
+    try:
+        if continuous:
+            console.print(
+                f"🔄 Continuously monitoring GPU resources "
+                f"(min={min_gpus}, interval={interval}s)"
+            )
+            resource_monitor.watch_continuous()
+        else:
+            console.print(
+                f"🎮 Waiting for {min_gpus} GPUs to become available "
+                f"(partition={partition or 'all'})"
+            )
+            resource_monitor.watch_until()
+            console.print(f"✅ {min_gpus} GPUs now available!")
+    except TimeoutError as e:
+        console.print(f"[red]⏱️  {e}[/red]")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Monitoring stopped by user[/yellow]")
+        sys.exit(0)
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
 
 
 @monitor_app.command("cluster")

--- a/src/srunx/cli/monitor.py
+++ b/src/srunx/cli/monitor.py
@@ -1,18 +1,20 @@
 """Monitor subcommands for jobs, resources, and cluster status."""
 
 import sys
-from typing import Annotated
+from typing import Annotated, cast
 
 import typer
 from rich.console import Console
 
 from srunx.callbacks import Callback, SlackCallback
+from srunx.cli.transport_options import LocalOpt, ProfileOpt, QuietOpt
 from srunx.client import Slurm
 from srunx.monitor.job_monitor import JobMonitor
 from srunx.monitor.report_types import ReportConfig
 from srunx.monitor.resource_monitor import ResourceMonitor
 from srunx.monitor.scheduler import ScheduledReporter
 from srunx.monitor.types import MonitorConfig, WatchMode
+from srunx.transport import resolve_transport
 
 # Create monitor subcommand app
 monitor_app = typer.Typer(
@@ -79,6 +81,9 @@ def monitor_jobs(
             "--continuous", "-c", help="Enable continuous monitoring (until Ctrl+C)"
         ),
     ] = False,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Monitor specific jobs until completion or send periodic reports.
 
@@ -112,93 +117,102 @@ def monitor_jobs(
         console.print("  srunx monitor cluster --schedule 1h --notify $WEBHOOK")
         sys.exit(1)
 
-    # State change monitoring mode (existing functionality)
-    client = Slurm()
+    with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+        # State change monitoring mode (existing functionality). Use the
+        # resolved transport's CLI-facing job ops so --profile picks up
+        # SSH via resolve_transport rather than silently falling back to
+        # a local Slurm singleton.
+        if all_jobs:
+            all_user_jobs = rt.job_ops.queue()
+            job_ids = [job.job_id for job in all_user_jobs if job.job_id is not None]
+            if not job_ids:
+                console.print("[yellow]No jobs found for current user[/yellow]")
+                sys.exit(0)
+            console.print(f"📋 Monitoring {len(job_ids)} jobs for current user")
 
-    # Get job IDs if --all is specified
-    if all_jobs:
-        all_user_jobs = client.queue()
-        job_ids = [job.job_id for job in all_user_jobs if job.job_id is not None]
-        if not job_ids:
-            console.print("[yellow]No jobs found for current user[/yellow]")
-            sys.exit(0)
-        console.print(f"📋 Monitoring {len(job_ids)} jobs for current user")
+        # Setup callbacks.
+        #
+        # Resolution order:
+        #   --endpoint → attach a durable watch per monitored job (poller
+        #                pipeline takes over delivery)
+        #   --notify   → in-process SlackCallback fallback (deprecated; kept
+        #                so endpoint-attach failures don't silently drop
+        #                notifications the user asked for)
+        callbacks: list[Callback] = []
+        if endpoint:
+            from srunx.cli.notification_setup import attach_notification_watch
+            from srunx.config import get_config
 
-    # Setup callbacks.
-    #
-    # Resolution order:
-    #   --endpoint → attach a durable watch per monitored job (poller
-    #                pipeline takes over delivery)
-    #   --notify   → in-process SlackCallback fallback (deprecated; kept
-    #                so endpoint-attach failures don't silently drop
-    #                notifications the user asked for)
-    callbacks: list[Callback] = []
-    if endpoint:
-        from srunx.cli.notification_setup import attach_notification_watch
-        from srunx.config import get_config
-
-        effective_preset = preset or get_config().notifications.default_preset
-        # Attach per-job watches upfront: monitor_jobs does not resubmit
-        # jobs, so the one-shot attach here is the equivalent of the
-        # Callback.on_job_submitted hook used by submit flows.
-        assert job_ids is not None
-        for _jid in job_ids:
-            attach_notification_watch(
-                job_id=int(_jid),
-                endpoint_name=endpoint,
-                preset=effective_preset,
+            effective_preset = preset or get_config().notifications.default_preset
+            # Attach per-job watches upfront: monitor_jobs does not resubmit
+            # jobs, so the one-shot attach here is the equivalent of the
+            # Callback.on_job_submitted hook used by submit flows.
+            assert job_ids is not None
+            for _jid in job_ids:
+                attach_notification_watch(
+                    job_id=int(_jid),
+                    endpoint_name=endpoint,
+                    preset=effective_preset,
+                )
+        if notify:
+            console.print(
+                "[yellow]⚠️  --notify is deprecated; use --endpoint instead.[/yellow]"
             )
-    if notify:
-        console.print(
-            "[yellow]⚠️  --notify is deprecated; use --endpoint instead.[/yellow]"
+            try:
+                callbacks.append(SlackCallback(notify))
+            except ValueError as e:
+                console.print(f"[red]Invalid webhook URL: {e}[/red]")
+                sys.exit(1)
+
+        # Create monitor config
+        config = MonitorConfig(
+            poll_interval=interval,
+            timeout=timeout if not continuous else None,
+            mode=WatchMode.CONTINUOUS if continuous else WatchMode.UNTIL_CONDITION,
+            notify_on_change=continuous or bool(notify) or bool(endpoint),
         )
+
+        # Create and run monitor. Pass the resolved transport's job ops
+        # explicitly so JobMonitor doesn't fall back to ``Slurm()`` when
+        # --profile selects an SSH transport. ``JobMonitor.client`` is
+        # typed ``Slurm | None`` for historical reasons, but both
+        # ``Slurm`` and ``SlurmSSHAdapter`` satisfy the subset of methods
+        # (``retrieve``) the monitor actually uses; the cast keeps mypy
+        # happy without forcing a JobMonitor refactor that belongs to a
+        # later phase.
+        assert job_ids is not None  # Type narrowing
+        job_monitor = JobMonitor(
+            job_ids=job_ids,
+            config=config,
+            callbacks=callbacks,
+            client=cast(Slurm, rt.job_ops),
+        )
+
         try:
-            callbacks.append(SlackCallback(notify))
-        except ValueError as e:
-            console.print(f"[red]Invalid webhook URL: {e}[/red]")
+            if continuous:
+                console.print(
+                    f"🔄 Continuously monitoring jobs {job_ids} "
+                    f"(interval={interval}s, press Ctrl+C to stop)"
+                )
+                job_monitor.watch_continuous()
+                console.print("✅ Monitoring stopped")
+            else:
+                console.print(
+                    f"🔍 Monitoring jobs {job_ids} "
+                    f"(interval={interval}s, timeout={timeout or 'None'}s)"
+                )
+                console.print("Press Ctrl+C to stop monitoring")
+                job_monitor.watch_until()
+                console.print("✅ All jobs reached terminal status")
+        except TimeoutError as e:
+            console.print(f"[red]⏱️  {e}[/red]")
             sys.exit(1)
-
-    # Create monitor config
-    config = MonitorConfig(
-        poll_interval=interval,
-        timeout=timeout if not continuous else None,
-        mode=WatchMode.CONTINUOUS if continuous else WatchMode.UNTIL_CONDITION,
-        notify_on_change=continuous or bool(notify) or bool(endpoint),
-    )
-
-    # Create and run monitor
-    assert job_ids is not None  # Type narrowing
-    job_monitor = JobMonitor(
-        job_ids=job_ids,
-        config=config,
-        callbacks=callbacks,
-    )
-
-    try:
-        if continuous:
-            console.print(
-                f"🔄 Continuously monitoring jobs {job_ids} "
-                f"(interval={interval}s, press Ctrl+C to stop)"
-            )
-            job_monitor.watch_continuous()
-            console.print("✅ Monitoring stopped")
-        else:
-            console.print(
-                f"🔍 Monitoring jobs {job_ids} "
-                f"(interval={interval}s, timeout={timeout or 'None'}s)"
-            )
-            console.print("Press Ctrl+C to stop monitoring")
-            job_monitor.watch_until()
-            console.print("✅ All jobs reached terminal status")
-    except TimeoutError as e:
-        console.print(f"[red]⏱️  {e}[/red]")
-        sys.exit(1)
-    except KeyboardInterrupt:
-        console.print("\n[yellow]Monitoring stopped by user[/yellow]")
-        sys.exit(0)
-    except Exception as e:
-        console.print(f"[red]Error: {e}[/red]")
-        sys.exit(1)
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Monitoring stopped by user[/yellow]")
+            sys.exit(0)
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
+            sys.exit(1)
 
 
 @monitor_app.command("resources")
@@ -227,6 +241,9 @@ def monitor_resources(
         bool,
         typer.Option("--continuous", "-c", help="Monitor continuously until Ctrl+C"),
     ] = False,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Monitor GPU resources until available or continuously.
 
@@ -237,6 +254,13 @@ def monitor_resources(
 
         # Continuous monitoring with notifications
         srunx monitor resources --min-gpus 2 --continuous --notify $WEBHOOK
+
+    Note:
+        --profile / --local / --quiet are accepted for CLI-wide parity
+        but ResourceMonitor currently queries local ``sinfo`` / ``squeue``
+        only; SSH-backed resource polling is a follow-up phase. Passing
+        ``--profile`` will emit the transport banner but not reroute the
+        underlying queries.
     """
     console = Console()
 
@@ -245,54 +269,65 @@ def monitor_resources(
         console.print("Usage: srunx monitor resources --min-gpus N")
         sys.exit(1)
 
-    # Setup callbacks
-    callbacks: list[Callback] = []
-    if notify:
+    # Call resolve_transport purely for conflict detection + banner
+    # emission. ResourceMonitor still queries local SLURM in Phase 5b;
+    # the SSH-aware refactor belongs to a later phase. ``_`` marks the
+    # resolved handle as intentionally unused for now.
+    with resolve_transport(profile=profile, local=local, quiet=quiet) as _:
+        if profile:
+            console.print(
+                "[yellow]⚠️  ResourceMonitor ignores --profile in this release; "
+                "resource queries still run against the local cluster.[/yellow]"
+            )
+
+        # Setup callbacks
+        callbacks: list[Callback] = []
+        if notify:
+            try:
+                callbacks.append(SlackCallback(notify))
+            except ValueError as e:
+                console.print(f"[red]Invalid webhook URL: {e}[/red]")
+                sys.exit(1)
+
+        # Create monitor config
+        config = MonitorConfig(
+            poll_interval=interval,
+            timeout=timeout if not continuous else None,
+            mode=WatchMode.CONTINUOUS if continuous else WatchMode.UNTIL_CONDITION,
+            notify_on_change=continuous or bool(notify),
+        )
+
+        # Create and run resource monitor
+        resource_monitor = ResourceMonitor(
+            min_gpus=min_gpus,
+            partition=partition,
+            config=config,
+            callbacks=callbacks,
+        )
+
         try:
-            callbacks.append(SlackCallback(notify))
-        except ValueError as e:
-            console.print(f"[red]Invalid webhook URL: {e}[/red]")
+            if continuous:
+                console.print(
+                    f"🔄 Continuously monitoring GPU resources "
+                    f"(min={min_gpus}, interval={interval}s)"
+                )
+                resource_monitor.watch_continuous()
+            else:
+                console.print(
+                    f"🎮 Waiting for {min_gpus} GPUs to become available "
+                    f"(partition={partition or 'all'})"
+                )
+                resource_monitor.watch_until()
+                console.print(f"✅ {min_gpus} GPUs now available!")
+        except TimeoutError as e:
+            console.print(f"[red]⏱️  {e}[/red]")
             sys.exit(1)
-
-    # Create monitor config
-    config = MonitorConfig(
-        poll_interval=interval,
-        timeout=timeout if not continuous else None,
-        mode=WatchMode.CONTINUOUS if continuous else WatchMode.UNTIL_CONDITION,
-        notify_on_change=continuous or bool(notify),
-    )
-
-    # Create and run resource monitor
-    resource_monitor = ResourceMonitor(
-        min_gpus=min_gpus,
-        partition=partition,
-        config=config,
-        callbacks=callbacks,
-    )
-
-    try:
-        if continuous:
-            console.print(
-                f"🔄 Continuously monitoring GPU resources "
-                f"(min={min_gpus}, interval={interval}s)"
-            )
-            resource_monitor.watch_continuous()
-        else:
-            console.print(
-                f"🎮 Waiting for {min_gpus} GPUs to become available "
-                f"(partition={partition or 'all'})"
-            )
-            resource_monitor.watch_until()
-            console.print(f"✅ {min_gpus} GPUs now available!")
-    except TimeoutError as e:
-        console.print(f"[red]⏱️  {e}[/red]")
-        sys.exit(1)
-    except KeyboardInterrupt:
-        console.print("\n[yellow]Monitoring stopped by user[/yellow]")
-        sys.exit(0)
-    except Exception as e:
-        console.print(f"[red]Error: {e}[/red]")
-        sys.exit(1)
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Monitoring stopped by user[/yellow]")
+            sys.exit(0)
+        except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
+            sys.exit(1)
 
 
 @monitor_app.command("cluster")
@@ -332,6 +367,9 @@ def monitor_cluster(
         bool,
         typer.Option("--daemon/--no-daemon", help="Run as background daemon"),
     ] = True,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Send periodic cluster status reports to Slack.
 
@@ -365,40 +403,47 @@ def monitor_cluster(
             daemon=daemon,
         )
 
-        # Create client and callback
-        client = Slurm()
-        try:
-            callback = SlackCallback(notify)
-        except ValueError as e:
-            console.print(f"[red]Invalid webhook URL: {e}[/red]")
-            sys.exit(1)
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            # ScheduledReporter only exercises ``client.queue(...)``
+            # (see _get_job_stats / _get_user_stats), which is part of
+            # JobOperationsProtocol. ``rt.job_ops`` is the CLI-facing
+            # handle and is either a local ``Slurm`` or an
+            # ``SlurmSSHAdapter``; the ``cast`` narrows the static type
+            # to match ScheduledReporter's concrete-``Slurm`` signature
+            # without changing that class (its refactor belongs to a
+            # later transport phase).
+            try:
+                callback = SlackCallback(notify)
+            except ValueError as e:
+                console.print(f"[red]Invalid webhook URL: {e}[/red]")
+                sys.exit(1)
 
-        # Create and run reporter
-        reporter = ScheduledReporter(client, callback, config)
+            # Create and run reporter
+            reporter = ScheduledReporter(cast(Slurm, rt.job_ops), callback, config)
 
-        # Display startup info
-        info_table = Table(show_header=False, box=None, padding=(0, 2))
-        info_table.add_column("Key", style="cyan", no_wrap=True)
-        info_table.add_column("Value", style="white")
+            # Display startup info
+            info_table = Table(show_header=False, box=None, padding=(0, 2))
+            info_table.add_column("Key", style="cyan", no_wrap=True)
+            info_table.add_column("Value", style="white")
 
-        info_table.add_row("📅 Schedule", schedule)
-        info_table.add_row("📊 Sections", ", ".join(include_list))
-        if partition:
-            info_table.add_row("🔧 Partition", partition)
-        info_table.add_row("🔔 Webhook", f"{notify[:50]}...")
+            info_table.add_row("📅 Schedule", schedule)
+            info_table.add_row("📊 Sections", ", ".join(include_list))
+            if partition:
+                info_table.add_row("🔧 Partition", partition)
+            info_table.add_row("🔔 Webhook", f"{notify[:50]}...")
 
-        console.print(
-            Panel(
-                info_table,
-                title="[bold green]🚀 Scheduled Cluster Reporter[/bold green]",
-                subtitle="[dim]Press Ctrl+C to stop[/dim]",
-                border_style="green",
+            console.print(
+                Panel(
+                    info_table,
+                    title="[bold green]🚀 Scheduled Cluster Reporter[/bold green]",
+                    subtitle="[dim]Press Ctrl+C to stop[/dim]",
+                    border_style="green",
+                )
             )
-        )
-        console.print()
+            console.print()
 
-        # Run reporter (blocking)
-        reporter.run()
+            # Run reporter (blocking)
+            reporter.run()
 
     except ValueError as e:
         console.print(f"[red]❌ Configuration error: {e}[/red]")

--- a/src/srunx/cli/notification_setup.py
+++ b/src/srunx/cli/notification_setup.py
@@ -44,6 +44,7 @@ def attach_notification_watch(
     endpoint_name: str,
     preset: str = "terminal",
     endpoint_kind: str = DEFAULT_ENDPOINT_KIND,
+    scheduler_key: str = "local",
 ) -> int | None:
     """Attach an endpoint-backed notification watch to a SLURM job.
 
@@ -128,9 +129,15 @@ def attach_notification_watch(
             # ``idempotency_key`` uniqueness, but the DB would still
             # accumulate zombie rows. Reuse an existing open watch +
             # subscription when one already exists.
+            #
+            # V5 grammar: ``target_ref`` is ``job:<scheduler_key>:<id>``
+            # for local, or ``job:ssh:<profile>:<id>`` for SSH. The
+            # ``scheduler_key`` kwarg encodes "local" / "ssh:<profile>"
+            # already, so a single format-string covers both.
+            target_ref = f"job:{scheduler_key}:{job_id}"
             existing = watch_repo.list_by_target(
                 kind="job",
-                target_ref=f"job:{job_id}",
+                target_ref=target_ref,
                 only_open=True,
             )
             for w in existing:
@@ -148,7 +155,7 @@ def attach_notification_watch(
                         )
                         return sub.id
 
-            watch_id = watch_repo.create(kind="job", target_ref=f"job:{job_id}")
+            watch_id = watch_repo.create(kind="job", target_ref=target_ref)
             subscription_id = sub_repo.create(
                 watch_id=watch_id,
                 endpoint_id=endpoint.id,
@@ -156,12 +163,16 @@ def attach_notification_watch(
             )
             # Only insert if no transition exists yet (dual-write may
             # have already seeded one on record_job).
-            if transition_repo.latest_for_job(job_id) is None:
+            if (
+                transition_repo.latest_for_job(job_id, scheduler_key=scheduler_key)
+                is None
+            ):
                 transition_repo.insert(
                     job_id=job_id,
                     from_status=None,
                     to_status="PENDING",
                     source="webhook",
+                    scheduler_key=scheduler_key,
                 )
             return subscription_id
         finally:

--- a/src/srunx/cli/transport_options.py
+++ b/src/srunx/cli/transport_options.py
@@ -47,7 +47,12 @@ QuietOpt = Annotated[
     typer.Option(
         "--quiet",
         "-q",
-        help="Suppress the transport banner on stderr.",
+        help=(
+            "Suppress the transport banner on stderr. Only meaningful "
+            "when an explicit transport source is selected "
+            "(--profile / --local / $SRUNX_SSH_PROFILE); the default "
+            "local path never prints a banner."
+        ),
     ),
 ]
 """``--quiet`` / ``-q``: suppress the transport banner (REQ-7)."""

--- a/src/srunx/cli/transport_options.py
+++ b/src/srunx/cli/transport_options.py
@@ -12,7 +12,6 @@ already reserve ``-p`` for ``--partition`` (P-8).
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -56,15 +55,3 @@ QuietOpt = Annotated[
     ),
 ]
 """``--quiet`` / ``-q``: suppress the transport banner (REQ-7)."""
-
-ScriptOpt = Annotated[
-    Path | None,
-    typer.Option(
-        "--script",
-        help=(
-            "Submit a pre-authored sbatch script file instead of a command. "
-            "Mutually exclusive with the positional COMMAND argument."
-        ),
-    ),
-]
-"""``--script <path>``: submit a ShellJob instead of a command list (REQ-6)."""

--- a/src/srunx/cli/transport_options.py
+++ b/src/srunx/cli/transport_options.py
@@ -1,0 +1,65 @@
+"""Shared transport-related CLI option definitions.
+
+Every CLI subcommand that talks to SLURM (``submit`` / ``cancel`` /
+``status`` / ``list`` / ``logs`` / ``monitor jobs`` / ``flow run``)
+re-uses these Annotated type aliases so help text, flag names, and
+short-flag reservations stay consistent.
+
+See REQ-6 for the enumerated CLI surface. No ``-p`` short flag is
+assigned to ``--profile`` because ``resources`` / ``monitor resources``
+already reserve ``-p`` for ``--partition`` (P-8).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+ProfileOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--profile",
+        help=(
+            "SSH profile name (from 'srunx ssh profile list'). When set, "
+            "commands run over SSH against that profile's cluster. "
+            "Mutually exclusive with --local."
+        ),
+    ),
+]
+"""``--profile <name>``: explicit SSH profile selection (REQ-1)."""
+
+LocalOpt = Annotated[
+    bool,
+    typer.Option(
+        "--local",
+        help=(
+            "Force local SLURM transport (overrides $SRUNX_SSH_PROFILE). "
+            "Mutually exclusive with --profile."
+        ),
+    ),
+]
+"""``--local``: force local transport even when env selects SSH (REQ-1)."""
+
+QuietOpt = Annotated[
+    bool,
+    typer.Option(
+        "--quiet",
+        "-q",
+        help="Suppress the transport banner on stderr.",
+    ),
+]
+"""``--quiet`` / ``-q``: suppress the transport banner (REQ-7)."""
+
+ScriptOpt = Annotated[
+    Path | None,
+    typer.Option(
+        "--script",
+        help=(
+            "Submit a pre-authored sbatch script file instead of a command. "
+            "Mutually exclusive with the positional COMMAND argument."
+        ),
+    ),
+]
+"""``--script <path>``: submit a ShellJob instead of a command list (REQ-6)."""

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -309,7 +309,7 @@ def _resolve_endpoint_id(endpoint: str | None) -> int | None:
     try:
         from srunx.db.connection import open_connection
         from srunx.db.repositories.endpoints import EndpointRepository
-    except Exception:  # pragma: no cover — DB unreachable
+    except ImportError:  # pragma: no cover — DB module unavailable
         return None
     conn = open_connection()
     try:

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -25,7 +25,71 @@ from srunx.sweep.expand import (
     parse_sweep_flags,
 )
 from srunx.sweep.orchestrator import SweepOrchestrator
-from srunx.transport import ResolvedTransport, resolve_transport
+from srunx.transport import (
+    ResolvedTransport,
+    peek_scheduler_key,
+    resolve_transport,
+)
+
+
+def _build_workflow_callbacks(
+    *,
+    endpoint: str | None,
+    effective_preset: str,
+    is_sweep: bool,
+    slack: bool,
+    debug: bool,
+    scheduler_key: str,
+) -> list[Callback]:
+    """Assemble the callback list for a CLI workflow invocation.
+
+    ``NotificationWatchCallback`` is omitted for sweep runs because the
+    orchestrator manages a sweep-level watch + subscription; attaching a
+    per-job callback there would spam one notification per cell. The
+    ``scheduler_key`` is threaded in so the watch the callback creates
+    targets the transport the workflow will actually submit against.
+
+    ``SlackCallback`` is legacy in-process delivery and is still attached
+    in both modes for backward compatibility.
+    """
+    callbacks: list[Callback] = []
+    if endpoint and not is_sweep:
+        callbacks.append(
+            NotificationWatchCallback(
+                endpoint_name=endpoint,
+                preset=effective_preset,
+                scheduler_key=scheduler_key,
+            )
+        )
+    if slack:
+        logger.warning(
+            "`--slack` is deprecated; configure an endpoint via "
+            "Settings → Notifications and pass `--endpoint <name>`."
+        )
+        webhook_url = os.getenv("SLACK_WEBHOOK_URL")
+        if not webhook_url:
+            raise ValueError("SLACK_WEBHOOK_URL environment variable is not set")
+        callbacks.append(SlackCallback(webhook_url=webhook_url))
+
+    if debug:
+        # Imported lazily to avoid pulling main.py's typer surface at
+        # module import time.
+        from srunx.cli.main import DebugCallback
+
+        callbacks.append(DebugCallback())
+
+    return callbacks
+
+
+def _pre_resolve_scheduler_key(profile: str | None, local: bool) -> str:
+    """Return the scheduler_key ``resolve_transport`` would select.
+
+    Thin wrapper around :func:`peek_scheduler_key` kept as a module-
+    local helper so the import has a guaranteed call site (ruff's
+    unused-import stripper otherwise drops the transport import).
+    """
+    return peek_scheduler_key(profile=profile, local=local)
+
 
 logger = get_logger(__name__)
 
@@ -499,49 +563,38 @@ def _execute_workflow(
             max_parallel,
         )
 
+        # Build callbacks BEFORE resolve_transport so the SSH adapter +
+        # pool both see the full callback list at construction time (the
+        # pool copies ``callbacks`` into ``_callbacks`` in ``__init__``,
+        # so a post-hoc mutation wouldn't reach pooled clones). The
+        # scheduler_key the transport will pick is deterministic from
+        # the CLI flags + env, so we can pre-compute it via
+        # :func:`peek_scheduler_key` and bind it to
+        # ``NotificationWatchCallback`` up front.
+        pre_scheduler_key = _pre_resolve_scheduler_key(profile, local)
+        effective_preset = preset or get_config().notifications.default_preset
+        is_sweep = sweep_spec is not None
+        callbacks = _build_workflow_callbacks(
+            endpoint=endpoint,
+            effective_preset=effective_preset,
+            is_sweep=is_sweep,
+            slack=slack,
+            debug=debug,
+            scheduler_key=pre_scheduler_key,
+        )
+
         # Resolve transport once for the whole invocation. The context
         # manager closes any SSH pool on exit. Validation / dry-run /
         # sweep / single-run all branch inside this scope so every path
         # sees the same executor_factory + submission_context.
-        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+        with resolve_transport(
+            profile=profile,
+            local=local,
+            quiet=quiet,
+            callbacks=callbacks,
+            submission_source="cli",
+        ) as rt:
             _warn_missing_mounts(rt)
-
-            # Setup callbacks if requested.
-            # ``NotificationWatchCallback`` attaches a per-job watch on every
-            # submission, which is right for non-sweep workflows but wrong
-            # for sweeps: sweep-level aggregation runs through the sweep_run
-            # watch + subscription created by the orchestrator, so adding
-            # per-job watches would spam one notification per cell job.
-            # ``SlackCallback`` is legacy in-process delivery and is still
-            # attached in both modes for backward compatibility.
-            callbacks: list[Callback] = []
-            effective_preset = preset or get_config().notifications.default_preset
-            is_sweep = sweep_spec is not None
-            if endpoint and not is_sweep:
-                callbacks.append(
-                    NotificationWatchCallback(
-                        endpoint_name=endpoint,
-                        preset=effective_preset,
-                    )
-                )
-            if slack:
-                logger.warning(
-                    "`--slack` is deprecated; configure an endpoint via "
-                    "Settings → Notifications and pass `--endpoint <name>`."
-                )
-                webhook_url = os.getenv("SLACK_WEBHOOK_URL")
-                if not webhook_url:
-                    raise ValueError(
-                        "SLACK_WEBHOOK_URL environment variable is not set"
-                    )
-                callbacks.append(SlackCallback(webhook_url=webhook_url))
-
-            if debug:
-                # Imported lazily to avoid pulling main.py's typer surface at
-                # module import time.
-                from srunx.cli.main import DebugCallback
-
-                callbacks.append(DebugCallback())
 
             if sweep_spec is not None:
                 if validate:

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -31,6 +31,8 @@ from srunx.transport import (
     resolve_transport,
 )
 
+logger = get_logger(__name__)
+
 
 def _build_workflow_callbacks(
     *,
@@ -80,18 +82,6 @@ def _build_workflow_callbacks(
 
     return callbacks
 
-
-def _pre_resolve_scheduler_key(profile: str | None, local: bool) -> str:
-    """Return the scheduler_key ``resolve_transport`` would select.
-
-    Thin wrapper around :func:`peek_scheduler_key` kept as a module-
-    local helper so the import has a guaranteed call site (ruff's
-    unused-import stripper otherwise drops the transport import).
-    """
-    return peek_scheduler_key(profile=profile, local=local)
-
-
-logger = get_logger(__name__)
 
 # Create Typer app for workflow management
 app = typer.Typer(
@@ -571,7 +561,7 @@ def _execute_workflow(
         # the CLI flags + env, so we can pre-compute it via
         # :func:`peek_scheduler_key` and bind it to
         # ``NotificationWatchCallback`` up front.
-        pre_scheduler_key = _pre_resolve_scheduler_key(profile, local)
+        pre_scheduler_key = peek_scheduler_key(profile=profile, local=local)
         effective_preset = preset or get_config().notifications.default_preset
         is_sweep = sweep_spec is not None
         callbacks = _build_workflow_callbacks(

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -11,11 +11,13 @@ import yaml  # type: ignore
 from rich.console import Console
 
 from srunx.callbacks import Callback, NotificationWatchCallback, SlackCallback
+from srunx.cli.transport_options import LocalOpt, ProfileOpt, QuietOpt
 from srunx.config import get_config
 from srunx.exceptions import WorkflowValidationError
 from srunx.logging import configure_workflow_logging, get_logger
-from srunx.models import Job, ShellJob
+from srunx.models import Job, ShellJob, Workflow
 from srunx.runner import WorkflowRunner
+from srunx.security import find_shell_script_violation
 from srunx.sweep import SweepSpec
 from srunx.sweep.expand import (
     merge_sweep_specs,
@@ -23,6 +25,7 @@ from srunx.sweep.expand import (
     parse_sweep_flags,
 )
 from srunx.sweep.orchestrator import SweepOrchestrator
+from srunx.transport import ResolvedTransport, resolve_transport
 
 logger = get_logger(__name__)
 
@@ -178,6 +181,9 @@ def execute_yaml(
             help="Maximum concurrent sweep cells (overrides YAML sweep.max_parallel)",
         ),
     ] = None,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Execute workflow from YAML file."""
     # If a subcommand was invoked, don't run the callback
@@ -206,6 +212,9 @@ def execute_yaml(
         sweep=sweep,
         fail_fast=fail_fast,
         max_parallel=max_parallel,
+        profile=profile,
+        local=local,
+        quiet=quiet,
     )
 
 
@@ -318,6 +327,60 @@ def _validate_all_sweep_cells(
             ) from exc
 
 
+def _enforce_shell_script_roots_cli(workflow: Workflow, rt: ResolvedTransport) -> None:
+    """Reject ShellJob script paths that escape the SSH profile's mounts.
+
+    Mirrors the Web router and MCP tool guards (see
+    :func:`srunx.web.routers.workflows._enforce_shell_script_roots` and
+    :func:`srunx.mcp.server._enforce_shell_script_roots_mcp`): when the
+    workflow will be dispatched over SSH, every :class:`ShellJob`
+    ``script_path`` must sit under one of the profile's mount ``local``
+    roots so the remote executor can map it to a legitimate remote path.
+
+    Local transport imposes no check: Phase 5b keeps local ShellJob
+    behaviour unchanged.
+    """
+    if rt.transport_type != "ssh":
+        return
+    ctx = rt.submission_context
+    if ctx is None or not ctx.mounts:
+        # Profile has no mounts configured: fall through and warn instead
+        # of raising — see _warn_missing_mounts.
+        return
+
+    allowed_roots = [Path(m.local).resolve() for m in ctx.mounts]
+    violation = find_shell_script_violation(workflow, allowed_roots)
+    if violation is not None:
+        raise typer.BadParameter(
+            f"ShellJob '{violation.job_name}' script_path "
+            f"'{violation.script_path}' is not under any mount's local root "
+            f"for profile '{rt.profile_name}'. "
+            f"Allowed roots: {[str(r) for r in allowed_roots]}"
+        )
+
+
+def _warn_missing_mounts(rt: ResolvedTransport) -> None:
+    """Warn when an SSH-bound flow has no profile mounts configured.
+
+    Without mount translation, workflow ``work_dir`` / ``log_dir`` /
+    ``ShellJob.script_path`` fields render verbatim on the remote side;
+    they must already exist there or the submission will fail at the
+    remote executor. The warning surfaces this expectation instead of
+    letting the failure happen silently in a sbatch script that SLURM
+    refuses.
+    """
+    if rt.transport_type != "ssh":
+        return
+    ctx = rt.submission_context
+    if ctx is None or not ctx.mounts:
+        logger.warning(
+            "Profile '%s' has no mounts configured; workflow paths "
+            "(work_dir / log_dir / script_path) will be rendered as-is "
+            "on the remote cluster.",
+            rt.profile_name,
+        )
+
+
 def _run_sweep(
     yaml_file: Path,
     workflow_data: dict[str, Any],
@@ -326,12 +389,18 @@ def _run_sweep(
     callbacks: list[Callback],
     endpoint_id: int | None,
     preset: str,
+    rt: ResolvedTransport,
 ) -> None:
     """Drive :class:`SweepOrchestrator` under a SIGINT → request_cancel guard.
 
     First Ctrl+C triggers :meth:`SweepOrchestrator.request_cancel` (drain
     pending cells). A second Ctrl+C re-raises ``KeyboardInterrupt`` so
     the user can escape a stuck orchestrator.
+
+    The resolved transport's ``executor_factory`` and ``submission_context``
+    are forwarded to the orchestrator so SSH-backed sweeps route each
+    cell through the pool + mount translation path already used by the
+    Web / MCP sweep surfaces.
     """
     orchestrator = SweepOrchestrator(
         workflow_yaml_path=yaml_file,
@@ -342,6 +411,8 @@ def _run_sweep(
         callbacks=callbacks,
         endpoint_id=endpoint_id,
         preset=preset,
+        executor_factory=rt.executor_factory,
+        submission_context=rt.submission_context,
     )
 
     original_handler = signal.getsignal(signal.SIGINT)
@@ -389,6 +460,9 @@ def _execute_workflow(
     fail_fast: bool = False,
     max_parallel: int | None = None,
     debug: bool = False,
+    profile: str | None = None,
+    local: bool = False,
+    quiet: bool = False,
 ) -> None:
     """Common workflow execution logic."""
     # Configure logging for workflow execution
@@ -425,130 +499,156 @@ def _execute_workflow(
             max_parallel,
         )
 
-        # Setup callbacks if requested.
-        # ``NotificationWatchCallback`` attaches a per-job watch on every
-        # submission, which is right for non-sweep workflows but wrong
-        # for sweeps: sweep-level aggregation runs through the sweep_run
-        # watch + subscription created by the orchestrator, so adding
-        # per-job watches would spam one notification per cell job.
-        # ``SlackCallback`` is legacy in-process delivery and is still
-        # attached in both modes for backward compatibility.
-        callbacks: list[Callback] = []
-        effective_preset = preset or get_config().notifications.default_preset
-        is_sweep = sweep_spec is not None
-        if endpoint and not is_sweep:
-            callbacks.append(
-                NotificationWatchCallback(
-                    endpoint_name=endpoint,
-                    preset=effective_preset,
+        # Resolve transport once for the whole invocation. The context
+        # manager closes any SSH pool on exit. Validation / dry-run /
+        # sweep / single-run all branch inside this scope so every path
+        # sees the same executor_factory + submission_context.
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            _warn_missing_mounts(rt)
+
+            # Setup callbacks if requested.
+            # ``NotificationWatchCallback`` attaches a per-job watch on every
+            # submission, which is right for non-sweep workflows but wrong
+            # for sweeps: sweep-level aggregation runs through the sweep_run
+            # watch + subscription created by the orchestrator, so adding
+            # per-job watches would spam one notification per cell job.
+            # ``SlackCallback`` is legacy in-process delivery and is still
+            # attached in both modes for backward compatibility.
+            callbacks: list[Callback] = []
+            effective_preset = preset or get_config().notifications.default_preset
+            is_sweep = sweep_spec is not None
+            if endpoint and not is_sweep:
+                callbacks.append(
+                    NotificationWatchCallback(
+                        endpoint_name=endpoint,
+                        preset=effective_preset,
+                    )
                 )
-            )
-        if slack:
-            logger.warning(
-                "`--slack` is deprecated; configure an endpoint via "
-                "Settings → Notifications and pass `--endpoint <name>`."
-            )
-            webhook_url = os.getenv("SLACK_WEBHOOK_URL")
-            if not webhook_url:
-                raise ValueError("SLACK_WEBHOOK_URL environment variable is not set")
-            callbacks.append(SlackCallback(webhook_url=webhook_url))
+            if slack:
+                logger.warning(
+                    "`--slack` is deprecated; configure an endpoint via "
+                    "Settings → Notifications and pass `--endpoint <name>`."
+                )
+                webhook_url = os.getenv("SLACK_WEBHOOK_URL")
+                if not webhook_url:
+                    raise ValueError(
+                        "SLACK_WEBHOOK_URL environment variable is not set"
+                    )
+                callbacks.append(SlackCallback(webhook_url=webhook_url))
 
-        if debug:
-            # Imported lazily to avoid pulling main.py's typer surface at
-            # module import time.
-            from srunx.cli.main import DebugCallback
+            if debug:
+                # Imported lazily to avoid pulling main.py's typer surface at
+                # module import time.
+                from srunx.cli.main import DebugCallback
 
-            callbacks.append(DebugCallback())
+                callbacks.append(DebugCallback())
 
-        if sweep_spec is not None:
-            if validate:
-                # Validate every matrix cell: a Jinja undefined or type
-                # error in a non-zero cell (e.g. only cell 3 references
-                # an undeclared arg) must still fail the validator.
-                _validate_all_sweep_cells(
+            if sweep_spec is not None:
+                if validate:
+                    # Validate every matrix cell: a Jinja undefined or type
+                    # error in a non-zero cell (e.g. only cell 3 references
+                    # an undeclared arg) must still fail the validator.
+                    _validate_all_sweep_cells(
+                        yaml_file=yaml_file,
+                        workflow_data=workflow_data,
+                        args_override=args_override,
+                        sweep_spec=sweep_spec,
+                        callbacks=callbacks,
+                    )
+                    logger.info("Workflow validation successful")
+                    return
+
+                if dry_run:
+                    _preview_sweep_dry_run(sweep_spec, workflow_data, args_override)
+                    return
+
+                # Enforce ShellJob script_path guard against the profile's
+                # mounts before any cell is submitted. Load the workflow
+                # once with empty cell args for the check; the orchestrator
+                # will reload per cell with its own args.
+                if rt.transport_type == "ssh":
+                    _check_runner = WorkflowRunner.from_yaml(
+                        yaml_file,
+                        callbacks=callbacks,
+                        args_override=args_override or None,
+                    )
+                    _enforce_shell_script_roots_cli(_check_runner.workflow, rt)
+
+                endpoint_id = _resolve_endpoint_id(endpoint)
+                _run_sweep(
                     yaml_file=yaml_file,
                     workflow_data=workflow_data,
                     args_override=args_override,
                     sweep_spec=sweep_spec,
                     callbacks=callbacks,
+                    endpoint_id=endpoint_id,
+                    preset=effective_preset,
+                    rt=rt,
                 )
+                return
+
+            # Non-sweep path.
+            runner = WorkflowRunner.from_yaml(
+                yaml_file,
+                callbacks=callbacks,
+                single_job=job,
+                args_override=args_override or None,
+                executor_factory=rt.executor_factory,
+                submission_context=rt.submission_context,
+            )
+
+            runner.workflow.validate()
+            _enforce_shell_script_roots_cli(runner.workflow, rt)
+
+            if validate:
                 logger.info("Workflow validation successful")
                 return
 
             if dry_run:
-                _preview_sweep_dry_run(sweep_spec, workflow_data, args_override)
+                console = Console()
+                console.print("🔍 Dry run mode - showing workflow structure:")
+                console.print(f"Workflow: {runner.workflow.name}")
+
+                jobs_to_execute = runner._get_jobs_to_execute(from_job, to_job, job)
+
+                if job:
+                    console.print(f"Executing single job: {job}")
+                elif from_job or to_job:
+                    range_info = []
+                    if from_job:
+                        range_info.append(f"from {from_job}")
+                    if to_job:
+                        range_info.append(f"to {to_job}")
+                    console.print(
+                        f"Executing jobs {' '.join(range_info)}: "
+                        f"{len(jobs_to_execute)} jobs"
+                    )
+                else:
+                    console.print(f"Executing all jobs: {len(jobs_to_execute)} jobs")
+
+                for job_obj in jobs_to_execute:
+                    if isinstance(job_obj, Job) and job_obj.command:
+                        command_str = (
+                            job_obj.command
+                            if isinstance(job_obj.command, str)
+                            else " ".join(job_obj.command or [])
+                        )
+                    elif isinstance(job_obj, ShellJob):
+                        command_str = f"Shell script: {job_obj.script_path}"
+                    else:
+                        command_str = "N/A"
+                    console.print(f"  - {job_obj.name}: {command_str}")
                 return
 
-            endpoint_id = _resolve_endpoint_id(endpoint)
-            _run_sweep(
-                yaml_file=yaml_file,
-                workflow_data=workflow_data,
-                args_override=args_override,
-                sweep_spec=sweep_spec,
-                callbacks=callbacks,
-                endpoint_id=endpoint_id,
-                preset=effective_preset,
-            )
-            return
+            # Execute workflow
+            results = runner.run(from_job=from_job, to_job=to_job, single_job=job)
 
-        # Non-sweep path.
-        runner = WorkflowRunner.from_yaml(
-            yaml_file,
-            callbacks=callbacks,
-            single_job=job,
-            args_override=args_override or None,
-        )
-
-        runner.workflow.validate()
-
-        if validate:
-            logger.info("Workflow validation successful")
-            return
-
-        if dry_run:
-            console = Console()
-            console.print("🔍 Dry run mode - showing workflow structure:")
-            console.print(f"Workflow: {runner.workflow.name}")
-
-            jobs_to_execute = runner._get_jobs_to_execute(from_job, to_job, job)
-
-            if job:
-                console.print(f"Executing single job: {job}")
-            elif from_job or to_job:
-                range_info = []
-                if from_job:
-                    range_info.append(f"from {from_job}")
-                if to_job:
-                    range_info.append(f"to {to_job}")
-                console.print(
-                    f"Executing jobs {' '.join(range_info)}: {len(jobs_to_execute)} jobs"
-                )
-            else:
-                console.print(f"Executing all jobs: {len(jobs_to_execute)} jobs")
-
-            for job_obj in jobs_to_execute:
-                if isinstance(job_obj, Job) and job_obj.command:
-                    command_str = (
-                        job_obj.command
-                        if isinstance(job_obj.command, str)
-                        else " ".join(job_obj.command or [])
-                    )
-                elif isinstance(job_obj, ShellJob):
-                    command_str = f"Shell script: {job_obj.script_path}"
+            logger.info("Job Results:")
+            for task_name, job_result in results.items():
+                if hasattr(job_result, "job_id") and job_result.job_id:
+                    logger.info(f"  {task_name}: Job ID {job_result.job_id}")
                 else:
-                    command_str = "N/A"
-                console.print(f"  - {job_obj.name}: {command_str}")
-            return
-
-        # Execute workflow
-        results = runner.run(from_job=from_job, to_job=to_job, single_job=job)
-
-        logger.info("Job Results:")
-        for task_name, job_result in results.items():
-            if hasattr(job_result, "job_id") and job_result.job_id:
-                logger.info(f"  {task_name}: Job ID {job_result.job_id}")
-            else:
-                logger.info(f"  {task_name}: {job_result}")
+                    logger.info(f"  {task_name}: {job_result}")
 
     except WorkflowValidationError as e:
         logger.error(f"❌ Workflow validation error: {e}")
@@ -680,6 +780,9 @@ def run_command(
             help="Maximum concurrent sweep cells (overrides YAML sweep.max_parallel)",
         ),
     ] = None,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Execute workflow from YAML file."""
     _execute_workflow(
@@ -697,6 +800,9 @@ def run_command(
         sweep=sweep,
         fail_fast=fail_fast,
         max_parallel=max_parallel,
+        profile=profile,
+        local=local,
+        quiet=quiet,
     )
 
 

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -153,6 +153,10 @@ class Slurm:
 
         # Record in the state DB (best-effort; failures log at debug
         # and never surface to the caller — see cli_helpers.py).
+        # Local ``Slurm`` only ever writes the local-transport triple;
+        # SSH submissions take the ``SlurmSSHAdapter.submit`` path which
+        # passes its own (transport_type='ssh', profile_name=...,
+        # scheduler_key='ssh:<profile>') values.
         if record_history:
             from srunx.db.cli_helpers import record_submission_from_job
 
@@ -160,6 +164,9 @@ class Slurm:
                 job,
                 workflow_name=workflow_name,
                 workflow_run_id=workflow_run_id,
+                transport_type="local",
+                profile_name=None,
+                scheduler_key="local",
             )
 
         all_callbacks = self.callbacks[:]

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -357,6 +357,7 @@ class Slurm:
                 user_name = parts[3] if len(parts) > 3 else None
                 status_str = parts[4]
                 elapsed_time = parts[5] if len(parts) > 5 else None
+                time_limit = parts[6] if len(parts) > 6 else None
                 nodes_str = parts[7] if len(parts) > 7 else "1"
                 tres = parts[9] if len(parts) > 9 else ""
 
@@ -384,6 +385,7 @@ class Slurm:
                     user=user_name,
                     partition=partition,
                     elapsed_time=elapsed_time,
+                    time_limit=time_limit,
                     nodes=nodes,
                     gpus=gpus,
                 )

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -58,6 +58,8 @@ class Slurm:
         record_history: bool = True,
         workflow_name: str | None = None,
         workflow_run_id: int | None = None,
+        *,
+        submission_context: "SubmissionRenderContext | None" = None,
     ) -> RunnableJobType:
         """Submit a job to SLURM.
 
@@ -72,6 +74,10 @@ class Slurm:
                 submitted from a workflow; persisted on the ``jobs`` row
                 so reports (``srunx report --workflow``, the Web history
                 JOIN) actually pick up CLI-launched workflow jobs.
+            submission_context: Accepted for
+                :class:`~srunx.client_protocol.JobOperationsProtocol`
+                conformance and ignored — local submission performs no
+                mount translation.
 
         Returns:
             Job instance with updated job_id and status.
@@ -79,6 +85,7 @@ class Slurm:
         Raises:
             subprocess.CalledProcessError: If job submission fails.
         """
+        del submission_context  # unused on the local path (see docstring)
         result = None
 
         if isinstance(job, Job):

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -26,7 +26,7 @@ from srunx.models import (
 from srunx.utils import GPU_TRES_RE, get_job_status, job_status_msg  # noqa: E402
 
 if TYPE_CHECKING:
-    from srunx.client_protocol import JobStatusInfo
+    from srunx.client_protocol import JobStatusInfo, LogChunk
     from srunx.rendering import SubmissionRenderContext
 
 logger = get_logger(__name__)
@@ -181,6 +181,109 @@ class Slurm:
             Job object with current status.
         """
         return get_job_status(job_id)
+
+    def status(self, job_id: int) -> BaseJob:
+        """Return a :class:`BaseJob` snapshot of ``job_id``'s state.
+
+        Thin alias for :meth:`retrieve` that satisfies
+        :class:`~srunx.client_protocol.JobOperationsProtocol`. Raises
+        :class:`~srunx.exceptions.JobNotFound` when ``sacct`` has no row
+        for ``job_id`` (the underlying ``get_job_status`` uses
+        ``ValueError`` for that condition, which we rewrap here to match
+        the Protocol contract).
+
+        TODO (Phase 5a): Wrap ``subprocess.FileNotFoundError`` /
+        ``CalledProcessError`` into ``TransportConnectionError`` /
+        ``RemoteCommandError`` once CLI tests have caught up; leaving the
+        raw ``subprocess.CalledProcessError`` as-is today preserves the
+        existing test expectations.
+        """
+        from srunx.exceptions import JobNotFound
+
+        try:
+            return self.retrieve(job_id)
+        except ValueError as exc:  # get_job_status raises ValueError on miss
+            raise JobNotFound(f"Job {job_id} not found") from exc
+
+    def tail_log_incremental(
+        self,
+        job_id: int,
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> "LogChunk":
+        """Return new log content since the given byte offsets.
+
+        Reads local log files using ``open`` + ``seek`` instead of a
+        subprocess ``tail``, so the Protocol contract (pure, no side
+        effects, no stdout writes) is honoured. If the log file does not
+        yet exist (e.g. the job is still PENDING), returns an empty chunk
+        with the offsets unchanged — callers should treat a missing file
+        as "no new data" rather than a hard error.
+        """
+        from srunx.client_protocol import LogChunk
+
+        stdout_path, stderr_path = self._find_log_paths(job_id)
+        stdout_content, new_stdout_offset = self._read_file_from_offset(
+            stdout_path, stdout_offset
+        )
+        if stderr_path is not None and stderr_path != stdout_path:
+            stderr_content, new_stderr_offset = self._read_file_from_offset(
+                stderr_path, stderr_offset
+            )
+        else:
+            stderr_content, new_stderr_offset = "", stderr_offset
+        return LogChunk(
+            stdout=stdout_content,
+            stderr=stderr_content,
+            stdout_offset=new_stdout_offset,
+            stderr_offset=new_stderr_offset,
+        )
+
+    @staticmethod
+    def _find_log_paths(
+        job_id: int, job_name: str | None = None
+    ) -> tuple[str | None, str | None]:
+        """Locate (stdout_path, stderr_path) for *job_id*.
+
+        Reuses :meth:`_find_log_files` discovery. When SLURM is configured
+        with a single combined log (the srunx default), both returned
+        paths will be the same — callers must deduplicate to avoid
+        double-counting byte offsets. Returns ``(None, None)`` when no
+        log file has appeared yet (common for PENDING jobs).
+        """
+        found_files, _ = Slurm._find_log_files(job_id, job_name)
+        if not found_files:
+            return None, None
+        stdout_path: str | None = found_files[0]
+        stderr_path: str | None = None
+        for candidate in found_files:
+            if "err" in Path(candidate).name.lower():
+                stderr_path = candidate
+                break
+        if stderr_path is None:
+            # srunx's default template routes stderr into the primary log.
+            stderr_path = stdout_path
+        return stdout_path, stderr_path
+
+    @staticmethod
+    def _read_file_from_offset(path: str | None, offset: int) -> tuple[str, int]:
+        """Read from *offset* to EOF. Missing file → ``("", offset)``."""
+        if not path:
+            return "", offset
+        try:
+            with open(path, "rb") as f:
+                f.seek(offset)
+                data = f.read()
+        except FileNotFoundError:
+            return "", offset
+        except OSError as exc:
+            logger.warning(f"Failed to read log file {path}: {exc}")
+            return "", offset
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            text = data.decode("utf-8", errors="replace")
+        return text, offset + len(data)
 
     def cancel(self, job_id: int) -> None:
         """Cancel a SLURM job.

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -199,11 +199,14 @@ class Slurm:
         ``ValueError`` for that condition, which we rewrap here to match
         the Protocol contract).
 
-        TODO (Phase 5a): Wrap ``subprocess.FileNotFoundError`` /
-        ``CalledProcessError`` into ``TransportConnectionError`` /
-        ``RemoteCommandError`` once CLI tests have caught up; leaving the
-        raw ``subprocess.CalledProcessError`` as-is today preserves the
-        existing test expectations.
+        Note: raw ``subprocess.FileNotFoundError`` / ``CalledProcessError``
+        from the ``sacct`` invocation are intentionally *not* wrapped
+        into transport-level exceptions here. The existing CLI test
+        suite asserts on the subprocess error types, and rewrapping
+        them would force a much larger behavioural change than this
+        Protocol-alignment method needs. A future unification pass
+        (with the CLI tests migrated in lockstep) can tighten this
+        contract.
         """
         from srunx.exceptions import JobNotFound
 

--- a/src/srunx/client_protocol.py
+++ b/src/srunx/client_protocol.py
@@ -55,12 +55,25 @@ class JobOperationsProtocol(Protocol):
     and polling wrappers may call them concurrently.
     """
 
-    def submit(self, job: RunnableJobType) -> RunnableJobType:
+    def submit(
+        self,
+        job: RunnableJobType,
+        *,
+        submission_context: SubmissionRenderContext | None = None,
+    ) -> RunnableJobType:
         """Submit *job* to SLURM and return the populated job object.
 
         The returned object MUST have ``job_id`` set. DB recording (via
         ``record_submission_from_job``) is the implementation's
         responsibility; callers must not record again.
+
+        ``submission_context`` carries mount / default-path metadata that
+        SSH-backed implementations apply via
+        :func:`srunx.rendering.normalize_job_for_submission` before
+        rendering the SLURM script, so CLI-supplied absolute ``work_dir``
+        / ``log_dir`` paths get rewritten to the remote-mount equivalents.
+        Local implementations accept the kwarg for Protocol conformance
+        but ignore it (local submission never performs mount translation).
         """
         ...
 

--- a/src/srunx/client_protocol.py
+++ b/src/srunx/client_protocol.py
@@ -12,10 +12,10 @@ from contextlib import AbstractContextManager
 from datetime import datetime
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
-    from srunx.models import RunnableJobType
+    from srunx.models import BaseJob, RunnableJobType
     from srunx.rendering import SubmissionRenderContext
 
 
@@ -31,6 +31,72 @@ class JobStatusInfo(BaseModel):
     completed_at: datetime | None = None
     duration_secs: int | None = None
     nodelist: str | None = None
+
+
+class LogChunk(BaseModel):
+    """Incremental log tail chunk returned by ``tail_log_incremental``.
+
+    Field names match the WebUI ``/api/jobs/{id}/logs`` wire shape so the
+    Protocol, the WebUI router, and the CLI all speak the same vocabulary.
+    """
+
+    stdout: str
+    stderr: str
+    stdout_offset: int = Field(ge=0)
+    stderr_offset: int = Field(ge=0)
+
+
+@runtime_checkable
+class JobOperationsProtocol(Protocol):
+    """CLI-facing job operations. Pure functions, no side-effects.
+
+    Implementations must be thread-safe for the read paths (``status`` /
+    ``queue`` / ``tail_log_incremental``) because CLI ``--follow`` loops
+    and polling wrappers may call them concurrently.
+    """
+
+    def submit(self, job: RunnableJobType) -> RunnableJobType:
+        """Submit *job* to SLURM and return the populated job object.
+
+        The returned object MUST have ``job_id`` set. DB recording (via
+        ``record_submission_from_job``) is the implementation's
+        responsibility; callers must not record again.
+        """
+        ...
+
+    def cancel(self, job_id: int) -> None:
+        """Cancel *job_id*. Raises :class:`JobNotFound` if unknown."""
+        ...
+
+    def status(self, job_id: int) -> BaseJob:
+        """Return a snapshot of *job_id*'s current status.
+
+        Raises :class:`JobNotFound` if unknown. The returned ``BaseJob``
+        MUST NOT trigger lazy refresh on attribute access (callers may
+        touch ``.status`` after the transport context is closed).
+        """
+        ...
+
+    def queue(self, user: str | None = None) -> list[BaseJob]:
+        """List jobs for *user* (defaults to the transport's current user).
+
+        Local: ``$USER``. SSH: the profile's username. Empty list if
+        none, never raises.
+        """
+        ...
+
+    def tail_log_incremental(
+        self,
+        job_id: int,
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> LogChunk:
+        """Return new log content since *stdout_offset* / *stderr_offset*.
+
+        For ``follow`` behaviour, callers poll this method with the
+        returned offsets. The Protocol itself never blocks.
+        """
+        ...
 
 
 @runtime_checkable

--- a/src/srunx/config.py
+++ b/src/srunx/config.py
@@ -83,12 +83,29 @@ class NotificationConfig(BaseModel):
     )
 
 
+class CliTransportConfig(BaseModel):
+    """CLI transport resolution behaviour (REQ-1, Phase 2)."""
+
+    use_current_profile: bool = Field(
+        default=True,
+        description=(
+            "When True (default), top-level CLI commands (submit / cancel / "
+            "status / list / logs / flow run / monitor jobs) fall back to the "
+            "active SSH profile set via 'srunx ssh profile set <name>' when "
+            "no explicit --profile / --local / $SRUNX_SSH_PROFILE is given. "
+            "Set to False to force pre-Phase-2 behaviour where the CLI only "
+            "routes through SSH on an explicit flag or env var."
+        ),
+    )
+
+
 class SrunxConfig(BaseModel):
     """Main srunx configuration."""
 
     resources: ResourceDefaults = Field(default_factory=ResourceDefaults)
     environment: EnvironmentDefaults = Field(default_factory=EnvironmentDefaults)
     notifications: NotificationConfig = Field(default_factory=NotificationConfig)
+    cli: CliTransportConfig = Field(default_factory=CliTransportConfig)
     log_dir: str = Field(default="logs", description="Default log directory")
     work_dir: str | None = Field(default=None, description="Default working directory")
 

--- a/src/srunx/db/cli_helpers.py
+++ b/src/srunx/db/cli_helpers.py
@@ -11,11 +11,12 @@ This replaces the dual-write helpers that lived inside
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from srunx.logging import get_logger
 
 if TYPE_CHECKING:
+    from srunx.db.models import SubmissionSource, TransportType
     from srunx.models import JobStatus, JobType
 
 logger = get_logger(__name__)
@@ -26,16 +27,25 @@ def record_submission_from_job(
     *,
     workflow_name: str | None = None,
     workflow_run_id: int | None = None,
+    transport_type: TransportType = "local",
+    profile_name: str | None = None,
+    scheduler_key: str = "local",
+    submission_source: SubmissionSource | None = None,
 ) -> None:
     """Insert a ``jobs`` row + seed a ``PENDING`` transition for ``job``.
 
-    ``workflow_name`` picks the ``submission_source`` (``'workflow'``
-    vs ``'cli'``). ``workflow_run_id`` — when provided — links the job
-    back to its ``workflow_runs`` row so ``compute_workflow_stats``
-    and the Web ``/api/workflows/runs`` history JOIN on
-    ``workflow_run_id`` actually pick up CLI-launched workflow jobs.
-    Passing ``None`` preserves the pre-existing behaviour for plain
-    ``srunx submit`` + standalone ``Slurm.submit`` callers.
+    ``workflow_name`` picks the default ``submission_source`` ("workflow"
+    vs "cli") when the caller does not pass ``submission_source``
+    explicitly. ``workflow_run_id`` — when provided — links the job back
+    to its ``workflow_runs`` row.
+
+    ``transport_type`` / ``profile_name`` / ``scheduler_key`` describe
+    where the job was submitted to. Defaults are the local-SLURM triple
+    so existing callers (CLI ``srunx submit``, local ``Slurm.submit``)
+    record exactly what they did before. SSH callers (``SlurmSSHAdapter``
+    on the Web / MCP / future CLI paths) must pass the matching triple;
+    :func:`srunx.db.repositories.jobs._validate_transport_triple` rejects
+    mismatches before they reach the DB.
 
     Fails closed — any exception is logged at debug and silently
     swallowed. The caller must NOT depend on a non-None return.
@@ -51,6 +61,16 @@ def record_submission_from_job(
         from srunx.db.repositories.jobs import JobRepository
         from srunx.models import Job
 
+        # ``submission_source`` falls back to the original workflow/cli
+        # heuristic when the caller does not set it explicitly. The
+        # Literal cast keeps mypy happy under ``from __future__ import
+        # annotations``.
+        effective_source: Literal["cli", "web", "workflow"]
+        if submission_source is not None:
+            effective_source = submission_source  # type: ignore[assignment]
+        else:
+            effective_source = "workflow" if workflow_name else "cli"
+
         with initialized_connection() as conn:
             resources = getattr(job, "resources", None)
             environment = getattr(job, "environment", None)
@@ -65,7 +85,10 @@ def record_submission_from_job(
                 job_id=int(job.job_id),
                 name=job.name,
                 status=(job._status.value if hasattr(job, "_status") else "PENDING"),
-                submission_source=("workflow" if workflow_name else "cli"),
+                submission_source=effective_source,
+                transport_type=transport_type,
+                profile_name=profile_name,
+                scheduler_key=scheduler_key,
                 command=command_val,
                 nodes=getattr(resources, "nodes", None) if resources else None,
                 gpus_per_node=(
@@ -98,6 +121,7 @@ def record_submission_from_job(
                     from_status=None,
                     to_status="PENDING",
                     source="webhook",
+                    scheduler_key=scheduler_key,
                 )
     except Exception as exc:  # noqa: BLE001 — best-effort
         logger.debug(f"record_submission_from_job failed: {exc}")
@@ -136,7 +160,12 @@ def create_cli_workflow_run(
         return None
 
 
-def record_completion(job_id: int, status: JobStatus) -> None:
+def record_completion(
+    job_id: int,
+    status: JobStatus,
+    *,
+    scheduler_key: str = "local",
+) -> None:
     """Mark ``job_id`` terminal in ``jobs`` + append a cli_monitor transition.
 
     No-ops if the job row doesn't exist in the state DB yet (e.g. the
@@ -144,6 +173,9 @@ def record_completion(job_id: int, status: JobStatus) -> None:
     read-modify-write of ``job_state_transitions`` runs inside a
     ``BEGIN IMMEDIATE`` so two racing observers (e.g. CLI monitor +
     poller) can't both append the same terminal state.
+
+    ``scheduler_key`` defaults to ``'local'`` so the CLI monitor path
+    (which only observes local SLURM) behaves identically to pre-V5.
     """
     try:
         from srunx.db.connection import initialized_connection, transaction
@@ -154,11 +186,13 @@ def record_completion(job_id: int, status: JobStatus) -> None:
 
         with initialized_connection() as conn:
             repo = JobRepository(conn)
-            if repo.get(job_id) is None:
+            if repo.get(job_id, scheduler_key=scheduler_key) is None:
                 return
             transition_repo = JobStateTransitionRepository(conn)
             with transaction(conn, "IMMEDIATE"):
-                latest = transition_repo.latest_for_job(job_id)
+                latest = transition_repo.latest_for_job(
+                    job_id, scheduler_key=scheduler_key
+                )
                 latest_status = latest.to_status if latest is not None else None
                 if latest_status != status.value:
                     transition_repo.insert(
@@ -166,8 +200,11 @@ def record_completion(job_id: int, status: JobStatus) -> None:
                         from_status=latest_status,
                         to_status=status.value,
                         source="cli_monitor",
+                        scheduler_key=scheduler_key,
                     )
-                repo.update_completion(job_id, status.value)
+                repo.update_completion(
+                    job_id, status.value, scheduler_key=scheduler_key
+                )
     except Exception as exc:  # noqa: BLE001 — best-effort
         logger.debug(f"record_completion failed: {exc}")
 

--- a/src/srunx/db/migrations.py
+++ b/src/srunx/db/migrations.py
@@ -338,6 +338,158 @@ CREATE INDEX idx_workflow_runs_sweep_run_id ON workflow_runs(sweep_run_id);
 
 
 # ---------------------------------------------------------------------------
+# v5 schema: CLI transport unification.
+#
+# 1. Rebuild ``jobs`` to add ``transport_type`` / ``profile_name`` /
+#    ``scheduler_key`` columns. The original ``UNIQUE(job_id)`` becomes
+#    ``UNIQUE(scheduler_key, job_id)`` so the same SLURM ``job_id`` can
+#    safely co-exist across multiple clusters (``local`` + ``ssh:<profile>``).
+#    A three-way CHECK constraint keeps ``(transport_type, profile_name,
+#    scheduler_key)`` internally consistent.
+# 2. Rebuild ``workflow_run_jobs`` so the child FK targets ``jobs.id``
+#    (AUTOINCREMENT PK) instead of ``jobs.job_id``. Column renamed
+#    ``job_id`` → ``jobs_row_id``. Backfilled via ``LEFT JOIN jobs``.
+# 3. Rebuild ``job_state_transitions`` the same way.
+# 4. Backfill ``watches.target_ref`` / ``events.source_ref`` that use the
+#    legacy 2-segment ``job:<id>`` form into the new 3-segment
+#    ``job:local:<id>`` form. The 2-segment form is fully retired; the
+#    ``ActiveWatchPoller`` parser no longer accepts it.
+# 5. Force-close every open watch as a mitigation for the pre-V5
+#    WebUI-SSH-submitted jobs that are backfilled as ``transport_type=
+#    'local'`` (the old schema had no column to tell them apart). Those
+#    watches would otherwise drive the poller to query local SLURM for
+#    remote job ids. The user can re-open watches after migration via
+#    the Web UI or CLI.
+#
+# Rebuild is required for (1), (2), (3) because SQLite cannot alter
+# UNIQUE, CHECK, or FK targets in place. All five steps run inside one
+# ``PRAGMA foreign_keys=OFF`` + ``BEGIN IMMEDIATE`` transaction so the
+# migration either fully applies or rolls back cleanly (see
+# ``_apply_fk_off_migration``).
+# ---------------------------------------------------------------------------
+
+SCHEMA_V5 = """
+-- (1) jobs rebuild ---------------------------------------------------
+CREATE TABLE jobs_v5 (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id            INTEGER NOT NULL,
+    transport_type    TEXT NOT NULL DEFAULT 'local'
+                        CHECK (transport_type IN ('local','ssh')),
+    profile_name      TEXT,
+    scheduler_key     TEXT NOT NULL DEFAULT 'local',
+    name              TEXT NOT NULL,
+    command           TEXT,
+    status            TEXT NOT NULL,
+    nodes             INTEGER,
+    gpus_per_node     INTEGER,
+    memory_per_node   TEXT,
+    time_limit        TEXT,
+    partition         TEXT,
+    nodelist          TEXT,
+    conda             TEXT,
+    venv              TEXT,
+    container         TEXT,
+    env_vars          TEXT,
+    submitted_at      TEXT NOT NULL,
+    started_at        TEXT,
+    completed_at      TEXT,
+    duration_secs     INTEGER,
+    workflow_run_id   INTEGER REFERENCES workflow_runs(id) ON DELETE SET NULL,
+    submission_source TEXT NOT NULL CHECK (submission_source IN ('cli','web','workflow')),
+    log_file          TEXT,
+    metadata          TEXT,
+    UNIQUE (scheduler_key, job_id),
+    CHECK (
+        (transport_type = 'local' AND profile_name IS NULL AND scheduler_key = 'local')
+        OR
+        (transport_type = 'ssh'   AND profile_name IS NOT NULL
+                                  AND scheduler_key = 'ssh:' || profile_name)
+    ),
+    CHECK (profile_name IS NULL OR instr(profile_name, ':') = 0)
+);
+INSERT INTO jobs_v5 (
+    id, job_id, transport_type, profile_name, scheduler_key,
+    name, command, status,
+    nodes, gpus_per_node, memory_per_node, time_limit,
+    partition, nodelist, conda, venv, container, env_vars,
+    submitted_at, started_at, completed_at, duration_secs,
+    workflow_run_id, submission_source, log_file, metadata
+)
+    SELECT
+        id, job_id, 'local', NULL, 'local',
+        name, command, status,
+        nodes, gpus_per_node, memory_per_node, time_limit,
+        partition, nodelist, conda, venv, container, env_vars,
+        submitted_at, started_at, completed_at, duration_secs,
+        workflow_run_id, submission_source, log_file, metadata
+    FROM jobs;
+DROP TABLE jobs;
+ALTER TABLE jobs_v5 RENAME TO jobs;
+CREATE INDEX idx_jobs_status          ON jobs(status);
+CREATE INDEX idx_jobs_submitted_at    ON jobs(submitted_at);
+CREATE INDEX idx_jobs_workflow_run_id ON jobs(workflow_run_id);
+CREATE INDEX idx_jobs_scheduler_key   ON jobs(scheduler_key);
+
+-- (2) workflow_run_jobs rebuild --------------------------------------
+CREATE TABLE workflow_run_jobs_v5 (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    workflow_run_id INTEGER NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+    jobs_row_id     INTEGER REFERENCES jobs(id) ON DELETE SET NULL,
+    job_name        TEXT NOT NULL,
+    depends_on      TEXT,
+    UNIQUE (workflow_run_id, job_name)
+);
+INSERT INTO workflow_run_jobs_v5 (id, workflow_run_id, jobs_row_id, job_name, depends_on)
+    SELECT wrj.id, wrj.workflow_run_id, j.id, wrj.job_name, wrj.depends_on
+    FROM workflow_run_jobs wrj
+    LEFT JOIN jobs j ON j.job_id = wrj.job_id AND j.scheduler_key = 'local';
+DROP TABLE workflow_run_jobs;
+ALTER TABLE workflow_run_jobs_v5 RENAME TO workflow_run_jobs;
+CREATE INDEX idx_wrj_run ON workflow_run_jobs(workflow_run_id);
+
+-- (3) job_state_transitions rebuild ----------------------------------
+CREATE TABLE job_state_transitions_v5 (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    jobs_row_id  INTEGER REFERENCES jobs(id) ON DELETE SET NULL,
+    from_status  TEXT,
+    to_status    TEXT NOT NULL,
+    observed_at  TEXT NOT NULL,
+    source       TEXT NOT NULL CHECK (source IN ('poller','cli_monitor','webhook'))
+);
+INSERT INTO job_state_transitions_v5 (
+    id, jobs_row_id, from_status, to_status, observed_at, source
+)
+    SELECT jst.id, j.id, jst.from_status, jst.to_status, jst.observed_at, jst.source
+    FROM job_state_transitions jst
+    LEFT JOIN jobs j ON j.job_id = jst.job_id AND j.scheduler_key = 'local';
+DROP TABLE job_state_transitions;
+ALTER TABLE job_state_transitions_v5 RENAME TO job_state_transitions;
+CREATE INDEX idx_jst_job_id      ON job_state_transitions(jobs_row_id, observed_at);
+CREATE INDEX idx_jst_observed_at ON job_state_transitions(observed_at);
+
+-- (4) target_ref / source_ref backfill -------------------------------
+UPDATE watches
+   SET target_ref = 'job:local:' || substr(target_ref, 5)
+ WHERE kind = 'job'
+   AND target_ref LIKE 'job:%'
+   AND target_ref NOT LIKE 'job:local:%'
+   AND target_ref NOT LIKE 'job:ssh:%';
+
+UPDATE events
+   SET source_ref = 'job:local:' || substr(source_ref, 5)
+ WHERE kind IN ('job.submitted','job.status_changed')
+   AND source_ref LIKE 'job:%'
+   AND source_ref NOT LIKE 'job:local:%'
+   AND source_ref NOT LIKE 'job:ssh:%';
+
+-- (5) force-close pre-V5 open watches --------------------------------
+UPDATE watches
+   SET closed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+ WHERE closed_at IS NULL;
+"""
+
+
+# ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
 
@@ -377,6 +529,12 @@ MIGRATIONS: list[Migration] = [
         version=4,
         name="v4_widen_triggered_by_mcp",
         sql=SCHEMA_V4,
+        requires_fk_off=True,
+    ),
+    Migration(
+        version=5,
+        name="v5_transport_scheduler_key",
+        sql=SCHEMA_V5,
         requires_fk_off=True,
     ),
 ]

--- a/src/srunx/db/migrations.py
+++ b/src/srunx/db/migrations.py
@@ -482,10 +482,16 @@ UPDATE events
    AND source_ref NOT LIKE 'job:local:%'
    AND source_ref NOT LIKE 'job:ssh:%';
 
--- (5) force-close pre-V5 open watches --------------------------------
+-- (5) force-close pre-V5 open job watches ----------------------------
+-- Only ``kind='job'`` watches carry the transport ambiguity the V5
+-- triple resolves. Workflow-run / sweep-run / resource / scheduled-
+-- report watches are transport-agnostic and must survive the migration
+-- so in-flight workflow cancellations, sweep aggregations, and
+-- scheduled reports keep working without re-creation.
 UPDATE watches
    SET closed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
- WHERE closed_at IS NULL;
+ WHERE closed_at IS NULL
+   AND kind = 'job';
 """
 
 
@@ -638,6 +644,14 @@ def _split_sql_statements(sql: str) -> list[str]:
     issues an implicit ``COMMIT`` at the start, which would silently
     terminate a surrounding ``BEGIN IMMEDIATE`` and run every DDL in
     autocommit — losing the atomicity contract we rely on for rollback.
+
+    Caveat: the splitter is intentionally simple and does **not**
+    understand SQLite string/identifier quoting. A literal ``;`` inside
+    a ``'...'`` string constant (e.g. a default value or a CHECK
+    constraint) would be treated as a statement boundary and break the
+    parse. Future migrations must therefore avoid embedding ``;`` in
+    string literals; escape with a ``||`` concatenation or a
+    ``char(59)`` expression if one is genuinely needed.
     """
     statements: list[str] = []
     buf: list[str] = []

--- a/src/srunx/db/migrations.py
+++ b/src/srunx/db/migrations.py
@@ -468,19 +468,22 @@ CREATE INDEX idx_jst_job_id      ON job_state_transitions(jobs_row_id, observed_
 CREATE INDEX idx_jst_observed_at ON job_state_transitions(observed_at);
 
 -- (4) target_ref / source_ref backfill -------------------------------
+-- Only rewrite bare ``job:<slurm_id>`` rows. The ``LIKE`` patterns used
+-- previously would match any future axis prefix (``job:foo:…``) that
+-- lacks a hard-coded NOT LIKE clause, so we match "exactly two colons
+-- don't exist yet" via ``instr(substr(ref, 5), ':') = 0`` — i.e. the
+-- tail after ``job:`` contains no further ``:`` character.
 UPDATE watches
    SET target_ref = 'job:local:' || substr(target_ref, 5)
  WHERE kind = 'job'
-   AND target_ref LIKE 'job:%'
-   AND target_ref NOT LIKE 'job:local:%'
-   AND target_ref NOT LIKE 'job:ssh:%';
+   AND substr(target_ref, 1, 4) = 'job:'
+   AND instr(substr(target_ref, 5), ':') = 0;
 
 UPDATE events
    SET source_ref = 'job:local:' || substr(source_ref, 5)
  WHERE kind IN ('job.submitted','job.status_changed')
-   AND source_ref LIKE 'job:%'
-   AND source_ref NOT LIKE 'job:local:%'
-   AND source_ref NOT LIKE 'job:ssh:%';
+   AND substr(source_ref, 1, 4) = 'job:'
+   AND instr(substr(source_ref, 5), ':') = 0;
 
 -- (5) force-close pre-V5 open job watches ----------------------------
 -- Only ``kind='job'`` watches carry the transport ambiguity the V5

--- a/src/srunx/db/models.py
+++ b/src/srunx/db/models.py
@@ -45,6 +45,7 @@ EventKind = Literal[
 DeliveryStatus = Literal["pending", "sending", "delivered", "abandoned"]
 TransitionSource = Literal["poller", "cli_monitor", "webhook"]
 SubmissionSource = Literal["cli", "web", "workflow"]
+TransportType = Literal["local", "ssh"]
 WorkflowRunStatus = Literal["pending", "running", "completed", "failed", "cancelled"]
 WorkflowRunTriggeredBy = Literal["cli", "web", "schedule", "mcp"]
 SweepStatus = Literal[
@@ -164,19 +165,42 @@ class SweepRun(BaseModel):
 
 
 class WorkflowRunJob(BaseModel):
+    """Row model for ``workflow_run_jobs``.
+
+    ``jobs_row_id`` (V5+) points at ``jobs.id`` (AUTOINCREMENT PK), not
+    the SLURM ``job_id``. The legacy ``job_id`` attribute is exposed as
+    a read-only mirror for backwards compatibility with callers that
+    used to read the SLURM id through this model; it is populated by
+    the repository via a ``LEFT JOIN jobs`` at read time.
+    """
+
     model_config = _MODEL_CONFIG
 
     id: int | None = None
     workflow_run_id: int
-    job_id: int | None = None  # filled after SLURM submit
+    jobs_row_id: int | None = None  # V5: FK to jobs.id (AUTOINCREMENT PK)
+    # Populated by the repo via LEFT JOIN jobs ON j.id = jobs_row_id.
+    # Kept for legacy call sites that read ``membership.job_id`` as the
+    # SLURM id. New code should prefer ``jobs_row_id`` + the repository's
+    # join-backed accessor.
+    job_id: int | None = None
     job_name: str
     depends_on: list[str] | None = None
 
 
 class JobStateTransition(BaseModel):
+    """Row model for ``job_state_transitions``.
+
+    ``jobs_row_id`` (V5+) points at ``jobs.id`` (AUTOINCREMENT PK).
+    """
+
     model_config = _MODEL_CONFIG
 
     id: int | None = None
+    jobs_row_id: int | None = None
+    # Mirror of the parent job's SLURM id, resolved by the repo via
+    # ``LEFT JOIN jobs ON j.id = jobs_row_id`` on reads. Legacy callers
+    # still access ``.job_id``; new code should resolve it explicitly.
     job_id: int | None = None
     from_status: str | None = None
     to_status: str
@@ -204,6 +228,9 @@ class Job(BaseModel):
 
     id: int | None = None
     job_id: int
+    transport_type: TransportType = "local"
+    profile_name: str | None = None
+    scheduler_key: str = "local"
     name: str
     command: list[str] | None = None
     status: str

--- a/src/srunx/db/repositories/events.py
+++ b/src/srunx/db/repositories/events.py
@@ -38,13 +38,28 @@ class EventRepository(BaseRepository):
 
     @staticmethod
     def _extract_source_id(source_ref: str) -> str:
-        """Return the id portion of a ``"<kind>:<id>"`` source_ref.
+        """Return the id portion of a structured ``source_ref``.
+
+        Grammar (V5+):
+        - ``job:local:<N>`` → ``<N>``
+        - ``job:ssh:<profile>:<N>`` → ``<N>``
+        - ``workflow_run:<N>`` → ``<N>``
+        - ``sweep_run:<N>`` → ``<N>``
+        - ``resource:<partition>:<threshold>:<window>`` → remainder after first ``:``
+
+        For ``job:*`` refs we always take the trailing numeric segment
+        so the dedup hash is stable across transports. Non-``job`` refs
+        keep the pre-V5 "remainder after first ``:``" semantics.
 
         Falls back to the full string when no ``:`` is present.
         """
-        if ":" in source_ref:
-            return source_ref.split(":", 1)[1]
-        return source_ref
+        if ":" not in source_ref:
+            return source_ref
+        kind, _, remainder = source_ref.partition(":")
+        if kind == "job":
+            # job:local:N → N ; job:ssh:profile:N → N
+            return remainder.rsplit(":", 1)[-1]
+        return remainder
 
     @staticmethod
     def _compute_payload_hash(kind: str, source_ref: str, payload: dict) -> str:

--- a/src/srunx/db/repositories/job_state_transitions.py
+++ b/src/srunx/db/repositories/job_state_transitions.py
@@ -7,9 +7,13 @@ monitor alike).
 
 V5 note: the on-disk column is ``jobs_row_id`` (FK to ``jobs.id``),
 but the public API still takes ``job_id`` (SLURM id) so existing
-callers work unchanged. ``scheduler_key='local'`` is the default, so
-a ``latest_for_job(123)`` call returns the transition for the local
-SLURM job 123 — which is exactly what the pre-V5 API meant.
+callers work unchanged. SF5 then hardened the API to **require**
+``scheduler_key`` as a keyword argument on :meth:`insert`,
+:meth:`latest_for_job`, and :meth:`history_for_job` — a silent
+fallback to ``'local'`` was the root cause of bugs #1/#2/#3, where
+SSH-backed jobs got their transitions looked up under the wrong axis.
+Callers pass ``scheduler_key='local'`` explicitly for local SLURM, or
+``'ssh:<profile>'`` for SSH transports.
 """
 
 from __future__ import annotations
@@ -53,16 +57,20 @@ class JobStateTransitionRepository(BaseRepository):
         source: TransitionSource,
         observed_at: str | None = None,
         *,
-        scheduler_key: str = "local",
+        scheduler_key: str,
     ) -> int:
         """Insert a new transition row. Returns the row's ``id``.
 
-        Accepts the SLURM ``job_id`` (+ ``scheduler_key``) for backwards
-        compatibility. The ``jobs_row_id`` column on disk is resolved
-        via a lookup against ``jobs``. If no matching jobs row exists
-        the transition is still inserted with ``jobs_row_id=NULL`` so
-        the append-only log is never silently dropped — the poller / CLI
-        still benefits from observability on orphan ids.
+        Accepts the SLURM ``job_id`` (+ ``scheduler_key``). The
+        ``jobs_row_id`` column on disk is resolved via a lookup against
+        ``jobs``. If no matching jobs row exists the transition is
+        still inserted with ``jobs_row_id=NULL`` so the append-only log
+        is never silently dropped — the poller / CLI still benefits
+        from observability on orphan ids.
+
+        ``scheduler_key`` is required (SF5); pass ``'local'`` explicitly
+        for local SLURM. Defaulting would silently dedup SSH transitions
+        against the local row's history.
         """
         observed_at = observed_at or now_iso()
         jobs_row_id = self._resolve_jobs_row_id(job_id, scheduler_key)
@@ -77,7 +85,7 @@ class JobStateTransitionRepository(BaseRepository):
         return int(cur.lastrowid or 0)
 
     def latest_for_job(
-        self, job_id: int, *, scheduler_key: str = "local"
+        self, job_id: int, *, scheduler_key: str
     ) -> JobStateTransition | None:
         """Return the most recent transition for ``(scheduler_key, job_id)``.
 
@@ -86,6 +94,9 @@ class JobStateTransitionRepository(BaseRepository):
         ``jobs_row_id`` from the ``jobs`` lookup so both pre-V5 writes
         (those with ``jobs_row_id`` set by backfill) and newly inserted
         rows match correctly.
+
+        ``scheduler_key`` is required (SF5); pass ``'local'`` explicitly
+        for local SLURM.
         """
         row = self.conn.execute(
             f"SELECT {', '.join(self._SELECT_COLUMNS)} "
@@ -98,9 +109,13 @@ class JobStateTransitionRepository(BaseRepository):
         return self._row_to_model(row, JobStateTransition)
 
     def history_for_job(
-        self, job_id: int, *, scheduler_key: str = "local"
+        self, job_id: int, *, scheduler_key: str
     ) -> list[JobStateTransition]:
-        """Return all transitions for the given job in chronological order."""
+        """Return all transitions for the given job in chronological order.
+
+        ``scheduler_key`` is required (SF5); pass ``'local'`` explicitly
+        for local SLURM.
+        """
         rows = self.conn.execute(
             f"SELECT {', '.join(self._SELECT_COLUMNS)} "
             "FROM job_state_transitions jst "

--- a/src/srunx/db/repositories/job_state_transitions.py
+++ b/src/srunx/db/repositories/job_state_transitions.py
@@ -4,6 +4,12 @@ Design reference: ``.claude/specs/notification-and-state-persistence/design.md``
 § Repositories. Records every observed job status change (SSOT for
 :class:`~srunx.pollers.active_watch_poller.ActiveWatchPoller` and CLI
 monitor alike).
+
+V5 note: the on-disk column is ``jobs_row_id`` (FK to ``jobs.id``),
+but the public API still takes ``job_id`` (SLURM id) so existing
+callers work unchanged. ``scheduler_key='local'`` is the default, so
+a ``latest_for_job(123)`` call returns the transition for the local
+SLURM job 123 — which is exactly what the pre-V5 API meant.
 """
 
 from __future__ import annotations
@@ -17,14 +23,27 @@ class JobStateTransitionRepository(BaseRepository):
 
     DATETIME_FIELDS = ("observed_at",)
 
-    _COLUMNS = (
-        "id",
-        "job_id",
-        "from_status",
-        "to_status",
-        "observed_at",
-        "source",
+    # Projection alias: the column is ``jobs_row_id`` but we re-expose it
+    # as ``job_id`` on the row dict so :class:`JobStateTransition` sees
+    # the legacy field name when read through ``_row_to_model``. The
+    # legacy public name ``JobStateTransition.job_id`` now carries the
+    # SLURM id, resolved via ``LEFT JOIN jobs``.
+    _SELECT_COLUMNS = (
+        "jst.id AS id",
+        "jst.jobs_row_id AS jobs_row_id",
+        "j.job_id AS job_id",
+        "jst.from_status AS from_status",
+        "jst.to_status AS to_status",
+        "jst.observed_at AS observed_at",
+        "jst.source AS source",
     )
+
+    def _resolve_jobs_row_id(self, job_id: int, scheduler_key: str) -> int | None:
+        row = self.conn.execute(
+            "SELECT id FROM jobs WHERE scheduler_key = ? AND job_id = ?",
+            (scheduler_key, job_id),
+        ).fetchone()
+        return int(row["id"]) if row is not None else None
 
     def insert(
         self,
@@ -33,38 +52,62 @@ class JobStateTransitionRepository(BaseRepository):
         to_status: str,
         source: TransitionSource,
         observed_at: str | None = None,
+        *,
+        scheduler_key: str = "local",
     ) -> int:
-        """Insert a new transition row. Returns the row's ``id``."""
+        """Insert a new transition row. Returns the row's ``id``.
+
+        Accepts the SLURM ``job_id`` (+ ``scheduler_key``) for backwards
+        compatibility. The ``jobs_row_id`` column on disk is resolved
+        via a lookup against ``jobs``. If no matching jobs row exists
+        the transition is still inserted with ``jobs_row_id=NULL`` so
+        the append-only log is never silently dropped — the poller / CLI
+        still benefits from observability on orphan ids.
+        """
         observed_at = observed_at or now_iso()
+        jobs_row_id = self._resolve_jobs_row_id(job_id, scheduler_key)
         cur = self.conn.execute(
             """
             INSERT OR REPLACE INTO job_state_transitions (
-                job_id, from_status, to_status, observed_at, source
+                jobs_row_id, from_status, to_status, observed_at, source
             ) VALUES (?, ?, ?, ?, ?)
             """,
-            (job_id, from_status, to_status, observed_at, source),
+            (jobs_row_id, from_status, to_status, observed_at, source),
         )
         return int(cur.lastrowid or 0)
 
-    def latest_for_job(self, job_id: int) -> JobStateTransition | None:
-        """Return the most recent transition for ``job_id``, or ``None``.
+    def latest_for_job(
+        self, job_id: int, *, scheduler_key: str = "local"
+    ) -> JobStateTransition | None:
+        """Return the most recent transition for ``(scheduler_key, job_id)``.
 
         Used by the poller for dedup: it only writes when the observed
-        ``to_status`` differs from the stored latest.
+        ``to_status`` differs from the stored latest. Resolves
+        ``jobs_row_id`` from the ``jobs`` lookup so both pre-V5 writes
+        (those with ``jobs_row_id`` set by backfill) and newly inserted
+        rows match correctly.
         """
         row = self.conn.execute(
-            f"SELECT {', '.join(self._COLUMNS)} FROM job_state_transitions "
-            "WHERE job_id = ? ORDER BY observed_at DESC, id DESC LIMIT 1",
-            (job_id,),
+            f"SELECT {', '.join(self._SELECT_COLUMNS)} "
+            "FROM job_state_transitions jst "
+            "LEFT JOIN jobs j ON j.id = jst.jobs_row_id "
+            "WHERE j.scheduler_key = ? AND j.job_id = ? "
+            "ORDER BY jst.observed_at DESC, jst.id DESC LIMIT 1",
+            (scheduler_key, job_id),
         ).fetchone()
         return self._row_to_model(row, JobStateTransition)
 
-    def history_for_job(self, job_id: int) -> list[JobStateTransition]:
-        """Return all transitions for ``job_id`` in chronological order."""
+    def history_for_job(
+        self, job_id: int, *, scheduler_key: str = "local"
+    ) -> list[JobStateTransition]:
+        """Return all transitions for the given job in chronological order."""
         rows = self.conn.execute(
-            f"SELECT {', '.join(self._COLUMNS)} FROM job_state_transitions "
-            "WHERE job_id = ? ORDER BY observed_at ASC, id ASC",
-            (job_id,),
+            f"SELECT {', '.join(self._SELECT_COLUMNS)} "
+            "FROM job_state_transitions jst "
+            "LEFT JOIN jobs j ON j.id = jst.jobs_row_id "
+            "WHERE j.scheduler_key = ? AND j.job_id = ? "
+            "ORDER BY jst.observed_at ASC, jst.id ASC",
+            (scheduler_key, job_id),
         ).fetchall()
         return [
             self._row_to_model(r, JobStateTransition)  # type: ignore[misc]

--- a/src/srunx/db/repositories/jobs.py
+++ b/src/srunx/db/repositories/jobs.py
@@ -10,12 +10,56 @@ from __future__ import annotations
 import sqlite3
 from typing import Any
 
-from srunx.db.models import Job, SubmissionSource
+from srunx.db.models import Job, SubmissionSource, TransportType
 from srunx.db.repositories.base import BaseRepository, now_iso
+
+# Validate that the (transport_type, profile_name, scheduler_key) triple
+# matches the V5 CHECK constraint on the ``jobs`` table. Raising here
+# gives callers a Python-level error with a clear message instead of a
+# sqlite IntegrityError that surfaces at INSERT time.
+_SCHEDULER_KEY_LOCAL = "local"
+
+
+def _validate_transport_triple(
+    transport_type: TransportType,
+    profile_name: str | None,
+    scheduler_key: str,
+) -> None:
+    if transport_type == "local":
+        if profile_name is not None:
+            raise ValueError("profile_name must be None for transport_type='local'")
+        if scheduler_key != _SCHEDULER_KEY_LOCAL:
+            raise ValueError(
+                f"scheduler_key must be 'local' for transport_type='local'; "
+                f"got {scheduler_key!r}"
+            )
+    elif transport_type == "ssh":
+        if not profile_name:
+            raise ValueError("profile_name is required for transport_type='ssh'")
+        if ":" in profile_name:
+            raise ValueError(f"profile_name must not contain ':'; got {profile_name!r}")
+        expected = f"ssh:{profile_name}"
+        if scheduler_key != expected:
+            raise ValueError(
+                f"scheduler_key must be {expected!r} for "
+                f"transport_type='ssh', profile_name={profile_name!r}; "
+                f"got {scheduler_key!r}"
+            )
+    else:  # pragma: no cover — Literal narrows this out
+        raise ValueError(f"unknown transport_type: {transport_type!r}")
 
 
 class JobRepository(BaseRepository):
-    """CRUD for the ``jobs`` table."""
+    """CRUD for the ``jobs`` table.
+
+    V5 (CLI transport unification) added ``transport_type`` /
+    ``profile_name`` / ``scheduler_key`` columns and broadened the
+    uniqueness key from ``job_id`` alone to ``(scheduler_key, job_id)``
+    so the same SLURM id can safely co-exist across ``local`` and
+    ``ssh:<profile>`` transports. The read / update API stays
+    backwards-compatible by defaulting ``scheduler_key='local'`` on
+    every lookup — pre-V5 callers see no change.
+    """
 
     JSON_FIELDS = ("command", "env_vars", "metadata")
     DATETIME_FIELDS = ("submitted_at", "started_at", "completed_at")
@@ -23,6 +67,9 @@ class JobRepository(BaseRepository):
     _COLUMNS = (
         "id",
         "job_id",
+        "transport_type",
+        "profile_name",
+        "scheduler_key",
         "name",
         "command",
         "status",
@@ -53,6 +100,9 @@ class JobRepository(BaseRepository):
         name: str,
         status: str,
         submission_source: SubmissionSource,
+        transport_type: TransportType = "local",
+        profile_name: str | None = None,
+        scheduler_key: str = "local",
         command: list[str] | None = None,
         nodes: int | None = None,
         gpus_per_node: int | None = None,
@@ -71,40 +121,50 @@ class JobRepository(BaseRepository):
     ) -> int:
         """Insert a new row for a just-submitted job.
 
-        Uses ``INSERT OR IGNORE`` on the ``job_id`` UNIQUE constraint:
-        if a row with this SLURM id already exists, the call is a
-        no-op and returns ``0``. Callers that want to mutate an
-        existing row should use :meth:`update_status` /
+        Uses ``INSERT OR IGNORE`` on the ``(scheduler_key, job_id)``
+        UNIQUE constraint (V5+): if a row with this combined key already
+        exists, the call is a no-op and returns ``0``. Callers that want
+        to mutate an existing row should use :meth:`update_status` /
         :meth:`update_completion` explicitly.
+
+        ``transport_type`` / ``profile_name`` / ``scheduler_key`` default
+        to the local-SLURM triple so pre-V5 callers remain source-compat.
+        For SSH submissions the caller must provide all three with a
+        consistent shape (``transport_type='ssh'``, non-None
+        ``profile_name`` without ``:``, ``scheduler_key='ssh:<profile>'``);
+        :func:`_validate_transport_triple` rejects mismatches up front.
 
         Rationale for **not** using ``INSERT OR REPLACE`` here
         (P1-2 in the Codex review triage): ``REPLACE`` executes
         ``DELETE`` + ``INSERT``, which triggers
         ``ON DELETE SET NULL`` on the FK references in
-        ``workflow_run_jobs.job_id`` and ``job_state_transitions.job_id``.
-        A re-submission path (or a bug-induced double call) would
-        silently orphan every prior transition and membership, which
-        corrupts the poller's dedup / aggregation invariants. It would
-        also reset a poller-advanced ``status='RUNNING'`` row back to
-        ``'PENDING'`` + rewrite ``submitted_at``. With ``IGNORE`` the
-        first call wins; subsequent callers observe ``lastrowid=0``
-        and must decide explicitly what to do.
+        ``workflow_run_jobs.jobs_row_id`` and
+        ``job_state_transitions.jobs_row_id``. A re-submission path
+        would silently orphan every prior transition and membership.
+        With ``IGNORE`` the first call wins; subsequent callers observe
+        ``lastrowid=0`` and must decide explicitly what to do.
         """
+        _validate_transport_triple(transport_type, profile_name, scheduler_key)
+
         submitted_at = submitted_at or now_iso()
         cur = self.conn.execute(
             """
             INSERT OR IGNORE INTO jobs (
-                job_id, name, command, status,
+                job_id, transport_type, profile_name, scheduler_key,
+                name, command, status,
                 nodes, gpus_per_node, memory_per_node, time_limit,
                 partition, nodelist,
                 conda, venv, container, env_vars,
                 submitted_at,
                 workflow_run_id, submission_source,
                 log_file, metadata
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 job_id,
+                transport_type,
+                profile_name,
+                scheduler_key,
                 name,
                 self._encode_json(command),
                 status,
@@ -138,6 +198,7 @@ class JobRepository(BaseRepository):
         job_id: int,
         status: str,
         *,
+        scheduler_key: str = "local",
         started_at: str | None = None,
         completed_at: str | None = None,
         duration_secs: int | None = None,
@@ -147,6 +208,9 @@ class JobRepository(BaseRepository):
 
         Called by :class:`~srunx.pollers.active_watch_poller.ActiveWatchPoller`
         on every detected transition. Returns True if a row was updated.
+
+        ``scheduler_key`` defaults to ``'local'`` so pre-V5 callers
+        continue to target the local-SLURM row unchanged.
         """
         sets: list[str] = ["status = ?"]
         vals: list[Any] = [status]
@@ -162,10 +226,10 @@ class JobRepository(BaseRepository):
         if nodelist is not None:
             sets.append("nodelist = ?")
             vals.append(nodelist)
-        vals.append(job_id)
+        vals.extend([scheduler_key, job_id])
 
         cur = self.conn.execute(
-            f"UPDATE jobs SET {', '.join(sets)} WHERE job_id = ?",
+            f"UPDATE jobs SET {', '.join(sets)} WHERE scheduler_key = ? AND job_id = ?",
             vals,
         )
         return cur.rowcount > 0
@@ -175,6 +239,8 @@ class JobRepository(BaseRepository):
         job_id: int,
         status: str,
         completed_at: str | None = None,
+        *,
+        scheduler_key: str = "local",
     ) -> bool:
         """Compatibility wrapper for the historical ``update_job_completion``.
 
@@ -182,7 +248,8 @@ class JobRepository(BaseRepository):
         """
         completed_at = completed_at or now_iso()
         row = self.conn.execute(
-            "SELECT submitted_at FROM jobs WHERE job_id = ?", (job_id,)
+            "SELECT submitted_at FROM jobs WHERE scheduler_key = ? AND job_id = ?",
+            (scheduler_key, job_id),
         ).fetchone()
         duration: int | None = None
         if row is not None:
@@ -196,14 +263,36 @@ class JobRepository(BaseRepository):
         return self.update_status(
             job_id,
             status,
+            scheduler_key=scheduler_key,
             completed_at=completed_at,
             duration_secs=duration,
         )
 
-    def get(self, job_id: int) -> Job | None:
+    def get(self, job_id: int, *, scheduler_key: str = "local") -> Job | None:
+        """Return the jobs row for ``(scheduler_key, job_id)``.
+
+        ``scheduler_key`` defaults to ``'local'`` so callers that only
+        deal with local-SLURM ids work unchanged. Use
+        :meth:`get_by_row_id` when the caller already has ``jobs.id``.
+        """
         row = self.conn.execute(
-            f"SELECT {', '.join(self._COLUMNS)} FROM jobs WHERE job_id = ?",
-            (job_id,),
+            f"SELECT {', '.join(self._COLUMNS)} FROM jobs "
+            "WHERE scheduler_key = ? AND job_id = ?",
+            (scheduler_key, job_id),
+        ).fetchone()
+        return self._row_to_model(row, Job)
+
+    def get_by_row_id(self, row_id: int) -> Job | None:
+        """Return the jobs row for ``jobs.id`` (AUTOINCREMENT PK).
+
+        Used by the V5 FK-retargeted child tables
+        (``workflow_run_jobs.jobs_row_id`` /
+        ``job_state_transitions.jobs_row_id``) that carry the row id
+        directly instead of the SLURM ``job_id``.
+        """
+        row = self.conn.execute(
+            f"SELECT {', '.join(self._COLUMNS)} FROM jobs WHERE id = ?",
+            (row_id,),
         ).fetchone()
         return self._row_to_model(row, Job)
 
@@ -275,8 +364,11 @@ class JobRepository(BaseRepository):
         rows = self.conn.execute(sql, params).fetchall()
         return {r["status"]: int(r["c"]) for r in rows}
 
-    def delete(self, job_id: int) -> bool:
-        cur = self.conn.execute("DELETE FROM jobs WHERE job_id = ?", (job_id,))
+    def delete(self, job_id: int, *, scheduler_key: str = "local") -> bool:
+        cur = self.conn.execute(
+            "DELETE FROM jobs WHERE scheduler_key = ? AND job_id = ?",
+            (scheduler_key, job_id),
+        )
         return cur.rowcount > 0
 
     # ------------------------------------------------------------------

--- a/src/srunx/db/repositories/jobs.py
+++ b/src/srunx/db/repositories/jobs.py
@@ -56,9 +56,16 @@ class JobRepository(BaseRepository):
     ``profile_name`` / ``scheduler_key`` columns and broadened the
     uniqueness key from ``job_id`` alone to ``(scheduler_key, job_id)``
     so the same SLURM id can safely co-exist across ``local`` and
-    ``ssh:<profile>`` transports. The read / update API stays
-    backwards-compatible by defaulting ``scheduler_key='local'`` on
-    every lookup — pre-V5 callers see no change.
+    ``ssh:<profile>`` transports.
+
+    SF5 hardened the read / update API: :meth:`get`, :meth:`update_status`,
+    :meth:`update_completion`, and :meth:`delete` now **require**
+    ``scheduler_key`` as a keyword argument. Callers must pass the
+    matching value (``'local'`` for local SLURM, ``'ssh:<profile>'`` for
+    SSH) so the axis is explicit at every call site and bugs #1/#2/#3
+    (silent fallback to ``'local'`` for SSH-backed jobs) cannot recur.
+    :meth:`record_submission` keeps its local-triple default because its
+    three transport columns are consistent with each other.
     """
 
     JSON_FIELDS = ("command", "env_vars", "metadata")
@@ -198,7 +205,7 @@ class JobRepository(BaseRepository):
         job_id: int,
         status: str,
         *,
-        scheduler_key: str = "local",
+        scheduler_key: str,
         started_at: str | None = None,
         completed_at: str | None = None,
         duration_secs: int | None = None,
@@ -209,8 +216,9 @@ class JobRepository(BaseRepository):
         Called by :class:`~srunx.pollers.active_watch_poller.ActiveWatchPoller`
         on every detected transition. Returns True if a row was updated.
 
-        ``scheduler_key`` defaults to ``'local'`` so pre-V5 callers
-        continue to target the local-SLURM row unchanged.
+        ``scheduler_key`` is required (SF5) so callers cannot accidentally
+        target the local-SLURM row when they meant an SSH transport.
+        Pass ``scheduler_key='local'`` explicitly for local SLURM.
         """
         sets: list[str] = ["status = ?"]
         vals: list[Any] = [status]
@@ -240,11 +248,15 @@ class JobRepository(BaseRepository):
         status: str,
         completed_at: str | None = None,
         *,
-        scheduler_key: str = "local",
+        scheduler_key: str,
     ) -> bool:
         """Compatibility wrapper for the historical ``update_job_completion``.
 
         Computes ``duration_secs`` from ``submitted_at`` when not provided.
+
+        ``scheduler_key`` is required (SF5); pass ``'local'`` explicitly
+        for local SLURM. Defaulting silently would silently fall back to
+        the local row for SSH transports.
         """
         completed_at = completed_at or now_iso()
         row = self.conn.execute(
@@ -268,12 +280,14 @@ class JobRepository(BaseRepository):
             duration_secs=duration,
         )
 
-    def get(self, job_id: int, *, scheduler_key: str = "local") -> Job | None:
+    def get(self, job_id: int, *, scheduler_key: str) -> Job | None:
         """Return the jobs row for ``(scheduler_key, job_id)``.
 
-        ``scheduler_key`` defaults to ``'local'`` so callers that only
-        deal with local-SLURM ids work unchanged. Use
-        :meth:`get_by_row_id` when the caller already has ``jobs.id``.
+        ``scheduler_key`` is required (SF5). Bugs #1/#2/#3 all originated
+        from code that forgot to pass it and silently got the local row
+        back for SSH-backed jobs. Pass ``scheduler_key='local'`` for
+        local SLURM, or use :meth:`get_by_row_id` when the caller
+        already has ``jobs.id``.
         """
         row = self.conn.execute(
             f"SELECT {', '.join(self._COLUMNS)} FROM jobs "
@@ -364,7 +378,12 @@ class JobRepository(BaseRepository):
         rows = self.conn.execute(sql, params).fetchall()
         return {r["status"]: int(r["c"]) for r in rows}
 
-    def delete(self, job_id: int, *, scheduler_key: str = "local") -> bool:
+    def delete(self, job_id: int, *, scheduler_key: str) -> bool:
+        """Delete the jobs row for ``(scheduler_key, job_id)``.
+
+        ``scheduler_key`` is required (SF5). Pass ``'local'`` explicitly
+        for local SLURM.
+        """
         cur = self.conn.execute(
             "DELETE FROM jobs WHERE scheduler_key = ? AND job_id = ?",
             (scheduler_key, job_id),

--- a/src/srunx/db/repositories/workflow_run_jobs.py
+++ b/src/srunx/db/repositories/workflow_run_jobs.py
@@ -2,6 +2,12 @@
 
 Design reference: ``.claude/specs/notification-and-state-persistence/design.md``
 § Repositories.
+
+V5 note: the on-disk column is ``jobs_row_id`` (FK to ``jobs.id``). The
+public API still accepts ``job_id`` (SLURM id, ``scheduler_key='local'``
+by default) so pre-V5 callers work unchanged — the repository performs
+the ``jobs.id`` lookup internally. Callers that have ``jobs.id`` in
+hand can use the new ``jobs_row_id`` kwarg directly.
 """
 
 from __future__ import annotations
@@ -15,13 +21,24 @@ class WorkflowRunJobRepository(BaseRepository):
 
     JSON_FIELDS = ("depends_on",)
 
-    _COLUMNS = (
-        "id",
-        "workflow_run_id",
-        "job_id",
-        "job_name",
-        "depends_on",
+    # Select joins ``jobs`` so the legacy ``job_id`` attribute on
+    # :class:`WorkflowRunJob` carries the SLURM id. ``jobs_row_id`` is
+    # the authoritative V5 FK.
+    _SELECT_COLUMNS = (
+        "wrj.id AS id",
+        "wrj.workflow_run_id AS workflow_run_id",
+        "wrj.jobs_row_id AS jobs_row_id",
+        "j.job_id AS job_id",
+        "wrj.job_name AS job_name",
+        "wrj.depends_on AS depends_on",
     )
+
+    def _resolve_jobs_row_id(self, job_id: int, scheduler_key: str) -> int | None:
+        row = self.conn.execute(
+            "SELECT id FROM jobs WHERE scheduler_key = ? AND job_id = ?",
+            (scheduler_key, job_id),
+        ).fetchone()
+        return int(row["id"]) if row is not None else None
 
     def create(
         self,
@@ -29,44 +46,67 @@ class WorkflowRunJobRepository(BaseRepository):
         job_name: str,
         depends_on: list[str] | None = None,
         job_id: int | None = None,
+        *,
+        scheduler_key: str = "local",
+        jobs_row_id: int | None = None,
     ) -> int:
         """Insert (or replace) a workflow_run_jobs row.
 
-        ``job_id`` is typically ``None`` until the underlying SLURM job has
-        been submitted; callers then invoke :meth:`update_job_id`. Returns
+        ``job_id`` (SLURM id) is resolved to ``jobs.id`` via
+        ``(scheduler_key, job_id)``. Alternatively callers that already
+        know the jobs row id can pass ``jobs_row_id`` directly. Returns
         the new row's ``id``.
         """
+        resolved_row_id: int | None
+        if jobs_row_id is not None:
+            resolved_row_id = jobs_row_id
+        elif job_id is not None:
+            resolved_row_id = self._resolve_jobs_row_id(job_id, scheduler_key)
+        else:
+            resolved_row_id = None
+
         cur = self.conn.execute(
             """
             INSERT OR REPLACE INTO workflow_run_jobs (
-                workflow_run_id, job_id, job_name, depends_on
+                workflow_run_id, jobs_row_id, job_name, depends_on
             ) VALUES (?, ?, ?, ?)
             """,
             (
                 workflow_run_id,
-                job_id,
+                resolved_row_id,
                 job_name,
                 self._encode_json(depends_on),
             ),
         )
         return int(cur.lastrowid or 0)
 
-    def update_job_id(self, row_id: int, job_id: int) -> bool:
+    def update_job_id(
+        self,
+        row_id: int,
+        job_id: int,
+        *,
+        scheduler_key: str = "local",
+    ) -> bool:
         """Associate a SLURM ``job_id`` with a previously-created row.
 
-        Returns True if a row was updated.
+        Resolves ``job_id`` to ``jobs.id`` via ``(scheduler_key, job_id)``
+        and writes the V5 ``jobs_row_id`` column. Returns True if a row
+        was updated.
         """
+        resolved_row_id = self._resolve_jobs_row_id(job_id, scheduler_key)
         cur = self.conn.execute(
-            "UPDATE workflow_run_jobs SET job_id = ? WHERE id = ?",
-            (job_id, row_id),
+            "UPDATE workflow_run_jobs SET jobs_row_id = ? WHERE id = ?",
+            (resolved_row_id, row_id),
         )
         return cur.rowcount > 0
 
     def list_by_run(self, workflow_run_id: int) -> list[WorkflowRunJob]:
         """Return every row belonging to ``workflow_run_id`` in insertion order."""
         rows = self.conn.execute(
-            f"SELECT {', '.join(self._COLUMNS)} FROM workflow_run_jobs "
-            "WHERE workflow_run_id = ? ORDER BY id ASC",
+            f"SELECT {', '.join(self._SELECT_COLUMNS)} "
+            "FROM workflow_run_jobs wrj "
+            "LEFT JOIN jobs j ON j.id = wrj.jobs_row_id "
+            "WHERE wrj.workflow_run_id = ? ORDER BY wrj.id ASC",
             (workflow_run_id,),
         ).fetchall()
         return [self._row_to_model(r, WorkflowRunJob) for r in rows if r is not None]  # type: ignore[misc]

--- a/src/srunx/exceptions.py
+++ b/src/srunx/exceptions.py
@@ -12,3 +12,52 @@ class WorkflowExecutionError(WorkflowError):
 
 class SweepExecutionError(WorkflowError):
     """Exception raised when sweep materialize / execution fails at the orchestrator boundary."""
+
+
+# ---------------------------------------------------------------------------
+# Transport / job operation exceptions (introduced by CLI transport unification)
+# ---------------------------------------------------------------------------
+
+
+class TransportError(Exception):
+    """Base class for transport-layer failures (local subprocess or SSH).
+
+    Callers (CLI / poller) catch this to render a uniform user-facing
+    error. Always attach a human-readable ``str(exc)`` summary.
+    """
+
+
+class TransportConnectionError(TransportError):
+    """SSH connection failed or local sbatch binary unavailable."""
+
+
+class TransportAuthError(TransportError):
+    """SSH authentication failed (wrong key, refused, etc.)."""
+
+
+class TransportTimeoutError(TransportError):
+    """SSH or scontrol / sbatch call exceeded its timeout."""
+
+
+class RemoteCommandError(TransportError):
+    """A remote command (e.g. ``scontrol show job``) returned non-zero.
+
+    Distinct from :class:`SubmissionError` — used for read-path commands
+    that are not ``sbatch`` itself.
+    """
+
+
+class JobNotFound(Exception):
+    """Job ID does not exist on the target SLURM cluster.
+
+    Separate from :class:`TransportError` because 'missing job' is a
+    user-level condition, not a transport failure.
+    """
+
+
+class SubmissionError(Exception):
+    """sbatch invocation reached the cluster but returned non-zero.
+
+    The sbatch process started (so transport succeeded) but sbatch
+    itself rejected the script (syntax error, quota, etc.).
+    """

--- a/src/srunx/models.py
+++ b/src/srunx/models.py
@@ -304,6 +304,10 @@ class BaseJob(BaseModel):
         default=None,
         description="Elapsed time in SLURM format (e.g., '1-02:30:45')",
     )
+    time_limit: str | None = Field(
+        default=None,
+        description="SLURM --time request (e.g., '1:00:00', 'UNLIMITED')",
+    )
     nodes: int | None = Field(
         default=None, ge=0, description="Number of nodes allocated to job"
     )

--- a/src/srunx/monitor/base.py
+++ b/src/srunx/monitor/base.py
@@ -122,14 +122,20 @@ class BaseMonitor(ABC):
         self._stop_requested = False
         self._setup_signal_handlers()
         start_time = time.time()
-        logger.info(
+        timeout_display = (
+            f"{self.config.timeout}s" if self.config.timeout else "no timeout"
+        )
+        # Developer trace — user-facing "🔍 Monitoring jobs ..." output
+        # is emitted by the CLI layer, so this stays at DEBUG to avoid
+        # double-printing the same information in different formats.
+        logger.debug(
             f"Starting until-condition monitoring "
-            f"(interval={self.config.poll_interval}s, timeout={self.config.timeout}s)"
+            f"(interval={self.config.poll_interval}s, timeout={timeout_display})"
         )
 
         while not self._stop_requested:
             if self.check_condition():
-                logger.info("Condition met, stopping monitor")
+                logger.debug("Condition met, stopping monitor")
                 self._notify_callbacks("condition_met")
                 return
 
@@ -145,7 +151,7 @@ class BaseMonitor(ABC):
 
             time.sleep(self.config.poll_interval)
 
-        logger.info("Monitor stopped by user request")
+        logger.debug("Monitor stopped by user request")
 
     def watch_continuous(self) -> None:
         """
@@ -166,7 +172,7 @@ class BaseMonitor(ABC):
         self._stop_requested = False
         self._setup_signal_handlers()
         previous_state: dict[str, Any] | None = None
-        logger.info(
+        logger.debug(
             f"Starting continuous monitoring "
             f"(interval={self.config.poll_interval}s, Ctrl+C to stop)"
         )
@@ -176,14 +182,14 @@ class BaseMonitor(ABC):
 
             # Notify only on state change (prevent duplicates)
             if current_state != previous_state and previous_state is not None:
-                logger.info(f"State changed: {previous_state} -> {current_state}")
+                logger.debug(f"State changed: {previous_state} -> {current_state}")
                 if self.config.notify_on_change:
                     self._notify_callbacks("state_changed")
 
             previous_state = current_state
             time.sleep(self.config.poll_interval)
 
-        logger.info("Continuous monitor stopped")
+        logger.debug("Continuous monitor stopped")
 
     @abstractmethod
     def _notify_callbacks(self, event: str) -> None:

--- a/src/srunx/monitor/job_monitor.py
+++ b/src/srunx/monitor/job_monitor.py
@@ -11,6 +11,7 @@ from srunx.monitor.base import BaseMonitor
 from srunx.monitor.types import MonitorConfig
 
 if TYPE_CHECKING:
+    from srunx.client_protocol import JobOperationsProtocol
     from srunx.db.repositories.job_state_transitions import (
         JobStateTransitionRepository,
     )
@@ -45,7 +46,7 @@ class JobMonitor(BaseMonitor):
         target_statuses: list[JobStatus] | None = None,
         config: MonitorConfig | None = None,
         callbacks: list[Callback] | None = None,
-        client: Slurm | None = None,
+        client: "JobOperationsProtocol | None" = None,
         transition_repo: "JobStateTransitionRepository | None" = None,
         scheduler_key: str = "local",
     ) -> None:
@@ -72,7 +73,7 @@ class JobMonitor(BaseMonitor):
         self._previous_states: dict[int, JobStatus] = {}
         self._cached_jobs: list[BaseJob] | None = None
 
-        logger.info(
+        logger.debug(
             f"JobMonitor initialized for jobs {self.job_ids}, "
             f"target statuses: {[s.value for s in self.target_statuses]}"
         )
@@ -80,8 +81,12 @@ class JobMonitor(BaseMonitor):
     def _get_monitored_jobs(self) -> list[BaseJob]:
         """Get monitored jobs, using per-cycle cache.
 
-        First call per cycle fetches from SLURM via client.retrieve();
-        subsequent calls within the same cycle return the cached result.
+        First call per cycle fetches from SLURM via
+        :meth:`JobOperationsProtocol.status`; subsequent calls within
+        the same cycle return the cached result. Uses the Protocol
+        method rather than :meth:`Slurm.retrieve` so SSH-backed
+        monitors (``srunx monitor jobs --profile ...``) work too —
+        ``retrieve`` is a local-Slurm-only legacy name.
         """
         if self._cached_jobs is not None:
             return self._cached_jobs
@@ -91,7 +96,7 @@ class JobMonitor(BaseMonitor):
         jobs: list[BaseJob] = []
         for job_id in self.job_ids:
             try:
-                jobs.append(self.client.retrieve(job_id))
+                jobs.append(self.client.status(job_id))
             except Exception as e:
                 logger.warning(f"Failed to retrieve job {job_id}: {e}")
                 placeholder = Job(

--- a/src/srunx/monitor/job_monitor.py
+++ b/src/srunx/monitor/job_monitor.py
@@ -31,6 +31,12 @@ class JobMonitor(BaseMonitor):
     ``job_state_transitions`` table with ``source='cli_monitor'``.
     DB failures are logged but never propagated — the CLI monitor must
     keep running even if the database is unavailable.
+
+    ``scheduler_key`` pins every DB write to the right transport axis
+    (``'local'`` or ``'ssh:<profile>'``). The CLI threads its resolved
+    transport's ``scheduler_key`` in so SSH-backed monitors don't
+    accidentally target the local-SLURM row (the regression the SF5
+    hardening pass closes at the repository layer).
     """
 
     def __init__(
@@ -41,6 +47,7 @@ class JobMonitor(BaseMonitor):
         callbacks: list[Callback] | None = None,
         client: Slurm | None = None,
         transition_repo: "JobStateTransitionRepository | None" = None,
+        scheduler_key: str = "local",
     ) -> None:
         super().__init__(config=config, callbacks=callbacks)
 
@@ -56,6 +63,12 @@ class JobMonitor(BaseMonitor):
         ]
         self.client = client or Slurm()
         self.transition_repo = transition_repo
+        # V5 axis: every DB write (transitions, completions) pins
+        # ``(scheduler_key, job_id)`` together. Defaults to ``'local'`` so
+        # existing local-SLURM callers stay source-compatible; the CLI
+        # monitor command now threads the resolved transport's key in so
+        # SSH-backed monitors write under the correct axis.
+        self.scheduler_key = scheduler_key
         self._previous_states: dict[int, JobStatus] = {}
         self._cached_jobs: list[BaseJob] | None = None
 
@@ -136,6 +149,7 @@ class JobMonitor(BaseMonitor):
                             from_status=previous_status.value,
                             to_status=current_status.value,
                             source="cli_monitor",
+                            scheduler_key=self.scheduler_key,
                         )
                     except Exception as e:
                         logger.warning(
@@ -166,7 +180,9 @@ class JobMonitor(BaseMonitor):
             from srunx.db.cli_helpers import record_completion
 
             try:
-                record_completion(int(job.job_id), status)
+                record_completion(
+                    int(job.job_id), status, scheduler_key=self.scheduler_key
+                )
             except Exception as exc:
                 # ``record_completion`` is best-effort internally, but a
                 # bug in it (or a monkeypatched test) must never prevent

--- a/src/srunx/notifications/adapters/slack_webhook.py
+++ b/src/srunx/notifications/adapters/slack_webhook.py
@@ -62,11 +62,27 @@ class SlackWebhookDeliveryAdapter:
 
     @staticmethod
     def _id_from_source_ref(source_ref: str, expected_prefix: str) -> str | None:
-        """Extract the numeric id from ``"<prefix>:<id>"`` shaped source_ref."""
+        """Extract the trailing id from a structured ``source_ref``.
+
+        Grammar accepted (V5+):
+
+        - ``job:local:<N>``          → ``"<N>"``
+        - ``job:ssh:<profile>:<N>``  → ``"<N>"``
+        - ``workflow_run:<N>``        → ``"<N>"``
+        - ``sweep_run:<N>``           → ``"<N>"``
+
+        The trailing segment (after the last ``:``) is always the id,
+        so we use :func:`str.rsplit` with ``maxsplit=1`` rather than a
+        prefix-strip — that keeps both the V5 3/4-segment ``job`` forms
+        and the transport-agnostic ``workflow_run`` / ``sweep_run``
+        forms rendering the same id in Slack messages.
+        """
         if not source_ref.startswith(f"{expected_prefix}:"):
             return None
-        suffix = source_ref[len(expected_prefix) + 1 :]
-        return suffix or None
+        head, _, tail = source_ref.rpartition(":")
+        if not head or not tail:
+            return None
+        return tail
 
     @staticmethod
     def _build_message(event: Event) -> tuple[str, list[dict[str, Any]]]:

--- a/src/srunx/notifications/service.py
+++ b/src/srunx/notifications/service.py
@@ -110,6 +110,8 @@ class NotificationService:
         job_id: int,
         endpoint_id: int | None,
         preset: str,
+        *,
+        scheduler_key: str = "local",
     ) -> int:
         """Create a job-kind watch and (optionally) its subscription.
 
@@ -119,11 +121,17 @@ class NotificationService:
                 from the new watch to this endpoint with ``preset``.
             preset: Preset string for the subscription. Ignored when
                 ``endpoint_id`` is ``None``.
+            scheduler_key: ``"local"`` (default) for local SLURM, or
+                ``"ssh:<profile>"`` for an SSH transport. Encoded into
+                the V5 3-segment ``target_ref`` grammar
+                ``job:<scheduler_key>:<id>`` so the poller can route
+                each watch back to the right transport.
 
         Returns:
             The newly-created ``watches.id``.
         """
-        watch_id = self.watch_repo.create(kind="job", target_ref=f"job:{job_id}")
+        target_ref = f"job:{scheduler_key}:{job_id}"
+        watch_id = self.watch_repo.create(kind="job", target_ref=target_ref)
         if endpoint_id is not None:
             self.subscription_repo.create(
                 watch_id=watch_id,

--- a/src/srunx/pollers/active_watch_poller.py
+++ b/src/srunx/pollers/active_watch_poller.py
@@ -114,18 +114,31 @@ def _dt_to_iso(value: object) -> str | None:
 
 
 def _parse_target_id(target_ref: str, expected_prefix: str) -> int | None:
-    """Return the integer id encoded in ``"<expected_prefix>:<id>"``.
+    """Return the integer id encoded in a watch ``target_ref``.
 
-    Returns ``None`` if the prefix does not match or the id portion
-    cannot be parsed — unexpected rows are simply skipped (logged at
-    debug by the caller) so a malformed watch never takes the cycle
-    down.
+    Accepts both the legacy 2-segment form (``"<prefix>:<id>"``) and the
+    V5+ 3-segment form for ``job`` refs (``"job:local:<id>"`` /
+    ``"job:ssh:<profile>:<id>"``). For non-``job`` prefixes the 2-segment
+    form remains authoritative.
+
+    Returns ``None`` if the prefix does not match or no numeric id can be
+    extracted — malformed rows are skipped rather than taking the cycle
+    down. Phase 6 replaces this helper with
+    :func:`_parse_target_ref` which returns the full
+    ``(scheduler_key, job_id)`` tuple; until then the poller only needs
+    the numeric id so we fall back to the trailing segment.
     """
     prefix, _, remainder = target_ref.partition(":")
     if prefix != expected_prefix or not remainder:
         return None
+    # For job refs the V5 form includes a transport segment (``local`` or
+    # ``ssh:<profile>``) before the numeric id; take the trailing
+    # segment. For workflow_run / sweep_run / etc the 2-segment form is
+    # final, so rsplit on a string with no ``:`` is a no-op and returns
+    # the original remainder.
+    tail = remainder.rsplit(":", 1)[-1]
     try:
-        return int(remainder)
+        return int(tail)
     except ValueError:
         return None
 
@@ -375,7 +388,13 @@ class ActiveWatchPoller:
                     "started_at": started_iso,
                     "completed_at": completed_iso,
                 }
-                source_ref = f"job:{job_id}"
+                # V5: source_ref uses the 3-segment grammar
+                # ``job:<scheduler_key>:<id>``. Phase 3 poller only
+                # watches local SLURM, so ``scheduler_key='local'`` is
+                # correct for every row the producer writes. Phase 6
+                # will make this transport-aware via a scheduler_key
+                # derived from the watch row.
+                source_ref = f"job:local:{job_id}"
                 event_id = event_repo.insert(
                     kind="job.status_changed",
                     source_ref=source_ref,

--- a/src/srunx/pollers/active_watch_poller.py
+++ b/src/srunx/pollers/active_watch_poller.py
@@ -697,11 +697,17 @@ class ActiveWatchPoller:
 
         child_statuses: list[str | None] = []
         for membership in memberships:
-            job_id = getattr(membership, "job_id", None)
-            if job_id is None:
+            # V5+: ``workflow_run_jobs.jobs_row_id`` is the authoritative
+            # FK to ``jobs.id``. Using ``jobs_row_id`` via
+            # :meth:`JobRepository.get_by_row_id` avoids the pre-V5
+            # ``scheduler_key='local'`` default, which would drop SSH
+            # workflow children and leave the workflow stuck "not all
+            # completed" forever.
+            jobs_row_id = getattr(membership, "jobs_row_id", None)
+            if jobs_row_id is None:
                 child_statuses.append(None)
                 continue
-            job = job_repo.get(job_id)
+            job = job_repo.get_by_row_id(jobs_row_id)
             child_statuses.append(job.status if job is not None else None)
 
         # Rule 1 — any CANCELLED wins.

--- a/src/srunx/pollers/active_watch_poller.py
+++ b/src/srunx/pollers/active_watch_poller.py
@@ -28,12 +28,26 @@ through it, and closes it in ``finally`` — this isolates the
 producer from FastAPI request connections and keeps WAL fsyncs off
 the hot web path.
 
+Single-process assumption
+-------------------------
+Phase 1 deployment is single-process: exactly one
+:class:`ActiveWatchPoller` instance (started from the FastAPI lifespan
+or the CLI worker) drives all open watches. Running more than one
+instance — e.g. scaling FastAPI to multiple worker processes without
+disabling the poller on all but one — would double-process each watch
+because there is no per-watch claim / lease yet.
+
+TODO (Phase 2): add a ``leased_until`` / ``worker_id`` sweep on
+``watches`` before shipping multi-worker deployments, mirroring the
+pattern already in :class:`~srunx.pollers.delivery_poller.DeliveryPoller`.
+
 See ``.claude/specs/notification-and-state-persistence/design.md``
 § ActiveWatchPoller.
 """
 
 from __future__ import annotations
 
+import re
 import sqlite3
 import time
 from collections.abc import Callable
@@ -117,6 +131,22 @@ def _dt_to_iso(value: object) -> str | None:
     return str(value)
 
 
+# SLURM job IDs are allocated as monotonically increasing 32-bit
+# integers; real-world ids are orders of magnitude below 10**12. We
+# reject both 0-and-below (not a valid SLURM id) and values above the
+# ceiling so a malicious ``target_ref`` cannot wedge the poller with
+# a huge int parse + DB probe (F3).
+_MAX_JOB_ID = 10**12
+_MAX_JOB_ID_DIGITS = 12
+
+# Profile names are constrained so they can round-trip through the
+# ``scheduler_key`` grammar (``ssh:<profile>``) unescaped. The same
+# regex is applied at profile creation time (see
+# ``srunx.ssh.core.config.validate_profile_name``) so a watch row can
+# only ever reach this parser with a name that matches (F4).
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_.\-]{1,64}$")
+
+
 def _parse_target_ref(
     target_ref: str, expected_kind: str = "job"
 ) -> tuple[str, int] | None:
@@ -131,8 +161,12 @@ def _parse_target_ref(
 
     - legacy 2-segment refs (``job:<N>``) — V5 migration backfills every
       existing row to 3+ segments, so this should not appear in practice;
-      returning ``None`` here keeps the parser strict (AC-8.4).
+      returning ``None`` here keeps the parser strict (AC-8.4). An
+      unexpected 2-segment row is logged at DEBUG so operators can spot
+      a rogue writer without breaking the cycle (F7).
     - malformed refs (non-int tail, unknown kind prefix, empty segments).
+    - numeric tails outside the accepted job-id range (F3).
+    - profile names that fail :data:`_PROFILE_NAME_RE` (F3/F4).
 
     Phase 6 callers use the returned ``scheduler_key`` to group watches
     by transport and to write ``source_ref`` back with the correct
@@ -143,16 +177,37 @@ def _parse_target_ref(
         return None
     if len(parts) < 3:
         # Legacy 2-segment — after V5 migration these should not exist.
+        logger.debug(
+            "Skipping 2-segment target_ref %r (post-V5 should not occur)",
+            target_ref,
+        )
+        return None
+
+    job_id_str = parts[-1]
+    # ``int()`` would happily eat signs / whitespace / underscores; we
+    # reject anything that isn't a pure digit run plus length-cap it so
+    # pathological inputs never reach the ``int`` cast.
+    if (
+        not job_id_str
+        or not job_id_str.isdigit()
+        or len(job_id_str) > _MAX_JOB_ID_DIGITS
+    ):
         return None
     try:
-        job_id = int(parts[-1])
+        job_id = int(job_id_str)
     except ValueError:
         return None
+    if job_id <= 0 or job_id > _MAX_JOB_ID:
+        return None
+
     middle = parts[1:-1]
     if middle == ["local"]:
         return ("local", job_id)
     if len(middle) == 2 and middle[0] == "ssh" and middle[1]:
-        return (f"ssh:{middle[1]}", job_id)
+        profile = middle[1]
+        if not _PROFILE_NAME_RE.match(profile):
+            return None
+        return (f"ssh:{profile}", job_id)
     return None
 
 
@@ -463,7 +518,7 @@ class ActiveWatchPoller:
                 continue
 
             current_status = status_info.status
-            latest = transition_repo.latest_for_job(job_id)
+            latest = transition_repo.latest_for_job(job_id, scheduler_key=scheduler_key)
 
             if latest is None:
                 # First observation of this job. Skip per design:
@@ -485,7 +540,7 @@ class ActiveWatchPoller:
             # (Slack, email, generic webhooks) can render informative
             # messages without having to re-query the DB or parse
             # source_ref themselves.
-            existing_job = job_repo.get(job_id)
+            existing_job = job_repo.get(job_id, scheduler_key=scheduler_key)
             job_name = existing_job.name if existing_job is not None else None
 
             with transaction(conn, "IMMEDIATE"):
@@ -494,10 +549,12 @@ class ActiveWatchPoller:
                     from_status=from_status,
                     to_status=current_status,
                     source="poller",
+                    scheduler_key=scheduler_key,
                 )
                 job_repo.update_status(
                     job_id,
                     current_status,
+                    scheduler_key=scheduler_key,
                     started_at=started_iso,
                     completed_at=completed_iso,
                     duration_secs=status_info.duration_secs,

--- a/src/srunx/pollers/active_watch_poller.py
+++ b/src/srunx/pollers/active_watch_poller.py
@@ -38,6 +38,7 @@ import sqlite3
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import anyio
 
@@ -60,6 +61,9 @@ from srunx.logging import get_logger
 from srunx.notifications.service import NotificationService
 from srunx.slurm.states import SLURM_TERMINAL_JOB_STATES
 from srunx.sweep.state_service import WorkflowRunStateService
+
+if TYPE_CHECKING:
+    from srunx.transport.registry import TransportRegistry
 
 logger = get_logger(__name__)
 
@@ -113,29 +117,65 @@ def _dt_to_iso(value: object) -> str | None:
     return str(value)
 
 
+def _parse_target_ref(
+    target_ref: str, expected_kind: str = "job"
+) -> tuple[str, int] | None:
+    """Parse a V5+ ``target_ref`` into ``(scheduler_key, job_id)``.
+
+    Grammar accepted (REQ-8 / AC-8.2 / AC-8.3):
+
+    - ``job:local:<N>``          → ``("local", N)``
+    - ``job:ssh:<profile>:<N>``  → ``(f"ssh:{profile}", N)``
+
+    Returns ``None`` for:
+
+    - legacy 2-segment refs (``job:<N>``) — V5 migration backfills every
+      existing row to 3+ segments, so this should not appear in practice;
+      returning ``None`` here keeps the parser strict (AC-8.4).
+    - malformed refs (non-int tail, unknown kind prefix, empty segments).
+
+    Phase 6 callers use the returned ``scheduler_key`` to group watches
+    by transport and to write ``source_ref`` back with the correct
+    transport segment.
+    """
+    parts = target_ref.split(":")
+    if not parts or parts[0] != expected_kind:
+        return None
+    if len(parts) < 3:
+        # Legacy 2-segment — after V5 migration these should not exist.
+        return None
+    try:
+        job_id = int(parts[-1])
+    except ValueError:
+        return None
+    middle = parts[1:-1]
+    if middle == ["local"]:
+        return ("local", job_id)
+    if len(middle) == 2 and middle[0] == "ssh" and middle[1]:
+        return (f"ssh:{middle[1]}", job_id)
+    return None
+
+
 def _parse_target_id(target_ref: str, expected_prefix: str) -> int | None:
     """Return the integer id encoded in a watch ``target_ref``.
 
-    Accepts both the legacy 2-segment form (``"<prefix>:<id>"``) and the
-    V5+ 3-segment form for ``job`` refs (``"job:local:<id>"`` /
-    ``"job:ssh:<profile>:<id>"``). For non-``job`` prefixes the 2-segment
-    form remains authoritative.
+    Thin wrapper around :func:`_parse_target_ref` for callers that only
+    need the numeric id (``workflow_run:<N>`` / ``sweep_run:<N>`` etc.).
+    For the ``job`` kind it drops the scheduler_key segment; new code
+    that needs transport awareness should call :func:`_parse_target_ref`
+    directly.
 
-    Returns ``None`` if the prefix does not match or no numeric id can be
-    extracted — malformed rows are skipped rather than taking the cycle
-    down. Phase 6 replaces this helper with
-    :func:`_parse_target_ref` which returns the full
-    ``(scheduler_key, job_id)`` tuple; until then the poller only needs
-    the numeric id so we fall back to the trailing segment.
+    Retains backward compatibility for the 2-segment ``workflow_run:<N>``
+    and ``sweep_run:<N>`` forms (those kinds never got the V5 scheduler
+    segment) while deferring to the strict 3+ segment parser for ``job``.
     """
+    if expected_prefix == "job":
+        parsed = _parse_target_ref(target_ref, "job")
+        return parsed[1] if parsed else None
+
     prefix, _, remainder = target_ref.partition(":")
     if prefix != expected_prefix or not remainder:
         return None
-    # For job refs the V5 form includes a transport segment (``local`` or
-    # ``ssh:<profile>``) before the numeric id; take the trailing
-    # segment. For workflow_run / sweep_run / etc the 2-segment form is
-    # final, so rsplit on a string with no ``:`` is a no-op and returns
-    # the original remainder.
     tail = remainder.rsplit(":", 1)[-1]
     try:
         return int(tail)
@@ -164,8 +204,9 @@ class ActiveWatchPoller:
 
     def __init__(
         self,
-        slurm_client: SlurmClientProtocol,
+        slurm_client: SlurmClientProtocol | None = None,
         *,
+        registry: TransportRegistry | None = None,
         db_path: Path | None = None,
         notification_service_factory: NotificationServiceFactory | None = None,
         interval_seconds: float = 15.0,
@@ -173,10 +214,17 @@ class ActiveWatchPoller:
         """Initialise the poller.
 
         Args:
-            slurm_client: Any implementation of :class:`SlurmClientProtocol`
-                (local :class:`~srunx.client.Slurm` or the SSH adapter).
-                ``queue_by_ids`` is invoked from a worker thread via
-                ``anyio.to_thread.run_sync``.
+            slurm_client: Legacy single-transport client kept for
+                backward compatibility with existing tests and the Web
+                app's single-profile lifespan. When provided without a
+                ``registry`` the poller runs in single-transport mode
+                and treats every job watch as belonging to that client
+                (same semantics as pre-Phase 6).
+            registry: V5 :class:`TransportRegistry`. When provided, the
+                poller groups watches by ``scheduler_key`` and routes
+                each group to the matching
+                :class:`SlurmClientProtocol` implementation (REQ-8).
+                Takes precedence over ``slurm_client``.
             db_path: Absolute path to the srunx state DB. ``None``
                 resolves to :func:`srunx.db.connection.get_db_path` at
                 connection time.
@@ -188,7 +236,17 @@ class ActiveWatchPoller:
                 R10.1 (``DeliveryPoller`` uses 10 s so the producer
                 stays slower than the consumer to avoid hammering
                 ``squeue``).
+
+        Raises:
+            ValueError: When neither ``registry`` nor ``slurm_client``
+                is supplied.
         """
+        if registry is None and slurm_client is None:
+            raise ValueError(
+                "ActiveWatchPoller requires either 'registry' (preferred) or "
+                "'slurm_client' (backcompat)."
+            )
+        self._registry = registry
         self._slurm_client = slurm_client
         self._db_path = db_path
         self._notification_service_factory = (
@@ -236,16 +294,24 @@ class ActiveWatchPoller:
             watches = watch_repo.list_open()
             open_watches = len(watches)
 
-            job_watches: list[tuple[int, int]] = []  # (watch_id, job_id)
+            # Group job watches by scheduler_key so each transport group
+            # can be routed to its own queue_client. Each entry is
+            # ``(watch_id, job_id)``; the outer dict key is the
+            # ``scheduler_key`` parsed from ``target_ref`` (REQ-8).
+            job_watches_by_scheduler: dict[str, list[tuple[int, int]]] = {}
             workflow_watches: list[tuple[int, int]] = []  # (watch_id, run_id)
 
             for watch in watches:
                 if watch.id is None:
                     continue
                 if watch.kind == "job":
-                    job_id = _parse_target_id(watch.target_ref, "job")
-                    if job_id is not None:
-                        job_watches.append((watch.id, job_id))
+                    parsed = _parse_target_ref(watch.target_ref, "job")
+                    if parsed is None:
+                        continue
+                    scheduler_key, job_id = parsed
+                    job_watches_by_scheduler.setdefault(scheduler_key, []).append(
+                        (watch.id, job_id)
+                    )
                 elif watch.kind == "workflow_run":
                     run_id = _parse_target_id(watch.target_ref, "workflow_run")
                     if run_id is not None:
@@ -254,28 +320,52 @@ class ActiveWatchPoller:
                 # TBD — Phase 1 ignores them here and lets the owning
                 # pollers handle them once they land.
 
-            # Batch SLURM query — a single round-trip covering every
-            # job-watch in one shot.
-            queue_result: dict[int, JobStatusInfo] = {}
-            job_ids = [job_id for _, job_id in job_watches]
-            if job_ids:
-                queue_result = await anyio.to_thread.run_sync(
-                    self._slurm_client.queue_by_ids, job_ids
-                )
+            # -- Job transitions (per scheduler_key) ---------------------------
+            # Each scheduler_key gets its own ``queue_by_ids`` round-trip
+            # against the matching transport, then produces events whose
+            # ``source_ref`` carries the scheduler_key so downstream
+            # notifications / dedup stay consistent across transports.
+            for scheduler_key, pairs in job_watches_by_scheduler.items():
+                queue_client = self._resolve_queue_client(scheduler_key)
+                if queue_client is None:
+                    logger.warning(
+                        "Unknown scheduler_key %r in %d watch(es); skipping "
+                        "this cycle (profile may have been removed). "
+                        "Watches will be retried next cycle.",
+                        scheduler_key,
+                        len(pairs),
+                    )
+                    continue
 
-            # -- Job transitions ------------------------------------------------
-            job_transitions, job_events = self._process_job_watches(
-                conn=conn,
-                job_watches=job_watches,
-                queue_result=queue_result,
-                job_repo=job_repo,
-                transition_repo=transition_repo,
-                event_repo=event_repo,
-                watch_repo=watch_repo,
-                notification_service=notification_service,
-            )
-            transitions_detected += job_transitions
-            events_emitted += job_events
+                job_ids = [jid for _, jid in pairs]
+                try:
+                    partial_result: dict[
+                        int, JobStatusInfo
+                    ] = await anyio.to_thread.run_sync(
+                        queue_client.queue_by_ids, job_ids
+                    )
+                except Exception as exc:  # noqa: BLE001 — transport failure
+                    logger.warning(
+                        "queue_by_ids failed for scheduler_key %r: %s; "
+                        "skipping this group for this cycle.",
+                        scheduler_key,
+                        exc,
+                    )
+                    continue
+
+                group_transitions, group_events = self._process_job_watches(
+                    conn=conn,
+                    job_watches=pairs,
+                    queue_result=partial_result,
+                    scheduler_key=scheduler_key,
+                    job_repo=job_repo,
+                    transition_repo=transition_repo,
+                    event_repo=event_repo,
+                    watch_repo=watch_repo,
+                    notification_service=notification_service,
+                )
+                transitions_detected += group_transitions
+                events_emitted += group_events
 
             # -- Workflow-run aggregation --------------------------------------
             wf_transitions, wf_events = self._process_workflow_watches(
@@ -304,19 +394,54 @@ class ActiveWatchPoller:
     # Job branch
     # ------------------------------------------------------------------
 
+    def _resolve_queue_client(self, scheduler_key: str) -> SlurmClientProtocol | None:
+        """Resolve ``scheduler_key`` to a ``SlurmClientProtocol``.
+
+        Preference order:
+
+        1. If a :class:`TransportRegistry` was injected, delegate to
+           :meth:`TransportRegistry.resolve` so SSH transports pick up
+           their profile-specific adapter (REQ-8).
+        2. Otherwise, fall back to the legacy single-transport
+           ``slurm_client`` for ``scheduler_key == "local"`` — this
+           keeps existing tests and single-profile Web lifespans
+           working without changes.
+
+        Returns ``None`` for unresolvable keys so the caller can log a
+        warning and skip the affected group (AC-8.5) without aborting
+        the entire cycle.
+        """
+        if self._registry is not None:
+            handle = self._registry.resolve(scheduler_key)
+            return handle.queue_client if handle is not None else None
+        # Backcompat: single-transport mode. Only local watches are
+        # served by the supplied client; SSH watches are skipped so the
+        # poller does not mis-route remote jobs to a local SLURM.
+        if scheduler_key == "local":
+            return self._slurm_client
+        return None
+
     def _process_job_watches(
         self,
         *,
         conn: sqlite3.Connection,
         job_watches: list[tuple[int, int]],
         queue_result: dict[int, JobStatusInfo],
+        scheduler_key: str,
         job_repo: JobRepository,
         transition_repo: JobStateTransitionRepository,
         event_repo: EventRepository,
         watch_repo: WatchRepository,
         notification_service: NotificationService,
     ) -> tuple[int, int]:
-        """Process every job-kind watch. Returns (transitions, events)."""
+        """Process every job-kind watch. Returns (transitions, events).
+
+        ``scheduler_key`` is the transport axis for every watch in the
+        ``job_watches`` slice; it's used to write V5-grammar
+        ``source_ref`` (``job:{scheduler_key}:{job_id}``) so
+        notifications / dedup / Slack templating all see the same
+        transport segment the watch was created with (REQ-8).
+        """
         transitions_count = 0
         events_count = 0
 
@@ -388,13 +513,11 @@ class ActiveWatchPoller:
                     "started_at": started_iso,
                     "completed_at": completed_iso,
                 }
-                # V5: source_ref uses the 3-segment grammar
-                # ``job:<scheduler_key>:<id>``. Phase 3 poller only
-                # watches local SLURM, so ``scheduler_key='local'`` is
-                # correct for every row the producer writes. Phase 6
-                # will make this transport-aware via a scheduler_key
-                # derived from the watch row.
-                source_ref = f"job:local:{job_id}"
+                # V5 grammar: ``job:<scheduler_key>:<id>``. In Phase 6
+                # the scheduler_key is threaded in from the watch row
+                # so SSH-backed watches produce ``job:ssh:<profile>:<id>``
+                # and local watches produce ``job:local:<id>``.
+                source_ref = f"job:{scheduler_key}:{job_id}"
                 event_id = event_repo.insert(
                     kind="job.status_changed",
                     source_ref=source_ref,

--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -149,6 +149,12 @@ def submit_job(
     ] = False,
 ):
     """Submit a SLURM job script to a remote server via SSH."""
+    typer.secho(
+        "WARNING: `srunx ssh submit` is deprecated; "
+        "use `srunx submit --script <path> --profile <name>` instead.",
+        err=True,
+        fg=typer.colors.YELLOW,
+    )
     setup_logging(verbose)
 
     # Validate script path
@@ -305,6 +311,12 @@ def show_logs(
     """Display job logs from remote SLURM server via SSH."""
     from rich.syntax import Syntax
 
+    typer.secho(
+        "WARNING: `srunx ssh logs` is deprecated; "
+        "use `srunx logs --profile <name> <job_id>` instead.",
+        err=True,
+        fg=typer.colors.YELLOW,
+    )
     setup_logging(verbose)
 
     try:

--- a/src/srunx/ssh/cli/profile_impl.py
+++ b/src/srunx/ssh/cli/profile_impl.py
@@ -11,7 +11,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from ..core.config import ConfigManager, ServerProfile
+from ..core.config import ConfigManager, ServerProfile, validate_profile_name
 
 console = Console()
 
@@ -75,6 +75,16 @@ def add_profile_impl(
 ):
     """Implementation for adding a new profile."""
     try:
+        # Validate the profile name up-front so a bad character fails
+        # with a clear message before we even read the config file (F4).
+        # ``scheduler_key`` grammar reserves ``:`` so profile names
+        # cannot contain it; length is capped at 64.
+        try:
+            validate_profile_name(name)
+        except ValueError as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+            raise typer.Exit(1) from exc
+
         config_manager = ConfigManager(config)
 
         # Validate connection parameters

--- a/src/srunx/ssh/core/config.py
+++ b/src/srunx/ssh/core/config.py
@@ -108,6 +108,7 @@ class ConfigManager:
             Path(config_path) if config_path else self._get_default_config_path()
         )
         self.config_data: dict[str, Any] = {}
+        self._loaded_mtime: float | None = None
         self.load_config()
 
     def _get_default_config_path(self) -> Path:
@@ -126,6 +127,7 @@ class ConfigManager:
                         self.save_config()
                     else:
                         self.config_data = json.loads(content)
+                self._loaded_mtime = self.config_path.stat().st_mtime
             except (OSError, json.JSONDecodeError) as e:
                 raise RuntimeError(
                     f"Failed to load config from {self.config_path}: {e}"
@@ -133,6 +135,24 @@ class ConfigManager:
         else:
             self.config_data = {"current_profile": None, "profiles": {}}
             self.save_config()
+
+    def _reload_if_stale(self) -> None:
+        """Re-read the config file when its mtime has advanced.
+
+        Long-lived :class:`ConfigManager` instances (e.g. held by the
+        web app ``TransportRegistry``) must observe external edits
+        (``srunx ssh profile add`` / ``remove``) so cached adapters do
+        not keep routing to stale profiles. The stat call is ~µs and
+        runs before each read-path lookup.
+        """
+        if self._loaded_mtime is None or not self.config_path.exists():
+            return
+        try:
+            current_mtime = self.config_path.stat().st_mtime
+        except OSError:
+            return
+        if current_mtime != self._loaded_mtime:
+            self.load_config()
 
     def save_config(self) -> None:
         """Save SSH profile data, preserving non-SSH keys (e.g. SrunxConfig)."""
@@ -178,12 +198,14 @@ class ConfigManager:
         return False
 
     def get_profile(self, name: str) -> ServerProfile | None:
+        self._reload_if_stale()
         profiles = self.config_data.get("profiles", {})
         if name in profiles:
             return ServerProfile.model_validate(profiles[name])
         return None
 
     def list_profiles(self) -> dict[str, ServerProfile]:
+        self._reload_if_stale()
         profiles = {}
         for name, data in self.config_data.get("profiles", {}).items():
             profiles[name] = ServerProfile.model_validate(data)

--- a/src/srunx/ssh/core/config.py
+++ b/src/srunx/ssh/core/config.py
@@ -1,9 +1,34 @@
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Shared profile-name regex. ``scheduler_key`` uses a colon-delimited
+# grammar (``ssh:<profile>``) that has to round-trip through SQLite
+# target_refs (``job:ssh:<profile>:<id>``), so profile names must not
+# contain ``:``. Length is capped at 64 so oversized names cannot
+# wedge UI tables or log lines.
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_.\-]{1,64}$")
+
+
+def validate_profile_name(name: str) -> None:
+    """Validate *name* against the shared profile-name regex.
+
+    Raises:
+        ValueError: When *name* is empty, too long, or contains any
+            character outside the allowed alphabet. ``':'`` is
+            explicitly called out because it's the scheduler_key
+            delimiter and the most likely accidental violation.
+    """
+    if not isinstance(name, str) or not _PROFILE_NAME_RE.match(name):
+        raise ValueError(
+            f"Invalid profile name {name!r}: must match "
+            f"{_PROFILE_NAME_RE.pattern}. Profile names cannot contain "
+            "':' (reserved for scheduler_key grammar) or exceed 64 characters."
+        )
 
 
 class MountConfig(BaseModel):
@@ -134,6 +159,7 @@ class ConfigManager:
             ) from e
 
     def add_profile(self, name: str, profile: ServerProfile) -> None:
+        validate_profile_name(name)
         if "profiles" not in self.config_data:
             self.config_data["profiles"] = {}
 

--- a/src/srunx/transport/__init__.py
+++ b/src/srunx/transport/__init__.py
@@ -13,6 +13,7 @@ from srunx.transport.registry import (
     ResolvedTransport,
     TransportHandle,
     TransportRegistry,
+    peek_scheduler_key,
     resolve_transport,
 )
 
@@ -20,5 +21,6 @@ __all__ = [
     "ResolvedTransport",
     "TransportHandle",
     "TransportRegistry",
+    "peek_scheduler_key",
     "resolve_transport",
 ]

--- a/src/srunx/transport/__init__.py
+++ b/src/srunx/transport/__init__.py
@@ -1,0 +1,24 @@
+"""Transport resolution layer for CLI unification.
+
+``resolve_transport()`` picks between local SLURM and SSH (per ``--profile`` /
+``$SRUNX_SSH_PROFILE``) and hands the CLI a uniform ``ResolvedTransport``
+carrying ``JobOperationsProtocol`` + ``WorkflowJobExecutorFactory`` + optional
+``SubmissionRenderContext``.
+
+See ``specs/cli-transport-unification/{spec,plan}.md`` REQ-1 / REQ-7 / REQ-8
+for the full resolution contract.
+"""
+
+from srunx.transport.registry import (
+    ResolvedTransport,
+    TransportHandle,
+    TransportRegistry,
+    resolve_transport,
+)
+
+__all__ = [
+    "ResolvedTransport",
+    "TransportHandle",
+    "TransportRegistry",
+    "resolve_transport",
+]

--- a/src/srunx/transport/__init__.py
+++ b/src/srunx/transport/__init__.py
@@ -13,14 +13,18 @@ from srunx.transport.registry import (
     ResolvedTransport,
     TransportHandle,
     TransportRegistry,
+    emit_transport_banner,
     peek_scheduler_key,
     resolve_transport,
+    resolve_transport_source,
 )
 
 __all__ = [
     "ResolvedTransport",
     "TransportHandle",
     "TransportRegistry",
+    "emit_transport_banner",
     "peek_scheduler_key",
     "resolve_transport",
+    "resolve_transport_source",
 ]

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -1,0 +1,425 @@
+"""Transport resolution + registry.
+
+This module is the single entry point CLI commands use to pick between
+local SLURM and an SSH-backed cluster. Higher layers call
+:func:`resolve_transport` (context manager) and receive a
+:class:`ResolvedTransport` that exposes the same
+:class:`~srunx.client_protocol.JobOperationsProtocol` / queue client /
+executor factory regardless of which transport was selected.
+
+Resolution priority (see REQ-1):
+
+    1. ``--profile <name>``
+    2. ``--local``
+    3. ``$SRUNX_SSH_PROFILE``
+    4. local fallback (silent, preserves AC-10.2)
+
+Banner emission (REQ-7): explicit sources print a one-line banner to
+stderr; the default path stays silent so existing scripts that rely on
+byte-exact CLI output keep working.
+
+The SSH-related imports (``SlurmSSHAdapter``, ``SlurmSSHExecutorPool``,
+``SubmissionRenderContext``, ``ConfigManager``) are gated inside
+:func:`_build_ssh_handle` so the local fallback path never pays the
+paramiko import cost (R-3).
+
+Manual verification cheatsheet:
+
+    $ srunx submit echo hi                # banner suppressed (default)
+    $ srunx submit --local echo hi        # banner: transport: local (from --local)
+    $ srunx submit --profile foo echo hi  # banner: transport: ssh:foo (from --profile)
+    $ SRUNX_SSH_PROFILE=foo srunx list    # banner: transport: ssh:foo (from env)
+    $ srunx list --quiet                  # banner suppressed for any source
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import typer
+from rich.console import Console
+
+from srunx.client import Slurm
+from srunx.client_protocol import (
+    JobOperationsProtocol,
+    SlurmClientProtocol,
+    WorkflowJobExecutorFactory,
+)
+from srunx.exceptions import TransportError
+from srunx.logging import get_logger
+
+if TYPE_CHECKING:
+    import sqlite3
+
+    from srunx.rendering import SubmissionRenderContext
+    from srunx.ssh.core.config import ServerProfile
+
+logger = get_logger(__name__)
+
+
+TransportSource = Literal["--profile", "--local", "env", "default"]
+
+
+@dataclass(frozen=True)
+class TransportHandle:
+    """Resolved transport with all Protocol clients attached.
+
+    Shared shape between the CLI resolver (:func:`resolve_transport`) and
+    the long-lived poller registry (:class:`TransportRegistry`). Every
+    caller needs the same set of bindings — job ops, queue client,
+    executor factory, optional submission render context — so we collect
+    them in one immutable record.
+
+    Attributes:
+        scheduler_key: ``"local"`` or ``"ssh:<profile>"``. The DB axis
+            used to group watches / jobs across clusters (REQ-8).
+        profile_name: ``None`` for local transport; the SSH profile name
+            for ``ssh:*`` transports.
+        transport_type: ``"local"`` or ``"ssh"``. Matches the
+            ``jobs.transport_type`` column domain.
+        job_ops: CLI-facing job operations (submit / cancel / status /
+            queue / tail_log_incremental).
+        queue_client: Poller-facing batch query client.
+        executor_factory: Context-manager factory for
+            :class:`~srunx.client_protocol.WorkflowJobExecutorProtocol`.
+            ``None`` is not returned — local uses a
+            ``nullcontext``-wrapped singleton, SSH returns a pool's
+            ``lease`` method.
+        submission_context: Mount-aware render context for SSH; ``None``
+            for local (no mount translation).
+    """
+
+    scheduler_key: str
+    profile_name: str | None
+    transport_type: Literal["local", "ssh"]
+    job_ops: JobOperationsProtocol
+    queue_client: SlurmClientProtocol
+    executor_factory: WorkflowJobExecutorFactory | None
+    submission_context: SubmissionRenderContext | None
+
+
+@dataclass(frozen=True)
+class ResolvedTransport:
+    """CLI-level transport resolution result.
+
+    Wraps a :class:`TransportHandle` with banner metadata (``label`` +
+    ``source``) so the CLI layer can both drive the resolved transport
+    and report which flag/env/default produced it.
+    """
+
+    label: str
+    source: TransportSource
+    handle: TransportHandle
+
+    # Convenience shortcuts to the underlying handle so CLI call sites
+    # don't need to reach through ``.handle.*`` for every attribute.
+    @property
+    def scheduler_key(self) -> str:
+        return self.handle.scheduler_key
+
+    @property
+    def profile_name(self) -> str | None:
+        return self.handle.profile_name
+
+    @property
+    def transport_type(self) -> Literal["local", "ssh"]:
+        return self.handle.transport_type
+
+    @property
+    def job_ops(self) -> JobOperationsProtocol:
+        return self.handle.job_ops
+
+    @property
+    def queue_client(self) -> SlurmClientProtocol:
+        return self.handle.queue_client
+
+    @property
+    def executor_factory(self) -> WorkflowJobExecutorFactory | None:
+        return self.handle.executor_factory
+
+    @property
+    def submission_context(self) -> SubmissionRenderContext | None:
+        return self.handle.submission_context
+
+
+def _emit_banner(resolved: ResolvedTransport, quiet: bool) -> None:
+    """Emit the one-line transport banner on stderr.
+
+    REQ-7 / AC-10.2: the default source (no flag, no env) stays silent
+    so existing scripts that diff stderr byte-for-byte keep passing.
+    ``quiet=True`` suppresses the banner even for explicit sources.
+    """
+    if quiet or resolved.source == "default":
+        return
+    Console(file=sys.stderr).print(
+        f"[dim]→ transport: {resolved.label} (from {resolved.source})[/dim]"
+    )
+
+
+def _build_local_handle(slurm: Slurm | None = None) -> TransportHandle:
+    """Build a :class:`TransportHandle` for local SLURM.
+
+    Reuses *slurm* when provided (keeps singleton semantics inside a
+    single CLI command) or mints a fresh :class:`Slurm` instance. The
+    executor factory wraps the shared client in a ``nullcontext`` so the
+    signature matches :data:`WorkflowJobExecutorFactory` — local
+    submission has no pool teardown to do.
+    """
+    local = slurm or Slurm()
+
+    def factory() -> Any:
+        return nullcontext(local)
+
+    return TransportHandle(
+        scheduler_key="local",
+        profile_name=None,
+        transport_type="local",
+        job_ops=local,
+        queue_client=local,
+        executor_factory=factory,
+        submission_context=None,
+    )
+
+
+def _build_ssh_handle(
+    profile_name: str,
+) -> tuple[TransportHandle, Any]:
+    """Build an SSH :class:`TransportHandle` and its backing executor pool.
+
+    Imports are local so ``SlurmSSHAdapter`` / paramiko / pool module
+    costs are never paid by CLI invocations that stay on local SLURM
+    (R-3 performance requirement).
+
+    Returns:
+        A ``(handle, pool)`` tuple. The caller is responsible for closing
+        the pool when the handle goes out of scope.
+
+    Raises:
+        TransportError: If the SSH profile is unknown or the adapter
+            factory rejects the configuration.
+    """
+    # Conditional imports — see module docstring.
+    from srunx.rendering import SubmissionRenderContext
+    from srunx.ssh.core.config import ConfigManager
+    from srunx.web.ssh_adapter import SlurmSSHAdapter, SlurmSSHAdapterSpec
+    from srunx.web.ssh_executor import SlurmSSHExecutorPool
+
+    cm = ConfigManager()
+    profile = cm.get_profile(profile_name)
+    if profile is None:
+        raise TransportError(
+            f"SSH profile '{profile_name}' not found. "
+            "Configure via 'srunx ssh profile add' or check "
+            "'srunx ssh profile list'."
+        )
+
+    try:
+        adapter = SlurmSSHAdapter(profile_name=profile_name)
+    except ValueError as exc:
+        raise TransportError(str(exc)) from exc
+
+    # Build the pool off the adapter's own connection spec so pooled
+    # clones inherit the exact same resolved hostname / identity file /
+    # proxy_jump / env_vars the singleton adapter uses.
+    spec: SlurmSSHAdapterSpec = adapter.connection_spec
+    pool = SlurmSSHExecutorPool(spec, callbacks=None, size=2)
+
+    # SubmissionRenderContext carries mount information for path
+    # translation. We only construct it when the profile actually
+    # declares mounts; otherwise downstream code should render paths
+    # verbatim.
+    mounts = tuple(profile.mounts) if profile.mounts else ()
+    render_context: SubmissionRenderContext | None = None
+    if mounts:
+        render_context = SubmissionRenderContext(
+            mount_name=None,
+            mounts=mounts,
+            default_work_dir=None,
+        )
+
+    handle = TransportHandle(
+        scheduler_key=f"ssh:{profile_name}",
+        profile_name=profile_name,
+        transport_type="ssh",
+        job_ops=adapter,
+        queue_client=adapter,
+        executor_factory=pool.lease,
+        submission_context=render_context,
+    )
+    return handle, pool
+
+
+@contextmanager
+def resolve_transport(
+    *,
+    profile: str | None = None,
+    local: bool = False,
+    quiet: bool = False,
+    banner: bool = True,
+) -> Iterator[ResolvedTransport]:
+    """Resolve transport for one CLI invocation.
+
+    Resolution order (REQ-1):
+
+        1. ``--profile <name>``
+        2. ``--local``
+        3. ``$SRUNX_SSH_PROFILE``
+        4. local fallback (silent)
+
+    Args:
+        profile: Value of ``--profile`` (explicit SSH profile name).
+        local: Value of ``--local`` (force local transport, overriding
+            ``$SRUNX_SSH_PROFILE``).
+        quiet: Suppress the stderr transport banner even for explicit
+            sources.
+        banner: Emit the one-line banner. Set ``False`` for tests or
+            library-style callers that don't want any stderr output.
+
+    Yields:
+        A :class:`ResolvedTransport` for the duration of the ``with``
+        block. SSH pools are closed on exit.
+
+    Raises:
+        typer.BadParameter: When ``--profile`` and ``--local`` are both
+            set (REQ-1, AC-1.2).
+        TransportError: When an explicit / env-selected SSH profile is
+            unknown or the adapter factory rejects it.
+    """
+    if profile and local:
+        raise typer.BadParameter(
+            "--profile and --local cannot be used together.",
+            param_hint="--profile / --local",
+        )
+
+    env_profile = os.environ.get("SRUNX_SSH_PROFILE")
+    pool: Any = None
+    handle: TransportHandle
+    source: TransportSource
+
+    if profile:
+        source = "--profile"
+        handle, pool = _build_ssh_handle(profile)
+    elif local:
+        source = "--local"
+        handle = _build_local_handle()
+    elif env_profile:
+        source = "env"
+        handle, pool = _build_ssh_handle(env_profile)
+    else:
+        source = "default"
+        handle = _build_local_handle()
+
+    resolved = ResolvedTransport(
+        label=handle.scheduler_key,
+        source=source,
+        handle=handle,
+    )
+
+    if banner:
+        _emit_banner(resolved, quiet)
+
+    try:
+        yield resolved
+    finally:
+        if pool is not None:
+            try:
+                pool.close()
+            except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+                logger.debug("Pool close failed (non-fatal): %s", exc)
+
+
+class TransportRegistry:
+    """Resolve ``scheduler_key`` values to :class:`TransportHandle` instances.
+
+    Two lifecycles share this class:
+
+    * CLI: one instance per command, :meth:`close` at the end.
+    * Web app / poller lifespan: one instance per process, :meth:`close`
+      on shutdown.
+
+    The registry caches handles by ``scheduler_key`` and tracks any SSH
+    executor pools it has created so :meth:`close` can drain them
+    uniformly.
+    """
+
+    def __init__(
+        self,
+        *,
+        local_client: Slurm | None = None,
+        profile_loader: Callable[[str], ServerProfile | None] | None = None,
+    ) -> None:
+        self._local_client = local_client or Slurm()
+        if profile_loader is None:
+            # Match _build_ssh_handle's default path — use ConfigManager.
+            # We import inside __init__ to keep the module import graph
+            # light for callers that inject their own profile_loader
+            # (common in tests).
+            from srunx.ssh.core.config import ConfigManager
+
+            cm = ConfigManager()
+            profile_loader = cm.get_profile
+        self._profile_loader = profile_loader
+        self._cache: dict[str, TransportHandle] = {}
+        self._pools: list[Any] = []
+
+    def resolve(self, scheduler_key: str) -> TransportHandle | None:
+        """Resolve ``scheduler_key`` to a :class:`TransportHandle`.
+
+        Returns ``None`` for unknown SSH profiles or malformed keys so
+        the poller can log a warning and skip the affected group
+        without crashing the whole cycle (AC-8.5).
+        """
+        if scheduler_key in self._cache:
+            return self._cache[scheduler_key]
+
+        if scheduler_key == "local":
+            handle = _build_local_handle(self._local_client)
+            self._cache[scheduler_key] = handle
+            return handle
+
+        if scheduler_key.startswith("ssh:"):
+            profile_name = scheduler_key[4:]
+            if not profile_name or self._profile_loader(profile_name) is None:
+                return None
+            try:
+                handle, pool = _build_ssh_handle(profile_name)
+            except TransportError as exc:
+                logger.warning(
+                    "Failed to build SSH transport %r: %s", scheduler_key, exc
+                )
+                return None
+            self._cache[scheduler_key] = handle
+            if pool is not None:
+                self._pools.append(pool)
+            return handle
+
+        return None
+
+    def known_scheduler_keys(self, db_connection: sqlite3.Connection) -> set[str]:
+        """Return every distinct ``scheduler_key`` currently persisted.
+
+        Poller group-by entry point (REQ-8): the V5 schema's
+        ``jobs.scheduler_key`` column is the authoritative axis. Unknown
+        keys in the result set are handed back unfiltered — it's the
+        caller's job to decide whether to warn+skip on an unresolvable
+        one.
+        """
+        rows = db_connection.execute(
+            "SELECT DISTINCT scheduler_key FROM jobs"
+        ).fetchall()
+        return {r[0] for r in rows if r[0]}
+
+    def close(self) -> None:
+        """Release every cached SSH pool. Idempotent."""
+        for pool in self._pools:
+            try:
+                pool.close()
+            except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+                logger.debug("Pool close failed (non-fatal): %s", exc)
+        self._pools.clear()
+        self._cache.clear()

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -156,11 +156,54 @@ def _emit_banner(resolved: ResolvedTransport, quiet: bool) -> None:
     so existing scripts that diff stderr byte-for-byte keep passing.
     ``quiet=True`` suppresses the banner even for explicit sources.
     """
-    if quiet or resolved.source == "default":
+    emit_transport_banner(label=resolved.label, source=resolved.source, quiet=quiet)
+
+
+def emit_transport_banner(
+    *,
+    label: str,
+    source: TransportSource,
+    quiet: bool,
+) -> None:
+    """Emit the transport banner without building a full handle.
+
+    Used by commands that only need banner + conflict detection (e.g.
+    ``srunx monitor resources``, which is local-only in Phase 5b).
+    Keeps the SF7 short-circuit path byte-for-byte identical to the
+    full :func:`resolve_transport` output so scripts that diff stderr
+    don't see a regression when we skip the SSH handle build.
+
+    REQ-7 / AC-10.2: ``source='default'`` stays silent and ``quiet=True``
+    suppresses the banner even for explicit sources.
+    """
+    if quiet or source == "default":
         return
-    Console(file=sys.stderr).print(
-        f"[dim]→ transport: {resolved.label} (from {resolved.source})[/dim]"
-    )
+    Console(file=sys.stderr).print(f"[dim]→ transport: {label} (from {source})[/dim]")
+
+
+def resolve_transport_source(
+    *, profile: str | None = None, local: bool = False
+) -> TransportSource:
+    """Return the :data:`TransportSource` ``resolve_transport`` would pick.
+
+    Pure helper that mirrors the source-detection limb of
+    :func:`resolve_transport` so callers using
+    :func:`emit_transport_banner` directly don't have to duplicate the
+    precedence rules. Raises :class:`typer.BadParameter` on the same
+    ``--profile`` + ``--local`` conflict.
+    """
+    if profile and local:
+        raise typer.BadParameter(
+            "--profile and --local cannot be used together.",
+            param_hint="--profile / --local",
+        )
+    if profile:
+        return "--profile"
+    if local:
+        return "--local"
+    if os.environ.get("SRUNX_SSH_PROFILE"):
+        return "env"
+    return "default"
 
 
 def _build_local_handle(slurm: Slurm | None = None) -> TransportHandle:
@@ -363,16 +406,15 @@ def peek_scheduler_key(*, profile: str | None = None, local: bool = False) -> st
 
 
 def _build_transport_label(handle: TransportHandle) -> str:
-    """Return a human-friendly label for the transport banner.
+    """Return the banner label for *handle*.
 
-    ``scheduler_key`` uses the ``ssh:<profile>`` grammar for machine
-    parsing; the banner is user-facing so we render ``SSH: <profile>``
-    for SSH and ``local SLURM`` for local to avoid looking like an
-    internal identifier.
+    Spec AC-7.3 prescribes the ``scheduler_key`` grammar (``local`` /
+    ``ssh:<profile>``) as the banner text so the same string callers see
+    on stderr matches what they'd see in DB rows / watch targets. Using
+    ``handle.scheduler_key`` directly is the simplest way to keep those
+    two surfaces aligned.
     """
-    if handle.transport_type == "local":
-        return "local SLURM"
-    return f"SSH: {handle.profile_name}"
+    return handle.scheduler_key
 
 
 @contextmanager

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-TransportSource = Literal["--profile", "--local", "env", "default"]
+TransportSource = Literal["--profile", "--local", "env", "current-profile", "default"]
 
 
 @dataclass(frozen=True)
@@ -184,7 +184,98 @@ def emit_transport_banner(
     # stale reference and raise "I/O operation on closed file" on the
     # second invocation. Construction is cheap (~µs) and banner
     # emission is not on any hot path.
-    Console(file=sys.stderr).print(f"[dim]→ transport: {label} (from {source})[/dim]")
+    #
+    # Rich markup: a colored dot flags transport kind (cyan for SSH,
+    # yellow for local), the scheduler_key is bold so it reads at a
+    # glance, and the source string trails in dim italic to show where
+    # the decision came from without stealing focus from the label.
+    is_ssh = label.startswith("ssh:")
+    dot_color = "cyan" if is_ssh else "yellow"
+    source_display = {
+        "--profile": "--profile",
+        "--local": "--local",
+        "env": "$SRUNX_SSH_PROFILE",
+        "current-profile": "current profile",
+    }.get(source, source)
+    Console(file=sys.stderr).print(
+        f"[{dot_color}]●[/{dot_color}] "
+        f"[bold]{label}[/bold]  "
+        f"[dim italic]· via {source_display}[/dim italic]"
+    )
+
+
+def _current_profile_name() -> str | None:
+    """Return the active SSH profile set via ``srunx ssh profile set``, or None.
+
+    Respects :attr:`srunx.config.CliTransportConfig.use_current_profile` —
+    when the user has opted out (``cli.use_current_profile = false``), this
+    function returns ``None`` so ``resolve_transport`` falls straight
+    through to local.
+
+    Any failure (config file missing, ConfigManager import error) is
+    swallowed and treated as "no current profile" — the resolver must
+    never raise from this path.
+    """
+    try:
+        from srunx.config import get_config
+        from srunx.ssh.core.config import ConfigManager
+    except ImportError:
+        return None
+    try:
+        if not get_config().cli.use_current_profile:
+            return None
+        name = ConfigManager().get_current_profile_name()
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug("Could not read current SSH profile: %s", exc)
+        return None
+    if not name:
+        return None
+    return name.strip() or None
+
+
+def _resolve_source_and_profile(
+    *, profile: str | None, local: bool
+) -> tuple[TransportSource, str | None]:
+    """Return the resolved ``(source, profile_name)`` pair.
+
+    Shared core between :func:`peek_scheduler_key`,
+    :func:`resolve_transport_source`, and :func:`resolve_transport` so the
+    5-way priority ladder lives in one place.
+
+    Priority:
+
+        1. ``--profile <name>``
+        2. ``--local``
+        3. ``$SRUNX_SSH_PROFILE``
+        4. active SSH profile (``srunx ssh profile set``) when
+           ``cli.use_current_profile`` is True (default)
+        5. local fallback (silent)
+
+    Raises :class:`typer.BadParameter` on the same ``--profile`` +
+    ``--local`` conflict so every entry point fails consistently.
+    """
+    profile = profile.strip() if profile else profile
+    if profile == "":
+        raise typer.BadParameter(
+            "--profile cannot be empty or whitespace.",
+            param_hint="--profile",
+        )
+    if profile and local:
+        raise typer.BadParameter(
+            "--profile and --local cannot be used together.",
+            param_hint="--profile / --local",
+        )
+    if profile:
+        return "--profile", profile
+    if local:
+        return "--local", None
+    env_profile = os.environ.get("SRUNX_SSH_PROFILE", "").strip()
+    if env_profile:
+        return "env", env_profile
+    current = _current_profile_name()
+    if current:
+        return "current-profile", current
+    return "default", None
 
 
 def resolve_transport_source(
@@ -198,18 +289,8 @@ def resolve_transport_source(
     precedence rules. Raises :class:`typer.BadParameter` on the same
     ``--profile`` + ``--local`` conflict.
     """
-    if profile and local:
-        raise typer.BadParameter(
-            "--profile and --local cannot be used together.",
-            param_hint="--profile / --local",
-        )
-    if profile:
-        return "--profile"
-    if local:
-        return "--local"
-    if os.environ.get("SRUNX_SSH_PROFILE"):
-        return "env"
-    return "default"
+    source, _ = _resolve_source_and_profile(profile=profile, local=local)
+    return source
 
 
 def _build_local_handle(slurm: Slurm | None = None) -> TransportHandle:
@@ -401,38 +482,16 @@ def peek_scheduler_key(*, profile: str | None = None, local: bool = False) -> st
 
     Pure function with no side effects — used by callers that need to
     bind callback state (e.g. ``NotificationWatchCallback.scheduler_key``)
-    before entering the transport context manager.
-
-    Resolution order mirrors :func:`resolve_transport` exactly:
-
-        1. ``profile`` → ``f"ssh:{profile}"``
-        2. ``local=True`` → ``"local"``
-        3. ``$SRUNX_SSH_PROFILE`` → ``f"ssh:{env}"``
-        4. default → ``"local"``
+    before entering the transport context manager. Resolution order
+    matches :func:`resolve_transport` including the current-profile
+    fallback (see :func:`_resolve_source_and_profile`).
 
     Raises :class:`typer.BadParameter` on the same ``--profile`` +
     ``--local`` conflict so callers fail consistently whether they
     peek first or go straight to :func:`resolve_transport`.
     """
-    profile = profile.strip() if profile else profile
-    if profile == "":
-        raise typer.BadParameter(
-            "--profile cannot be empty or whitespace.",
-            param_hint="--profile",
-        )
-    if profile and local:
-        raise typer.BadParameter(
-            "--profile and --local cannot be used together.",
-            param_hint="--profile / --local",
-        )
-    if profile:
-        return f"ssh:{profile}"
-    if local:
-        return "local"
-    env_profile = os.environ.get("SRUNX_SSH_PROFILE", "").strip()
-    if env_profile:
-        return f"ssh:{env_profile}"
-    return "local"
+    _, resolved_profile = _resolve_source_and_profile(profile=profile, local=local)
+    return f"ssh:{resolved_profile}" if resolved_profile else "local"
 
 
 def _build_transport_label(handle: TransportHandle) -> str:
@@ -461,12 +520,14 @@ def resolve_transport(
 ) -> Iterator[ResolvedTransport]:
     """Resolve transport for one CLI invocation.
 
-    Resolution order (REQ-1):
+    Resolution order (REQ-1, Phase 2 extended):
 
         1. ``--profile <name>``
         2. ``--local``
         3. ``$SRUNX_SSH_PROFILE``
-        4. local fallback (silent)
+        4. active SSH profile (``srunx ssh profile set``) when
+           ``cli.use_current_profile`` is True (default)
+        5. local fallback (silent)
 
     Args:
         profile: Value of ``--profile`` (explicit SSH profile name).
@@ -501,46 +562,20 @@ def resolve_transport(
         TransportError: When an explicit / env-selected SSH profile is
             unknown or the adapter factory rejects it.
     """
-    profile = profile.strip() if profile else profile
-    if profile == "":
-        raise typer.BadParameter(
-            "--profile cannot be empty or whitespace.",
-            param_hint="--profile",
-        )
-    if profile and local:
-        raise typer.BadParameter(
-            "--profile and --local cannot be used together.",
-            param_hint="--profile / --local",
-        )
+    source, resolved_profile = _resolve_source_and_profile(profile=profile, local=local)
 
-    env_profile = os.environ.get("SRUNX_SSH_PROFILE", "").strip() or None
     pool: Any = None
     handle: TransportHandle
-    source: TransportSource
 
-    if profile:
-        source = "--profile"
+    if resolved_profile is not None:
         handle, pool = _build_ssh_handle(
-            profile,
-            callbacks=callbacks,
-            submission_source=submission_source,
-            mount_name=mount_name,
-            pool_size=pool_size,
-        )
-    elif local:
-        source = "--local"
-        handle = _build_local_handle()
-    elif env_profile:
-        source = "env"
-        handle, pool = _build_ssh_handle(
-            env_profile,
+            resolved_profile,
             callbacks=callbacks,
             submission_source=submission_source,
             mount_name=mount_name,
             pool_size=pool_size,
         )
     else:
-        source = "default"
         handle = _build_local_handle()
 
     resolved = ResolvedTransport(

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -178,6 +178,12 @@ def emit_transport_banner(
     """
     if quiet or source == "default":
         return
+    # Construct a fresh Console each call so the emitter picks up the
+    # *current* ``sys.stderr``. pytest's capture swaps ``sys.stderr``
+    # between tests, and a module-level cached Console would hold a
+    # stale reference and raise "I/O operation on closed file" on the
+    # second invocation. Construction is cheap (~µs) and banner
+    # emission is not on any hot path.
     Console(file=sys.stderr).print(f"[dim]→ transport: {label} (from {source})[/dim]")
 
 
@@ -231,11 +237,54 @@ def _build_local_handle(slurm: Slurm | None = None) -> TransportHandle:
     )
 
 
+def _resolve_submission_context(
+    *,
+    profile_name: str,
+    profile_mounts: Sequence[Any] | None,
+    mount_name: str | None,
+) -> SubmissionRenderContext | None:
+    """Decide the ``SubmissionRenderContext`` for an SSH profile.
+
+    Split out of :func:`_build_ssh_handle` so the mount auto-selection
+    policy lives in one place and can be tested independently.
+
+    Returns ``None`` when the profile has no mounts at all (no
+    translation possible). Otherwise returns a context with
+    ``mount_name`` set to either the caller's explicit choice, the
+    single mount's name (auto-selection), or ``None`` when the profile
+    declares multiple mounts and the caller did not pick one (logs a
+    warning so the silent no-translation fallback is visible).
+    """
+    from srunx.rendering import SubmissionRenderContext
+
+    mounts = tuple(profile_mounts) if profile_mounts else ()
+    if not mounts:
+        return None
+
+    resolved_mount_name = mount_name
+    if resolved_mount_name is None:
+        if len(mounts) == 1:
+            resolved_mount_name = mounts[0].name
+        else:
+            logger.warning(
+                "SSH profile %r declares %d mounts; no mount selected "
+                "so path translation is disabled. Pass mount_name "
+                "explicitly to enable translation.",
+                profile_name,
+                len(mounts),
+            )
+    return SubmissionRenderContext(
+        mount_name=resolved_mount_name,
+        mounts=mounts,
+        default_work_dir=None,
+    )
+
+
 def _build_ssh_handle(
     profile_name: str,
     *,
+    submission_source: str,
     callbacks: Sequence[Callback] | None = None,
-    submission_source: str = "web",
     mount_name: str | None = None,
     pool_size: int = 2,
 ) -> tuple[TransportHandle, Any]:
@@ -276,7 +325,6 @@ def _build_ssh_handle(
             factory rejects the configuration.
     """
     # Conditional imports — see module docstring.
-    from srunx.rendering import SubmissionRenderContext
     from srunx.ssh.core.config import ConfigManager
     from srunx.web.ssh_adapter import SlurmSSHAdapter, SlurmSSHAdapterSpec
     from srunx.web.ssh_executor import SlurmSSHExecutorPool
@@ -318,35 +366,11 @@ def _build_ssh_handle(
     # orphan the pool's SSH capacity. Wrap the remaining work so the
     # pool is drained before the exception propagates (Fix F8).
     try:
-        # SubmissionRenderContext carries mount information for path
-        # translation. We only construct it when the profile actually
-        # declares mounts; otherwise downstream code should render paths
-        # verbatim.
-        mounts = tuple(profile.mounts) if profile.mounts else ()
-        render_context: SubmissionRenderContext | None = None
-        if mounts:
-            # Auto-select a single mount so the common case (one mount per
-            # profile) gets translation without requiring a --mount flag.
-            # Multi-mount profiles with no explicit ``mount_name`` opt out
-            # of translation and warn — the caller must pass a mount hint
-            # or reconsider the profile layout.
-            resolved_mount_name = mount_name
-            if resolved_mount_name is None:
-                if len(mounts) == 1:
-                    resolved_mount_name = mounts[0].name
-                else:
-                    logger.warning(
-                        "SSH profile %r declares %d mounts; no mount selected "
-                        "so path translation is disabled. Pass mount_name "
-                        "explicitly to enable translation.",
-                        profile_name,
-                        len(mounts),
-                    )
-            render_context = SubmissionRenderContext(
-                mount_name=resolved_mount_name,
-                mounts=mounts,
-                default_work_dir=None,
-            )
+        render_context = _resolve_submission_context(
+            profile_name=profile_name,
+            profile_mounts=profile.mounts,
+            mount_name=mount_name,
+        )
 
         handle = TransportHandle(
             scheduler_key=f"ssh:{profile_name}",
@@ -390,6 +414,12 @@ def peek_scheduler_key(*, profile: str | None = None, local: bool = False) -> st
     ``--local`` conflict so callers fail consistently whether they
     peek first or go straight to :func:`resolve_transport`.
     """
+    profile = profile.strip() if profile else profile
+    if profile == "":
+        raise typer.BadParameter(
+            "--profile cannot be empty or whitespace.",
+            param_hint="--profile",
+        )
     if profile and local:
         raise typer.BadParameter(
             "--profile and --local cannot be used together.",
@@ -399,7 +429,7 @@ def peek_scheduler_key(*, profile: str | None = None, local: bool = False) -> st
         return f"ssh:{profile}"
     if local:
         return "local"
-    env_profile = os.environ.get("SRUNX_SSH_PROFILE")
+    env_profile = os.environ.get("SRUNX_SSH_PROFILE", "").strip()
     if env_profile:
         return f"ssh:{env_profile}"
     return "local"
@@ -471,13 +501,19 @@ def resolve_transport(
         TransportError: When an explicit / env-selected SSH profile is
             unknown or the adapter factory rejects it.
     """
+    profile = profile.strip() if profile else profile
+    if profile == "":
+        raise typer.BadParameter(
+            "--profile cannot be empty or whitespace.",
+            param_hint="--profile",
+        )
     if profile and local:
         raise typer.BadParameter(
             "--profile and --local cannot be used together.",
             param_hint="--profile / --local",
         )
 
-    env_profile = os.environ.get("SRUNX_SSH_PROFILE")
+    env_profile = os.environ.get("SRUNX_SSH_PROFILE", "").strip() or None
     pool: Any = None
     handle: TransportHandle
     source: TransportSource
@@ -545,8 +581,15 @@ class TransportRegistry:
         *,
         local_client: Slurm | None = None,
         profile_loader: Callable[[str], ServerProfile | None] | None = None,
+        submission_source: str = "web",
     ) -> None:
         self._local_client = local_client or Slurm()
+        # Origin tag the registry attaches to every SSH handle it builds.
+        # Web app lifespan uses the default ``"web"``; CLI-scoped registries
+        # (rare today) could construct with ``"cli"``. The value flows into
+        # ``_build_ssh_handle`` so ``jobs.submission_source`` is recorded
+        # with the correct caller identity.
+        self._submission_source = submission_source
         if profile_loader is None:
             # Match _build_ssh_handle's default path — use ConfigManager.
             # We import inside __init__ to keep the module import graph
@@ -619,7 +662,10 @@ class TransportRegistry:
             if not profile_name or self._profile_loader(profile_name) is None:
                 return None
             try:
-                built, pool = _build_ssh_handle(profile_name)
+                built, pool = _build_ssh_handle(
+                    profile_name,
+                    submission_source=self._submission_source,
+                )
             except TransportError as exc:
                 logger.warning(
                     "Failed to build SSH transport %r: %s", scheduler_key, exc

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -36,7 +36,8 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Callable, Iterator
+import threading
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
@@ -56,6 +57,7 @@ from srunx.logging import get_logger
 if TYPE_CHECKING:
     import sqlite3
 
+    from srunx.callbacks import Callback
     from srunx.rendering import SubmissionRenderContext
     from srunx.ssh.core.config import ServerProfile
 
@@ -188,12 +190,39 @@ def _build_local_handle(slurm: Slurm | None = None) -> TransportHandle:
 
 def _build_ssh_handle(
     profile_name: str,
+    *,
+    callbacks: Sequence[Callback] | None = None,
+    submission_source: str = "web",
+    mount_name: str | None = None,
+    pool_size: int = 2,
 ) -> tuple[TransportHandle, Any]:
     """Build an SSH :class:`TransportHandle` and its backing executor pool.
 
     Imports are local so ``SlurmSSHAdapter`` / paramiko / pool module
     costs are never paid by CLI invocations that stay on local SLURM
     (R-3 performance requirement).
+
+    Args:
+        profile_name: Name of the SSH profile to resolve.
+        callbacks: Optional callbacks to attach to both the singleton
+            adapter (used for ad-hoc ``submit`` / ``status`` / ``queue``
+            ops) and every pooled clone (used by the sweep / workflow
+            execution path). Defaults to ``None`` so routes that don't
+            run through :class:`NotificationWatchCallback` don't pay any
+            callback cost.
+        submission_source: Origin tag recorded on the ``jobs`` row for
+            every job submitted through this handle. Routers leave the
+            default ``'web'``; CLI passes ``'cli'``; MCP passes ``'mcp'``.
+        mount_name: Explicit mount selection for path translation. When
+            ``None`` and the profile declares exactly one mount we
+            auto-select it so ``flow run --profile`` gets mount
+            translation out of the box. Multi-mount profiles with no
+            explicit ``mount_name`` fall back to "no translation" and
+            emit a warning.
+        pool_size: Number of pooled SSH adapters. Default ``2`` for
+            single-shot CLI / MCP. Long-lived callers (Web app lifespan)
+            should pass a higher value (e.g. 8) to handle concurrent
+            request traffic.
 
     Returns:
         A ``(handle, pool)`` tuple. The caller is responsible for closing
@@ -219,39 +248,131 @@ def _build_ssh_handle(
         )
 
     try:
-        adapter = SlurmSSHAdapter(profile_name=profile_name)
+        adapter = SlurmSSHAdapter(
+            profile_name=profile_name,
+            callbacks=callbacks,
+            submission_source=submission_source,
+        )
     except ValueError as exc:
         raise TransportError(str(exc)) from exc
 
     # Build the pool off the adapter's own connection spec so pooled
     # clones inherit the exact same resolved hostname / identity file /
-    # proxy_jump / env_vars the singleton adapter uses.
+    # proxy_jump / env_vars the singleton adapter uses. Pooled clones
+    # also pick up the same callback list so per-cell jobs in the
+    # workflow / sweep path fire ``on_job_submitted`` (including
+    # :class:`NotificationWatchCallback`) with the adapter's
+    # ``scheduler_key`` already bound.
     spec: SlurmSSHAdapterSpec = adapter.connection_spec
-    pool = SlurmSSHExecutorPool(spec, callbacks=None, size=2)
-
-    # SubmissionRenderContext carries mount information for path
-    # translation. We only construct it when the profile actually
-    # declares mounts; otherwise downstream code should render paths
-    # verbatim.
-    mounts = tuple(profile.mounts) if profile.mounts else ()
-    render_context: SubmissionRenderContext | None = None
-    if mounts:
-        render_context = SubmissionRenderContext(
-            mount_name=None,
-            mounts=mounts,
-            default_work_dir=None,
-        )
-
-    handle = TransportHandle(
-        scheduler_key=f"ssh:{profile_name}",
-        profile_name=profile_name,
-        transport_type="ssh",
-        job_ops=adapter,
-        queue_client=adapter,
-        executor_factory=pool.lease,
-        submission_context=render_context,
+    pool = SlurmSSHExecutorPool(
+        spec,
+        callbacks=callbacks,
+        size=pool_size,
+        submission_source=submission_source,
     )
-    return handle, pool
+
+    # Any failure between pool construction and handle return would
+    # orphan the pool's SSH capacity. Wrap the remaining work so the
+    # pool is drained before the exception propagates (Fix F8).
+    try:
+        # SubmissionRenderContext carries mount information for path
+        # translation. We only construct it when the profile actually
+        # declares mounts; otherwise downstream code should render paths
+        # verbatim.
+        mounts = tuple(profile.mounts) if profile.mounts else ()
+        render_context: SubmissionRenderContext | None = None
+        if mounts:
+            # Auto-select a single mount so the common case (one mount per
+            # profile) gets translation without requiring a --mount flag.
+            # Multi-mount profiles with no explicit ``mount_name`` opt out
+            # of translation and warn — the caller must pass a mount hint
+            # or reconsider the profile layout.
+            resolved_mount_name = mount_name
+            if resolved_mount_name is None:
+                if len(mounts) == 1:
+                    resolved_mount_name = mounts[0].name
+                else:
+                    logger.warning(
+                        "SSH profile %r declares %d mounts; no mount selected "
+                        "so path translation is disabled. Pass mount_name "
+                        "explicitly to enable translation.",
+                        profile_name,
+                        len(mounts),
+                    )
+            render_context = SubmissionRenderContext(
+                mount_name=resolved_mount_name,
+                mounts=mounts,
+                default_work_dir=None,
+            )
+
+        handle = TransportHandle(
+            scheduler_key=f"ssh:{profile_name}",
+            profile_name=profile_name,
+            transport_type="ssh",
+            job_ops=adapter,
+            queue_client=adapter,
+            executor_factory=pool.lease,
+            submission_context=render_context,
+        )
+        return handle, pool
+    except Exception:
+        # Best-effort: drop the pool before the caller's ``finally``
+        # clause has a chance to run (it only fires when the CM actually
+        # yielded a ResolvedTransport, which we never reach here).
+        try:
+            pool.close()
+        except Exception as close_exc:  # noqa: BLE001 — best-effort cleanup
+            logger.debug(
+                "Pool close during orphan cleanup failed (non-fatal): %s",
+                close_exc,
+            )
+        raise
+
+
+def peek_scheduler_key(*, profile: str | None = None, local: bool = False) -> str:
+    """Return the scheduler_key ``resolve_transport`` would pick.
+
+    Pure function with no side effects — used by callers that need to
+    bind callback state (e.g. ``NotificationWatchCallback.scheduler_key``)
+    before entering the transport context manager.
+
+    Resolution order mirrors :func:`resolve_transport` exactly:
+
+        1. ``profile`` → ``f"ssh:{profile}"``
+        2. ``local=True`` → ``"local"``
+        3. ``$SRUNX_SSH_PROFILE`` → ``f"ssh:{env}"``
+        4. default → ``"local"``
+
+    Raises :class:`typer.BadParameter` on the same ``--profile`` +
+    ``--local`` conflict so callers fail consistently whether they
+    peek first or go straight to :func:`resolve_transport`.
+    """
+    if profile and local:
+        raise typer.BadParameter(
+            "--profile and --local cannot be used together.",
+            param_hint="--profile / --local",
+        )
+    if profile:
+        return f"ssh:{profile}"
+    if local:
+        return "local"
+    env_profile = os.environ.get("SRUNX_SSH_PROFILE")
+    if env_profile:
+        return f"ssh:{env_profile}"
+    return "local"
+
+
+def _build_transport_label(handle: TransportHandle) -> str:
+    """Return a human-friendly label for the transport banner.
+
+    ``scheduler_key`` uses the ``ssh:<profile>`` grammar for machine
+    parsing; the banner is user-facing so we render ``SSH: <profile>``
+    for SSH and ``local SLURM`` for local to avoid looking like an
+    internal identifier.
+    """
+    if handle.transport_type == "local":
+        return "local SLURM"
+    return f"SSH: {handle.profile_name}"
 
 
 @contextmanager
@@ -261,6 +382,10 @@ def resolve_transport(
     local: bool = False,
     quiet: bool = False,
     banner: bool = True,
+    callbacks: Sequence[Callback] | None = None,
+    submission_source: str = "cli",
+    mount_name: str | None = None,
+    pool_size: int = 2,
 ) -> Iterator[ResolvedTransport]:
     """Resolve transport for one CLI invocation.
 
@@ -279,6 +404,20 @@ def resolve_transport(
             sources.
         banner: Emit the one-line banner. Set ``False`` for tests or
             library-style callers that don't want any stderr output.
+        callbacks: Optional callbacks to forward into the SSH adapter
+            singleton and every pooled clone. Non-SSH paths ignore
+            ``callbacks`` (local ``Slurm`` callbacks are wired at the
+            ``Slurm`` callsite, not here).
+        submission_source: Origin tag for ``jobs.submission_source``.
+            Defaults to ``'cli'`` which is correct for every CLI entry
+            point; the value is a no-op on the local path and is passed
+            through to :class:`SlurmSSHAdapter` on SSH.
+        mount_name: Explicit mount selection forwarded to the SSH
+            handle builder for path translation. ``None`` triggers
+            single-mount auto-selection.
+        pool_size: Pool size forwarded to the SSH executor pool. Default
+            ``2`` matches single-shot CLI usage; long-lived callers pass
+            a larger value.
 
     Yields:
         A :class:`ResolvedTransport` for the duration of the ``with``
@@ -303,19 +442,31 @@ def resolve_transport(
 
     if profile:
         source = "--profile"
-        handle, pool = _build_ssh_handle(profile)
+        handle, pool = _build_ssh_handle(
+            profile,
+            callbacks=callbacks,
+            submission_source=submission_source,
+            mount_name=mount_name,
+            pool_size=pool_size,
+        )
     elif local:
         source = "--local"
         handle = _build_local_handle()
     elif env_profile:
         source = "env"
-        handle, pool = _build_ssh_handle(env_profile)
+        handle, pool = _build_ssh_handle(
+            env_profile,
+            callbacks=callbacks,
+            submission_source=submission_source,
+            mount_name=mount_name,
+            pool_size=pool_size,
+        )
     else:
         source = "default"
         handle = _build_local_handle()
 
     resolved = ResolvedTransport(
-        label=handle.scheduler_key,
+        label=_build_transport_label(handle),
         source=source,
         handle=handle,
     )
@@ -366,6 +517,23 @@ class TransportRegistry:
         self._profile_loader = profile_loader
         self._cache: dict[str, TransportHandle] = {}
         self._pools: list[Any] = []
+        # ``_lock`` guards ``_cache`` and ``_pools``. The lock is only
+        # held around map/list mutations and cheap lookups — SSH
+        # ``_build_ssh_handle`` runs outside the lock so a paramiko
+        # connect does not block concurrent resolves (F6).
+        self._lock = threading.Lock()
+
+    def _disconnect_handle_quietly(self, handle: TransportHandle) -> None:
+        """Best-effort disconnect of a cached SSH adapter (F1)."""
+        if handle.transport_type != "ssh":
+            return
+        disconnect = getattr(handle.job_ops, "disconnect", None)
+        if disconnect is None:
+            return
+        try:
+            disconnect()
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            logger.debug("Adapter disconnect failed (non-fatal): %s", exc)
 
     def resolve(self, scheduler_key: str) -> TransportHandle | None:
         """Resolve ``scheduler_key`` to a :class:`TransportHandle`.
@@ -373,32 +541,91 @@ class TransportRegistry:
         Returns ``None`` for unknown SSH profiles or malformed keys so
         the poller can log a warning and skip the affected group
         without crashing the whole cycle (AC-8.5).
+
+        On cache hit for an ``ssh:<profile>`` key, re-validate the
+        profile still exists. A profile can be deleted between the
+        first resolve and a later one; returning a stale handle would
+        mis-route subsequent watches. If the profile has disappeared,
+        invalidate the cache entry and return ``None`` (F1).
         """
-        if scheduler_key in self._cache:
-            return self._cache[scheduler_key]
+        # Cache hit path: hold the lock only long enough to read the
+        # entry and (on SSH) invalidate it when the profile is gone.
+        with self._lock:
+            cached = self._cache.get(scheduler_key)
+        if cached is not None:
+            if scheduler_key.startswith("ssh:"):
+                profile_name = scheduler_key[4:]
+                if self._profile_loader(profile_name) is None:
+                    # Profile deleted — evict under the lock, then
+                    # disconnect outside to avoid holding the lock
+                    # during blocking I/O.
+                    with self._lock:
+                        stale = self._cache.pop(scheduler_key, None)
+                    if stale is not None:
+                        self._disconnect_handle_quietly(stale)
+                    return None
+            return cached
 
+        # Build path — run the actual construction outside the lock so
+        # paramiko connects / profile reads do not serialise concurrent
+        # resolves of *different* scheduler keys.
         if scheduler_key == "local":
-            handle = _build_local_handle(self._local_client)
-            self._cache[scheduler_key] = handle
-            return handle
-
-        if scheduler_key.startswith("ssh:"):
+            built: TransportHandle | None = _build_local_handle(self._local_client)
+            pool: Any = None
+        elif scheduler_key.startswith("ssh:"):
             profile_name = scheduler_key[4:]
             if not profile_name or self._profile_loader(profile_name) is None:
                 return None
             try:
-                handle, pool = _build_ssh_handle(profile_name)
+                built, pool = _build_ssh_handle(profile_name)
             except TransportError as exc:
                 logger.warning(
                     "Failed to build SSH transport %r: %s", scheduler_key, exc
                 )
                 return None
-            self._cache[scheduler_key] = handle
-            if pool is not None:
-                self._pools.append(pool)
-            return handle
+        else:
+            return None
 
-        return None
+        # Insert-or-return-existing under the lock. A concurrent thread
+        # may have beaten us to the cache; if so, drop our freshly built
+        # handle (and pool) and hand the caller the shared one.
+        assert built is not None  # narrows type from above (local/ssh both built)
+        with self._lock:
+            existing = self._cache.get(scheduler_key)
+            if existing is not None:
+                # Another thread won — drop our pool before returning.
+                discard_pool = pool
+                discard_handle: TransportHandle | None = built
+            else:
+                self._cache[scheduler_key] = built
+                if pool is not None:
+                    self._pools.append(pool)
+                discard_pool = None
+                discard_handle = None
+
+        if discard_pool is not None:
+            try:
+                discard_pool.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "Pool close during concurrent-resolve cleanup failed: %s", exc
+                )
+        if discard_handle is not None:
+            self._disconnect_handle_quietly(discard_handle)
+
+        return existing if existing is not None else built
+
+    def register_handle(self, handle: TransportHandle) -> None:
+        """Seed the cache with a pre-built :class:`TransportHandle`.
+
+        Used by the Web app lifespan to reuse the already-connected
+        startup adapter instead of re-opening a second SSH session
+        (F11). If the slot is already occupied, the incoming handle is
+        silently dropped — callers should treat this as "best effort
+        seeding, never replace" semantics.
+        """
+        with self._lock:
+            self._cache.setdefault(handle.scheduler_key, handle)
 
     def known_scheduler_keys(self, db_connection: sqlite3.Connection) -> set[str]:
         """Return every distinct ``scheduler_key`` currently persisted.
@@ -415,11 +642,22 @@ class TransportRegistry:
         return {r[0] for r in rows if r[0]}
 
     def close(self) -> None:
-        """Release every cached SSH pool. Idempotent."""
-        for pool in self._pools:
+        """Release every cached SSH pool + disconnect SSH adapters.
+
+        Idempotent. Pool closes and adapter disconnects run outside the
+        lock to avoid holding it during blocking I/O; the lock is only
+        held long enough to snapshot + clear the internal state.
+        """
+        with self._lock:
+            handles = list(self._cache.values())
+            pools = list(self._pools)
+            self._pools.clear()
+            self._cache.clear()
+
+        for handle in handles:
+            self._disconnect_handle_quietly(handle)
+        for pool in pools:
             try:
                 pool.close()
             except Exception as exc:  # noqa: BLE001 — best-effort cleanup
                 logger.debug("Pool close failed (non-fatal): %s", exc)
-        self._pools.clear()
-        self._cache.clear()

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -369,14 +369,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 transport_registry = TransportRegistry()
                 if profile_name:
                     seeded_key = f"ssh:{profile_name}"
-                    transport_registry._cache[seeded_key] = TransportHandle(
-                        scheduler_key=seeded_key,
-                        profile_name=profile_name,
-                        transport_type="ssh",
-                        job_ops=adapter,
-                        queue_client=adapter,
-                        executor_factory=None,
-                        submission_context=None,
+                    transport_registry.register_handle(
+                        TransportHandle(
+                            scheduler_key=seeded_key,
+                            profile_name=profile_name,
+                            transport_type="ssh",
+                            job_ops=adapter,
+                            queue_client=adapter,
+                            executor_factory=None,
+                            submission_context=None,
+                        )
                     )
                 app.state.transport_registry = transport_registry
                 pollers.append(ActiveWatchPoller(registry=transport_registry))

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -353,7 +353,33 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         pollers: list[Poller] = []
         if os.environ.get("SRUNX_DISABLE_ACTIVE_WATCH_POLLER") != "1":
             if adapter is not None:
-                pollers.append(ActiveWatchPoller(slurm_client=adapter))
+                # Phase 6 REQ-8: hand the poller a TransportRegistry so
+                # watches grouped by ``scheduler_key`` route to the
+                # matching queue_client. We seed the registry's cache
+                # with the already-connected startup adapter under
+                # ``ssh:<profile>`` so we don't re-open a second SSH
+                # session; ``local`` remains resolvable via the default
+                # :class:`Slurm` singleton for any legacy
+                # ``job:local:<id>`` watches still in the DB.
+                from srunx.transport.registry import (
+                    TransportHandle,
+                    TransportRegistry,
+                )
+
+                transport_registry = TransportRegistry()
+                if profile_name:
+                    seeded_key = f"ssh:{profile_name}"
+                    transport_registry._cache[seeded_key] = TransportHandle(
+                        scheduler_key=seeded_key,
+                        profile_name=profile_name,
+                        transport_type="ssh",
+                        job_ops=adapter,
+                        queue_client=adapter,
+                        executor_factory=None,
+                        submission_context=None,
+                    )
+                app.state.transport_registry = transport_registry
+                pollers.append(ActiveWatchPoller(registry=transport_registry))
             else:
                 logger.info("Skipping ActiveWatchPoller: no SLURM client is available")
         if os.environ.get("SRUNX_DISABLE_DELIVERY_POLLER") != "1":
@@ -449,6 +475,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                     logger.warning("Poller shutdown raised", exc_info=True)
             tg.cancel_scope.cancel()
     finally:
+        # Release the TransportRegistry first so any SSH pools it
+        # created (outside the seeded startup adapter) get closed
+        # before we drop the startup adapter below. ``close()`` is
+        # idempotent and never raises to the caller.
+        registry_to_close = getattr(app.state, "transport_registry", None)
+        if registry_to_close is not None:
+            try:
+                registry_to_close.close()
+            except Exception:
+                logger.warning("TransportRegistry close raised", exc_info=True)
+
         # Disconnect the *current* adapter (may differ from startup adapter after profile switch)
         from .deps import get_active_profile_name
 

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -170,11 +170,19 @@ def _record_and_watch(
             source="webhook",
         )
         if req.notify and req.endpoint_id is not None:
-            watch_id = watch_repo.create(kind="job", target_ref=f"job:{job_id}")
+            # V5 grammar: ``job:<scheduler_key>:<id>``. Web-submitted
+            # jobs currently go through the legacy
+            # ``SlurmSSHAdapter.submit_job`` alias which backfills the
+            # jobs row as local (Phase 3 preserves this). Keep watch /
+            # event refs consistent with that until the Phase 5a CLI
+            # migration + Phase 6 poller update cut over to the real
+            # SSH scheduler_key.
+            target_ref = f"job:local:{job_id}"
+            watch_id = watch_repo.create(kind="job", target_ref=target_ref)
             sub_repo.create(watch_id, req.endpoint_id, req.preset)
             event_id = event_repo.insert(
                 kind="job.submitted",
-                source_ref=f"job:{job_id}",
+                source_ref=target_ref,
                 payload={"job_id": job_id, "job_name": job_name},
             )
             # Fan out the job.submitted event so ``preset='all'`` subscribers

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -135,6 +135,7 @@ def _record_and_watch(
     job_id: int,
     job_name: str,
     req: JobSubmitRequest,
+    adapter: SlurmSSHAdapter,
 ) -> None:
     """Persist the submission record and (optionally) create a notification watch.
 
@@ -144,7 +145,21 @@ def _record_and_watch(
 
     Endpoint validation is done BEFORE this function is called (in the
     request path, pre-sbatch) so that a 4xx never strands a SLURM job.
+
+    The transport axis (local vs ``ssh:<profile>``) is taken from the
+    adapter so the watch / event rows are keyed to the same transport
+    the poller will query — without this, an SSH-submitted job's watch
+    would be written with ``scheduler_key='local'`` and the poller
+    would look it up on the wrong cluster.
     """
+    scheduler_key = adapter.scheduler_key
+    if scheduler_key.startswith("ssh:"):
+        transport_type = "ssh"
+        profile_name: str | None = scheduler_key[len("ssh:") :]
+    else:
+        transport_type = "local"
+        profile_name = None
+
     job_repo = JobRepository(conn)
     watch_repo = WatchRepository(conn)
     sub_repo = SubscriptionRepository(conn)
@@ -159,6 +174,9 @@ def _record_and_watch(
             name=job_name,
             status="PENDING",
             submission_source="web",
+            transport_type=transport_type,  # type: ignore[arg-type]
+            profile_name=profile_name,
+            scheduler_key=scheduler_key,
         )
         # Seed baseline transition so ActiveWatchPoller's first observation
         # produces a real transition (from_status='PENDING') rather than
@@ -168,16 +186,13 @@ def _record_and_watch(
             from_status=None,
             to_status="PENDING",
             source="webhook",
+            scheduler_key=scheduler_key,
         )
         if req.notify and req.endpoint_id is not None:
-            # V5 grammar: ``job:<scheduler_key>:<id>``. Web-submitted
-            # jobs currently go through the legacy
-            # ``SlurmSSHAdapter.submit_job`` alias which backfills the
-            # jobs row as local (Phase 3 preserves this). Keep watch /
-            # event refs consistent with that until the Phase 5a CLI
-            # migration + Phase 6 poller update cut over to the real
-            # SSH scheduler_key.
-            target_ref = f"job:local:{job_id}"
+            # V5 grammar: ``job:<scheduler_key>:<id>``. The adapter-owned
+            # ``scheduler_key`` already encodes ``local`` / ``ssh:<profile>``
+            # so a single format-string covers both transports.
+            target_ref = f"job:{scheduler_key}:{job_id}"
             watch_id = watch_repo.create(kind="job", target_ref=target_ref)
             sub_repo.create(watch_id, req.endpoint_id, req.preset)
             event_id = event_repo.insert(
@@ -270,6 +285,7 @@ async def submit_job(
                     job_id=int(job_id),
                     job_name=req.job_name or req.name,
                     req=req,
+                    adapter=adapter,
                 )
             )
         except HTTPException:

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -432,9 +432,13 @@ def _build_run_response(conn: sqlite3.Connection, run: DBWorkflowRun) -> dict[st
     job_repo = JobRepository(conn)
     jobs_by_id: dict[int, str] = {}
     for m in memberships:
-        if m.job_id is None:
+        # V5+: ``jobs_row_id`` is the authoritative FK to ``jobs.id``.
+        # Looking up via ``get_by_row_id`` avoids the pre-V5
+        # ``scheduler_key='local'`` default, which would drop SSH
+        # workflow children and miss their statuses in the API response.
+        if m.jobs_row_id is None or m.job_id is None:
             continue
-        job = job_repo.get(m.job_id)
+        job = job_repo.get_by_row_id(m.jobs_row_id)
         if job is not None:
             jobs_by_id[m.job_id] = job.status
     return _serialize_run(run, memberships, jobs_by_id)

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -989,11 +989,27 @@ async def _submit_jobs_bfs(
         # otherwise commit on its own — a mid-sequence failure would
         # leave e.g. the jobs row inserted with no transition or
         # membership to match it, breaking poller dedup downstream.
+        #
+        # Transport axis: pick up the adapter's scheduler_key so SSH-
+        # submitted workflow jobs land on the correct (ssh, profile,
+        # scheduler_key) triple — otherwise the poller would query
+        # local SLURM for remote job ids.
+        wf_scheduler_key = adapter.scheduler_key
+        if wf_scheduler_key.startswith("ssh:"):
+            wf_transport_type = "ssh"
+            wf_profile_name: str | None = wf_scheduler_key[len("ssh:") :]
+        else:
+            wf_transport_type = "local"
+            wf_profile_name = None
+
         def _persist(
             jid: int = slurm_id,
             jname: str = current_name,
             job_obj: Job | ShellJob = current_job,
             deps: list[str] = depends_on,
+            tt: str = wf_transport_type,
+            pn: str | None = wf_profile_name,
+            sk: str = wf_scheduler_key,
         ) -> None:
             resources = getattr(job_obj, "resources", None)
             environment = getattr(job_obj, "environment", None)
@@ -1004,6 +1020,9 @@ async def _submit_jobs_bfs(
                     name=jname,
                     status="PENDING",
                     submission_source="workflow",
+                    transport_type=tt,  # type: ignore[arg-type]
+                    profile_name=pn,
+                    scheduler_key=sk,
                     workflow_run_id=run_id,
                     command=command_val if isinstance(command_val, list) else None,
                     nodes=getattr(resources, "nodes", None) if resources else None,
@@ -1035,12 +1054,14 @@ async def _submit_jobs_bfs(
                     from_status=None,
                     to_status="PENDING",
                     source="webhook",
+                    scheduler_key=sk,
                 )
                 wrj_repo.create(
                     workflow_run_id=run_id,
                     job_name=jname,
                     depends_on=deps or None,
                     job_id=jid,
+                    scheduler_key=sk,
                 )
 
         await anyio.to_thread.run_sync(_persist)

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -470,6 +470,7 @@ class SlurmSSHAdapter:
                     "nodes": num_nodes,
                     "gpus": gpus_per_node * num_nodes,
                     "elapsed_time": parts[5].strip(),
+                    "time_limit": parts[6].strip(),
                 }
             )
 
@@ -1034,6 +1035,7 @@ class SlurmSSHAdapter:
                 nodes=entry.get("nodes"),
                 gpus=entry.get("gpus"),
                 elapsed_time=entry.get("elapsed_time"),
+                time_limit=entry.get("time_limit"),
                 user=effective_user,
             )
             job.status = status_enum

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -28,7 +28,8 @@ from srunx.ssh.core.ssh_config import SSHConfigParser  # noqa: F811
 from srunx.utils import GPU_TRES_RE  # noqa: E402
 
 if TYPE_CHECKING:
-    from srunx.models import JobStatus, RunnableJobType
+    from srunx.client_protocol import LogChunk
+    from srunx.models import BaseJob, JobStatus, RunnableJobType
     from srunx.rendering import SubmissionRenderContext
 
 logger = get_logger(__name__)
@@ -705,6 +706,244 @@ class SlurmSSHAdapter:
             info["output"] = ""
             info["error"] = ""
         return info
+
+    # ── JobOperationsProtocol surface (Phase 2) ──────
+    #
+    # These methods align SlurmSSHAdapter with
+    # :class:`srunx.client_protocol.JobOperationsProtocol` so the Web UI,
+    # MCP, and (future) top-level CLI can all drive a remote SLURM via
+    # the same 5 entry points they use for the local ``Slurm`` client.
+    # The existing ``submit_job`` / ``cancel_job`` / ``get_job_status`` /
+    # ``list_jobs`` / ``get_job_output`` methods are intentionally kept as
+    # backwards-compatible aliases so Phase 2 is non-breaking for callers
+    # that haven't migrated yet.
+    #
+    # Phase 2 note: DB recording via ``record_submission_from_job`` is
+    # deliberately NOT called from :meth:`submit` here. The
+    # ``transport_type`` / ``profile_name`` / ``scheduler_key`` columns
+    # on ``jobs`` do not yet exist (Phase 3 adds them via migration V5),
+    # so recording would either drop metadata or break the schema. Phase
+    # 3 will wire the recording call with the new kwargs.
+
+    def submit(self, job: RunnableJobType) -> RunnableJobType:
+        """Submit *job* over SSH and return it with ``job_id`` populated.
+
+        Renders the SLURM script locally (Jinja), uploads it via sftp,
+        invokes ``sbatch`` on the remote, mutates *job* in place to set
+        ``job_id`` and ``status = PENDING``, and returns the same object.
+        See :meth:`run` for the full lifecycle (render + submit + monitor
+        + callbacks). This method is submit-only; it does not block on
+        SLURM state transitions.
+        """
+        import tempfile as _tempfile
+
+        import paramiko
+
+        from srunx.exceptions import (
+            SubmissionError,
+            TransportAuthError,
+            TransportConnectionError,
+            TransportTimeoutError,
+        )
+        from srunx.models import (
+            Job,
+            JobStatus,
+            ShellJob,
+            render_job_script,
+            render_shell_job_script,
+        )
+        from srunx.template import get_template_path
+
+        if isinstance(job, Job):
+            template_path = job.template if job.template else get_template_path("base")
+        elif isinstance(job, ShellJob):
+            template_path = None
+        else:
+            raise ValueError(f"Unsupported job type: {type(job).__name__}")
+
+        with _tempfile.TemporaryDirectory() as tmpdir:
+            if isinstance(job, Job):
+                assert template_path is not None  # narrow for mypy
+                script_path = render_job_script(template_path, job, output_dir=tmpdir)
+            else:  # ShellJob — narrowed by the elif above
+                script_path = render_shell_job_script(job.script_path, job, tmpdir)
+            with open(script_path, encoding="utf-8") as f:
+                script_content = f.read()
+
+        try:
+            with self._io_lock:
+                self._ensure_connected()
+                result = self._client.submit_sbatch_job(
+                    script_content, job_name=job.name
+                )
+        except paramiko.AuthenticationException as exc:
+            raise TransportAuthError(f"SSH authentication failed: {exc}") from exc
+        except TimeoutError as exc:
+            raise TransportTimeoutError(f"SSH timed out: {exc}") from exc
+        except (paramiko.SSHException, OSError) as exc:
+            raise TransportConnectionError(f"SSH connection failed: {exc}") from exc
+
+        if result is None or not result.job_id:
+            raise SubmissionError(f"sbatch rejected submission for job '{job.name}'")
+
+        job.job_id = int(result.job_id)
+        job.status = JobStatus.PENDING
+        return job
+
+    def cancel(self, job_id: int) -> None:
+        """Cancel *job_id* on the remote cluster.
+
+        Raises :class:`~srunx.exceptions.JobNotFound` when ``scancel``
+        reports the job is missing, :class:`TransportError` subclasses
+        for SSH-layer failures. The legacy :meth:`cancel_job` API is
+        preserved below as a no-op alias for backwards compat.
+        """
+
+        import paramiko
+
+        from srunx.exceptions import (
+            JobNotFound,
+            RemoteCommandError,
+            TransportAuthError,
+            TransportConnectionError,
+            TransportTimeoutError,
+        )
+
+        try:
+            _run_slurm_cmd(self, f"scancel {int(job_id)}")
+        except paramiko.AuthenticationException as exc:
+            raise TransportAuthError(f"SSH authentication failed: {exc}") from exc
+        except TimeoutError as exc:
+            raise TransportTimeoutError(f"SSH timed out: {exc}") from exc
+        except paramiko.SSHException as exc:
+            raise TransportConnectionError(f"SSH connection failed: {exc}") from exc
+        except RuntimeError as exc:
+            # ``_run_slurm_cmd`` wraps non-zero-exit stderr into RuntimeError.
+            # SLURM's scancel emits "Invalid job id specified" for unknown
+            # ids; surface that as JobNotFound so callers can handle it as
+            # a user-level condition rather than a transport failure.
+            msg = str(exc).lower()
+            if "invalid job id" in msg or "invalid job specification" in msg:
+                raise JobNotFound(f"Job {job_id} not found on remote cluster") from exc
+            raise RemoteCommandError(str(exc)) from exc
+
+    def status(self, job_id: int) -> BaseJob:
+        """Return a snapshot :class:`BaseJob` for *job_id*.
+
+        Uses :meth:`queue_by_ids` (already Protocol-compliant) so both
+        active and terminal jobs resolve through the same code path as
+        the notification poller. Raises
+        :class:`~srunx.exceptions.JobNotFound` when SLURM has no record
+        of ``job_id``.
+
+        P-14 mitigation: we return a ``BaseJob`` with ``job_id=None``
+        on the returned model would defeat ``refresh()``'s early-out,
+        so we keep ``job_id`` set but set the status to a terminal
+        value when SLURM reports one. Callers in Phase 5a that want a
+        strictly non-refreshing DTO should read :class:`JobStatusInfo`
+        via ``queue_by_ids`` directly.
+        """
+        from srunx.exceptions import JobNotFound
+        from srunx.models import BaseJob, JobStatus
+
+        info_map = self.queue_by_ids([int(job_id)])
+        info = info_map.get(int(job_id))
+        if info is None:
+            raise JobNotFound(f"Job {job_id} not found on remote cluster")
+
+        try:
+            status_enum = JobStatus(info.status)
+        except ValueError:
+            status_enum = JobStatus.UNKNOWN
+
+        job = BaseJob(
+            name=f"job_{job_id}",
+            job_id=int(job_id),
+            nodelist=info.nodelist,
+        )
+        job.status = status_enum
+        return job
+
+    def queue(self, user: str | None = None) -> list[BaseJob]:
+        """List jobs for *user* (defaults to the profile's username).
+
+        Adapts :meth:`list_jobs` (which yields dicts) into Pydantic
+        :class:`BaseJob` objects so the return type matches
+        :class:`~srunx.client_protocol.JobOperationsProtocol.queue`.
+        ``user=None`` uses the profile's configured username, matching
+        the Protocol's "transport's current user" contract.
+        """
+        from srunx.models import BaseJob, JobStatus
+
+        effective_user = user if user is not None else self._username or None
+
+        raw_entries = self.list_jobs(user=effective_user)
+        out: list[BaseJob] = []
+        for entry in raw_entries:
+            status_str = str(entry.get("status", "UNKNOWN"))
+            try:
+                status_enum = JobStatus(status_str)
+            except ValueError:
+                status_enum = JobStatus.UNKNOWN
+            try:
+                job_id_val = int(entry["job_id"]) if entry.get("job_id") else None
+            except (TypeError, ValueError):
+                continue
+            job = BaseJob(
+                name=str(entry.get("name", "job")),
+                job_id=job_id_val,
+                partition=entry.get("partition"),
+                nodes=entry.get("nodes"),
+                gpus=entry.get("gpus"),
+                elapsed_time=entry.get("elapsed_time"),
+                user=effective_user,
+            )
+            job.status = status_enum
+            out.append(job)
+        return out
+
+    def tail_log_incremental(
+        self,
+        job_id: int,
+        stdout_offset: int = 0,
+        stderr_offset: int = 0,
+    ) -> LogChunk:
+        """Return new log content since the given byte offsets.
+
+        Thin wrapper around :meth:`get_job_output` which already returns
+        ``(stdout, stderr, new_stdout_offset, new_stderr_offset)``. Pure
+        function: no stdout writes, no blocking. Callers that want
+        ``tail -f`` semantics poll this method in a loop.
+        """
+
+        import paramiko
+
+        from srunx.client_protocol import LogChunk
+        from srunx.exceptions import (
+            TransportAuthError,
+            TransportConnectionError,
+            TransportTimeoutError,
+        )
+
+        try:
+            stdout, stderr, new_stdout_offset, new_stderr_offset = self.get_job_output(
+                int(job_id),
+                stdout_offset=stdout_offset,
+                stderr_offset=stderr_offset,
+            )
+        except paramiko.AuthenticationException as exc:
+            raise TransportAuthError(f"SSH authentication failed: {exc}") from exc
+        except TimeoutError as exc:
+            raise TransportTimeoutError(f"SSH timed out: {exc}") from exc
+        except paramiko.SSHException as exc:
+            raise TransportConnectionError(f"SSH connection failed: {exc}") from exc
+
+        return LogChunk(
+            stdout=stdout,
+            stderr=stderr,
+            stdout_offset=new_stdout_offset,
+            stderr_offset=new_stderr_offset,
+        )
 
     # ── Workflow executor surface (Step 4) ───────────
 

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -140,12 +140,21 @@ class SlurmSSHAdapter:
         env_vars: dict[str, str] | None = None,
         mounts: Sequence[MountConfig] | None = None,
         callbacks: Sequence[Callback] | None = None,
+        submission_source: str = "web",
     ) -> None:
         # Reentrant lock: some code paths call _ensure_connected() explicitly
         # from inside another locked section (e.g. _run_slurm_cmd). An RLock
         # lets the same thread re-enter without self-deadlocking while still
         # serializing I/O across threads.
         self._io_lock: threading.RLock = threading.RLock()
+
+        # Mutable origin tag for ``record_submission`` writes. The Web router
+        # default is ``'web'``; the CLI wrapper passes ``'cli'`` via
+        # ``_build_ssh_handle(..., submission_source='cli')``. MCP callers
+        # pass ``'mcp'``. Exposed as a public attribute so the transport
+        # registry can rebind it without threading a kwarg through every
+        # Protocol signature (see review fix #7).
+        self.submission_source: str = submission_source
 
         # Resolved connection params — persisted so connection_spec() can
         # reproduce this adapter in Step 4's pool factory. Populated below
@@ -244,6 +253,21 @@ class SlurmSSHAdapter:
         else:
             raise ValueError("Either profile_name or (hostname, username) required")
 
+    # ── Public introspection ──────────────────────
+
+    @property
+    def scheduler_key(self) -> str:
+        """Return the V5 transport axis for this adapter.
+
+        ``"local"`` when no profile is bound (legacy direct-hostname
+        tests) or ``f"ssh:{profile_name}"`` otherwise. Exposed publicly
+        so callers (Web routers, poller, etc.) don't reach into
+        ``_profile_name`` to build target_refs / scheduler_keys.
+        """
+        if self._profile_name is None:
+            return "local"
+        return f"ssh:{self._profile_name}"
+
     # ── Connection spec (for Step 4 pool factory) ─────
 
     @property
@@ -272,6 +296,7 @@ class SlurmSSHAdapter:
         spec: SlurmSSHAdapterSpec,
         *,
         callbacks: Sequence[Callback] | None = None,
+        submission_source: str = "web",
     ) -> SlurmSSHAdapter:
         """Create a fresh adapter from a connection spec.
 
@@ -282,8 +307,21 @@ class SlurmSSHAdapter:
 
         ``callbacks`` are attached on construction so the pool's chosen
         callback list propagates into each cloned adapter's ``run`` path.
+
+        ``submission_source`` is carried through from the pool's origin
+        tag so per-cell sweep jobs record the correct transport origin
+        in the ``jobs.submission_source`` column.
         """
-        return cls(
+        # NOTE: ``profile_name`` is intentionally NOT forwarded into the
+        # clone's constructor — setting ``profile_name`` there triggers
+        # the full ``ConfigManager`` + ``~/.ssh/config`` resolution path,
+        # which would re-parse the profile on every pooled lease (and
+        # fail in test environments that stub out the ConfigManager).
+        # The spec already captures the fully-resolved connection params,
+        # so we use the direct-hostname branch and then manually bind
+        # ``_profile_name`` so ``scheduler_key`` / completion recording
+        # target the correct SSH axis.
+        adapter = cls(
             hostname=spec.hostname,
             username=spec.username,
             key_filename=spec.key_filename,
@@ -292,7 +330,10 @@ class SlurmSSHAdapter:
             env_vars=dict(spec.env_vars) if spec.env_vars else None,
             mounts=list(spec.mounts) if spec.mounts else None,
             callbacks=callbacks,
+            submission_source=submission_source,
         )
+        adapter._profile_name = spec.profile_name
+        return adapter
 
     @property
     def is_connected(self) -> bool:
@@ -637,7 +678,16 @@ class SlurmSSHAdapter:
         raise ValueError(f"No job information found for job {job_id}")
 
     def cancel_job(self, job_id: int) -> None:
-        """Cancel a SLURM job via scancel."""
+        """Cancel a SLURM job via scancel.
+
+        Legacy alias retained for pre-Protocol callers
+        (``web.routers.jobs`` / ``web.routers.workflows``). New code
+        should call :meth:`cancel` instead, which raises typed
+        transport exceptions and aligns with
+        :class:`~srunx.client_protocol.JobOperationsProtocol`. This
+        alias will remain until the remaining web router call sites
+        are migrated.
+        """
         _run_slurm_cmd(self, f"scancel {job_id}")
 
     def submit_job(
@@ -646,7 +696,14 @@ class SlurmSSHAdapter:
         job_name: str | None = None,
         dependency: str | None = None,
     ) -> dict[str, Any]:
-        """Submit a job via sbatch. Returns job info dict."""
+        """Submit a job via sbatch. Returns job info dict.
+
+        Legacy alias retained for pre-Protocol callers
+        (``web.routers.jobs`` / ``web.routers.workflows`` /
+        ``web.routers.templates``). New code should call :meth:`submit`
+        with a :class:`~srunx.models.Job` instance. This alias will
+        remain until those routers migrate to the Protocol surface.
+        """
         result = self._client.submit_sbatch_job(
             script_content, job_name=job_name, dependency=dependency
         )
@@ -680,7 +737,15 @@ class SlurmSSHAdapter:
         )
 
     def get_job_status(self, job_id: int) -> str:
-        """Get job status string."""
+        """Get job status string.
+
+        Legacy alias retained for callers that want just the raw SLURM
+        state string (``mcp.server`` and the adapter's own
+        :meth:`_monitor_until_terminal` loop). New code should call
+        :meth:`status` which returns a full :class:`BaseJob` snapshot
+        conforming to
+        :class:`~srunx.client_protocol.JobOperationsProtocol`.
+        """
         return self._client.get_job_status(str(job_id))
 
     def get_job_output_detailed(
@@ -789,10 +854,12 @@ class SlurmSSHAdapter:
         job.status = JobStatus.PENDING
 
         # Record submission with SSH transport metadata. The adapter
-        # cannot observe the caller's ``submission_source`` context
-        # directly (Web / MCP / CLI); Phase 5a CLI integration will
-        # supply it explicitly through a wrapper. Default to ``'web'``
-        # since the Web UI is the dominant caller today.
+        # carries its ``submission_source`` as mutable state set by the
+        # transport registry (``_build_ssh_handle``) — the Web path
+        # leaves the default ``'web'``, the CLI wrapper passes
+        # ``'cli'``, MCP passes ``'mcp'``. This avoids widening the
+        # JobOperationsProtocol signature with a kwarg that would
+        # break every existing Protocol implementor.
         if self._profile_name is not None:
             self._record_job_submission(
                 job,
@@ -801,7 +868,7 @@ class SlurmSSHAdapter:
                 transport_type="ssh",
                 profile_name=self._profile_name,
                 scheduler_key=f"ssh:{self._profile_name}",
-                submission_source="web",
+                submission_source=self.submission_source,
             )
 
         return job
@@ -852,13 +919,16 @@ class SlurmSSHAdapter:
         :class:`~srunx.exceptions.JobNotFound` when SLURM has no record
         of ``job_id``.
 
-        P-14 mitigation: we return a ``BaseJob`` with ``job_id=None``
-        on the returned model would defeat ``refresh()``'s early-out,
-        so we keep ``job_id`` set but set the status to a terminal
-        value when SLURM reports one. Callers in Phase 5a that want a
-        strictly non-refreshing DTO should read :class:`JobStatusInfo`
-        via ``queue_by_ids`` directly.
+        The returned :class:`BaseJob` is a static snapshot — per the
+        :class:`JobOperationsProtocol.status` contract it must NOT
+        trigger a lazy ``sacct`` refresh on ``.status`` access (a local
+        ``sacct`` probe against an SSH-only job id would either miss
+        entirely or return a misleading result). ``_last_refresh`` is
+        parked in the far future so ``BaseJob.status`` observes the
+        snapshot verbatim.
         """
+        import time as _time
+
         from srunx.exceptions import JobNotFound
         from srunx.models import BaseJob, JobStatus
 
@@ -878,6 +948,10 @@ class SlurmSSHAdapter:
             nodelist=info.nodelist,
         )
         job.status = status_enum
+        # Park the lazy-refresh clock far in the future so ``.status``
+        # access never triggers a local ``sacct`` subprocess for an SSH
+        # job id. See :class:`JobOperationsProtocol.status` contract.
+        job._last_refresh = _time.time() + 10**9
         return job
 
     def queue(self, user: str | None = None) -> list[BaseJob]:
@@ -1077,6 +1151,7 @@ class SlurmSSHAdapter:
                 transport_type="ssh",
                 profile_name=self._profile_name,
                 scheduler_key=f"ssh:{self._profile_name}",
+                submission_source=self.submission_source,
             )
         else:
             self._record_job_submission(
@@ -1247,13 +1322,19 @@ class SlurmSSHAdapter:
         except Exception as exc:  # noqa: BLE001 — best-effort
             logger.debug(f"_record_job_submission failed: {exc}")
 
-    @staticmethod
-    def _record_completion_safe(job_id: int, status: JobStatus) -> None:
-        """Record terminal status in ``jobs`` / ``job_state_transitions``."""
+    def _record_completion_safe(self, job_id: int, status: JobStatus) -> None:
+        """Record terminal status in ``jobs`` / ``job_state_transitions``.
+
+        Targets the adapter's own ``scheduler_key`` so SSH-backed jobs
+        update the remote-cluster row rather than a (possibly
+        nonexistent) local row. When no profile is bound (legacy
+        direct-hostname tests), falls back to ``'local'`` to preserve
+        pre-V5 behaviour.
+        """
         try:
             from srunx.db.cli_helpers import record_completion
 
-            record_completion(job_id, status)
+            record_completion(job_id, status, scheduler_key=self.scheduler_key)
         except Exception as exc:  # noqa: BLE001 — best-effort
             logger.debug(f"_record_completion_safe failed: {exc}")
 

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -371,7 +371,18 @@ class SlurmSSHAdapter:
             self._client.disconnect()
 
     def _ensure_connected(self) -> None:
-        """Reconnect if the SSH connection has dropped.
+        """Connect (or reconnect) the SSH session if needed.
+
+        Three states:
+
+        1. ``ssh_client is None`` — adapter was never connected. Happens
+           for every adapter built by
+           :func:`srunx.transport.registry._build_ssh_handle` (CLI
+           scope, MCP tool handlers, tests). Log as "connecting" —
+           calling this a "reconnect" would be misleading.
+        2. ``transport`` absent or inactive — the session was open but
+           dropped (idle timeout, network blip). Log as "reconnecting".
+        3. Transport active — no-op.
 
         Safe to call from inside another ``_io_lock`` region because the
         lock is reentrant. Callers that invoke SSH I/O directly on
@@ -382,18 +393,23 @@ class SlurmSSHAdapter:
         """
         with self._io_lock:
             ssh = self._client.ssh_client
-            needs_reconnect = ssh is None
-            if not needs_reconnect:
-                transport = ssh.get_transport()  # type: ignore[union-attr]
-                needs_reconnect = transport is None or not transport.is_active()
-
-            if needs_reconnect:
-                logger.warning("SSH connection lost, reconnecting...")
-                self._client.disconnect()
+            if ssh is None:
+                logger.debug("SSH adapter connecting for the first time")
                 if not self._client.connect():
-                    raise RuntimeError("SSH reconnection failed")
+                    raise RuntimeError("SSH connection failed")
                 self._set_keepalive()
-                logger.info("SSH reconnection successful")
+                return
+
+            transport = ssh.get_transport()
+            if transport is not None and transport.is_active():
+                return  # happy path — connection already up
+
+            logger.warning("SSH connection lost, reconnecting...")
+            self._client.disconnect()
+            if not self._client.connect():
+                raise RuntimeError("SSH reconnection failed")
+            self._set_keepalive()
+            logger.info("SSH reconnection successful")
 
     def __enter__(self) -> SlurmSSHAdapter:
         self.connect()
@@ -704,9 +720,11 @@ class SlurmSSHAdapter:
         with a :class:`~srunx.models.Job` instance. This alias will
         remain until those routers migrate to the Protocol surface.
         """
-        result = self._client.submit_sbatch_job(
-            script_content, job_name=job_name, dependency=dependency
-        )
+        with self._io_lock:
+            self._ensure_connected()
+            result = self._client.submit_sbatch_job(
+                script_content, job_name=job_name, dependency=dependency
+            )
         if result is None:
             raise RuntimeError("sbatch submission failed")
         return {
@@ -728,13 +746,22 @@ class SlurmSSHAdapter:
         """Get job stdout/stderr log contents from remote.
 
         Returns ``(stdout, stderr, new_stdout_offset, new_stderr_offset)``.
+
+        Ensures the SSH connection is live before reading — callers that
+        reach this method via a fresh :class:`SlurmSSHAdapter` (e.g. CLI
+        ``srunx logs --profile foo``, which builds the adapter via
+        :func:`srunx.transport.registry._build_ssh_handle` without the
+        Web app's startup connect) would otherwise hit
+        ``SSH client is not connected`` on the first call.
         """
-        return self._client.get_job_output(
-            str(job_id),
-            job_name=job_name,
-            stdout_offset=stdout_offset,
-            stderr_offset=stderr_offset,
-        )
+        with self._io_lock:
+            self._ensure_connected()
+            return self._client.get_job_output(
+                str(job_id),
+                job_name=job_name,
+                stdout_offset=stdout_offset,
+                stderr_offset=stderr_offset,
+            )
 
     def get_job_status(self, job_id: int) -> str:
         """Get job status string.
@@ -746,7 +773,9 @@ class SlurmSSHAdapter:
         conforming to
         :class:`~srunx.client_protocol.JobOperationsProtocol`.
         """
-        return self._client.get_job_status(str(job_id))
+        with self._io_lock:
+            self._ensure_connected()
+            return self._client.get_job_status(str(job_id))
 
     def get_job_output_detailed(
         self,

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -783,7 +783,12 @@ class SlurmSSHAdapter:
     # backwards-compatible aliases so callers that haven't migrated yet
     # stay working.
 
-    def submit(self, job: RunnableJobType) -> RunnableJobType:
+    def submit(
+        self,
+        job: RunnableJobType,
+        *,
+        submission_context: SubmissionRenderContext | None = None,
+    ) -> RunnableJobType:
         """Submit *job* over SSH and return it with ``job_id`` populated.
 
         Renders the SLURM script locally (Jinja), uploads it via sftp,
@@ -792,6 +797,12 @@ class SlurmSSHAdapter:
         See :meth:`run` for the full lifecycle (render + submit + monitor
         + callbacks). This method is submit-only; it does not block on
         SLURM state transitions.
+
+        ``submission_context`` (when provided) applies mount-aware
+        :func:`normalize_job_for_submission` before rendering so absolute
+        local ``work_dir`` / ``log_dir`` paths get rewritten to the
+        profile's remote mount root. Passing ``None`` preserves the
+        pre-Bug-6 behaviour of rendering the job verbatim.
 
         Records the submission in the state DB with the
         (``transport_type='ssh'``, ``profile_name=<this adapter's
@@ -816,7 +827,15 @@ class SlurmSSHAdapter:
             render_job_script,
             render_shell_job_script,
         )
+        from srunx.rendering import normalize_job_for_submission
         from srunx.template import get_template_path
+
+        # Apply mount-aware path translation before we inspect the job's
+        # type for template resolution. ``normalize_job_for_submission``
+        # returns a ``model_copy`` when a rewrite is needed, so we rebind
+        # ``job`` and use the normalized instance for rendering + DB
+        # recording. See :meth:`run` for the mirror call-site.
+        job = normalize_job_for_submission(job, submission_context)
 
         if isinstance(job, Job):
             template_path = job.template if job.template else get_template_path("base")

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -707,7 +707,7 @@ class SlurmSSHAdapter:
             info["error"] = ""
         return info
 
-    # ── JobOperationsProtocol surface (Phase 2) ──────
+    # ── JobOperationsProtocol surface ────────────────
     #
     # These methods align SlurmSSHAdapter with
     # :class:`srunx.client_protocol.JobOperationsProtocol` so the Web UI,
@@ -715,15 +715,8 @@ class SlurmSSHAdapter:
     # the same 5 entry points they use for the local ``Slurm`` client.
     # The existing ``submit_job`` / ``cancel_job`` / ``get_job_status`` /
     # ``list_jobs`` / ``get_job_output`` methods are intentionally kept as
-    # backwards-compatible aliases so Phase 2 is non-breaking for callers
-    # that haven't migrated yet.
-    #
-    # Phase 2 note: DB recording via ``record_submission_from_job`` is
-    # deliberately NOT called from :meth:`submit` here. The
-    # ``transport_type`` / ``profile_name`` / ``scheduler_key`` columns
-    # on ``jobs`` do not yet exist (Phase 3 adds them via migration V5),
-    # so recording would either drop metadata or break the schema. Phase
-    # 3 will wire the recording call with the new kwargs.
+    # backwards-compatible aliases so callers that haven't migrated yet
+    # stay working.
 
     def submit(self, job: RunnableJobType) -> RunnableJobType:
         """Submit *job* over SSH and return it with ``job_id`` populated.
@@ -734,6 +727,12 @@ class SlurmSSHAdapter:
         See :meth:`run` for the full lifecycle (render + submit + monitor
         + callbacks). This method is submit-only; it does not block on
         SLURM state transitions.
+
+        Records the submission in the state DB with the
+        (``transport_type='ssh'``, ``profile_name=<this adapter's
+        profile>``, ``scheduler_key='ssh:<profile>'``) triple so the
+        poller can look the job up under the right transport. DB writes
+        are best-effort and never mask an sbatch success.
         """
         import tempfile as _tempfile
 
@@ -788,6 +787,23 @@ class SlurmSSHAdapter:
 
         job.job_id = int(result.job_id)
         job.status = JobStatus.PENDING
+
+        # Record submission with SSH transport metadata. The adapter
+        # cannot observe the caller's ``submission_source`` context
+        # directly (Web / MCP / CLI); Phase 5a CLI integration will
+        # supply it explicitly through a wrapper. Default to ``'web'``
+        # since the Web UI is the dominant caller today.
+        if self._profile_name is not None:
+            self._record_job_submission(
+                job,
+                workflow_name=None,
+                workflow_run_id=None,
+                transport_type="ssh",
+                profile_name=self._profile_name,
+                scheduler_key=f"ssh:{self._profile_name}",
+                submission_source="web",
+            )
+
         return job
 
     def cancel(self, job_id: int) -> None:
@@ -1047,11 +1063,27 @@ class SlurmSSHAdapter:
         logger.debug(f"Submitted job '{job.name}' via SSH with ID {job_id}")
 
         # --- 3. Record submission in state DB (best-effort) ---
-        self._record_job_submission(
-            job,
-            workflow_name=workflow_name,
-            workflow_run_id=workflow_run_id,
-        )
+        # When the adapter knows which SSH profile it represents, record
+        # the true (ssh, profile, scheduler_key) triple so the poller
+        # looks the job up under the right transport. When no profile
+        # is bound (direct hostname constructor, legacy sweep tests),
+        # fall back to the pre-V5 local triple to preserve mock-based
+        # test expectations.
+        if self._profile_name is not None:
+            self._record_job_submission(
+                job,
+                workflow_name=workflow_name,
+                workflow_run_id=workflow_run_id,
+                transport_type="ssh",
+                profile_name=self._profile_name,
+                scheduler_key=f"ssh:{self._profile_name}",
+            )
+        else:
+            self._record_job_submission(
+                job,
+                workflow_name=workflow_name,
+                workflow_run_id=workflow_run_id,
+            )
 
         # --- 4. Fire on_job_submitted callbacks ---
         for callback in self.callbacks:
@@ -1168,20 +1200,50 @@ class SlurmSSHAdapter:
         *,
         workflow_name: str | None,
         workflow_run_id: int | None,
+        transport_type: str = "ssh",
+        profile_name: str | None = None,
+        scheduler_key: str | None = None,
+        submission_source: str | None = None,
     ) -> None:
         """Insert a ``jobs`` row for the SSH-submitted job.
 
         Thin wrapper around :func:`record_submission_from_job` — same
-        best-effort contract as the local :class:`Slurm` executor.
+        best-effort contract as the local :class:`Slurm` executor. For
+        backward compatibility with the :meth:`run` callsite that only
+        passes ``workflow_name`` / ``workflow_run_id``, when
+        ``profile_name`` / ``scheduler_key`` are not provided we record
+        the row as local (the original pre-V5 behaviour); callsites that
+        want the SSH triple must pass them explicitly.
         """
         try:
             from srunx.db.cli_helpers import record_submission_from_job
 
-            record_submission_from_job(
-                job,
-                workflow_name=workflow_name,
-                workflow_run_id=workflow_run_id,
-            )
+            if profile_name is None:
+                # Legacy callsite (pre-V5 style) — pass only the two
+                # original kwargs so tests that mock
+                # ``record_submission_from_job`` with the original
+                # signature (``(job, *, workflow_name, workflow_run_id)``)
+                # keep working. The DB default is local anyway.
+                record_submission_from_job(
+                    job,
+                    workflow_name=workflow_name,
+                    workflow_run_id=workflow_run_id,
+                )
+            else:
+                resolved_scheduler_key = (
+                    scheduler_key
+                    if scheduler_key is not None
+                    else f"ssh:{profile_name}"
+                )
+                record_submission_from_job(
+                    job,
+                    workflow_name=workflow_name,
+                    workflow_run_id=workflow_run_id,
+                    transport_type=transport_type,  # type: ignore[arg-type]
+                    profile_name=profile_name,
+                    scheduler_key=resolved_scheduler_key,
+                    submission_source=submission_source,  # type: ignore[arg-type]
+                )
         except Exception as exc:  # noqa: BLE001 — best-effort
             logger.debug(f"_record_job_submission failed: {exc}")
 

--- a/src/srunx/web/ssh_executor.py
+++ b/src/srunx/web/ssh_executor.py
@@ -106,12 +106,17 @@ class SlurmSSHExecutorPool:
         *,
         callbacks: Sequence[Callback] | None = None,
         size: int = 8,
+        submission_source: str = "web",
     ) -> None:
         if size <= 0:
             raise ValueError(f"Pool size must be positive, got {size}")
         self._spec = spec
         self._callbacks: list[Callback] = list(callbacks) if callbacks else []
         self._size = size
+        # Propagated into each cloned adapter's ``submission_source`` so
+        # per-cell sweep jobs record the correct transport origin in
+        # ``jobs.submission_source`` (see review fix #7).
+        self._submission_source = submission_source
         # Unbounded internal queue so release is always non-blocking; we
         # gate creation via ``_created`` so ``_free`` never holds more than
         # ``size`` adapters.
@@ -131,7 +136,11 @@ class SlurmSSHExecutorPool:
         Does not connect eagerly — :meth:`SlurmSSHAdapter.run` and sibling
         SSH I/O methods call ``_ensure_connected`` on their first use.
         """
-        return SlurmSSHAdapter.from_spec(self._spec, callbacks=self._callbacks)
+        return SlurmSSHAdapter.from_spec(
+            self._spec,
+            callbacks=self._callbacks,
+            submission_source=self._submission_source,
+        )
 
     def _acquire(self, timeout: float | None = 30.0) -> SlurmSSHAdapter:
         """Pop a free adapter, build a new one, or block up to ``timeout``."""

--- a/tests/cli/test_main_backcompat.py
+++ b/tests/cli/test_main_backcompat.py
@@ -33,8 +33,9 @@ class TestDefaultPathSilentBanner:
             slurm_cls.return_value = client
             result = runner.invoke(app, ["submit", "echo", "hi"])
         assert result.exit_code == 0
-        assert "→ transport:" not in result.stderr
-        assert "→ transport:" not in result.output
+        # Banner suppression: no ``●`` bullet + no ``via`` source string.
+        assert "via" not in result.stderr
+        assert "via" not in result.output
 
     def test_list_emits_no_banner_on_default_path(self):
         runner = CliRunner()
@@ -44,7 +45,7 @@ class TestDefaultPathSilentBanner:
             slurm_cls.return_value = client
             result = runner.invoke(app, ["list"])
         assert result.exit_code == 0
-        assert "→ transport:" not in result.stderr
+        assert "via" not in result.stderr
 
 
 class TestExplicitSourceEmitsBanner:
@@ -58,8 +59,8 @@ class TestExplicitSourceEmitsBanner:
             slurm_cls.return_value = client
             result = runner.invoke(app, ["list", "--local"])
         assert result.exit_code == 0
-        assert "→ transport: local" in result.stderr
-        assert "from --local" in result.stderr
+        assert "local" in result.stderr
+        assert "via --local" in result.stderr
 
 
 class TestSSHHappyPath:

--- a/tests/cli/test_main_backcompat.py
+++ b/tests/cli/test_main_backcompat.py
@@ -1,0 +1,131 @@
+"""CLI backward-compatibility regression tests.
+
+Captures the AC-10.2 / AC-6.x contracts the transport unification spec
+promises: default flag-less invocations stay byte-compatible with
+pre-transport CLI, and explicit ``--profile`` routes submit / cancel /
+status through the SSH adapter path (not the local ``Slurm`` singleton).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+
+
+class TestDefaultPathSilentBanner:
+    """AC-10.2: flag-less CLI must not emit a transport banner.
+
+    The banner would change stderr byte-for-byte compared to pre-transport
+    CLI output; legacy scripts that diff stderr (and our own golden tests)
+    must not see any new line.
+    """
+
+    def test_submit_emits_no_banner_on_default_path(self):
+        runner = CliRunner()
+        with patch("srunx.cli.main.Slurm") as slurm_cls:
+            client = MagicMock()
+            client.submit.return_value = MagicMock(
+                job_id=12345, name="job", command=["echo", "hi"]
+            )
+            slurm_cls.return_value = client
+            result = runner.invoke(app, ["submit", "echo", "hi"])
+        assert result.exit_code == 0
+        assert "→ transport:" not in result.stderr
+        assert "→ transport:" not in result.output
+
+    def test_list_emits_no_banner_on_default_path(self):
+        runner = CliRunner()
+        with patch("srunx.cli.main.Slurm") as slurm_cls:
+            client = MagicMock()
+            client.queue.return_value = []
+            slurm_cls.return_value = client
+            result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "→ transport:" not in result.stderr
+
+
+class TestExplicitSourceEmitsBanner:
+    """AC-7.3: explicit transport sources print a banner on stderr."""
+
+    def test_local_flag_emits_banner(self):
+        runner = CliRunner()
+        with patch("srunx.cli.main.Slurm") as slurm_cls:
+            client = MagicMock()
+            client.queue.return_value = []
+            slurm_cls.return_value = client
+            result = runner.invoke(app, ["list", "--local"])
+        assert result.exit_code == 0
+        assert "→ transport: local" in result.stderr
+        assert "from --local" in result.stderr
+
+
+class TestSSHHappyPath:
+    """AC-6.1 / AC-6.2: --profile routes through the SSH adapter.
+
+    We swap ``_build_ssh_handle`` for a handle whose ``job_ops`` is a mock,
+    so the CLI exercises the SSH branch of :func:`resolve_transport` without
+    spinning up paramiko.
+    """
+
+    def _fake_handle(self, scheduler_key: str = "ssh:dgx"):
+        from srunx.transport.registry import TransportHandle
+
+        job_ops = MagicMock()
+        job_ops.submit.side_effect = lambda job, **_: job
+        job_ops.cancel.return_value = None
+        job_ops.status.return_value = MagicMock(
+            job_id=12345, name="mocked", status=MagicMock(name="RUNNING")
+        )
+        job_ops.queue.return_value = []
+        handle = TransportHandle(
+            scheduler_key=scheduler_key,
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=job_ops,
+            queue_client=job_ops,
+            executor_factory=None,
+            submission_context=None,
+        )
+        pool = MagicMock()
+        pool.close.return_value = None
+        return handle, pool, job_ops
+
+    def test_cancel_with_profile_routes_through_ssh_adapter(self):
+        """AC-6.1: srunx cancel --profile foo 12345 hits adapter.cancel()."""
+        handle, pool, job_ops = self._fake_handle()
+        runner = CliRunner()
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(handle, pool),
+        ):
+            result = runner.invoke(app, ["cancel", "--profile", "dgx", "12345"])
+        assert result.exit_code == 0, result.output + result.stderr
+        job_ops.cancel.assert_called_once_with(12345)
+
+    def test_status_with_profile_routes_through_ssh_adapter(self):
+        """AC-6.2: srunx status --profile foo 12345 hits adapter.status()."""
+        handle, pool, job_ops = self._fake_handle()
+        runner = CliRunner()
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(handle, pool),
+        ):
+            result = runner.invoke(app, ["status", "--profile", "dgx", "12345"])
+        # status may exit 0 or print output — we only care that the
+        # adapter path was taken.
+        job_ops.status.assert_called_once_with(12345)
+
+
+class TestProfileWhitespaceNormalized:
+    """B fix: whitespace in --profile is stripped; empty→BadParameter."""
+
+    def test_whitespace_only_profile_rejected(self):
+        runner = CliRunner()
+        result = runner.invoke(app, ["list", "--profile", "   "])
+        assert result.exit_code != 0
+        # Error message from typer.BadParameter or similar
+        combined = (result.output + result.stderr).lower()
+        assert "empty" in combined or "whitespace" in combined

--- a/tests/cli/test_main_transport.py
+++ b/tests/cli/test_main_transport.py
@@ -1,0 +1,64 @@
+"""Phase 5a: CLI main.py transport integration tests.
+
+Covers the cross-cutting transport surface added to ``submit`` / ``list``
+in :mod:`srunx.cli.main`:
+
+* ``--script`` vs positional command mutual exclusion (AC-6.5).
+* ``--profile`` + ``--local`` conflict detection (AC-1.2).
+* ``--format json --quiet`` stdout purity (AC-7.1) — also guards the
+  incidental fix where the pre-existing "No jobs in queue" banner used
+  to leak into JSON output.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+
+
+class TestSubmitScript:
+    def test_script_and_command_mutually_exclusive(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(app, ["submit", "--script", "/tmp/foo.sh", "echo", "hi"])
+        assert result.exit_code != 0
+        # Typer emits the BadParameter message to either output stream
+        # depending on how the Click error formatter is configured;
+        # accept both so the test stays stable.
+        combined = (result.stderr or "") + (result.output or "")
+        assert "mutually exclusive" in combined.lower()
+
+    def test_no_script_no_command_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(app, ["submit"])
+        assert result.exit_code != 0
+
+
+class TestTransportConflict:
+    def test_profile_and_local_conflict(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["submit", "--profile", "foo", "--local", "echo", "hi"]
+        )
+        assert result.exit_code != 0
+
+
+class TestListJsonBannerIsolation:
+    """AC-7.1: --format json --quiet stdout must be pure JSON."""
+
+    def test_json_quiet_stdout_is_pure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mock queue so no SLURM call happens."""
+        from srunx.client import Slurm
+
+        monkeypatch.setattr(Slurm, "queue", lambda self, user=None: [])
+        runner = CliRunner()
+        result = runner.invoke(app, ["list", "--format", "json", "--quiet"])
+        assert result.exit_code == 0
+        # Empty queue should emit ``[]`` now that the pre-existing bug
+        # (human-readable "No jobs in queue" printed before the JSON
+        # branch) is fixed.
+        parsed = json.loads(result.stdout)
+        assert parsed == []

--- a/tests/cli/test_monitor_transport.py
+++ b/tests/cli/test_monitor_transport.py
@@ -1,0 +1,50 @@
+"""Phase 5b: monitor CLI transport integration.
+
+Covers the ``--profile`` / ``--local`` conflict check (REQ-1, AC-1.2)
+for ``srunx monitor jobs`` — the shared ``resolve_transport`` entry
+point raises :class:`typer.BadParameter` before any SLURM work happens,
+so the runner exits non-zero without touching the network.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+
+
+class TestMonitorJobsTransport:
+    """``srunx monitor jobs`` transport flag plumbing."""
+
+    def test_profile_and_local_conflict(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["monitor", "jobs", "--profile", "foo", "--local", "12345"],
+        )
+        assert result.exit_code != 0
+
+
+class TestMonitorResourcesTransport:
+    """``srunx monitor resources`` accepts the options as future no-ops.
+
+    Phase 5b documents that the flags are available for CLI parity even
+    though ResourceMonitor itself still queries the local cluster. The
+    conflict check must still fire on ``--profile`` + ``--local``.
+    """
+
+    def test_profile_and_local_conflict(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "monitor",
+                "resources",
+                "--min-gpus",
+                "1",
+                "--profile",
+                "foo",
+                "--local",
+            ],
+        )
+        assert result.exit_code != 0

--- a/tests/cli/test_notification_setup.py
+++ b/tests/cli/test_notification_setup.py
@@ -83,7 +83,9 @@ def test_attach_watch_happy_path(isolated_db: Path) -> None:
 
         # A PENDING transition should be present so the poller's first
         # observation produces a real state change.
-        latest = JobStateTransitionRepository(conn).latest_for_job(job_id)
+        latest = JobStateTransitionRepository(conn).latest_for_job(
+            job_id, scheduler_key="local"
+        )
         assert latest is not None
         assert latest.to_status == "PENDING"
     finally:

--- a/tests/cli/test_notification_setup.py
+++ b/tests/cli/test_notification_setup.py
@@ -196,7 +196,9 @@ def test_cli_submit_with_endpoint_creates_watch_and_subscription(
     conn = open_connection()
     try:
         watches = WatchRepository(conn).list_open()
-        job_watches = [w for w in watches if w.target_ref == "job:77777"]
+        # V5 grammar: target_ref is ``job:<scheduler_key>:<id>`` so local
+        # SLURM jobs are ``job:local:<id>``.
+        job_watches = [w for w in watches if w.target_ref == "job:local:77777"]
         assert len(job_watches) == 1
 
         assert job_watches[0].id is not None

--- a/tests/cli/test_workflow_transport.py
+++ b/tests/cli/test_workflow_transport.py
@@ -1,0 +1,31 @@
+"""Phase 5b: workflow CLI transport integration.
+
+Covers the ``--profile`` / ``--local`` conflict check (REQ-1, AC-1.2)
+for ``srunx flow run`` — the shared ``resolve_transport`` entry point
+raises :class:`typer.BadParameter` before any SLURM work happens, so
+the runner exits non-zero without touching the network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+
+
+class TestFlowRunTransport:
+    """``srunx flow run`` transport flag plumbing."""
+
+    def test_profile_and_local_conflict(self, tmp_path: Path) -> None:
+        yaml_file = tmp_path / "wf.yaml"
+        yaml_file.write_text(
+            "name: test\njobs:\n  - name: a\n    command: ['echo', 'hi']\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["flow", "run", "--profile", "foo", "--local", str(yaml_file)],
+        )
+        assert result.exit_code != 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,23 @@ from srunx.models import Job, JobEnvironment, JobResource
 
 
 @pytest.fixture(autouse=True)
+def _disable_current_profile_fallback(monkeypatch):
+    """Neutralise the Phase 2 current-profile fallback for every test.
+
+    The real ``~/.config/srunx/config.json`` on a developer machine may
+    have ``current_profile`` set via ``srunx ssh profile set``. Without
+    this fixture, tests that expect the "default → local" transport
+    path (AC-10.2 backward compat suite) would fail on that developer's
+    machine because ``resolve_transport`` now falls through to the
+    active SSH profile. Individual tests that *want* to exercise the
+    current-profile fallback should monkeypatch it back in explicitly.
+    """
+    import srunx.transport.registry as _reg
+
+    monkeypatch.setattr(_reg, "_current_profile_name", lambda: None)
+
+
+@pytest.fixture(autouse=True)
 def _isolate_legacy_history_db(tmp_path_factory, monkeypatch):
     """Make sure no test can delete the user's real ``~/.srunx/history.db``.
 

--- a/tests/db/repositories/test_job_state_transitions.py
+++ b/tests/db/repositories/test_job_state_transitions.py
@@ -46,7 +46,7 @@ def test_insert_returns_positive_id(
     conn: sqlite3.Connection, repo: JobStateTransitionRepository
 ) -> None:
     _seed_job(conn, 1)
-    row_id = repo.insert(1, None, "PENDING", "poller")
+    row_id = repo.insert(1, None, "PENDING", "poller", scheduler_key="local")
     assert row_id > 0
 
 
@@ -54,8 +54,8 @@ def test_insert_default_observed_at_is_parseable(
     conn: sqlite3.Connection, repo: JobStateTransitionRepository
 ) -> None:
     _seed_job(conn, 1)
-    repo.insert(1, None, "PENDING", "poller")
-    latest = repo.latest_for_job(1)
+    repo.insert(1, None, "PENDING", "poller", scheduler_key="local")
+    latest = repo.latest_for_job(1, scheduler_key="local")
     assert latest is not None
     assert isinstance(latest.observed_at, datetime)
 
@@ -65,9 +65,14 @@ def test_insert_with_explicit_observed_at(
 ) -> None:
     _seed_job(conn, 1)
     repo.insert(
-        1, "PENDING", "RUNNING", "cli_monitor", observed_at="2026-04-18T01:02:03.000Z"
+        1,
+        "PENDING",
+        "RUNNING",
+        "cli_monitor",
+        observed_at="2026-04-18T01:02:03.000Z",
+        scheduler_key="local",
     )
-    latest = repo.latest_for_job(1)
+    latest = repo.latest_for_job(1, scheduler_key="local")
     assert latest is not None
     assert latest.from_status == "PENDING"
     assert latest.to_status == "RUNNING"
@@ -80,23 +85,44 @@ def test_insert_with_explicit_observed_at(
 def test_latest_for_job_missing_returns_none(
     repo: JobStateTransitionRepository,
 ) -> None:
-    assert repo.latest_for_job(9999) is None
+    assert repo.latest_for_job(9999, scheduler_key="local") is None
 
 
 def test_latest_for_job_picks_most_recent(
     conn: sqlite3.Connection, repo: JobStateTransitionRepository
 ) -> None:
     _seed_job(conn, 1)
-    repo.insert(1, None, "PENDING", "poller", observed_at="2026-04-18T00:00:00Z")
-    repo.insert(1, "PENDING", "RUNNING", "poller", observed_at="2026-04-18T00:05:00Z")
-    repo.insert(1, "RUNNING", "COMPLETED", "poller", observed_at="2026-04-18T00:10:00Z")
-    latest = repo.latest_for_job(1)
+    repo.insert(
+        1,
+        None,
+        "PENDING",
+        "poller",
+        observed_at="2026-04-18T00:00:00Z",
+        scheduler_key="local",
+    )
+    repo.insert(
+        1,
+        "PENDING",
+        "RUNNING",
+        "poller",
+        observed_at="2026-04-18T00:05:00Z",
+        scheduler_key="local",
+    )
+    repo.insert(
+        1,
+        "RUNNING",
+        "COMPLETED",
+        "poller",
+        observed_at="2026-04-18T00:10:00Z",
+        scheduler_key="local",
+    )
+    latest = repo.latest_for_job(1, scheduler_key="local")
     assert latest is not None
     assert latest.to_status == "COMPLETED"
 
 
 def test_history_for_job_empty(repo: JobStateTransitionRepository) -> None:
-    assert repo.history_for_job(9999) == []
+    assert repo.history_for_job(9999, scheduler_key="local") == []
 
 
 def test_history_for_job_is_chronological(
@@ -104,11 +130,32 @@ def test_history_for_job_is_chronological(
 ) -> None:
     _seed_job(conn, 1)
     # Insert out of chronological order — repo must still return ASC by observed_at.
-    repo.insert(1, "RUNNING", "COMPLETED", "poller", observed_at="2026-04-18T00:10:00Z")
-    repo.insert(1, None, "PENDING", "poller", observed_at="2026-04-18T00:00:00Z")
-    repo.insert(1, "PENDING", "RUNNING", "poller", observed_at="2026-04-18T00:05:00Z")
+    repo.insert(
+        1,
+        "RUNNING",
+        "COMPLETED",
+        "poller",
+        observed_at="2026-04-18T00:10:00Z",
+        scheduler_key="local",
+    )
+    repo.insert(
+        1,
+        None,
+        "PENDING",
+        "poller",
+        observed_at="2026-04-18T00:00:00Z",
+        scheduler_key="local",
+    )
+    repo.insert(
+        1,
+        "PENDING",
+        "RUNNING",
+        "poller",
+        observed_at="2026-04-18T00:05:00Z",
+        scheduler_key="local",
+    )
 
-    history = repo.history_for_job(1)
+    history = repo.history_for_job(1, scheduler_key="local")
     assert [t.to_status for t in history] == ["PENDING", "RUNNING", "COMPLETED"]
     # Ensure datetime conversion happened for every row.
     assert all(isinstance(t.observed_at, datetime) for t in history)
@@ -119,24 +166,28 @@ def test_history_scoped_by_job(
 ) -> None:
     _seed_job(conn, 1)
     _seed_job(conn, 2)
-    repo.insert(1, None, "PENDING", "poller")
-    repo.insert(2, None, "RUNNING", "webhook")
-    assert [t.to_status for t in repo.history_for_job(1)] == ["PENDING"]
-    assert [t.to_status for t in repo.history_for_job(2)] == ["RUNNING"]
+    repo.insert(1, None, "PENDING", "poller", scheduler_key="local")
+    repo.insert(2, None, "RUNNING", "webhook", scheduler_key="local")
+    assert [t.to_status for t in repo.history_for_job(1, scheduler_key="local")] == [
+        "PENDING"
+    ]
+    assert [t.to_status for t in repo.history_for_job(2, scheduler_key="local")] == [
+        "RUNNING"
+    ]
 
 
 def test_job_delete_sets_jobs_row_id_null(
     conn: sqlite3.Connection, repo: JobStateTransitionRepository
 ) -> None:
     _seed_job(conn, 1)
-    repo.insert(1, None, "PENDING", "poller")
+    repo.insert(1, None, "PENDING", "poller", scheduler_key="local")
     # V5: FK is ``jobs_row_id`` → ``jobs.id`` with ON DELETE SET NULL.
     # Deleting the jobs row orphans the transition but preserves the
     # append-only log (the SET NULL cascade zeroes ``jobs_row_id``).
     conn.execute("DELETE FROM jobs WHERE job_id = 1")
     conn.commit()
 
-    assert repo.latest_for_job(1) is None
+    assert repo.latest_for_job(1, scheduler_key="local") is None
     orphan = conn.execute(
         "SELECT jobs_row_id, to_status FROM job_state_transitions"
     ).fetchone()

--- a/tests/db/repositories/test_job_state_transitions.py
+++ b/tests/db/repositories/test_job_state_transitions.py
@@ -125,18 +125,20 @@ def test_history_scoped_by_job(
     assert [t.to_status for t in repo.history_for_job(2)] == ["RUNNING"]
 
 
-def test_job_delete_sets_job_id_null(
+def test_job_delete_sets_jobs_row_id_null(
     conn: sqlite3.Connection, repo: JobStateTransitionRepository
 ) -> None:
     _seed_job(conn, 1)
     repo.insert(1, None, "PENDING", "poller")
-    # FK is ON DELETE SET NULL; transition row survives but job_id goes NULL.
+    # V5: FK is ``jobs_row_id`` → ``jobs.id`` with ON DELETE SET NULL.
+    # Deleting the jobs row orphans the transition but preserves the
+    # append-only log (the SET NULL cascade zeroes ``jobs_row_id``).
     conn.execute("DELETE FROM jobs WHERE job_id = 1")
     conn.commit()
 
     assert repo.latest_for_job(1) is None
     orphan = conn.execute(
-        "SELECT job_id, to_status FROM job_state_transitions"
+        "SELECT jobs_row_id, to_status FROM job_state_transitions"
     ).fetchone()
-    assert orphan["job_id"] is None
+    assert orphan["jobs_row_id"] is None
     assert orphan["to_status"] == "PENDING"

--- a/tests/db/repositories/test_jobs.py
+++ b/tests/db/repositories/test_jobs.py
@@ -97,17 +97,25 @@ def test_record_submission_ignore_preserves_fk_references(
 ) -> None:
     """P1-2: ensure the FK references survive a duplicate call.
 
-    ``INSERT OR REPLACE`` would have cascaded a ``SET NULL`` through the
-    ``job_state_transitions.job_id`` FK; ``INSERT OR IGNORE`` preserves.
+    ``INSERT OR REPLACE`` would have cascaded a ``SET NULL`` through
+    the ``job_state_transitions.jobs_row_id`` FK; ``INSERT OR IGNORE``
+    preserves.
     """
     repo.record_submission(
         job_id=210, name="fk-test", status="PENDING", submission_source="web"
     )
+    # Resolve the jobs.id (AUTOINCREMENT PK) so the transition points
+    # at the correct V5 FK target.
+    jobs_row_id = conn.execute(
+        "SELECT id FROM jobs WHERE scheduler_key = 'local' AND job_id = ?",
+        (210,),
+    ).fetchone()[0]
     # Simulate a prior transition observed by the poller.
     conn.execute(
-        "INSERT INTO job_state_transitions (job_id, to_status, observed_at, source) "
+        "INSERT INTO job_state_transitions "
+        "(jobs_row_id, to_status, observed_at, source) "
         "VALUES (?, 'RUNNING', '2026-04-19T00:00:00Z', 'poller')",
-        (210,),
+        (jobs_row_id,),
     )
     conn.commit()
 
@@ -121,9 +129,9 @@ def test_record_submission_ignore_preserves_fk_references(
 
     # The prior transition still references the jobs row — not SET NULL.
     rows = conn.execute(
-        "SELECT job_id FROM job_state_transitions WHERE to_status='RUNNING'"
+        "SELECT jobs_row_id FROM job_state_transitions WHERE to_status='RUNNING'"
     ).fetchall()
-    assert [r[0] for r in rows] == [210]
+    assert [r[0] for r in rows] == [jobs_row_id]
 
 
 def test_update_status_fills_optional_fields(repo: JobRepository) -> None:

--- a/tests/db/repositories/test_jobs.py
+++ b/tests/db/repositories/test_jobs.py
@@ -46,7 +46,7 @@ def test_record_submission_roundtrip(repo: JobRepository) -> None:
     )
     assert row_id > 0
 
-    job = repo.get(101)
+    job = repo.get(101, scheduler_key="local")
     assert job is not None
     assert job.job_id == 101
     assert job.name == "train"
@@ -84,7 +84,7 @@ def test_record_submission_duplicate_job_id_is_noop(
     )
     assert second_row_id == 0  # INSERT OR IGNORE → no row inserted
 
-    job = repo.get(202)
+    job = repo.get(202, scheduler_key="local")
     assert job is not None
     # Original fields preserved — not clobbered to "second" / RUNNING.
     assert job.name == "first"
@@ -141,11 +141,12 @@ def test_update_status_fills_optional_fields(repo: JobRepository) -> None:
     updated = repo.update_status(
         303,
         "RUNNING",
+        scheduler_key="local",
         started_at="2026-04-19T01:00:00.000Z",
         nodelist="node01",
     )
     assert updated is True
-    job = repo.get(303)
+    job = repo.get(303, scheduler_key="local")
     assert job is not None
     assert job.status == "RUNNING"
     assert job.nodelist == "node01"
@@ -153,7 +154,7 @@ def test_update_status_fills_optional_fields(repo: JobRepository) -> None:
 
 
 def test_update_status_returns_false_for_missing(repo: JobRepository) -> None:
-    assert repo.update_status(99999, "RUNNING") is False
+    assert repo.update_status(99999, "RUNNING", scheduler_key="local") is False
 
 
 def test_update_completion_computes_duration(repo: JobRepository) -> None:
@@ -165,10 +166,13 @@ def test_update_completion_computes_duration(repo: JobRepository) -> None:
         submitted_at="2026-04-19T10:00:00.000Z",
     )
     ok = repo.update_completion(
-        404, "COMPLETED", completed_at="2026-04-19T11:00:00.000Z"
+        404,
+        "COMPLETED",
+        completed_at="2026-04-19T11:00:00.000Z",
+        scheduler_key="local",
     )
     assert ok is True
-    job = repo.get(404)
+    job = repo.get(404, scheduler_key="local")
     assert job is not None
     assert job.status == "COMPLETED"
     assert job.duration_secs == 3600
@@ -180,8 +184,8 @@ def test_update_completion_defaults_completed_at_to_now(
     repo.record_submission(
         job_id=405, name="t", status="PENDING", submission_source="cli"
     )
-    assert repo.update_completion(405, "COMPLETED") is True
-    job = repo.get(405)
+    assert repo.update_completion(405, "COMPLETED", scheduler_key="local") is True
+    job = repo.get(405, scheduler_key="local")
     assert job is not None and job.completed_at is not None
 
 
@@ -294,7 +298,11 @@ def test_count_by_status_in_range_uses_timestamp_field(repo: JobRepository) -> N
         submitted_at="2026-01-01T00:00:00Z",
     )
     repo.update_status(
-        901, "COMPLETED", completed_at="2026-04-19T12:00:00Z", duration_secs=1
+        901,
+        "COMPLETED",
+        scheduler_key="local",
+        completed_at="2026-04-19T12:00:00Z",
+        duration_secs=1,
     )
     # Submitted inside the window, not yet completed → excluded under
     # completed_at because ``completed_at >= ?`` is false when it's NULL.
@@ -339,9 +347,9 @@ def test_delete_existing_returns_true(repo: JobRepository) -> None:
     repo.record_submission(
         job_id=901, name="t", status="PENDING", submission_source="cli"
     )
-    assert repo.delete(901) is True
-    assert repo.get(901) is None
+    assert repo.delete(901, scheduler_key="local") is True
+    assert repo.get(901, scheduler_key="local") is None
 
 
 def test_delete_missing_returns_false(repo: JobRepository) -> None:
-    assert repo.delete(99999) is False
+    assert repo.delete(99999, scheduler_key="local") is False

--- a/tests/db/test_migration_v5.py
+++ b/tests/db/test_migration_v5.py
@@ -1,0 +1,435 @@
+"""Migration V5 tests — schema + data migration for CLI transport unification.
+
+AC references (see ``specs/cli-transport-unification/spec.md``):
+- AC-5.1: transport_type / profile_name / scheduler_key present on jobs.
+- AC-5.2: scheduler_key NOT NULL for every row after migration.
+- AC-5.3: legacy 2-segment target_ref forms are backfilled to 3-segment.
+- AC-5.4: same job_id can coexist under different scheduler_keys.
+- AC-5.5: workflow_run_jobs + job_state_transitions FK → jobs.id.
+- AC-5.6: jobs.submission_source CHECK allowlist unchanged.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from srunx.db.connection import open_connection
+from srunx.db.migrations import apply_migrations
+
+
+def _migrated(tmp_path: Path) -> sqlite3.Connection:
+    conn = open_connection(tmp_path / "v5.db")
+    apply_migrations(conn)
+    return conn
+
+
+class TestJobsColumns:
+    """AC-5.1 / AC-5.2 — transport columns exist and are NOT NULL."""
+
+    def test_v5_adds_transport_columns(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(jobs)")}
+        finally:
+            conn.close()
+        assert "transport_type" in cols
+        assert "profile_name" in cols
+        assert "scheduler_key" in cols
+
+    def test_scheduler_key_not_null_after_insert(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, transport_type, profile_name, scheduler_key,
+                    name, status, submitted_at, submission_source
+                ) VALUES (?, 'local', NULL, 'local', 'x', 'PENDING',
+                         '2026-04-22T00:00:00Z', 'cli')
+                """,
+                (1,),
+            )
+            conn.commit()
+            null_count = conn.execute(
+                "SELECT COUNT(*) FROM jobs WHERE scheduler_key IS NULL"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert null_count == 0
+
+
+class TestCompositeUniqueness:
+    """AC-5.4 — ``UNIQUE(scheduler_key, job_id)`` allows cross-transport duplicates."""
+
+    def test_same_job_id_under_different_scheduler_keys(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, transport_type, profile_name, scheduler_key,
+                    name, status, submitted_at, submission_source
+                ) VALUES (?, 'local', NULL, 'local', 'a', 'PENDING',
+                         '2026-04-22T00:00:00Z', 'cli')
+                """,
+                (12345,),
+            )
+            conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, transport_type, profile_name, scheduler_key,
+                    name, status, submitted_at, submission_source
+                ) VALUES (?, 'ssh', 'dgx', 'ssh:dgx', 'b', 'PENDING',
+                         '2026-04-22T00:00:00Z', 'cli')
+                """,
+                (12345,),
+            )
+            conn.commit()
+            count = conn.execute(
+                "SELECT COUNT(*) FROM jobs WHERE job_id = 12345"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert count == 2
+
+    def test_duplicate_job_id_same_scheduler_key_fails(self, tmp_path: Path) -> None:
+        """Sanity: the UNIQUE still fires when the pair matches."""
+        conn = _migrated(tmp_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, transport_type, profile_name, scheduler_key,
+                    name, status, submitted_at, submission_source
+                ) VALUES (?, 'local', NULL, 'local', 'a', 'PENDING',
+                         '2026-04-22T00:00:00Z', 'cli')
+                """,
+                (42,),
+            )
+            conn.commit()
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        job_id, transport_type, profile_name, scheduler_key,
+                        name, status, submitted_at, submission_source
+                    ) VALUES (?, 'local', NULL, 'local', 'b', 'PENDING',
+                             '2026-04-22T00:00:00Z', 'cli')
+                    """,
+                    (42,),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+
+class TestTripleCheckConstraint:
+    """CHECK constraint guards the (transport_type, profile_name, scheduler_key) triple."""
+
+    def test_local_with_profile_name_is_rejected(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        job_id, transport_type, profile_name, scheduler_key,
+                        name, status, submitted_at, submission_source
+                    ) VALUES (?, 'local', 'dgx', 'local', 'x', 'PENDING',
+                             '2026-04-22T00:00:00Z', 'cli')
+                    """,
+                    (1,),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_ssh_without_profile_name_is_rejected(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        job_id, transport_type, profile_name, scheduler_key,
+                        name, status, submitted_at, submission_source
+                    ) VALUES (?, 'ssh', NULL, 'ssh:', 'x', 'PENDING',
+                             '2026-04-22T00:00:00Z', 'cli')
+                    """,
+                    (1,),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+    def test_profile_name_with_colon_is_rejected(self, tmp_path: Path) -> None:
+        """``profile_name`` must not contain ``:`` (scheduler_key parser relies on this)."""
+        conn = _migrated(tmp_path)
+        try:
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO jobs (
+                        job_id, transport_type, profile_name, scheduler_key,
+                        name, status, submitted_at, submission_source
+                    ) VALUES (?, 'ssh', 'bad:name', 'ssh:bad:name', 'x',
+                             'PENDING', '2026-04-22T00:00:00Z', 'cli')
+                    """,
+                    (1,),
+                )
+                conn.commit()
+        finally:
+            conn.close()
+
+
+class TestForeignKeyRetarget:
+    """AC-5.5 — workflow_run_jobs / job_state_transitions FK → jobs.id."""
+
+    def test_workflow_run_jobs_fk_points_at_jobs_id(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            fks = conn.execute("PRAGMA foreign_key_list(workflow_run_jobs)").fetchall()
+        finally:
+            conn.close()
+        jobs_fks = [fk for fk in fks if fk[2] == "jobs"]
+        assert jobs_fks, f"no FK to jobs found in {fks}"
+        # fk tuple: (id, seq, table, from, to, on_update, on_delete, match)
+        to_cols = {fk[4] for fk in jobs_fks}
+        assert "id" in to_cols, f"expected FK → jobs.id, got {to_cols}"
+
+    def test_job_state_transitions_fk_points_at_jobs_id(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            fks = conn.execute(
+                "PRAGMA foreign_key_list(job_state_transitions)"
+            ).fetchall()
+        finally:
+            conn.close()
+        jobs_fks = [fk for fk in fks if fk[2] == "jobs"]
+        assert jobs_fks, f"no FK to jobs found in {fks}"
+        to_cols = {fk[4] for fk in jobs_fks}
+        assert "id" in to_cols, f"expected FK → jobs.id, got {to_cols}"
+
+    def test_workflow_run_jobs_has_jobs_row_id_column(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            cols = {
+                row[1] for row in conn.execute("PRAGMA table_info(workflow_run_jobs)")
+            }
+        finally:
+            conn.close()
+        assert "jobs_row_id" in cols
+        assert "job_id" not in cols  # old column retired
+
+    def test_job_state_transitions_has_jobs_row_id_column(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(job_state_transitions)")
+            }
+        finally:
+            conn.close()
+        assert "jobs_row_id" in cols
+        assert "job_id" not in cols
+
+
+class TestSubmissionSourcePreserved:
+    """AC-5.6 — submission_source CHECK allowlist untouched."""
+
+    def test_allowed_values_present_in_table_sql(self, tmp_path: Path) -> None:
+        conn = _migrated(tmp_path)
+        try:
+            sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE name = 'jobs'"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        for value in ("cli", "web", "workflow"):
+            assert f"'{value}'" in sql, (
+                f"expected submission_source allowlist to include {value!r}; "
+                f"sql=\n{sql}"
+            )
+
+
+class TestTargetRefBackfill:
+    """AC-5.3 — legacy ``job:<N>`` refs are backfilled to ``job:local:<N>``."""
+
+    def test_pre_v5_legacy_refs_are_rewritten(self, tmp_path: Path) -> None:
+        """Apply v1..v4, seed legacy 2-segment rows, then apply V5 and check."""
+        from srunx.db.migrations import (
+            MIGRATIONS,
+            _apply_fk_off_migration,
+            _apply_tx_migration,
+        )
+
+        conn = open_connection(tmp_path / "pre_v5.db")
+        try:
+            for mig in MIGRATIONS[:-1]:  # everything except V5
+                if mig.requires_fk_off:
+                    _apply_fk_off_migration(conn, mig)
+                else:
+                    _apply_tx_migration(conn, mig)
+
+            # Seed legacy-form watch and event rows, representative of
+            # what a pre-V5 deployment would have written.
+            conn.execute(
+                """
+                INSERT INTO watches (kind, target_ref, created_at)
+                VALUES ('job', 'job:111', '2026-04-22T00:00:00Z')
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO events
+                    (kind, source_ref, payload, payload_hash, observed_at)
+                VALUES (
+                    'job.status_changed', 'job:111', '{}', 'hash-1',
+                    '2026-04-22T00:00:00Z'
+                )
+                """
+            )
+            conn.commit()
+
+            v5 = MIGRATIONS[-1]
+            assert v5.name == "v5_transport_scheduler_key"
+            _apply_fk_off_migration(conn, v5)
+
+            # After V5 the legacy ``job:<N>`` form should be completely
+            # gone; every row uses the 3-segment form.
+            bad_watches = conn.execute(
+                """
+                SELECT COUNT(*) FROM watches
+                WHERE kind = 'job'
+                  AND target_ref NOT LIKE 'job:local:%'
+                  AND target_ref NOT LIKE 'job:ssh:%'
+                """
+            ).fetchone()[0]
+            bad_events = conn.execute(
+                """
+                SELECT COUNT(*) FROM events
+                WHERE kind IN ('job.submitted','job.status_changed')
+                  AND source_ref NOT LIKE 'job:local:%'
+                  AND source_ref NOT LIKE 'job:ssh:%'
+                """
+            ).fetchone()[0]
+            backfilled_watch = conn.execute(
+                "SELECT target_ref FROM watches WHERE kind = 'job'"
+            ).fetchone()
+            backfilled_event = conn.execute(
+                "SELECT source_ref FROM events WHERE kind = 'job.status_changed'"
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert bad_watches == 0, "legacy 2-segment target_ref survived V5"
+        assert bad_events == 0, "legacy 2-segment source_ref survived V5"
+        assert backfilled_watch[0] == "job:local:111"
+        assert backfilled_event[0] == "job:local:111"
+
+
+class TestOpenWatchForceClose:
+    """V5 migration force-closes every open watch (P-15 mitigation).
+
+    Pre-V5 WebUI-submitted SSH jobs are backfilled as
+    ``transport_type='local'`` because the schema had no column to tell
+    them apart. Their open watches would drive the poller to query
+    local SLURM for remote job ids, leading to false terminal
+    transitions. The migration closes all open watches so the user can
+    re-open the ones that still matter.
+    """
+
+    def test_open_watches_force_closed_by_migration(self, tmp_path: Path) -> None:
+        # Reach into the migration machinery: open the DB, apply only
+        # up through V4, insert an open watch, then apply V5 and check.
+        from srunx.db.migrations import (
+            MIGRATIONS,
+            _apply_fk_off_migration,
+            _apply_tx_migration,
+        )
+
+        conn = open_connection(tmp_path / "pre_v5.db")
+        try:
+            for mig in MIGRATIONS[:-1]:  # everything except V5
+                if mig.requires_fk_off:
+                    _apply_fk_off_migration(conn, mig)
+                else:
+                    _apply_tx_migration(conn, mig)
+
+            # Seed an open watch (closed_at IS NULL).
+            conn.execute(
+                """
+                INSERT INTO watches (kind, target_ref, created_at)
+                VALUES ('job', 'job:555', '2026-04-22T00:00:00Z')
+                """
+            )
+            conn.commit()
+            open_before = conn.execute(
+                "SELECT COUNT(*) FROM watches WHERE closed_at IS NULL"
+            ).fetchone()[0]
+            assert open_before == 1
+
+            # Now apply V5.
+            v5 = MIGRATIONS[-1]
+            assert v5.name == "v5_transport_scheduler_key"
+            _apply_fk_off_migration(conn, v5)
+
+            open_after = conn.execute(
+                "SELECT COUNT(*) FROM watches WHERE closed_at IS NULL"
+            ).fetchone()[0]
+            backfilled = conn.execute(
+                "SELECT target_ref FROM watches WHERE kind = 'job'"
+            ).fetchall()
+        finally:
+            conn.close()
+        assert open_after == 0, "V5 migration must close every open watch"
+        # And the target_ref was backfilled to 3-segment form.
+        assert all(r[0] == "job:local:555" for r in backfilled), backfilled
+
+
+class TestDataBackfill:
+    """Pre-V5 data is preserved and labelled as local transport."""
+
+    def test_existing_jobs_rows_backfilled_as_local(self, tmp_path: Path) -> None:
+        from srunx.db.migrations import (
+            MIGRATIONS,
+            _apply_fk_off_migration,
+            _apply_tx_migration,
+        )
+
+        conn = open_connection(tmp_path / "pre_v5.db")
+        try:
+            for mig in MIGRATIONS[:-1]:
+                if mig.requires_fk_off:
+                    _apply_fk_off_migration(conn, mig)
+                else:
+                    _apply_tx_migration(conn, mig)
+
+            conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_id, name, status, submitted_at, submission_source
+                ) VALUES (?, 'legacy', 'COMPLETED',
+                         '2026-04-22T00:00:00Z', 'cli')
+                """,
+                (777,),
+            )
+            conn.commit()
+
+            v5 = MIGRATIONS[-1]
+            _apply_fk_off_migration(conn, v5)
+
+            row = conn.execute(
+                "SELECT job_id, transport_type, profile_name, scheduler_key "
+                "FROM jobs WHERE job_id = 777"
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert row is not None
+        assert row["transport_type"] == "local"
+        assert row["profile_name"] is None
+        assert row["scheduler_key"] == "local"

--- a/tests/db/test_migration_v5.py
+++ b/tests/db/test_migration_v5.py
@@ -332,17 +332,23 @@ class TestTargetRefBackfill:
 
 
 class TestOpenWatchForceClose:
-    """V5 migration force-closes every open watch (P-15 mitigation).
+    """V5 migration force-closes only ``kind='job'`` open watches.
 
     Pre-V5 WebUI-submitted SSH jobs are backfilled as
     ``transport_type='local'`` because the schema had no column to tell
-    them apart. Their open watches would drive the poller to query
+    them apart. Their open job watches would drive the poller to query
     local SLURM for remote job ids, leading to false terminal
-    transitions. The migration closes all open watches so the user can
-    re-open the ones that still matter.
+    transitions. The migration closes all open **job** watches so the
+    user can re-open the ones that still matter.
+
+    Non-job watches (``workflow_run`` / ``sweep_run`` /
+    ``resource_threshold`` / ``scheduled_report``) are transport-
+    agnostic and therefore preserved across migration — closing them
+    would silently break in-flight workflow cancellations, sweep
+    aggregations, and scheduled reports.
     """
 
-    def test_open_watches_force_closed_by_migration(self, tmp_path: Path) -> None:
+    def test_open_job_watches_force_closed_by_migration(self, tmp_path: Path) -> None:
         # Reach into the migration machinery: open the DB, apply only
         # up through V4, insert an open watch, then apply V5 and check.
         from srunx.db.migrations import (
@@ -378,14 +384,14 @@ class TestOpenWatchForceClose:
             _apply_fk_off_migration(conn, v5)
 
             open_after = conn.execute(
-                "SELECT COUNT(*) FROM watches WHERE closed_at IS NULL"
+                "SELECT COUNT(*) FROM watches WHERE closed_at IS NULL AND kind = 'job'"
             ).fetchone()[0]
             backfilled = conn.execute(
                 "SELECT target_ref FROM watches WHERE kind = 'job'"
             ).fetchall()
         finally:
             conn.close()
-        assert open_after == 0, "V5 migration must close every open watch"
+        assert open_after == 0, "V5 migration must close every open job watch"
         # And the target_ref was backfilled to 3-segment form.
         assert all(r[0] == "job:local:555" for r in backfilled), backfilled
 

--- a/tests/monitor/test_job_monitor_ssot.py
+++ b/tests/monitor/test_job_monitor_ssot.py
@@ -102,7 +102,7 @@ def test_transitions_recorded_with_cli_monitor_source(
         iter([JobStatus.PENDING, JobStatus.RUNNING, JobStatus.COMPLETED]),
     )
 
-    history = repo.history_for_job(job_id)
+    history = repo.history_for_job(job_id, scheduler_key="local")
     # First observation (previous=None) is NOT recorded; only the real
     # transitions are persisted.
     assert [(t.from_status, t.to_status) for t in history] == [
@@ -124,7 +124,7 @@ def test_first_observation_is_not_recorded(
 
     _drive_states(monitor, client, iter([JobStatus.PENDING]))
 
-    assert repo.history_for_job(job_id) == []
+    assert repo.history_for_job(job_id, scheduler_key="local") == []
 
 
 def test_duplicate_status_does_not_produce_extra_rows(
@@ -151,7 +151,7 @@ def test_duplicate_status_does_not_produce_extra_rows(
         ),
     )
 
-    history = repo.history_for_job(job_id)
+    history = repo.history_for_job(job_id, scheduler_key="local")
     assert [(t.from_status, t.to_status) for t in history] == [
         ("PENDING", "RUNNING"),
         ("RUNNING", "COMPLETED"),
@@ -183,8 +183,8 @@ def test_multiple_jobs_tracked_independently(
         )
         monitor._notify_callbacks("state_changed")
 
-    hist_100 = repo.history_for_job(100)
-    hist_200 = repo.history_for_job(200)
+    hist_100 = repo.history_for_job(100, scheduler_key="local")
+    hist_200 = repo.history_for_job(200, scheduler_key="local")
 
     assert [(t.from_status, t.to_status) for t in hist_100] == [
         ("PENDING", "RUNNING"),
@@ -227,7 +227,7 @@ def test_no_repo_injected_no_writes_no_errors(
     )
 
     # Only the terminal transition is mirrored by the history dual-write.
-    history = repo.history_for_job(job_id)
+    history = repo.history_for_job(job_id, scheduler_key="local")
     assert [(t.from_status, t.to_status) for t in history] == [
         (None, "COMPLETED"),
     ]
@@ -286,4 +286,5 @@ def test_repo_insert_called_with_expected_arguments() -> None:
         from_status="PENDING",
         to_status="RUNNING",
         source="cli_monitor",
+        scheduler_key="local",
     )

--- a/tests/monitor/test_job_monitor_ssot.py
+++ b/tests/monitor/test_job_monitor_ssot.py
@@ -75,7 +75,7 @@ def _drive_states(
     """
     for status in states:
         monitor._cached_jobs = None
-        client.retrieve = MagicMock(
+        client.status = MagicMock(
             side_effect=lambda _jid, _s=status: _make_job(_jid, _s)
         )
         monitor._notify_callbacks("state_changed")
@@ -178,7 +178,7 @@ def test_multiple_jobs_tracked_independently(
 
     for cycle in cycle_states:
         monitor._cached_jobs = None
-        client.retrieve = MagicMock(
+        client.status = MagicMock(
             side_effect=lambda jid, _c=cycle: _make_job(jid, _c[jid])
         )
         monitor._notify_callbacks("state_changed")

--- a/tests/notifications/test_service.py
+++ b/tests/notifications/test_service.py
@@ -317,7 +317,8 @@ class TestCreateWatchForJob:
         watch = watches.get(watch_id)
         assert watch is not None
         assert watch.kind == "job"
-        assert watch.target_ref == "job:99"
+        # V5 grammar: ``job:<scheduler_key>:<id>``; default is local.
+        assert watch.target_ref == "job:local:99"
         assert subscriptions.list_by_watch(watch_id) == []
 
     def test_with_endpoint(

--- a/tests/pollers/test_active_watch_poller.py
+++ b/tests/pollers/test_active_watch_poller.py
@@ -67,6 +67,7 @@ def _seed_pending_transition(conn: sqlite3.Connection, job_id: int, status: str)
         from_status=None,
         to_status=status,
         source="poller",
+        scheduler_key="local",
     )
 
 
@@ -114,7 +115,9 @@ class TestJobTransitions:
         poller = ActiveWatchPoller(stub, db_path=db_path)
         _run_once(poller)
 
-        transitions = JobStateTransitionRepository(conn).history_for_job(job_id)
+        transitions = JobStateTransitionRepository(conn).history_for_job(
+            job_id, scheduler_key="local"
+        )
         assert len(transitions) == 2
         assert transitions[0].to_status == "PENDING"
         assert transitions[1].from_status == "PENDING"
@@ -135,7 +138,7 @@ class TestJobTransitions:
         assert event.payload.get("job_id") == job_id
         assert event.payload.get("job_name") == f"job_{job_id}"
 
-        job_row = JobRepository(conn).get(job_id)
+        job_row = JobRepository(conn).get(job_id, scheduler_key="local")
         assert job_row is not None
         assert job_row.status == "RUNNING"
         assert job_row.nodelist == "node01"
@@ -164,7 +167,9 @@ class TestJobTransitions:
         _run_once(ActiveWatchPoller(stub, db_path=db_path))
 
         # Transition + event present…
-        transitions = JobStateTransitionRepository(conn).history_for_job(job_id)
+        transitions = JobStateTransitionRepository(conn).history_for_job(
+            job_id, scheduler_key="local"
+        )
         assert any(t.to_status == "RUNNING" for t in transitions)
         events = EventRepository(conn).list_recent()
         assert any(e.kind == "job.status_changed" for e in events)
@@ -202,7 +207,7 @@ class TestJobTransitions:
         assert watch is not None
         assert watch.closed_at is not None
 
-        job_row = JobRepository(conn).get(job_id)
+        job_row = JobRepository(conn).get(job_id, scheduler_key="local")
         assert job_row is not None
         assert job_row.status == "COMPLETED"
         assert job_row.duration_secs == 3600
@@ -221,7 +226,9 @@ class TestJobTransitions:
         stub = StubSlurmClient({job_id: JobStatusInfo(status="RUNNING")})
         _run_once(ActiveWatchPoller(stub, db_path=db_path))
 
-        transitions = JobStateTransitionRepository(conn).history_for_job(job_id)
+        transitions = JobStateTransitionRepository(conn).history_for_job(
+            job_id, scheduler_key="local"
+        )
         # Only the seed transition — the poller should not insert a duplicate.
         assert len(transitions) == 1
 
@@ -243,7 +250,9 @@ class TestJobTransitions:
         stub = StubSlurmClient({})
         _run_once(ActiveWatchPoller(stub, db_path=db_path))
 
-        transitions = JobStateTransitionRepository(conn).history_for_job(job_id)
+        transitions = JobStateTransitionRepository(conn).history_for_job(
+            job_id, scheduler_key="local"
+        )
         assert len(transitions) == 1  # still only the seed row
 
         events = EventRepository(conn).list_recent()
@@ -269,7 +278,9 @@ class TestJobTransitions:
         stub = StubSlurmClient({job_id: JobStatusInfo(status="RUNNING")})
         _run_once(ActiveWatchPoller(stub, db_path=db_path))
 
-        transitions = JobStateTransitionRepository(conn).history_for_job(job_id)
+        transitions = JobStateTransitionRepository(conn).history_for_job(
+            job_id, scheduler_key="local"
+        )
         assert transitions == []
 
         events = EventRepository(conn).list_recent()

--- a/tests/pollers/test_active_watch_poller.py
+++ b/tests/pollers/test_active_watch_poller.py
@@ -56,7 +56,9 @@ def _seed_job(conn: sqlite3.Connection, job_id: int, *, status: str = "PENDING")
 
 
 def _seed_open_job_watch(conn: sqlite3.Connection, job_id: int) -> int:
-    return WatchRepository(conn).create(kind="job", target_ref=f"job:{job_id}")
+    # V5+ grammar: ``job:<scheduler_key>:<id>``. Local SLURM jobs always
+    # use ``scheduler_key='local'``.
+    return WatchRepository(conn).create(kind="job", target_ref=f"job:local:{job_id}")
 
 
 def _seed_pending_transition(conn: sqlite3.Connection, job_id: int, status: str) -> int:
@@ -123,7 +125,9 @@ class TestJobTransitions:
         status_events = [e for e in recent_events if e.kind == "job.status_changed"]
         assert len(status_events) == 1
         event = status_events[0]
-        assert event.source_ref == f"job:{job_id}"
+        # V5 grammar: ``job:<scheduler_key>:<id>``; local SLURM jobs use
+        # ``scheduler_key='local'``.
+        assert event.source_ref == f"job:local:{job_id}"
         assert event.payload.get("from_status") == "PENDING"
         assert event.payload.get("to_status") == "RUNNING"
         # Payload is enriched with job_id + job_name so adapters do not

--- a/tests/pollers/test_active_watch_poller_transport.py
+++ b/tests/pollers/test_active_watch_poller_transport.py
@@ -1,0 +1,227 @@
+"""Phase 6: ActiveWatchPoller transport-aware tests.
+
+Exercise the V5 ``target_ref`` parser and the scheduler_key group-by
+loop so that watches belonging to different transports (local vs
+``ssh:<profile>``) each hit the matching ``queue_by_ids`` endpoint,
+and that unknown scheduler_keys degrade gracefully (AC-8.5).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from srunx.client_protocol import JobStatusInfo
+from srunx.db.repositories.job_state_transitions import (
+    JobStateTransitionRepository,
+)
+from srunx.db.repositories.jobs import JobRepository
+from srunx.db.repositories.watches import WatchRepository
+from srunx.pollers.active_watch_poller import (
+    ActiveWatchPoller,
+    _parse_target_ref,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_target_ref
+# ---------------------------------------------------------------------------
+
+
+class TestParseTargetRef:
+    """AC-8.2 / AC-8.3 / AC-8.4 — V5 grammar parser."""
+
+    def test_local_form(self) -> None:
+        # AC-8.2
+        assert _parse_target_ref("job:local:12345", "job") == ("local", 12345)
+
+    def test_ssh_form(self) -> None:
+        # AC-8.3
+        assert _parse_target_ref("job:ssh:dgx:12345", "job") == ("ssh:dgx", 12345)
+
+    def test_ssh_form_with_hyphens_in_profile(self) -> None:
+        # Profile names may contain hyphens / underscores (just not colons).
+        assert _parse_target_ref("job:ssh:my-cluster_01:7", "job") == (
+            "ssh:my-cluster_01",
+            7,
+        )
+
+    def test_legacy_2segment_returns_none(self) -> None:
+        # AC-8.4 — after V5 migration these rows should not exist.
+        assert _parse_target_ref("job:12345", "job") is None
+
+    def test_wrong_kind_returns_none(self) -> None:
+        assert _parse_target_ref("job:local:12345", "workflow_run") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _parse_target_ref("", "job") is None
+
+    def test_non_int_tail_returns_none(self) -> None:
+        assert _parse_target_ref("job:local:notanint", "job") is None
+
+    def test_malformed_unknown_middle_returns_none(self) -> None:
+        assert _parse_target_ref("job:foo:42", "job") is None
+
+    def test_ssh_missing_profile_returns_none(self) -> None:
+        # ``job:ssh::42`` has an empty profile segment.
+        assert _parse_target_ref("job:ssh::42", "job") is None
+
+    def test_ssh_too_many_segments_returns_none(self) -> None:
+        # ``job:ssh:profile:extra:42`` has more than one profile segment;
+        # profile names are guaranteed not to contain ``:`` so we reject
+        # the ref rather than guess at the split.
+        assert _parse_target_ref("job:ssh:profile:extra:42", "job") is None
+
+
+# ---------------------------------------------------------------------------
+# Transport-aware run_cycle
+# ---------------------------------------------------------------------------
+
+
+class _StubQueueClient:
+    """Stub implementing ``SlurmClientProtocol.queue_by_ids`` only."""
+
+    def __init__(self, responses: dict[int, JobStatusInfo]) -> None:
+        self.responses = responses
+        self.calls: list[list[int]] = []
+
+    def queue_by_ids(self, job_ids: list[int]) -> dict[int, JobStatusInfo]:
+        self.calls.append(list(job_ids))
+        return {jid: self.responses[jid] for jid in job_ids if jid in self.responses}
+
+
+class _StubRegistry:
+    """Tiny ``TransportRegistry`` stand-in — resolve by lookup table."""
+
+    def __init__(self, clients: dict[str, _StubQueueClient | None]) -> None:
+        self._clients = clients
+        self.resolve_calls: list[str] = []
+
+    def resolve(self, scheduler_key: str):  # type: ignore[no-untyped-def]
+        self.resolve_calls.append(scheduler_key)
+        client = self._clients.get(scheduler_key)
+        if client is None:
+            return None
+
+        class _Handle:
+            def __init__(self, qc: _StubQueueClient) -> None:
+                self.queue_client = qc
+                self.job_ops = qc
+                self.scheduler_key = scheduler_key
+
+        return _Handle(client)
+
+
+def _seed_job(conn: sqlite3.Connection, job_id: int, status: str = "PENDING") -> int:
+    return JobRepository(conn).record_submission(
+        job_id=job_id,
+        name=f"job_{job_id}",
+        status=status,
+        submission_source="web",
+    )
+
+
+def _seed_watch(conn: sqlite3.Connection, target_ref: str) -> int:
+    return WatchRepository(conn).create(kind="job", target_ref=target_ref)
+
+
+def _seed_pending_transition(conn: sqlite3.Connection, job_id: int, status: str) -> int:
+    return JobStateTransitionRepository(conn).insert(
+        job_id=job_id,
+        from_status=None,
+        to_status=status,
+        source="poller",
+    )
+
+
+class TestRegistryGroupBy:
+    """AC-8.1 / AC-8.5 — registry-driven group-by behaviour."""
+
+    def test_multiple_scheduler_keys_each_queried_once(
+        self,
+        tmp_srunx_db: tuple[sqlite3.Connection, Path],
+    ) -> None:
+        # AC-8.1: watches spanning local + ssh:dgx produce two
+        # queue_by_ids calls, one per transport group.
+        import anyio
+
+        conn, db_path = tmp_srunx_db
+
+        _seed_job(conn, 100, "PENDING")
+        _seed_job(conn, 200, "PENDING")
+        _seed_watch(conn, "job:local:100")
+        _seed_watch(conn, "job:ssh:dgx:200")
+        _seed_pending_transition(conn, 100, "PENDING")
+        _seed_pending_transition(conn, 200, "PENDING")
+
+        local = _StubQueueClient({100: JobStatusInfo(status="RUNNING")})
+        ssh = _StubQueueClient({200: JobStatusInfo(status="RUNNING")})
+        registry = _StubRegistry({"local": local, "ssh:dgx": ssh})
+
+        poller = ActiveWatchPoller(registry=registry, db_path=db_path)  # type: ignore[arg-type]
+        anyio.run(poller.run_cycle)
+
+        assert local.calls == [[100]]
+        assert ssh.calls == [[200]]
+        # Both scheduler_keys were resolved at least once.
+        assert "local" in registry.resolve_calls
+        assert "ssh:dgx" in registry.resolve_calls
+
+    def test_unknown_scheduler_key_warned_and_skipped(
+        self,
+        tmp_srunx_db: tuple[sqlite3.Connection, Path],
+    ) -> None:
+        # AC-8.5: watches whose profile has been deleted stay open;
+        # the poller logs a warning and keeps processing other groups.
+        import anyio
+
+        conn, db_path = tmp_srunx_db
+
+        _seed_job(conn, 10, "PENDING")
+        _seed_job(conn, 20, "PENDING")
+        _seed_watch(conn, "job:local:10")
+        _seed_watch(conn, "job:ssh:ghost:20")
+        _seed_pending_transition(conn, 10, "PENDING")
+        _seed_pending_transition(conn, 20, "PENDING")
+
+        local = _StubQueueClient({10: JobStatusInfo(status="RUNNING")})
+        # ``ssh:ghost`` is intentionally missing — registry.resolve returns None.
+        registry = _StubRegistry({"local": local, "ssh:ghost": None})
+
+        poller = ActiveWatchPoller(registry=registry, db_path=db_path)  # type: ignore[arg-type]
+        # Should not raise: the ssh:ghost group is skipped, local is processed.
+        anyio.run(poller.run_cycle)
+
+        assert local.calls == [[10]]
+
+    def test_empty_cycle_is_noop(
+        self,
+        tmp_srunx_db: tuple[sqlite3.Connection, Path],
+    ) -> None:
+        import anyio
+
+        _conn, db_path = tmp_srunx_db
+        registry = _StubRegistry({"local": _StubQueueClient({})})
+        poller = ActiveWatchPoller(registry=registry, db_path=db_path)  # type: ignore[arg-type]
+        anyio.run(poller.run_cycle)
+
+
+class TestBackCompatConstructor:
+    """Constructor requires at least one of ``registry`` / ``slurm_client``."""
+
+    def test_requires_registry_or_slurm_client(self) -> None:
+        with pytest.raises(ValueError):
+            ActiveWatchPoller()
+
+    def test_legacy_slurm_client_still_accepted(
+        self,
+        tmp_srunx_db: tuple[sqlite3.Connection, Path],
+    ) -> None:
+        # Pre-Phase-6 call shape: positional ``slurm_client``. The
+        # existing poller tests rely on this so we must not break it.
+        _conn, db_path = tmp_srunx_db
+        stub = _StubQueueClient({})
+        # Positional arg should still work.
+        poller = ActiveWatchPoller(stub, db_path=db_path)
+        assert poller is not None

--- a/tests/pollers/test_active_watch_poller_transport.py
+++ b/tests/pollers/test_active_watch_poller_transport.py
@@ -126,12 +126,19 @@ def _seed_watch(conn: sqlite3.Connection, target_ref: str) -> int:
     return WatchRepository(conn).create(kind="job", target_ref=target_ref)
 
 
-def _seed_pending_transition(conn: sqlite3.Connection, job_id: int, status: str) -> int:
+def _seed_pending_transition(
+    conn: sqlite3.Connection,
+    job_id: int,
+    status: str,
+    *,
+    scheduler_key: str = "local",
+) -> int:
     return JobStateTransitionRepository(conn).insert(
         job_id=job_id,
         from_status=None,
         to_status=status,
         source="poller",
+        scheduler_key=scheduler_key,
     )
 
 

--- a/tests/ssh/cli/test_deprecation.py
+++ b/tests/ssh/cli/test_deprecation.py
@@ -1,0 +1,56 @@
+"""Phase 7: ssh subcommand deprecation warnings."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+
+class TestSshSubmitDeprecation:
+    def test_warning_on_stderr(self, tmp_path):
+        """AC-9.1: ssh submit emits deprecation warning to stderr."""
+        from srunx.cli.main import app
+
+        script = tmp_path / "foo.sh"
+        script.write_text("#!/bin/bash\necho hi\n")
+        runner = CliRunner()
+        # Use an invalid profile so the command fails fast without touching
+        # real SSH. The deprecation warning fires before any profile lookup,
+        # so it should appear on stderr regardless of the eventual exit code.
+        result = runner.invoke(
+            app,
+            ["ssh", "submit", str(script), "--profile", "nonexistent_profile_xyz"],
+            catch_exceptions=False,
+        )
+        assert "deprecated" in result.stderr.lower()
+
+
+class TestSshLogsDeprecation:
+    def test_warning_on_stderr(self):
+        from srunx.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["ssh", "logs", "12345", "--profile", "nonexistent_profile_xyz"],
+            catch_exceptions=False,
+        )
+        assert "deprecated" in result.stderr.lower()
+
+
+class TestNoDeprecationOnOtherCommands:
+    """AC-9.2, AC-9.3: ssh profile list / ssh sync have no warning."""
+
+    def test_ssh_profile_list_no_warning(self):
+        from srunx.cli.main import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["ssh", "profile", "list"], catch_exceptions=False)
+        assert "deprecated" not in result.stderr.lower()
+
+    def test_ssh_sync_help_no_warning(self):
+        from srunx.cli.main import app
+
+        runner = CliRunner()
+        # --help avoids needing real SSH.
+        result = runner.invoke(app, ["ssh", "sync", "--help"], catch_exceptions=False)
+        assert "deprecated" not in result.stderr.lower()

--- a/tests/sweep/test_sweep_ssh_integration.py
+++ b/tests/sweep/test_sweep_ssh_integration.py
@@ -448,9 +448,11 @@ class TestWebDispatchPoolLifecycle:
                 *,
                 callbacks: Any = None,
                 size: int = 8,
+                submission_source: str = "web",
             ) -> None:
                 self.spec = spec_arg
                 self.size = size
+                self.submission_source = submission_source
                 self.close_calls = 0
                 pool_instances.append(self)
 
@@ -597,7 +599,14 @@ class TestWebDispatchPoolLifecycle:
         sizes: list[int] = []
 
         class _SpyPool:
-            def __init__(self, spec_arg: Any, *, callbacks: Any = None, size: int = 8):
+            def __init__(
+                self,
+                spec_arg: Any,
+                *,
+                callbacks: Any = None,
+                size: int = 8,
+                submission_source: str = "web",
+            ):
                 sizes.append(size)
 
             def lease(self) -> Any:  # pragma: no cover

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -502,6 +502,7 @@ class TestNotificationWatchCallback:
                 endpoint_name="my-slack",
                 preset="terminal",
                 endpoint_kind="slack_webhook",
+                scheduler_key="local",
             )
 
     def test_on_job_submitted_without_job_id_is_noop(self):
@@ -542,4 +543,5 @@ class TestNotificationWatchCallback:
                 endpoint_name="ops",
                 preset="all",
                 endpoint_kind="slack_webhook",
+                scheduler_key="local",
             )

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -22,19 +22,40 @@ def mock_jobs():
     jobs = []
 
     # Job 1: With GPUs
-    job1 = Job(name="gpu_job", job_id=12345, command=["python", "train.py"])
+    job1 = Job(
+        name="gpu_job",
+        job_id=12345,
+        command=["python", "train.py"],
+        nodes=2,
+        gpus=8,
+        time_limit="4:00:00",
+    )
     job1._status = JobStatus.RUNNING
     job1.resources = JobResource(nodes=2, gpus_per_node=4, time_limit="4:00:00")
     jobs.append(job1)
 
     # Job 2: No GPUs
-    job2 = Job(name="cpu_job", job_id=12346, command=["python", "process.py"])
+    job2 = Job(
+        name="cpu_job",
+        job_id=12346,
+        command=["python", "process.py"],
+        nodes=1,
+        gpus=0,
+        time_limit="1:00:00",
+    )
     job2._status = JobStatus.PENDING
     job2.resources = JobResource(nodes=1, gpus_per_node=0, time_limit="1:00:00")
     jobs.append(job2)
 
     # Job 3: Multiple GPUs per node
-    job3 = Job(name="multi_gpu", job_id=12347, command=["python", "parallel.py"])
+    job3 = Job(
+        name="multi_gpu",
+        job_id=12347,
+        command=["python", "parallel.py"],
+        nodes=4,
+        gpus=8,
+        time_limit="2:00:00",
+    )
     job3._status = JobStatus.COMPLETED
     job3.resources = JobResource(nodes=4, gpus_per_node=2, time_limit="2:00:00")
     jobs.append(job3)

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -290,7 +290,7 @@ class TestJobMonitorHistoryIntegration:
 
         with patch("srunx.db.cli_helpers.record_completion") as rec:
             monitor._notify_transition(job, JobStatus.COMPLETED)
-            rec.assert_called_once_with(123, JobStatus.COMPLETED)
+            rec.assert_called_once_with(123, JobStatus.COMPLETED, scheduler_key="local")
 
     def test_notify_transition_updates_history_on_failure(self):
         from srunx.monitor.job_monitor import JobMonitor
@@ -303,7 +303,7 @@ class TestJobMonitorHistoryIntegration:
 
         with patch("srunx.db.cli_helpers.record_completion") as rec:
             monitor._notify_transition(job, JobStatus.FAILED)
-            rec.assert_called_once_with(456, JobStatus.FAILED)
+            rec.assert_called_once_with(456, JobStatus.FAILED, scheduler_key="local")
 
     def test_notify_transition_skips_history_for_running(self):
         from unittest.mock import MagicMock

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -57,7 +57,7 @@ class TestHistoricalCountsDbFirst:
                 submission_source="cli",
                 submitted_at=ts,
             )
-            repo.update_status(i, status, completed_at=ts)
+            repo.update_status(i, status, completed_at=ts, scheduler_key="local")
         # One CANCELLED row, also finished in-window.
         repo.record_submission(
             job_id=2000,
@@ -66,7 +66,7 @@ class TestHistoricalCountsDbFirst:
             submission_source="cli",
             submitted_at=ts,
         )
-        repo.update_status(2000, "CANCELLED", completed_at=ts)
+        repo.update_status(2000, "CANCELLED", completed_at=ts, scheduler_key="local")
 
         reporter = _make_reporter()
         assert reporter._get_historical_counts() == (2, 1, 1)
@@ -92,7 +92,7 @@ class TestHistoricalCountsDbFirst:
             submission_source="cli",
             submitted_at=stale,
         )
-        repo.update_status(3000, "COMPLETED", completed_at=stale)
+        repo.update_status(3000, "COMPLETED", completed_at=stale, scheduler_key="local")
 
         reporter = _make_reporter(timeframe="24h")
         assert reporter._get_historical_counts() == (0, 0, 0)
@@ -136,7 +136,12 @@ class TestHistoricalCountsDbFirst:
             submission_source="cli",
             submitted_at=stale_submit,  # outside the 24h window
         )
-        repo.update_status(4000, "COMPLETED", completed_at=recent_complete)
+        repo.update_status(
+            4000,
+            "COMPLETED",
+            completed_at=recent_complete,
+            scheduler_key="local",
+        )
 
         reporter = _make_reporter(timeframe="24h")
         assert reporter._get_historical_counts() == (1, 0, 0)

--- a/tests/test_transport_protocols.py
+++ b/tests/test_transport_protocols.py
@@ -1,0 +1,57 @@
+"""Unit tests for Phase 1 of CLI transport unification."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from srunx.client_protocol import JobOperationsProtocol, LogChunk
+from srunx.exceptions import (
+    JobNotFound,
+    RemoteCommandError,
+    SubmissionError,
+    TransportAuthError,
+    TransportConnectionError,
+    TransportError,
+    TransportTimeoutError,
+)
+
+
+class TestLogChunk:
+    def test_construct_zero_offsets(self) -> None:
+        chunk = LogChunk(stdout="", stderr="", stdout_offset=0, stderr_offset=0)
+        assert chunk.stdout == ""
+        assert chunk.stdout_offset == 0
+
+    def test_construct_positive_offsets(self) -> None:
+        chunk = LogChunk(stdout="a", stderr="b", stdout_offset=10, stderr_offset=5)
+        assert chunk.stdout_offset == 10
+
+    def test_negative_stdout_offset_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LogChunk(stdout="", stderr="", stdout_offset=-1, stderr_offset=0)
+
+    def test_negative_stderr_offset_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            LogChunk(stdout="", stderr="", stdout_offset=0, stderr_offset=-1)
+
+
+class TestJobOperationsProtocol:
+    def test_is_runtime_checkable(self) -> None:
+        """Phase 1 only defines the protocol; no implementation yet."""
+        # A bare object doesn't satisfy the protocol
+        assert not isinstance(object(), JobOperationsProtocol)
+
+
+class TestExceptionHierarchy:
+    def test_transport_subclasses(self) -> None:
+        assert issubclass(TransportConnectionError, TransportError)
+        assert issubclass(TransportAuthError, TransportError)
+        assert issubclass(TransportTimeoutError, TransportError)
+        assert issubclass(RemoteCommandError, TransportError)
+
+    def test_job_not_found_independent(self) -> None:
+        assert not issubclass(JobNotFound, TransportError)
+
+    def test_submission_error_independent(self) -> None:
+        assert not issubclass(SubmissionError, TransportError)

--- a/tests/test_transport_protocols_phase2.py
+++ b/tests/test_transport_protocols_phase2.py
@@ -1,0 +1,178 @@
+"""Phase 2: LSP alignment of Slurm and SlurmSSHAdapter with JobOperationsProtocol.
+
+These tests verify the new Protocol-conformant entry points added in
+``src/srunx/client.py`` and ``src/srunx/web/ssh_adapter.py`` without
+exercising the full submit path (which would need a live SLURM or SSH
+endpoint). The goal is surface conformance, not behavioural regression
+— existing tests cover the latter.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from srunx.client import Slurm
+from srunx.client_protocol import JobOperationsProtocol, LogChunk
+
+
+class TestSlurmProtocolCompliance:
+    def test_slurm_satisfies_protocol(self) -> None:
+        """``Slurm()`` must be a runtime-checkable JobOperationsProtocol."""
+        assert isinstance(Slurm(), JobOperationsProtocol)
+
+    def test_status_delegates_to_retrieve(self) -> None:
+        """``status`` is a thin alias for ``retrieve`` on the happy path."""
+        s = Slurm()
+        with patch.object(s, "retrieve", return_value="mock_result") as m:
+            assert s.status(12345) == "mock_result"
+            m.assert_called_once_with(12345)
+
+    def test_status_wraps_unknown_id_into_job_not_found(self) -> None:
+        """``retrieve`` raises ValueError on missing jobs; status converts it."""
+        from srunx.exceptions import JobNotFound
+
+        s = Slurm()
+        with patch.object(s, "retrieve", side_effect=ValueError("no such job")):
+            with pytest.raises(JobNotFound):
+                s.status(99999)
+
+
+class TestSlurmTailLogIncremental:
+    def test_missing_file_returns_empty_chunk_at_same_offset(self) -> None:
+        """If the log file doesn't exist yet, return empty LogChunk at same offset."""
+        s = Slurm()
+        with patch.object(Slurm, "_find_log_paths", return_value=(None, None)):
+            chunk = s.tail_log_incremental(job_id=1, stdout_offset=0, stderr_offset=0)
+            assert isinstance(chunk, LogChunk)
+            assert chunk.stdout == ""
+            assert chunk.stderr == ""
+            assert chunk.stdout_offset == 0
+            assert chunk.stderr_offset == 0
+
+    def test_reads_from_offset_and_advances(self, tmp_path) -> None:
+        """Reading from a real file advances the offset by bytes consumed."""
+        log = tmp_path / "job.log"
+        log.write_text("line1\nline2\n")
+        s = Slurm()
+        with patch.object(Slurm, "_find_log_paths", return_value=(str(log), str(log))):
+            # Fresh read: offset 0 → all bytes.
+            chunk = s.tail_log_incremental(job_id=1, stdout_offset=0, stderr_offset=0)
+            assert chunk.stdout == "line1\nline2\n"
+            assert chunk.stdout_offset == len(b"line1\nline2\n")
+            # When stderr is the same path as stdout, we don't double-count.
+            assert chunk.stderr == ""
+            assert chunk.stderr_offset == 0
+
+    def test_returns_log_chunk_type(self) -> None:
+        """Return value is a Pydantic LogChunk, not a tuple or dict."""
+        s = Slurm()
+        with patch.object(Slurm, "_find_log_paths", return_value=(None, None)):
+            chunk = s.tail_log_incremental(job_id=1)
+        assert isinstance(chunk, LogChunk)
+
+
+class TestSlurmSSHAdapterProtocolCompliance:
+    """SSHAdapter needs a live SSH connection to instantiate — use
+    class-level structural checks instead of ``isinstance(instance, ...)``.
+    """
+
+    def test_ssh_adapter_has_protocol_methods(self) -> None:
+        """Structural check: all 5 Protocol methods are defined."""
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        for method in ("submit", "cancel", "status", "queue", "tail_log_incremental"):
+            assert hasattr(SlurmSSHAdapter, method), f"missing method: {method}"
+            assert callable(getattr(SlurmSSHAdapter, method))
+
+    def test_ssh_adapter_backcompat_aliases_preserved(self) -> None:
+        """Existing method names must still be callable (non-breaking change)."""
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        for legacy_method in (
+            "submit_job",
+            "cancel_job",
+            "get_job_status",
+            "list_jobs",
+            "get_job_output",
+        ):
+            assert hasattr(SlurmSSHAdapter, legacy_method), (
+                f"legacy method removed: {legacy_method}"
+            )
+            assert callable(getattr(SlurmSSHAdapter, legacy_method))
+
+    def test_ssh_adapter_status_returns_base_job_shape(self) -> None:
+        """``status`` returns a BaseJob whose ``status`` attribute is a JobStatus."""
+        from srunx.client_protocol import JobStatusInfo
+        from srunx.models import BaseJob, JobStatus
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        # Patch out ``queue_by_ids`` to avoid touching any SSH client.
+        with patch.object(
+            SlurmSSHAdapter,
+            "queue_by_ids",
+            return_value={99: JobStatusInfo(status="RUNNING")},
+        ):
+            # Bypass __init__ entirely — we only test the status() path shape.
+            adapter = SlurmSSHAdapter.__new__(SlurmSSHAdapter)
+            result = adapter.status(99)
+        assert isinstance(result, BaseJob)
+        assert result.job_id == 99
+        assert result._status == JobStatus.RUNNING
+
+    def test_ssh_adapter_status_raises_job_not_found(self) -> None:
+        """Missing job → JobNotFound, matching the Protocol contract."""
+        from srunx.exceptions import JobNotFound
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        with patch.object(SlurmSSHAdapter, "queue_by_ids", return_value={}):
+            adapter = SlurmSSHAdapter.__new__(SlurmSSHAdapter)
+            with pytest.raises(JobNotFound):
+                adapter.status(99999)
+
+    def test_ssh_adapter_queue_returns_list_base_job(self) -> None:
+        """``queue`` adapts list_jobs dicts into Pydantic BaseJob instances."""
+        from srunx.models import BaseJob, JobStatus
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        fake_rows = [
+            {
+                "name": "jobA",
+                "job_id": 101,
+                "status": "RUNNING",
+                "partition": "gpu",
+                "nodes": 1,
+                "gpus": 2,
+                "elapsed_time": "0:10",
+            }
+        ]
+        with patch.object(SlurmSSHAdapter, "list_jobs", return_value=fake_rows):
+            adapter = SlurmSSHAdapter.__new__(SlurmSSHAdapter)
+            adapter._username = "alice"  # queue() reads profile's username on None
+            out = adapter.queue(user="alice")
+        assert isinstance(out, list)
+        assert len(out) == 1
+        assert isinstance(out[0], BaseJob)
+        assert out[0].job_id == 101
+        assert out[0]._status == JobStatus.RUNNING
+
+    def test_ssh_adapter_tail_log_incremental_returns_log_chunk(self) -> None:
+        """``tail_log_incremental`` returns a Pydantic LogChunk."""
+        from srunx.client_protocol import LogChunk
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        with patch.object(
+            SlurmSSHAdapter,
+            "get_job_output",
+            return_value=("stdout bytes", "stderr bytes", 12, 12),
+        ):
+            adapter = SlurmSSHAdapter.__new__(SlurmSSHAdapter)
+            chunk = adapter.tail_log_incremental(
+                job_id=1, stdout_offset=0, stderr_offset=0
+            )
+        assert isinstance(chunk, LogChunk)
+        assert chunk.stdout == "stdout bytes"
+        assert chunk.stderr == "stderr bytes"
+        assert chunk.stdout_offset == 12
+        assert chunk.stderr_offset == 12

--- a/tests/transport/test_current_profile.py
+++ b/tests/transport/test_current_profile.py
@@ -1,0 +1,109 @@
+"""Phase 2: active SSH profile fallback.
+
+``resolve_transport`` / ``peek_scheduler_key`` / ``resolve_transport_source``
+all consult ``srunx ssh profile set`` as the 4th-priority fallback (before
+``local``). This module pins the precedence ladder and the config opt-out.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import srunx.transport.registry as _reg
+from srunx.transport import (
+    peek_scheduler_key,
+    resolve_transport,
+    resolve_transport_source,
+)
+
+
+class TestCurrentProfileFallback:
+    def test_current_profile_picked_when_no_flag_or_env(self, capsys, monkeypatch):
+        """No --profile / --local / env → current profile drives resolution."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        # Override the autouse fixture in conftest that forces None.
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: "dgx")
+
+        with patch("srunx.transport.registry._build_ssh_handle") as mock_build:
+            handle = MagicMock()
+            handle.scheduler_key = "ssh:dgx"
+            handle.profile_name = "dgx"
+            handle.transport_type = "ssh"
+            mock_build.return_value = (handle, MagicMock())
+            with resolve_transport() as rt:
+                assert rt.source == "current-profile"
+                assert rt.scheduler_key == "ssh:dgx"
+        assert "via current profile" in capsys.readouterr().err
+
+    def test_env_beats_current_profile(self, monkeypatch):
+        """$SRUNX_SSH_PROFILE (priority 3) overrides current profile (4)."""
+        monkeypatch.setenv("SRUNX_SSH_PROFILE", "envprof")
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: "dgx")
+
+        with patch("srunx.transport.registry._build_ssh_handle") as mock_build:
+            handle = MagicMock()
+            handle.scheduler_key = "ssh:envprof"
+            handle.profile_name = "envprof"
+            handle.transport_type = "ssh"
+            mock_build.return_value = (handle, None)
+            with resolve_transport() as rt:
+                assert rt.source == "env"
+                assert rt.scheduler_key == "ssh:envprof"
+
+    def test_local_flag_beats_current_profile(self, monkeypatch):
+        """--local overrides the current-profile fallback."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: "dgx")
+        with resolve_transport(local=True) as rt:
+            assert rt.source == "--local"
+            assert rt.scheduler_key == "local"
+
+    def test_explicit_profile_beats_current_profile(self, monkeypatch):
+        """--profile overrides the current-profile fallback."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: "dgx")
+        with patch("srunx.transport.registry._build_ssh_handle") as mock_build:
+            handle = MagicMock()
+            handle.scheduler_key = "ssh:explicit"
+            handle.profile_name = "explicit"
+            handle.transport_type = "ssh"
+            mock_build.return_value = (handle, None)
+            with resolve_transport(profile="explicit") as rt:
+                assert rt.source == "--profile"
+                assert rt.scheduler_key == "ssh:explicit"
+
+    def test_no_current_profile_falls_through_to_local(self, monkeypatch):
+        """When config has no active profile, resolution stays on local."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: None)
+        with resolve_transport() as rt:
+            assert rt.source == "default"
+            assert rt.scheduler_key == "local"
+
+
+class TestPeekAndSourceParity:
+    def test_peek_scheduler_key_honours_current_profile(self, monkeypatch):
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: "pyxis")
+        assert peek_scheduler_key() == "ssh:pyxis"
+
+    def test_resolve_transport_source_honours_current_profile(self, monkeypatch):
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: "pyxis")
+        assert resolve_transport_source() == "current-profile"
+
+
+class TestOptOut:
+    def test_use_current_profile_false_disables_fallback(self, monkeypatch):
+        """When ``cli.use_current_profile=False``, active profile is ignored.
+
+        We mock :func:`_current_profile_name` directly because it's the
+        single point where the config flag is read.
+        """
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        # _current_profile_name returns None when the config flag is off;
+        # simulate that path.
+        monkeypatch.setattr(_reg, "_current_profile_name", lambda: None)
+        with resolve_transport() as rt:
+            assert rt.source == "default"
+            assert rt.scheduler_key == "local"

--- a/tests/transport/test_registry.py
+++ b/tests/transport/test_registry.py
@@ -44,8 +44,8 @@ class TestResolveTransport:
             assert rt.scheduler_key == "local"
             assert rt.source == "--local"
         captured = capsys.readouterr()
-        assert "transport: local" in captured.err
-        assert "from --local" in captured.err
+        assert "local" in captured.err
+        assert "via --local" in captured.err
 
     def test_profile_and_local_conflict(self, monkeypatch):
         """AC-1.2: --profile + --local is rejected at startup."""
@@ -74,7 +74,7 @@ class TestResolveTransport:
                 assert rt.source == "env"
                 assert rt.scheduler_key == "ssh:envprof"
         captured = capsys.readouterr()
-        assert "from env" in captured.err
+        assert "via $SRUNX_SSH_PROFILE" in captured.err
 
     def test_local_flag_overrides_env(self, monkeypatch, capsys):
         """AC-1.4: --local beats $SRUNX_SSH_PROFILE."""
@@ -83,7 +83,7 @@ class TestResolveTransport:
             assert rt.scheduler_key == "local"
             assert rt.source == "--local"
         captured = capsys.readouterr()
-        assert "from --local" in captured.err
+        assert "via --local" in captured.err
 
     def test_profile_flag_beats_env(self, monkeypatch, capsys):
         """REQ-1: --profile beats $SRUNX_SSH_PROFILE."""

--- a/tests/transport/test_registry.py
+++ b/tests/transport/test_registry.py
@@ -104,7 +104,19 @@ class TestResolveTransport:
             with resolve_transport(profile="cli") as rt:
                 assert rt.source == "--profile"
                 assert rt.scheduler_key == "ssh:cli"
-            build.assert_called_once_with("cli")
+            # Fix #5: callbacks + submission_source are now forwarded
+            # from resolve_transport into _build_ssh_handle so pooled
+            # clones inherit the caller's callback list. F9/F2: the
+            # forwarded kwarg list also carries ``mount_name`` and
+            # ``pool_size`` so we assert on argument presence rather
+            # than an exhaustive signature.
+            build.assert_called_once()
+            args, kwargs = build.call_args
+            assert args == ("cli",)
+            assert kwargs.get("callbacks") is None
+            assert kwargs.get("submission_source") == "cli"
+            assert kwargs.get("mount_name") is None
+            assert kwargs.get("pool_size") == 2
 
     def test_quiet_suppresses_banner(self, capsys, monkeypatch):
         """--quiet silences the banner even when source is explicit."""

--- a/tests/transport/test_registry.py
+++ b/tests/transport/test_registry.py
@@ -1,0 +1,265 @@
+"""Phase 4: resolve_transport and TransportRegistry tests.
+
+Covers the Phase-4 AC:
+
+* AC-1.2: ``--profile`` and ``--local`` together raise ``BadParameter``.
+* AC-1.4: ``--local`` overrides ``$SRUNX_SSH_PROFILE``.
+* AC-8.5: unknown SSH profile returns ``None`` (no crash).
+* Plus banner emission semantics (REQ-7 / AC-10.2).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from srunx.transport import (
+    ResolvedTransport,
+    TransportHandle,
+    TransportRegistry,
+    resolve_transport,
+)
+
+
+class TestResolveTransport:
+    def test_default_is_local_and_silent(self, capsys, monkeypatch):
+        """AC-10.2: fallback path is silent on stderr."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with resolve_transport(profile=None, local=False) as rt:
+            assert rt.scheduler_key == "local"
+            assert rt.source == "default"
+            assert rt.transport_type == "local"
+            assert rt.profile_name is None
+            assert rt.executor_factory is not None
+            assert rt.submission_context is None
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_local_flag_emits_banner(self, capsys, monkeypatch):
+        """AC-7 / REQ-7: explicit --local produces a stderr banner."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with resolve_transport(profile=None, local=True) as rt:
+            assert rt.scheduler_key == "local"
+            assert rt.source == "--local"
+        captured = capsys.readouterr()
+        assert "transport: local" in captured.err
+        assert "from --local" in captured.err
+
+    def test_profile_and_local_conflict(self, monkeypatch):
+        """AC-1.2: --profile + --local is rejected at startup."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with pytest.raises(typer.BadParameter):
+            with resolve_transport(profile="foo", local=True):
+                pass
+
+    def test_env_source_when_only_env_set(self, monkeypatch, capsys):
+        """REQ-1: $SRUNX_SSH_PROFILE picks SSH transport when no flag set."""
+        monkeypatch.setenv("SRUNX_SSH_PROFILE", "envprof")
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:envprof",
+            profile_name="envprof",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ):
+            with resolve_transport() as rt:
+                assert rt.source == "env"
+                assert rt.scheduler_key == "ssh:envprof"
+        captured = capsys.readouterr()
+        assert "from env" in captured.err
+
+    def test_local_flag_overrides_env(self, monkeypatch, capsys):
+        """AC-1.4: --local beats $SRUNX_SSH_PROFILE."""
+        monkeypatch.setenv("SRUNX_SSH_PROFILE", "envprof")
+        with resolve_transport(local=True) as rt:
+            assert rt.scheduler_key == "local"
+            assert rt.source == "--local"
+        captured = capsys.readouterr()
+        assert "from --local" in captured.err
+
+    def test_profile_flag_beats_env(self, monkeypatch, capsys):
+        """REQ-1: --profile beats $SRUNX_SSH_PROFILE."""
+        monkeypatch.setenv("SRUNX_SSH_PROFILE", "envprof")
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:cli",
+            profile_name="cli",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ) as build:
+            with resolve_transport(profile="cli") as rt:
+                assert rt.source == "--profile"
+                assert rt.scheduler_key == "ssh:cli"
+            build.assert_called_once_with("cli")
+
+    def test_quiet_suppresses_banner(self, capsys, monkeypatch):
+        """--quiet silences the banner even when source is explicit."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with resolve_transport(local=True, quiet=True) as rt:
+            assert rt.scheduler_key == "local"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_banner_kwarg_false_suppresses_even_without_quiet(
+        self, capsys, monkeypatch
+    ):
+        """Library callers can opt out of banners entirely via banner=False."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with resolve_transport(local=True, banner=False) as rt:
+            assert rt.scheduler_key == "local"
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_ssh_pool_closed_on_exit(self, monkeypatch):
+        """SSH pools must be closed when the context manager exits."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:foo",
+            profile_name="foo",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        fake_pool = MagicMock()
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, fake_pool),
+        ):
+            with resolve_transport(profile="foo", banner=False):
+                pass
+        fake_pool.close.assert_called_once()
+
+    def test_ssh_pool_close_failure_is_swallowed(self, monkeypatch):
+        """A noisy pool.close() must not propagate out of the CM."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:foo",
+            profile_name="foo",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        fake_pool = MagicMock()
+        fake_pool.close.side_effect = RuntimeError("boom")
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, fake_pool),
+        ):
+            with resolve_transport(profile="foo", banner=False):
+                pass
+        fake_pool.close.assert_called_once()
+
+    def test_resolved_transport_shortcut_properties(self, monkeypatch):
+        """ResolvedTransport shortcut properties must mirror the handle."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with resolve_transport(local=True, banner=False) as rt:
+            assert isinstance(rt, ResolvedTransport)
+            assert rt.scheduler_key == rt.handle.scheduler_key
+            assert rt.profile_name is rt.handle.profile_name
+            assert rt.transport_type == rt.handle.transport_type
+            assert rt.job_ops is rt.handle.job_ops
+            assert rt.queue_client is rt.handle.queue_client
+            assert rt.executor_factory is rt.handle.executor_factory
+            assert rt.submission_context is rt.handle.submission_context
+
+
+class TestTransportRegistry:
+    def test_local_always_resolves(self):
+        reg = TransportRegistry(profile_loader=lambda name: None)
+        handle = reg.resolve("local")
+        assert handle is not None
+        assert handle.scheduler_key == "local"
+        assert handle.transport_type == "local"
+        assert handle.profile_name is None
+        reg.close()
+
+    def test_local_handle_is_cached(self):
+        reg = TransportRegistry(profile_loader=lambda name: None)
+        first = reg.resolve("local")
+        second = reg.resolve("local")
+        assert first is second
+        reg.close()
+
+    def test_unknown_ssh_profile_returns_none(self):
+        """AC-8.5: unresolvable SSH profile returns None."""
+        reg = TransportRegistry(profile_loader=lambda name: None)
+        assert reg.resolve("ssh:nonexistent") is None
+        reg.close()
+
+    def test_malformed_scheduler_key_returns_none(self):
+        reg = TransportRegistry(profile_loader=lambda name: None)
+        assert reg.resolve("malformed") is None
+        assert reg.resolve("") is None
+        assert reg.resolve("ssh:") is None
+        reg.close()
+
+    def test_ssh_build_failure_returns_none_and_logs(self):
+        """A TransportError while building an SSH handle yields None, not a crash."""
+        from srunx.exceptions import TransportError
+
+        # Profile loader says the profile exists...
+        profile_loader = MagicMock(return_value=MagicMock(mounts=[]))
+        reg = TransportRegistry(profile_loader=profile_loader)
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            side_effect=TransportError("forged failure"),
+        ):
+            assert reg.resolve("ssh:broken") is None
+        reg.close()
+
+    def test_close_disposes_pools(self):
+        """close() drains every pool accumulated via SSH resolves."""
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:foo",
+            profile_name="foo",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        fake_pool = MagicMock()
+        profile_loader = MagicMock(return_value=MagicMock(mounts=[]))
+        reg = TransportRegistry(profile_loader=profile_loader)
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, fake_pool),
+        ):
+            handle = reg.resolve("ssh:foo")
+            assert handle is fake_handle
+
+        reg.close()
+        fake_pool.close.assert_called_once()
+
+    def test_known_scheduler_keys_reads_jobs_table(self):
+        """DISTINCT scheduler_key reader pulls from the jobs table only."""
+        conn = MagicMock()
+        conn.execute.return_value.fetchall.return_value = [
+            ("local",),
+            ("ssh:dgx",),
+            (None,),  # NULL row — should be filtered out
+        ]
+        reg = TransportRegistry(profile_loader=lambda name: None)
+        keys = reg.known_scheduler_keys(conn)
+        assert keys == {"local", "ssh:dgx"}
+        # Exact SQL check so we catch accidental JOINs / filter additions.
+        conn.execute.assert_called_once_with("SELECT DISTINCT scheduler_key FROM jobs")
+        reg.close()

--- a/tests/transport/test_review_fixes.py
+++ b/tests/transport/test_review_fixes.py
@@ -131,6 +131,173 @@ class TestPollerThreadsSchedulerKey:
 
 
 # ---------------------------------------------------------------------------
+# Final-review Bug #2: monitor jobs threads scheduler_key through to
+# attach_notification_watch so the per-job watch targets the right axis.
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorJobsThreadsSchedulerKey:
+    """Final-review Bug #2: ``srunx monitor jobs`` must not drop scheduler_key.
+
+    Before the fix, ``cli/monitor.py:monitor_jobs`` called
+    ``attach_notification_watch(job_id=..., endpoint_name=...,
+    preset=...)`` with no ``scheduler_key=``. The default ``'local'``
+    would then land on the SSH-backed job's watch — the poller would
+    look under ``job:local:<id>`` and never observe the SSH transitions.
+
+    The fix threads ``rt.scheduler_key`` from the resolved transport
+    into every attach call.
+    """
+
+    def test_ssh_monitor_attaches_watch_under_ssh_scheduler_key(
+        self, monkeypatch
+    ) -> None:
+        """A CLI ``monitor jobs --profile dgx 777`` attach must carry
+        ``scheduler_key='ssh:dgx'`` to ``attach_notification_watch``."""
+        from srunx.cli import monitor as monitor_cli
+
+        captured: list[dict[str, object]] = []
+
+        def _fake_attach(**kwargs: object) -> int | None:
+            captured.append(dict(kwargs))
+            return 1
+
+        monkeypatch.setattr(
+            "srunx.cli.notification_setup.attach_notification_watch",
+            _fake_attach,
+        )
+
+        # Drive the attach branch directly. ``monitor_jobs`` is a typer
+        # command; calling the module function with a fabricated
+        # ResolvedTransport exercises the exact code path without
+        # spinning up JobMonitor polling or real SLURM queries.
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+        # Patch _build_ssh_handle so resolve_transport returns our stub
+        # without touching paramiko / config manager.
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ):
+            # The real ``JobMonitor`` loop would block on polling; stub
+            # it into a no-op that signals "already terminal" so
+            # monitor_jobs returns after the attach step.
+            class _NoopMonitor:
+                def __init__(self, **_kwargs: object) -> None:
+                    self._kwargs = _kwargs
+
+                def watch_until(self) -> None:
+                    return None
+
+                def watch_continuous(self) -> None:
+                    return None
+
+            monkeypatch.setattr(monitor_cli, "JobMonitor", _NoopMonitor)
+
+            # Invoke the command function directly (bypasses Typer).
+            monitor_cli.monitor_jobs(
+                job_ids=[777],
+                all_jobs=False,
+                schedule=None,
+                interval=60,
+                timeout=None,
+                notify=None,
+                endpoint="ep",
+                preset="terminal",
+                continuous=False,
+                profile="dgx",
+                local=False,
+                quiet=True,
+            )
+
+        assert captured, "attach_notification_watch was not invoked"
+        assert captured[0].get("scheduler_key") == "ssh:dgx", (
+            "Bug #2 regressed: CLI monitor dropped scheduler_key on the "
+            "attach_notification_watch call"
+        )
+        assert captured[0].get("job_id") == 777
+        assert captured[0].get("endpoint_name") == "ep"
+
+
+# ---------------------------------------------------------------------------
+# Final-review Bug #3: web/_build_run_response uses get_by_row_id so SSH
+# workflow children are resolved without the scheduler_key='local' default.
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowResponseResolvesSSHChildren:
+    """Final-review Bug #3: ``_build_run_response`` must not lose SSH children.
+
+    The pre-fix code called ``job_repo.get(m.job_id)`` which defaulted
+    ``scheduler_key='local'`` — a workflow whose child ran over SSH
+    would show up with status ``None`` in ``job_statuses``. The fix
+    switches to ``job_repo.get_by_row_id(m.jobs_row_id)`` which is
+    axis-free.
+    """
+
+    def test_ssh_workflow_child_status_is_populated(
+        self, tmp_srunx_db: tuple[sqlite3.Connection, Path]
+    ) -> None:
+        from srunx.db.repositories.workflow_run_jobs import (
+            WorkflowRunJobRepository,
+        )
+        from srunx.db.repositories.workflow_runs import WorkflowRunRepository
+        from srunx.web.routers.workflows import _build_run_response
+
+        conn, _ = tmp_srunx_db
+
+        # Seed a workflow_run
+        run_id = WorkflowRunRepository(conn).create(
+            workflow_name="wf_ssh",
+            yaml_path=None,
+            args=None,
+            triggered_by="web",
+        )
+
+        # Seed one SSH-backed child job + membership.
+        row_id = JobRepository(conn).record_submission(
+            job_id=8001,
+            name="ssh_child",
+            status="RUNNING",
+            submission_source="workflow",
+            transport_type="ssh",
+            profile_name="dgx",
+            scheduler_key="ssh:dgx",
+            workflow_run_id=run_id,
+        )
+        assert row_id > 0
+
+        WorkflowRunJobRepository(conn).create(
+            workflow_run_id=run_id,
+            job_name="ssh_child",
+            jobs_row_id=row_id,
+        )
+
+        run = WorkflowRunRepository(conn).get(run_id)
+        assert run is not None
+
+        response = _build_run_response(conn, run)
+
+        # Bug #3 fix: the SSH-backed child's status must surface, not be
+        # silently dropped because the axis default was ``'local'``.
+        assert response["job_statuses"].get("ssh_child") == "RUNNING", (
+            "Bug #3 regressed: SSH workflow child was dropped from "
+            "job_statuses (scheduler_key='local' default silently "
+            "matched no row)"
+        )
+        assert response["job_ids"].get("ssh_child") == "8001"
+
+
+# ---------------------------------------------------------------------------
 # Fix #4: V5 migration only force-closes job watches
 # ---------------------------------------------------------------------------
 
@@ -638,19 +805,23 @@ class TestPoolOrphanProtection:
         fake_pool.close.assert_called_once()
 
 
-class TestBannerLabelIsHumanReadable:
-    """F10: ``ResolvedTransport.label`` prefers a human-friendly rendering."""
+class TestBannerLabelMatchesSchedulerKey:
+    """Bug #7 / AC-7.3: ``ResolvedTransport.label`` uses the scheduler_key grammar.
 
-    def test_local_label_is_friendly(self, monkeypatch) -> None:
+    The banner text must match the strings callers see in DB rows, watch
+    targets, and ``scheduler_key`` — i.e. ``local`` and ``ssh:<profile>``
+    — so operators can grep one surface and hit every related row.
+    """
+
+    def test_local_label_matches_scheduler_key(self, monkeypatch) -> None:
         from srunx.transport import resolve_transport
 
         monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
         with resolve_transport(local=True, banner=False) as rt:
-            assert rt.label == "local SLURM"
-            # scheduler_key stays machine-parseable.
+            assert rt.label == "local"
             assert rt.scheduler_key == "local"
 
-    def test_ssh_label_is_friendly(self, monkeypatch) -> None:
+    def test_ssh_label_matches_scheduler_key(self, monkeypatch) -> None:
         from srunx.transport import resolve_transport
 
         monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
@@ -668,7 +839,7 @@ class TestBannerLabelIsHumanReadable:
             return_value=(fake_handle, None),
         ):
             with resolve_transport(profile="dgx", banner=False) as rt:
-                assert rt.label == "SSH: dgx"
+                assert rt.label == "ssh:dgx"
                 assert rt.scheduler_key == "ssh:dgx"
 
 

--- a/tests/transport/test_review_fixes.py
+++ b/tests/transport/test_review_fixes.py
@@ -1,0 +1,675 @@
+"""Regression tests for the post-implementation review fixes.
+
+Seven MUST-FIX findings were raised by Codex + code-reviewer against the
+CLI transport unification feature branch. These tests pin the behaviour
+each fix restores so subsequent refactors can't silently regress.
+
+Each ``Test*`` class corresponds to one review finding (see the PR
+description). The tests are intentionally small and depend only on
+public module surfaces or documented private seams (``_build_ssh_handle``
+is already monkey-patched by the existing transport test suite, so
+adding one more patch point carries zero coupling cost).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from srunx.callbacks import NotificationWatchCallback
+from srunx.client_protocol import JobStatusInfo
+from srunx.db.connection import open_connection
+from srunx.db.migrations import (
+    MIGRATIONS,
+    _apply_fk_off_migration,
+    _apply_tx_migration,
+)
+from srunx.db.repositories.job_state_transitions import (
+    JobStateTransitionRepository,
+)
+from srunx.db.repositories.jobs import JobRepository
+from srunx.db.repositories.watches import WatchRepository
+from srunx.pollers.active_watch_poller import ActiveWatchPoller
+from srunx.transport import (
+    TransportHandle,
+    peek_scheduler_key,
+    resolve_transport,
+)
+
+# ---------------------------------------------------------------------------
+# Fix #1: Poller threads scheduler_key into every repo call
+# ---------------------------------------------------------------------------
+
+
+class _StubQueueClient:
+    """Minimal ``SlurmClientProtocol`` stub."""
+
+    def __init__(self, responses: dict[int, JobStatusInfo]) -> None:
+        self.responses = responses
+        self.calls: list[list[int]] = []
+
+    def queue_by_ids(self, job_ids: list[int]) -> dict[int, JobStatusInfo]:
+        self.calls.append(list(job_ids))
+        return {jid: self.responses[jid] for jid in job_ids if jid in self.responses}
+
+
+class _StubRegistry:
+    def __init__(self, clients: dict[str, _StubQueueClient]) -> None:
+        self._clients = clients
+
+    def resolve(self, scheduler_key: str):  # type: ignore[no-untyped-def]
+        client = self._clients.get(scheduler_key)
+        if client is None:
+            return None
+
+        class _Handle:
+            def __init__(self, qc: _StubQueueClient) -> None:
+                self.queue_client = qc
+                self.scheduler_key = scheduler_key
+
+        return _Handle(client)
+
+
+class TestPollerThreadsSchedulerKey:
+    """Fix #1: SSH-transport watches must not be joined against scheduler_key='local'."""
+
+    def test_ssh_watch_transitions_fire(
+        self, tmp_srunx_db: tuple[sqlite3.Connection, Path]
+    ) -> None:
+        """A poller cycle for ``ssh:dgx`` must insert the transition under
+        the matching scheduler_key, not under the default ``'local'``."""
+        import anyio
+
+        conn, db_path = tmp_srunx_db
+
+        # Seed an SSH-recorded job + baseline PENDING transition under
+        # scheduler_key='ssh:dgx'.
+        JobRepository(conn).record_submission(
+            job_id=500,
+            name="ssh_job",
+            status="PENDING",
+            submission_source="web",
+            transport_type="ssh",
+            profile_name="dgx",
+            scheduler_key="ssh:dgx",
+        )
+        JobStateTransitionRepository(conn).insert(
+            job_id=500,
+            from_status=None,
+            to_status="PENDING",
+            source="webhook",
+            scheduler_key="ssh:dgx",
+        )
+        WatchRepository(conn).create(kind="job", target_ref="job:ssh:dgx:500")
+
+        ssh = _StubQueueClient({500: JobStatusInfo(status="RUNNING")})
+        registry = _StubRegistry({"ssh:dgx": ssh})
+
+        poller = ActiveWatchPoller(registry=registry, db_path=db_path)  # type: ignore[arg-type]
+        anyio.run(poller.run_cycle)
+
+        # The poller must have recorded PENDING→RUNNING against the SSH
+        # scheduler_key (not against 'local'). If #1 regressed, the
+        # latest_for_job('local', 500) lookup inside the poller would
+        # return None and no transition would be written.
+        latest = JobStateTransitionRepository(conn).latest_for_job(
+            500, scheduler_key="ssh:dgx"
+        )
+        assert latest is not None, (
+            "SSH transition lost — poller joined on scheduler_key='local'"
+        )
+        assert latest.to_status == "RUNNING"
+
+        # And the jobs.status update targeted the SSH row.
+        job_row = JobRepository(conn).get(500, scheduler_key="ssh:dgx")
+        assert job_row is not None
+        assert job_row.status == "RUNNING"
+
+
+# ---------------------------------------------------------------------------
+# Fix #4: V5 migration only force-closes job watches
+# ---------------------------------------------------------------------------
+
+
+class TestV5MigrationPreservesNonJobWatches:
+    """Fix #4: workflow_run / sweep_run / resource watches survive V5."""
+
+    def _apply_through_v4(self, db_path: Path) -> sqlite3.Connection:
+        conn = open_connection(db_path)
+        for mig in MIGRATIONS[:-1]:  # everything except V5
+            if mig.requires_fk_off:
+                _apply_fk_off_migration(conn, mig)
+            else:
+                _apply_tx_migration(conn, mig)
+        return conn
+
+    def test_workflow_run_watch_survives_v5(self, tmp_path: Path) -> None:
+        conn = self._apply_through_v4(tmp_path / "db.sqlite")
+        try:
+            conn.execute(
+                "INSERT INTO watches (kind, target_ref, created_at) "
+                "VALUES ('workflow_run', 'workflow_run:77', '2026-04-22T00:00:00Z')"
+            )
+            conn.execute(
+                "INSERT INTO watches (kind, target_ref, created_at) "
+                "VALUES ('sweep_run', 'sweep_run:42', '2026-04-22T00:00:00Z')"
+            )
+            conn.execute(
+                "INSERT INTO watches (kind, target_ref, created_at) "
+                "VALUES ('resource_threshold', 'resource:gpu:4', "
+                "'2026-04-22T00:00:00Z')"
+            )
+            conn.execute(
+                "INSERT INTO watches (kind, target_ref, created_at) "
+                "VALUES ('job', 'job:999', '2026-04-22T00:00:00Z')"
+            )
+            conn.commit()
+
+            v5 = MIGRATIONS[-1]
+            assert v5.name == "v5_transport_scheduler_key"
+            _apply_fk_off_migration(conn, v5)
+
+            rows = conn.execute(
+                "SELECT kind, closed_at FROM watches ORDER BY kind"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        by_kind = {r["kind"]: r["closed_at"] for r in rows}
+        assert by_kind["workflow_run"] is None, "V5 must not close workflow_run watches"
+        assert by_kind["sweep_run"] is None, "V5 must not close sweep_run watches"
+        assert by_kind["resource_threshold"] is None, (
+            "V5 must not close resource_threshold watches"
+        )
+        # Only the job watch should have been force-closed.
+        assert by_kind["job"] is not None, (
+            "V5 must force-close pre-migration job watches "
+            "(they carry ambiguous transport provenance)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fix #6: SlurmSSHAdapter.status() returns a non-refreshing BaseJob
+# ---------------------------------------------------------------------------
+
+
+class TestStatusSnapshotDoesNotRefresh:
+    """Fix #6: Protocol contract — status() snapshot must not re-query SLURM."""
+
+    def test_status_returns_parked_refresh_clock(self) -> None:
+        from unittest.mock import patch as _patch
+
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        # Build an adapter bypassing __init__ so we don't need real SSH.
+        adapter = object.__new__(SlurmSSHAdapter)
+        adapter._io_lock = __import__("threading").RLock()
+        adapter._client = MagicMock()
+        adapter.callbacks = []
+        adapter._profile_name = "dgx"
+        adapter._hostname = "testhost"
+        adapter._username = "tester"
+        adapter._key_filename = None
+        adapter._port = 22
+        adapter._proxy_jump = None
+        adapter._env_vars = {}
+        adapter._mounts = ()
+        adapter.submission_source = "cli"
+
+        # Stub queue_by_ids so status() gets a deterministic reply.
+        def _stub_queue(job_ids):
+            return {job_ids[0]: JobStatusInfo(status="RUNNING")}
+
+        adapter.queue_by_ids = _stub_queue  # type: ignore[method-assign]
+
+        # Any lazy refresh would invoke subprocess.run inside BaseJob.refresh.
+        with _patch("srunx.models.subprocess.run") as sub_run:
+            job = adapter.status(12345)
+            # Touch .status AFTER the static _REFRESH_INTERVAL has long
+            # elapsed — a non-parked _last_refresh would fire sacct here.
+            time.sleep(0.01)
+            _ = job.status
+            _ = job.status
+
+        sub_run.assert_not_called()
+        # And the parked clock is far in the future.
+        assert job._last_refresh > time.time() + 10**6
+
+
+# ---------------------------------------------------------------------------
+# Fix #5: resolve_transport forwards callbacks into the SSH pool
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTransportForwardsCallbacks:
+    """Fix #5: ``resolve_transport(callbacks=...)`` lands on SSH pool + adapter."""
+
+    def test_callbacks_passed_to_build_ssh_handle(self, monkeypatch) -> None:
+        """The forwarded callbacks list reaches ``_build_ssh_handle``."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+
+        cb = NotificationWatchCallback(
+            endpoint_name="ep",
+            preset="terminal",
+            scheduler_key="ssh:foo",
+        )
+
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:foo",
+            profile_name="foo",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ) as build:
+            with resolve_transport(profile="foo", callbacks=[cb], banner=False):
+                pass
+
+            build.assert_called_once()
+            args, kwargs = build.call_args
+            assert args == ("foo",)
+            assert kwargs.get("callbacks") == [cb]
+            assert kwargs.get("submission_source") == "cli"
+
+
+class TestNotificationWatchCallbackSchedulerKey:
+    """Fix #5: NotificationWatchCallback threads scheduler_key into attach."""
+
+    def test_callback_passes_scheduler_key_to_attach(self) -> None:
+        cb = NotificationWatchCallback(
+            endpoint_name="ep",
+            preset="terminal",
+            scheduler_key="ssh:dgx",
+        )
+
+        captured: dict[str, object] = {}
+
+        def _fake_attach(**kwargs: object) -> int | None:
+            captured.update(kwargs)
+            return 1
+
+        job = MagicMock()
+        job.job_id = 123
+
+        with patch(
+            "srunx.cli.notification_setup.attach_notification_watch",
+            side_effect=_fake_attach,
+        ):
+            cb.on_job_submitted(job)
+
+        assert captured.get("scheduler_key") == "ssh:dgx"
+        assert captured.get("job_id") == 123
+
+
+# ---------------------------------------------------------------------------
+# Fix #7: submission_source is pluggable per-handle
+# ---------------------------------------------------------------------------
+
+
+class TestPeekSchedulerKey:
+    """Helper used by CLI callers to bind callbacks before resolve_transport."""
+
+    def test_profile_wins(self, monkeypatch) -> None:
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        assert peek_scheduler_key(profile="foo") == "ssh:foo"
+
+    def test_local_wins_over_env(self, monkeypatch) -> None:
+        monkeypatch.setenv("SRUNX_SSH_PROFILE", "envprof")
+        assert peek_scheduler_key(local=True) == "local"
+
+    def test_env_when_no_flags(self, monkeypatch) -> None:
+        monkeypatch.setenv("SRUNX_SSH_PROFILE", "envprof")
+        assert peek_scheduler_key() == "ssh:envprof"
+
+    def test_default_is_local(self, monkeypatch) -> None:
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        assert peek_scheduler_key() == "local"
+
+    def test_profile_local_conflict_raises(self, monkeypatch) -> None:
+        import typer
+
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with pytest.raises(typer.BadParameter):
+            peek_scheduler_key(profile="foo", local=True)
+
+
+class TestSubmissionSourcePerHandle:
+    """Fix #7: ``submission_source`` defaults can be overridden at handle build."""
+
+    def test_cli_submission_source_lands_on_adapter(self, monkeypatch) -> None:
+        """``resolve_transport`` passes ``submission_source`` into
+        ``_build_ssh_handle`` kwargs; the adapter records the origin tag."""
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:foo",
+            profile_name="foo",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ) as build:
+            with resolve_transport(
+                profile="foo",
+                submission_source="mcp",
+                banner=False,
+            ):
+                pass
+
+        build.assert_called_once()
+        _, kwargs = build.call_args
+        assert kwargs.get("submission_source") == "mcp"
+
+
+# ---------------------------------------------------------------------------
+# Phase-7 review fixes (SHOULD / NIT)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCacheInvalidation:
+    """F1: TransportRegistry invalidates SSH cache entries when profile is removed."""
+
+    def test_profile_deletion_invalidates_cache(self) -> None:
+        """After a profile is deleted, a cache hit must re-check and return None."""
+        from srunx.transport.registry import TransportRegistry
+
+        profiles: dict[str, MagicMock] = {"foo": MagicMock(mounts=[])}
+
+        def loader(name: str):
+            return profiles.get(name)
+
+        reg = TransportRegistry(profile_loader=loader)
+
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:foo",
+            profile_name="foo",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        fake_pool = MagicMock()
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, fake_pool),
+        ):
+            first = reg.resolve("ssh:foo")
+            assert first is fake_handle
+
+        # Simulate the admin deleting the profile.
+        del profiles["foo"]
+
+        # Cache hit path must re-validate the profile and return None.
+        assert reg.resolve("ssh:foo") is None
+        # Stale adapter's disconnect() must have been called.
+        fake_handle.job_ops.disconnect.assert_called_once()  # type: ignore[attr-defined]
+        reg.close()
+
+    def test_close_disconnects_ssh_adapters(self) -> None:
+        """F1: ``close()`` must call ``disconnect()`` on cached SSH adapters."""
+        from srunx.transport.registry import TransportRegistry
+
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:foo",
+            profile_name="foo",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        reg = TransportRegistry(profile_loader=lambda name: MagicMock(mounts=[]))
+        reg.register_handle(fake_handle)
+        reg.close()
+        fake_handle.job_ops.disconnect.assert_called_once()  # type: ignore[attr-defined]
+
+
+class TestParseTargetRefHardening:
+    """F3: ``_parse_target_ref`` rejects pathological inputs."""
+
+    def test_rejects_zero_job_id(self) -> None:
+        from srunx.pollers.active_watch_poller import _parse_target_ref
+
+        assert _parse_target_ref("job:local:0", "job") is None
+
+    def test_rejects_negative_job_id(self) -> None:
+        from srunx.pollers.active_watch_poller import _parse_target_ref
+
+        # Leading ``-`` fails the isdigit() check before int() is called.
+        assert _parse_target_ref("job:local:-1", "job") is None
+
+    def test_rejects_overflow_job_id(self) -> None:
+        from srunx.pollers.active_watch_poller import _parse_target_ref
+
+        # 13-digit tail exceeds _MAX_JOB_ID_DIGITS cap.
+        assert _parse_target_ref("job:local:1234567890123", "job") is None
+
+    def test_rejects_nul_byte_in_profile(self) -> None:
+        from srunx.pollers.active_watch_poller import _parse_target_ref
+
+        assert _parse_target_ref("job:ssh:pro\x00file:1", "job") is None
+
+    def test_rejects_oversized_profile(self) -> None:
+        from srunx.pollers.active_watch_poller import _parse_target_ref
+
+        long_name = "a" * 65  # just past the 64-char cap
+        assert _parse_target_ref(f"job:ssh:{long_name}:1", "job") is None
+
+    def test_accepts_valid_local(self) -> None:
+        from srunx.pollers.active_watch_poller import _parse_target_ref
+
+        assert _parse_target_ref("job:local:42", "job") == ("local", 42)
+
+    def test_accepts_valid_ssh(self) -> None:
+        from srunx.pollers.active_watch_poller import _parse_target_ref
+
+        assert _parse_target_ref("job:ssh:my-cluster_01:42", "job") == (
+            "ssh:my-cluster_01",
+            42,
+        )
+
+
+class TestValidateProfileName:
+    """F4: ``validate_profile_name`` rejects invalid profile names."""
+
+    def test_accepts_valid_names(self) -> None:
+        from srunx.ssh.core.config import validate_profile_name
+
+        # None of these should raise.
+        for name in ("foo", "my-cluster_01", "dgx.prod", "a", "a" * 64):
+            validate_profile_name(name)
+
+    def test_rejects_colon(self) -> None:
+        from srunx.ssh.core.config import validate_profile_name
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            validate_profile_name("bad:name")
+
+    def test_rejects_nul_byte(self) -> None:
+        from srunx.ssh.core.config import validate_profile_name
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            validate_profile_name("bad\x00name")
+
+    def test_rejects_path_separator(self) -> None:
+        from srunx.ssh.core.config import validate_profile_name
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            validate_profile_name("some/path")
+
+    def test_rejects_too_long(self) -> None:
+        from srunx.ssh.core.config import validate_profile_name
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            validate_profile_name("a" * 65)
+
+    def test_rejects_empty(self) -> None:
+        from srunx.ssh.core.config import validate_profile_name
+
+        with pytest.raises(ValueError, match="Invalid profile name"):
+            validate_profile_name("")
+
+
+class TestRegistryThreadSafety:
+    """F6: Concurrent resolves of the same key build only one handle."""
+
+    def test_concurrent_resolve_converges_on_one_handle(self) -> None:
+        """Two threads hitting the same ``ssh:<profile>`` key must
+        converge on a single TransportHandle even though the build
+        path runs outside the cache lock."""
+        import threading
+        import time
+
+        from srunx.transport.registry import TransportRegistry
+
+        built_pools: list[MagicMock] = []
+        pool_lock = threading.Lock()
+
+        def slow_build(profile_name, *args, **kwargs):
+            # Simulate paramiko connect latency so both threads race
+            # through the build path.
+            time.sleep(0.05)
+            handle = TransportHandle(
+                scheduler_key=f"ssh:{profile_name}",
+                profile_name=profile_name,
+                transport_type="ssh",
+                job_ops=MagicMock(),
+                queue_client=MagicMock(),
+                executor_factory=MagicMock(),
+                submission_context=None,
+            )
+            pool = MagicMock()
+            with pool_lock:
+                built_pools.append(pool)
+            return (handle, pool)
+
+        reg = TransportRegistry(profile_loader=lambda name: MagicMock(mounts=[]))
+        results: list[TransportHandle | None] = [None, None]
+
+        def worker(idx: int) -> None:
+            results[idx] = reg.resolve("ssh:foo")
+
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            side_effect=slow_build,
+        ):
+            t1 = threading.Thread(target=worker, args=(0,))
+            t2 = threading.Thread(target=worker, args=(1,))
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+
+        # Both threads must observe the same cached handle.
+        assert results[0] is not None
+        assert results[1] is results[0]
+
+        # If both threads raced past the cache miss, the losing
+        # thread's pool must have been closed (orphan cleanup) so only
+        # the cached one stays live.
+        if len(built_pools) > 1:
+            closed_pools = [p for p in built_pools if p.close.called]
+            assert len(closed_pools) == len(built_pools) - 1, (
+                "concurrent-resolve cleanup must close all but one pool"
+            )
+
+        reg.close()
+
+
+class TestPoolOrphanProtection:
+    """F8: A failure after ``SlurmSSHExecutorPool(...)`` must close the pool."""
+
+    def test_pool_closed_on_render_context_failure(self) -> None:
+        from srunx.transport.registry import _build_ssh_handle
+
+        # Use a simple object for the mount so ``mounts[0].name`` picks
+        # up a plain string rather than a mock's auto-name.
+        class _FakeMount:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        fake_profile = MagicMock()
+        fake_profile.mounts = [_FakeMount("m1")]
+
+        fake_cm = MagicMock()
+        fake_cm.get_profile.return_value = fake_profile
+
+        fake_pool = MagicMock()
+
+        # SubmissionRenderContext is frozen so we can't easily force it
+        # to throw at construction; instead patch it into a function
+        # that raises. The registry's orphan guard must catch the
+        # exception, close the pool, and re-raise.
+        with (
+            patch("srunx.ssh.core.config.ConfigManager", return_value=fake_cm),
+            patch(
+                "srunx.web.ssh_adapter.SlurmSSHAdapter",
+                return_value=MagicMock(connection_spec=MagicMock()),
+            ),
+            patch(
+                "srunx.web.ssh_executor.SlurmSSHExecutorPool",
+                return_value=fake_pool,
+            ),
+            patch(
+                "srunx.rendering.SubmissionRenderContext",
+                side_effect=RuntimeError("render setup blew up"),
+            ),
+            pytest.raises(RuntimeError, match="render setup blew up"),
+        ):
+            _build_ssh_handle("foo")
+
+        fake_pool.close.assert_called_once()
+
+
+class TestBannerLabelIsHumanReadable:
+    """F10: ``ResolvedTransport.label`` prefers a human-friendly rendering."""
+
+    def test_local_label_is_friendly(self, monkeypatch) -> None:
+        from srunx.transport import resolve_transport
+
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        with resolve_transport(local=True, banner=False) as rt:
+            assert rt.label == "local SLURM"
+            # scheduler_key stays machine-parseable.
+            assert rt.scheduler_key == "local"
+
+    def test_ssh_label_is_friendly(self, monkeypatch) -> None:
+        from srunx.transport import resolve_transport
+
+        monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=MagicMock(),
+            queue_client=MagicMock(),
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ):
+            with resolve_transport(profile="dgx", banner=False) as rt:
+                assert rt.label == "SSH: dgx"
+                assert rt.scheduler_key == "ssh:dgx"
+
+
+# ``tmp_srunx_db`` is provided by tests/conftest.py — no local override needed.

--- a/tests/transport/test_review_fixes.py
+++ b/tests/transport/test_review_fixes.py
@@ -800,7 +800,7 @@ class TestPoolOrphanProtection:
             ),
             pytest.raises(RuntimeError, match="render setup blew up"),
         ):
-            _build_ssh_handle("foo")
+            _build_ssh_handle("foo", submission_source="cli")
 
         fake_pool.close.assert_called_once()
 

--- a/tests/web/test_router_history.py
+++ b/tests/web/test_router_history.py
@@ -81,6 +81,7 @@ def _seed(db_path: Path) -> None:
             "COMPLETED",
             completed_at="2026-01-01T01:00:00Z",
             duration_secs=3600,
+            scheduler_key="local",
         )
         repo.record_submission(
             job_id=101,

--- a/tests/web/test_router_templates.py
+++ b/tests/web/test_router_templates.py
@@ -39,6 +39,7 @@ def mock_adapter() -> MagicMock:
         "job_id": 10001,
         "status": "PENDING",
     }
+    adapter.scheduler_key = "local"
     return adapter
 
 

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -593,7 +593,7 @@ class TestWorkflowsRouter:
             # FK: each membership's job_id points at a real jobs row.
             for m in memberships:
                 assert m.job_id is not None
-                job = JobRepository(conn).get(m.job_id)
+                job = JobRepository(conn).get(m.job_id, scheduler_key="local")
                 assert job is not None
                 assert job.status == "PENDING"
                 assert job.submission_source == "workflow"
@@ -603,7 +603,9 @@ class TestWorkflowsRouter:
             # them ActiveWatchPoller would skip the first observation.
             for m in memberships:
                 assert m.job_id is not None
-                latest = JobStateTransitionRepository(conn).latest_for_job(m.job_id)
+                latest = JobStateTransitionRepository(conn).latest_for_job(
+                    m.job_id, scheduler_key="local"
+                )
                 assert latest is not None
                 assert latest.to_status == "PENDING"
                 assert latest.source == "webhook"

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -59,6 +59,10 @@ def mock_adapter() -> MagicMock:
         "command": [],
         "resources": {},
     }
+    # Fix #3: the routers now read ``adapter.scheduler_key`` to build the
+    # V5 transport triple. Default to local so existing tests (that
+    # never set this explicitly) continue to behave like pre-V5 mocks.
+    adapter.scheduler_key = "local"
     return adapter
 
 

--- a/tests/web/test_ssh_adapter_run.py
+++ b/tests/web/test_ssh_adapter_run.py
@@ -37,6 +37,10 @@ def _bare_adapter(callbacks: list[Callback] | None = None) -> SlurmSSHAdapter:
     adapter._proxy_jump = None
     adapter._env_vars = {}
     adapter._mounts = ()
+    # Review fix #7: submission_source is mutable per-handle state the
+    # transport registry sets; tests that bypass __init__ must provide
+    # a default so submit()/run() branches that rely on it don't AttributeError.
+    adapter.submission_source = "web"
 
     transport = MagicMock()
     transport.is_active.return_value = True

--- a/tests/web/test_ssh_executor_pool.py
+++ b/tests/web/test_ssh_executor_pool.py
@@ -58,6 +58,7 @@ def _bare_adapter(*, connected: bool = True) -> SlurmSSHAdapter:
     adapter._proxy_jump = None
     adapter._env_vars = {}
     adapter._mounts = ()
+    adapter.submission_source = "web"
 
     # Emulate a live paramiko session so ``is_connected`` returns True.
     if connected:

--- a/tests/web/test_sweep_runs_api.py
+++ b/tests/web/test_sweep_runs_api.py
@@ -36,6 +36,7 @@ def mock_adapter() -> MagicMock:
         "command": [],
         "resources": {},
     }
+    adapter.scheduler_key = "local"
     return adapter
 
 


### PR DESCRIPTION
## Summary

Unifies top-level CLI (`srunx submit` / `cancel` / `status` / `list` / `logs` / `flow run` / `monitor jobs`) so it routes through the same transport abstraction (`SlurmSSHAdapter` via `TransportRegistry`) that the Web UI and MCP sweep already use. Ships in a single branch but structured as 8 SDD phases plus review-driven fixes and UX polish.

## Highlights

- New `--profile <name>` / `--local` / `--quiet` / `--script` flags on every transport-aware command. Resolution order: `--profile` → `--local` → `$SRUNX_SSH_PROFILE` → active SSH profile (`srunx ssh profile set`, Phase 2) → local fallback.
- `JobOperationsProtocol` (submit / cancel / status / queue / tail_log_incremental) added alongside existing `SlurmClientProtocol` + `WorkflowJobExecutorProtocol`. Both `Slurm` and `SlurmSSHAdapter` implement all three (LSP).
- Pydantic `LogChunk` return type for incremental log tail, matching the WebUI wire shape.
- Transport-agnostic exception hierarchy (`TransportError` / `TransportConnectionError` / `TransportAuthError` / `TransportTimeoutError` / `JobNotFound` / `SubmissionError` / `RemoteCommandError`).
- Migration V5: `jobs` gains `transport_type` / `profile_name` / `scheduler_key`, `UNIQUE(job_id)` replaced by composite `UNIQUE(scheduler_key, job_id)`, `workflow_run_jobs.job_id` / `job_state_transitions.job_id` FK retargeted to `jobs.id` (Option A). Legacy pre-V5 open job-watches force-closed with `close_reason='v5_migration'`.
- `_parse_target_ref` hardened (3+ segment grammar, profile_name charset, job_id bounds) and `target_ref` / `source_ref` backfilled to the new form.
- Active-watch poller groups by `scheduler_key` via `TransportRegistry.resolve` — unknown profiles log a warning and skip (AC-8.5).
- `srunx ssh submit` / `srunx ssh logs` emit a deprecation warning pointing to the unified top-level commands; `ssh profile *` / `ssh sync` / `ssh test` untouched.
- UX polish: richer banner (`● ssh:pyxis · via --profile`, cyan/yellow dot), `srunx list` shows `Elapsed` + `Limit` (fix pre-existing N/A bug), SSH adapter's `_ensure_connected` distinguishes first-connect from reconnect.

## Review loop

Spec and plan went through two rounds of Codex MCP + subagent reviews (requirements / design / bugs / quality / conventions / spec-compliance) before implementation. Post-implementation found 20+ additional issues — all surfaced as MUST/SHOULD/NIT in the final commits:

- poller `scheduler_key` plumbing (SSH workflow transitions were silently dropped)
- `SlurmSSHAdapter.run()` completion was updating the local row on SSH jobs
- web routers still wrote local-only triple for SSH submissions
- V5 migration force-close scope narrowed to `kind='job'`
- `NotificationWatchCallback` / `resolve_transport` callback + scheduler_key plumbing for SSH workflow runs
- `SlurmSSHAdapter.status()` no longer lazy-refreshes via local sacct (Protocol contract)
- `submission_source` plumbing (CLI tags as `'cli'`, Web as `'web'`)
- TransportRegistry cache invalidation on profile deletion + thread safety
- Flow-run mount auto-selection + ShellJob script_path guard parity with WebUI/MCP

## Verification

- `uv run ruff check .` ✓ clean
- `uv run mypy .` ✓ clean
- `uv run pytest -q` ✓ 1842 passed, 2 skipped
- Real WebUI smoke against the pyxis cluster via Playwright: dashboard, jobs list (51 rows), logs viewer, workflow sweep → actual SLURM job submitted, completed in 3s, `/api/jobs/<id>` reports `scheduler_key='ssh:pyxis'`, V5 migration applied cleanly to the pre-existing `~/.config/srunx/srunx.db`.
- Real CLI tested against pyxis: `srunx logs 19733` (no flag, picks up current profile), `srunx list --profile pyxis`, `srunx status 19733 --profile pyxis` all work end-to-end.

## SDD

Full spec / plan / task breakdown lives under `specs/cli-transport-unification/` for future reference.

## Test plan

- [ ] `uv run pytest` passes locally
- [ ] `uv run ruff check .` and `uv run mypy .` pass
- [ ] With an existing V4 DB, first CLI invocation applies V5 cleanly (`PRAGMA table_info(jobs)` shows `scheduler_key`; `watches` 3-segment `target_ref`)
- [ ] `srunx submit echo hi` (no flags) behaves identically to pre-PR (AC-10.2: no banner, same stdout/stderr)
- [ ] `srunx submit --profile <your-ssh-profile> echo hi` submits against the remote cluster and records `transport_type='ssh'` in DB
- [ ] `srunx ssh submit foo.sh --profile <your-profile>` still works and emits a yellow deprecation warning on stderr
- [ ] Web UI startup + dashboard + job logs + workflow/sweep run — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)