### PR TITLE
feat(cli): auto-sync mounts and execute mount-resident scripts in place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,12 +21,14 @@ counterpart.
 - `uv run srunx sbatch --wrap "cmd ..."` - Wrap a command into a SLURM job (mutually exclusive with the positional script)
 - `uv run srunx sbatch --profile <name> ...` - Submit over SSH to a configured profile
 - `uv run srunx squeue` - List user's jobs in the queue
+- `uv run srunx squeue -j <job_id>` - Filter to a specific job (replaces the old `srunx status` for active jobs)
 - `uv run srunx squeue --show-gpus` - Include GPU allocation column
 - `uv run srunx squeue --format json` - Emit JSON instead of a table
 - `uv run srunx scancel <job_id>` - Cancel a job
-- `uv run srunx sinfo` - Display current GPU/node resource availability
+- `uv run srunx sinfo` - Display current GPU/node resource availability (local-only in this release; see #139)
 - `uv run srunx sinfo --partition gpu --format json` - Partition resources as JSON
 - `uv run srunx sacct` - DB-backed job execution history (uses srunx.db, not real sacct)
+- `uv run srunx sacct -j <job_id>` - Filter history to a specific job (replaces `srunx status` for finished jobs)
 - `uv run srunx sreport` - Aggregated execution report from srunx.db
 - `uv run srunx tail <job_id> --follow` - Stream job logs (use `--profile` for SSH)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,46 @@ counterpart.
 layer on top. `status` was intentionally dropped — use `squeue -j <id>` or
 `sacct -j <id>` depending on whether the job is active or historical.
 
+##### Auto-sync + in-place execution
+
+When the positional script lives under one of the SSH profile's mounts
+(`mount.local`), srunx:
+
+1. **Auto-rsyncs** that mount to the remote (`mount.remote`) under a
+   per-mount file lock (default ON; opt out with `--no-sync` or
+   `[sync] auto = false`).
+2. Translates the script path to its remote equivalent and invokes
+   `sbatch` **directly on the remote file** — no tmp copy, no
+   ``-o $SLURM_LOG_DIR/%x_%j.log`` auto-injection, your script's own
+   `#SBATCH` directives win.
+3. ``cd``s into the script's mount-translated parent directory before
+   sbatch, so relative paths inside the script (e.g.
+   ``#SBATCH --output=./logs/%j.out``) resolve where you'd expect.
+
+Generated artifacts (``--wrap``, ``--template``, workflow ShellJobs
+with Jinja substitution) always go through the historical
+``$SRUNX_TEMP_DIR`` upload path because the rendered bytes have no
+canonical home in the mount.
+
+Sync defaults are configured under `[sync]` in
+`~/.config/srunx/config.json`:
+
+```json
+{
+  "sync": {
+    "auto": true,
+    "lock_timeout_seconds": 120,
+    "warn_dirty": true,
+    "require_clean": false
+  }
+}
+```
+
+Per-invocation overrides:
+
+- `srunx sbatch --sync` / `--no-sync`
+- `SRUNX_SYNC_AUTO=0` / `SRUNX_SYNC_REQUIRE_CLEAN=1` etc.
+
 ##### Transport Selection (unified CLI)
 All job-management commands above accept `--profile <name>` / `--local` /
 `--quiet`. Resolution order:

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ srunx watch cluster --schedule 1h --notify $SLACK_WEBHOOK
 Keep your local editor workflow while running on the cluster:
 
 ```bash
-# Submit to remote cluster
-srunx ssh submit train.py --host dgx-server
+# Submit to remote cluster (auto-syncs the script's mount first, then runs in-place)
+srunx sbatch train.sh --profile dgx-server
 
 # Manage connection profiles
 srunx ssh profile add myserver --ssh-host dgx1

--- a/docs/how-to/user_guide.md
+++ b/docs/how-to/user_guide.md
@@ -228,7 +228,7 @@ srunx flow run pipeline.yaml
 Validate workflow syntax:
 
 ``` bash
-srunx flow validate pipeline.yaml
+srunx flow run --validate pipeline.yaml
 ```
 
 Run with custom parameters:

--- a/docs/how-to/workflows.md
+++ b/docs/how-to/workflows.md
@@ -282,7 +282,7 @@ srunx flow run pipeline.yaml
 Validate workflow before execution:
 
 ``` bash
-srunx flow validate pipeline.yaml
+srunx flow run --validate pipeline.yaml
 ```
 
 Dry run (show what would be executed):

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -84,7 +84,7 @@ srunx flow run workflow.yaml
 Validate a workflow:
 
 ``` bash
-srunx flow validate workflow.yaml
+srunx flow run --validate workflow.yaml
 ```
 
 ## Environment Setup

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -54,6 +54,7 @@ def _submit_via_transport(
     verbose: bool,
     callbacks: list[Callback],
     config: Any,
+    extra_sbatch_args: list[str] | None = None,
 ) -> Any:
     """Dispatch a submit to the right adapter method + optional mount sync.
 
@@ -64,17 +65,26 @@ def _submit_via_transport(
 
     * IN_PLACE: rsync the owning mount (unless ``--no-sync``),
       translate to the remote path, and invoke
-      ``adapter.submit_remote_sbatch`` — the script stays where the
-      user edits it, preserving their own ``#SBATCH`` directives.
-    * TEMP_UPLOAD: fall through to the existing ``rt.job_ops.submit``
-      path which uploads a rendered script into
-      ``$SRUNX_TEMP_DIR`` (the historical behaviour).
+      ``rt.job_ops.submit_remote_sbatch`` — the script stays where
+      the user edits it, preserving their own ``#SBATCH`` directives.
+      The per-mount sync lock is held across both rsync and sbatch
+      so a concurrent CLI invocation can't rsync stale bytes between
+      our sync and our submission (Codex blocker #3).
+    * TEMP_UPLOAD: fall through to ``rt.job_ops.submit`` which
+      uploads a rendered script into ``$SRUNX_TEMP_DIR`` (legacy).
 
     ``is_rendered_artifact`` is True when the caller forced a template
     render (``--template <name>``): even if the positional script
     happens to sit under a mount, the submitted bytes came from the
     template engine, not the on-disk source, so running "in place"
     would execute the wrong thing.
+
+    ``extra_sbatch_args`` are CLI-side resource flags (``-N`` /
+    ``--gres=gpu:N`` / etc.) that need to reach the cluster's
+    ``sbatch`` command line in IN_PLACE mode. SLURM treats them as
+    overrides of the script's ``#SBATCH`` directives, matching real
+    sbatch's precedence. Closes Codex blocker #1: previously these
+    flags silently no-op'd in ShellJob (positional-script) mode.
     """
     from srunx.cli.submission_plan import (
         SubmissionMode,
@@ -83,7 +93,7 @@ def _submit_via_transport(
     from srunx.exceptions import TransportError
     from srunx.models import ShellJob as _ShellJob
     from srunx.sync.lock import SyncLockTimeoutError
-    from srunx.sync.service import SyncAbortedError, ensure_mount_synced
+    from srunx.sync.service import SyncAbortedError, mount_sync_session
 
     if rt.transport_type == "local":
         client = Slurm(callbacks=callbacks)
@@ -91,13 +101,9 @@ def _submit_via_transport(
 
     # --- SSH transport ---
     sub_ctx = rt.submission_context
-    mounts = tuple(sub_ctx.mounts) if sub_ctx is not None else ()
     effective_sync = config.sync.auto if sync_flag is None else sync_flag
     is_rendered_artifact = template is not None
 
-    # Build a lightweight shim profile object that exposes just ``.mounts``
-    # — the submission planner is duck-typed on mount shape so we avoid
-    # reaching for a second ConfigManager lookup here.
     from srunx.ssh.core.config import ConfigManager
 
     profile = ConfigManager().get_profile(profile_name) if profile_name else None
@@ -115,55 +121,97 @@ def _submit_via_transport(
     if plan.mode == SubmissionMode.TEMP_UPLOAD:
         return rt.job_ops.submit(job, submission_context=sub_ctx)
 
-    # IN_PLACE branch: sync if required, then submit the remote path
-    # through the dedicated adapter method.
+    # IN_PLACE branch: hold the per-(profile,mount) lock across the
+    # entire sync + sbatch handoff so a concurrent invocation can't
+    # rsync different bytes in between.
     assert plan.mount is not None
     assert plan.remote_script_path is not None
     assert profile_name is not None and profile is not None
 
-    if plan.sync_required:
-        try:
-            outcome = ensure_mount_synced(
-                profile_name=profile_name,
-                profile=profile,
-                mount=plan.mount,
-                config=config.sync,
-            )
-            if outcome.performed:
-                Console().print(f"⇅  Synced mount [cyan]{plan.mount.name}[/cyan]")
-        except SyncAbortedError as exc:
-            raise typer.BadParameter(str(exc)) from exc
-        except SyncLockTimeoutError as exc:
-            raise typer.BadParameter(str(exc)) from exc
-        except RuntimeError as exc:
-            # rsync subprocess failure — abort rather than silently
-            # submitting a stale workspace.
-            raise typer.BadParameter(f"rsync failed: {exc}") from exc
-
-    # Reach into the SSH adapter for the dedicated remote-sbatch entry
-    # point. Fall back to the queue_client so both the direct adapter
-    # and the pooled Web executor satisfy the same interface.
-    adapter = getattr(rt.job_ops, "_adapter", rt.job_ops)
-    if not hasattr(adapter, "submit_remote_sbatch"):
+    if not hasattr(rt.job_ops, "submit_remote_sbatch"):
         raise TransportError(
             "Current transport does not support in-place submission; "
             "re-run with --no-sync to force the legacy tmp-upload path."
         )
 
-    job_name = job.name if isinstance(job, _ShellJob) else job.name
-    result = adapter.submit_remote_sbatch(
-        plan.remote_script_path,
-        submit_cwd=plan.submit_cwd,
-        job_name=job_name,
-    )
+    try:
+        with mount_sync_session(
+            profile_name=profile_name,
+            profile=profile,
+            mount=plan.mount,
+            config=config.sync,
+            sync_required=plan.sync_required,
+        ) as outcome:
+            if outcome.performed:
+                Console().print(f"⇅  Synced mount [cyan]{plan.mount.name}[/cyan]")
+            submitted = rt.job_ops.submit_remote_sbatch(
+                plan.remote_script_path,
+                submit_cwd=plan.submit_cwd,
+                job_name=job.name,
+                extra_sbatch_args=extra_sbatch_args or None,
+                callbacks_job=job,
+            )
+    except SyncAbortedError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except SyncLockTimeoutError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except RuntimeError as exc:
+        # rsync subprocess failure — abort rather than silently
+        # submitting a stale workspace.
+        raise typer.BadParameter(f"rsync failed: {exc}") from exc
 
-    # Keep downstream code (wait / notification watch) happy by
-    # mutating the original ShellJob so it carries the new job_id +
-    # remote path back out.
+    # Re-mutate the original ShellJob so the wait/notification watch
+    # path (which reads job_id off the original instance the caller
+    # constructed) sees the post-submit state.
     if isinstance(job, _ShellJob):
-        job.job_id = result["job_id"]
         job.script_path = plan.remote_script_path
-    return job
+    return submitted
+
+
+def _build_extra_sbatch_args(
+    *,
+    nodes: int,
+    gpus_per_node: int,
+    ntasks_per_node: int,
+    cpus_per_task: int,
+    memory: str | None,
+    time: str | None,
+    nodelist: str | None,
+    partition: str | None,
+    work_dir: str | None,
+    log_dir: str | None,
+) -> list[str]:
+    """Forward user-supplied CLI flags to ``sbatch`` for ShellJob mode.
+
+    In ShellJob (positional-script) mode the on-disk script owns its
+    own ``#SBATCH`` directives. CLI resource flags override those
+    directives via the sbatch command line — same precedence as real
+    sbatch. Defaults are NOT forwarded so unstated flags don't shadow
+    the script's own values. Closes Codex blocker #1 on PR #134.
+    """
+    args: list[str] = []
+    if nodes != 1:
+        args.append(f"--nodes={nodes}")
+    if gpus_per_node > 0:
+        args.append(f"--gpus-per-node={gpus_per_node}")
+    if ntasks_per_node != 1:
+        args.append(f"--ntasks-per-node={ntasks_per_node}")
+    if cpus_per_task != 1:
+        args.append(f"--cpus-per-task={cpus_per_task}")
+    if memory:
+        args.append(f"--mem={memory}")
+    if time:
+        args.append(f"--time={time}")
+    if nodelist:
+        args.append(f"--nodelist={nodelist}")
+    if partition:
+        args.append(f"--partition={partition}")
+    if work_dir:
+        args.append(f"--chdir={work_dir}")
+    if log_dir:
+        args.append(f"--output={log_dir}/%x_%j.log")
+        args.append(f"--error={log_dir}/%x_%j.log")
+    return args
 
 
 def _parse_gres_gpu(gres: str | None) -> int | None:
@@ -832,6 +880,25 @@ def sbatch(
     # callbacks + template_path + verbose) which the Protocol does not
     # yet expose; SSH path uses the Protocol method, and the adapter
     # owns its own DB recording + callbacks lifecycle.
+    # CLI resource flags need to reach ``sbatch`` in IN_PLACE
+    # mode — they get baked into the rendered Job.resources for the
+    # tmp-upload path, but ShellJob (positional script) on the
+    # in-place path has no such render step. Forward only
+    # user-supplied (non-default) values so unstated flags don't
+    # shadow the script's own ``#SBATCH`` directives.
+    extra_sbatch_args = _build_extra_sbatch_args(
+        nodes=nodes,
+        gpus_per_node=gpus_per_node,
+        ntasks_per_node=ntasks_per_node,
+        cpus_per_task=cpus_per_task,
+        memory=memory,
+        time=time,
+        nodelist=nodelist,
+        partition=partition,
+        work_dir=work_dir,
+        log_dir=log_dir if log_dir != config.log_dir else None,
+    )
+
     with resolve_transport(
         profile=profile,
         local=local,
@@ -850,6 +917,7 @@ def sbatch(
             verbose=verbose,
             callbacks=callbacks,
             config=config,
+            extra_sbatch_args=extra_sbatch_args,
         )
         client = Slurm(callbacks=callbacks) if rt.transport_type == "local" else None
 
@@ -908,6 +976,17 @@ def sbatch(
 
 @app.command("squeue")
 def squeue(
+    job_filter: Annotated[
+        list[int] | None,
+        typer.Option(
+            "-j",
+            "--jobs",
+            help=(
+                "Filter to one or more specific job IDs. Replaces the old "
+                "``srunx status <id>`` command — equivalent to ``squeue -j ID``."
+            ),
+        ),
+    ] = None,
     show_gpus: Annotated[
         bool,
         typer.Option("--show-gpus", "-g", help="Show GPU allocation for each job"),
@@ -924,6 +1003,7 @@ def squeue(
 
     Examples:
         srunx squeue
+        srunx squeue -j 12345
         srunx squeue --show-gpus
         srunx squeue --format json
         srunx squeue --show-gpus --format json
@@ -939,6 +1019,13 @@ def squeue(
                 jobs = client.queue()
             else:
                 jobs = rt.job_ops.queue()
+
+        # Filter to user-specified job IDs after the queue() call so
+        # the dispatch path stays simple; SLURM's own ``squeue -j`` does
+        # the same in-memory filtering at the client side.
+        if job_filter:
+            wanted = {int(j) for j in job_filter}
+            jobs = [j for j in jobs if j.job_id in wanted]
 
         # JSON format output (emit before the "empty queue" banner so
         # --format json stdout stays pure JSON — AC-7.1 / AC-7.2).
@@ -1073,6 +1160,14 @@ def sinfo(
     ] = "table",
 ) -> None:
     """Display current GPU resource availability.
+
+    .. note::
+
+       Local-only in this release. Unlike ``sbatch`` / ``squeue`` /
+       ``scancel`` / ``tail``, ``sinfo`` does not yet accept
+       ``--profile`` — :class:`ResourceMonitor` always queries the
+       local cluster's ``sinfo`` / ``squeue``. SSH parity is tracked in
+       https://github.com/ksterx/srunx/issues/139.
 
     Examples:
         srunx sinfo
@@ -1475,6 +1570,18 @@ def template_show(
 
 @app.command("sacct")
 def sacct(
+    job_filter: Annotated[
+        list[int] | None,
+        typer.Option(
+            "-j",
+            "--jobs",
+            help=(
+                "Filter to one or more specific job IDs. Replaces the old "
+                "``srunx status <id>`` command for finished jobs — equivalent "
+                "to ``sacct -j ID``."
+            ),
+        ),
+    ] = None,
     limit: Annotated[
         int, typer.Option("--limit", "-n", help="Number of jobs to show")
     ] = 50,
@@ -1484,6 +1591,13 @@ def sacct(
         from srunx.db.cli_helpers import list_recent_jobs
 
         jobs = list_recent_jobs(limit=limit)
+
+        # Client-side filter (matches squeue ``-j`` semantics). Cheap
+        # because list_recent_jobs caps at ``limit`` rows; if perf
+        # becomes an issue, push the filter into the SQL query.
+        if job_filter:
+            wanted = {int(j) for j in job_filter}
+            jobs = [j for j in jobs if int(j["job_id"]) in wanted]
 
         if not jobs:
             console = Console()

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -43,6 +43,129 @@ from srunx.transport import resolve_transport
 logger = get_logger(__name__)
 
 
+def _submit_via_transport(
+    *,
+    rt: Any,
+    job: Any,
+    script_path: Path | None,
+    profile_name: str | None,
+    sync_flag: bool | None,
+    template: str | None,
+    verbose: bool,
+    callbacks: list[Callback],
+    config: Any,
+) -> Any:
+    """Dispatch a submit to the right adapter method + optional mount sync.
+
+    Local transport keeps the rich ``Slurm.submit`` signature
+    (callbacks + template_path + verbose). The SSH transport goes
+    through :func:`srunx.cli.submission_plan.plan_sbatch_submission`
+    to decide between:
+
+    * IN_PLACE: rsync the owning mount (unless ``--no-sync``),
+      translate to the remote path, and invoke
+      ``adapter.submit_remote_sbatch`` — the script stays where the
+      user edits it, preserving their own ``#SBATCH`` directives.
+    * TEMP_UPLOAD: fall through to the existing ``rt.job_ops.submit``
+      path which uploads a rendered script into
+      ``$SRUNX_TEMP_DIR`` (the historical behaviour).
+
+    ``is_rendered_artifact`` is True when the caller forced a template
+    render (``--template <name>``): even if the positional script
+    happens to sit under a mount, the submitted bytes came from the
+    template engine, not the on-disk source, so running "in place"
+    would execute the wrong thing.
+    """
+    from srunx.cli.submission_plan import (
+        SubmissionMode,
+        plan_sbatch_submission,
+    )
+    from srunx.exceptions import TransportError
+    from srunx.models import ShellJob as _ShellJob
+    from srunx.sync.lock import SyncLockTimeoutError
+    from srunx.sync.service import SyncAbortedError, ensure_mount_synced
+
+    if rt.transport_type == "local":
+        client = Slurm(callbacks=callbacks)
+        return client.submit(job, template_path=template, verbose=verbose)
+
+    # --- SSH transport ---
+    sub_ctx = rt.submission_context
+    mounts = tuple(sub_ctx.mounts) if sub_ctx is not None else ()
+    effective_sync = config.sync.auto if sync_flag is None else sync_flag
+    is_rendered_artifact = template is not None
+
+    # Build a lightweight shim profile object that exposes just ``.mounts``
+    # — the submission planner is duck-typed on mount shape so we avoid
+    # reaching for a second ConfigManager lookup here.
+    from srunx.ssh.core.config import ConfigManager
+
+    profile = ConfigManager().get_profile(profile_name) if profile_name else None
+    plan = plan_sbatch_submission(
+        script_path=script_path,
+        profile=profile,
+        cwd=Path.cwd(),
+        sync_enabled=effective_sync,
+        is_rendered_artifact=is_rendered_artifact,
+    )
+
+    for w in plan.warnings:
+        logger.warning(w)
+
+    if plan.mode == SubmissionMode.TEMP_UPLOAD:
+        return rt.job_ops.submit(job, submission_context=sub_ctx)
+
+    # IN_PLACE branch: sync if required, then submit the remote path
+    # through the dedicated adapter method.
+    assert plan.mount is not None
+    assert plan.remote_script_path is not None
+    assert profile_name is not None and profile is not None
+
+    if plan.sync_required:
+        try:
+            outcome = ensure_mount_synced(
+                profile_name=profile_name,
+                profile=profile,
+                mount=plan.mount,
+                config=config.sync,
+            )
+            if outcome.performed:
+                Console().print(f"⇅  Synced mount [cyan]{plan.mount.name}[/cyan]")
+        except SyncAbortedError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        except SyncLockTimeoutError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        except RuntimeError as exc:
+            # rsync subprocess failure — abort rather than silently
+            # submitting a stale workspace.
+            raise typer.BadParameter(f"rsync failed: {exc}") from exc
+
+    # Reach into the SSH adapter for the dedicated remote-sbatch entry
+    # point. Fall back to the queue_client so both the direct adapter
+    # and the pooled Web executor satisfy the same interface.
+    adapter = getattr(rt.job_ops, "_adapter", rt.job_ops)
+    if not hasattr(adapter, "submit_remote_sbatch"):
+        raise TransportError(
+            "Current transport does not support in-place submission; "
+            "re-run with --no-sync to force the legacy tmp-upload path."
+        )
+
+    job_name = job.name if isinstance(job, _ShellJob) else job.name
+    result = adapter.submit_remote_sbatch(
+        plan.remote_script_path,
+        submit_cwd=plan.submit_cwd,
+        job_name=job_name,
+    )
+
+    # Keep downstream code (wait / notification watch) happy by
+    # mutating the original ShellJob so it carries the new job_id +
+    # remote path back out.
+    if isinstance(job, _ShellJob):
+        job.job_id = result["job_id"]
+        job.script_path = plan.remote_script_path
+    return job
+
+
 def _parse_gres_gpu(gres: str | None) -> int | None:
     """Parse a sbatch-style ``--gres=gpu:N`` value into an integer GPU count.
 
@@ -515,6 +638,18 @@ def sbatch(
     template: Annotated[
         str | None, typer.Option("--template", help="Custom SLURM script template")
     ] = None,
+    sync: Annotated[
+        bool | None,
+        typer.Option(
+            "--sync/--no-sync",
+            help=(
+                "Rsync the script's enclosing mount before sbatch. Default "
+                "comes from ``config.sync.auto`` (true unless explicitly "
+                "disabled). ``--no-sync`` submits against the remote's "
+                "current state — useful when you manage sync yourself."
+            ),
+        ),
+    ] = None,
     verbose: Annotated[
         bool, typer.Option("--verbose", "-v", help="Show verbose output")
     ] = False,
@@ -705,18 +840,18 @@ def sbatch(
         submission_source="cli",
     ) as rt:
         client: Slurm | None
-        if rt.transport_type == "local":
-            client = Slurm(callbacks=callbacks)
-            submitted_job = client.submit(job, template_path=template, verbose=verbose)
-        else:
-            # SSH path: callbacks + submission_source were threaded into
-            # ``resolve_transport`` so the adapter + pool fire callbacks
-            # and tag the jobs row correctly. The submission render
-            # context handles ``--work-dir`` / path translation.
-            submitted_job = rt.job_ops.submit(
-                job, submission_context=rt.submission_context
-            )
-            client = None
+        submitted_job = _submit_via_transport(
+            rt=rt,
+            job=job,
+            script_path=script,
+            profile_name=rt.profile_name,
+            sync_flag=sync,
+            template=template,
+            verbose=verbose,
+            callbacks=callbacks,
+            config=config,
+        )
+        client = Slurm(callbacks=callbacks) if rt.transport_type == "local" else None
 
         # Attach a durable notification watch if the user asked for one.
         if effective_endpoint and submitted_job.job_id is not None:

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -134,16 +134,29 @@ def _submit_via_transport(
             "re-run with --no-sync to force the legacy tmp-upload path."
         )
 
+    # We split the try/except across the sync phase and the submit
+    # phase so a sbatch failure can never wear an "rsync failed"
+    # error message. Codex follow-up on PR #134.
     try:
-        with mount_sync_session(
+        sync_ctx = mount_sync_session(
             profile_name=profile_name,
             profile=profile,
             mount=plan.mount,
             config=config.sync,
             sync_required=plan.sync_required,
-        ) as outcome:
-            if outcome.performed:
-                Console().print(f"⇅  Synced mount [cyan]{plan.mount.name}[/cyan]")
+        )
+        sync_ctx_entered = sync_ctx.__enter__()
+    except SyncAbortedError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except SyncLockTimeoutError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except RuntimeError as exc:
+        raise typer.BadParameter(f"rsync failed: {exc}") from exc
+
+    try:
+        if sync_ctx_entered.performed:
+            Console().print(f"⇅  Synced mount [cyan]{plan.mount.name}[/cyan]")
+        try:
             submitted = rt.job_ops.submit_remote_sbatch(
                 plan.remote_script_path,
                 submit_cwd=plan.submit_cwd,
@@ -151,14 +164,13 @@ def _submit_via_transport(
                 extra_sbatch_args=extra_sbatch_args or None,
                 callbacks_job=job,
             )
-    except SyncAbortedError as exc:
-        raise typer.BadParameter(str(exc)) from exc
-    except SyncLockTimeoutError as exc:
-        raise typer.BadParameter(str(exc)) from exc
-    except RuntimeError as exc:
-        # rsync subprocess failure — abort rather than silently
-        # submitting a stale workspace.
-        raise typer.BadParameter(f"rsync failed: {exc}") from exc
+        except RuntimeError as exc:
+            # In-place sbatch failure: surface the underlying message
+            # verbatim. Distinct from the "rsync failed" wrapper above
+            # so users can tell which phase failed.
+            raise typer.BadParameter(f"sbatch failed: {exc}") from exc
+    finally:
+        sync_ctx.__exit__(None, None, None)
 
     # Re-mutate the original ShellJob so the wait/notification watch
     # path (which reads job_id off the original instance the caller
@@ -168,49 +180,69 @@ def _submit_via_transport(
     return submitted
 
 
-def _build_extra_sbatch_args(
-    *,
-    nodes: int,
-    gpus_per_node: int,
-    ntasks_per_node: int,
-    cpus_per_task: int,
-    memory: str | None,
-    time: str | None,
-    nodelist: str | None,
-    partition: str | None,
-    work_dir: str | None,
-    log_dir: str | None,
-) -> list[str]:
-    """Forward user-supplied CLI flags to ``sbatch`` for ShellJob mode.
+_SBATCH_FLAG_BY_PARAM: dict[str, str] = {
+    "nodes": "--nodes",
+    "gpus_per_node": "--gpus-per-node",
+    "ntasks_per_node": "--ntasks-per-node",
+    "cpus_per_task": "--cpus-per-task",
+    "memory": "--mem",
+    "time": "--time",
+    "nodelist": "--nodelist",
+    "partition": "--partition",
+    "work_dir": "--chdir",
+}
 
-    In ShellJob (positional-script) mode the on-disk script owns its
-    own ``#SBATCH`` directives. CLI resource flags override those
-    directives via the sbatch command line — same precedence as real
-    sbatch. Defaults are NOT forwarded so unstated flags don't shadow
-    the script's own values. Closes Codex blocker #1 on PR #134.
+
+def _build_extra_sbatch_args(
+    ctx: typer.Context,
+    *,
+    values: dict[str, object],
+    log_dir_user: str | None,
+) -> list[str]:
+    """Forward CLI-typed flags to ``sbatch`` for ShellJob mode.
+
+    "CLI-typed" means the user wrote the flag on the command line —
+    determined via Click's :meth:`Context.get_parameter_source`. We
+    deliberately do NOT compare against defaults because that
+    confuses three different cases:
+
+    * ``srunx sbatch script.sh`` — no flag typed, planner default 1.
+    * ``srunx sbatch script.sh --nodes 1`` — explicit 1, must
+      override any ``#SBATCH --nodes=8`` in the script.
+    * ``srunx sbatch script.sh`` with config providing ``work_dir``
+      — config injected, user did NOT type ``-D``, so the script's
+      ``#SBATCH --chdir=`` (if any) wins.
+
+    The default-comparison heuristic the previous version used got
+    all three confused — Codex follow-up on PR #134.
+
+    ``log_dir_user`` is passed in separately because the sbatch flag
+    expansion (``--output=`` + ``--error=``) builds two args from one
+    typed value, and the conversion lives at the call site (caller
+    knows the configured default to suppress).
     """
+    from click.core import ParameterSource
+
     args: list[str] = []
-    if nodes != 1:
-        args.append(f"--nodes={nodes}")
-    if gpus_per_node > 0:
-        args.append(f"--gpus-per-node={gpus_per_node}")
-    if ntasks_per_node != 1:
-        args.append(f"--ntasks-per-node={ntasks_per_node}")
-    if cpus_per_task != 1:
-        args.append(f"--cpus-per-task={cpus_per_task}")
-    if memory:
-        args.append(f"--mem={memory}")
-    if time:
-        args.append(f"--time={time}")
-    if nodelist:
-        args.append(f"--nodelist={nodelist}")
-    if partition:
-        args.append(f"--partition={partition}")
-    if work_dir:
-        args.append(f"--chdir={work_dir}")
-    if log_dir:
-        args.append(f"--output={log_dir}/%x_%j.log")
-        args.append(f"--error={log_dir}/%x_%j.log")
+    for param_name, sbatch_flag in _SBATCH_FLAG_BY_PARAM.items():
+        try:
+            source = ctx.get_parameter_source(param_name)
+        except (LookupError, AttributeError):
+            # No such parameter; defensive against signature drift.
+            source = None
+        if source != ParameterSource.COMMANDLINE:
+            continue
+        value = values.get(param_name)
+        if value is None or value == "":
+            continue
+        args.append(f"{sbatch_flag}={value}")
+
+    if log_dir_user:
+        # ``--log-dir`` was explicitly typed; expand into the
+        # ``--output`` + ``--error`` pair sbatch expects.
+        args.append(f"--output={log_dir_user}/%x_%j.log")
+        args.append(f"--error={log_dir_user}/%x_%j.log")
+
     return args
 
 
@@ -538,6 +570,7 @@ def _parse_container_args(container_arg: str | None) -> ContainerResource | None
 
 @app.command("sbatch")
 def sbatch(
+    ctx: typer.Context,
     script: Annotated[
         Path | None,
         typer.Argument(
@@ -883,21 +916,47 @@ def sbatch(
     # CLI resource flags need to reach ``sbatch`` in IN_PLACE
     # mode — they get baked into the rendered Job.resources for the
     # tmp-upload path, but ShellJob (positional script) on the
-    # in-place path has no such render step. Forward only
-    # user-supplied (non-default) values so unstated flags don't
-    # shadow the script's own ``#SBATCH`` directives.
-    extra_sbatch_args = _build_extra_sbatch_args(
-        nodes=nodes,
-        gpus_per_node=gpus_per_node,
-        ntasks_per_node=ntasks_per_node,
-        cpus_per_task=cpus_per_task,
-        memory=memory,
-        time=time,
-        nodelist=nodelist,
-        partition=partition,
-        work_dir=work_dir,
-        log_dir=log_dir if log_dir != config.log_dir else None,
+    # in-place path has no such render step. Forward only flags the
+    # user actually typed on the command line (via Click's
+    # ParameterSource); never forward defaults nor config-injected
+    # values, so the on-disk ``#SBATCH`` directives stay authoritative
+    # for anything the user did not explicitly override.
+    from click.core import ParameterSource
+
+    log_dir_user = (
+        log_dir
+        if ctx.get_parameter_source("log_dir") == ParameterSource.COMMANDLINE
+        else None
     )
+    extra_sbatch_args = _build_extra_sbatch_args(
+        ctx,
+        values={
+            "nodes": nodes,
+            "gpus_per_node": gpus_per_node,
+            "ntasks_per_node": ntasks_per_node,
+            "cpus_per_task": cpus_per_task,
+            "memory": memory,
+            "time": time,
+            "nodelist": nodelist,
+            "partition": partition,
+            "work_dir": work_dir,
+        },
+        log_dir_user=log_dir_user,
+    )
+
+    # ``--gres=gpu:N`` was parsed earlier into ``gpus_per_node``; if
+    # the user typed ``--gres`` (not ``--gpus-per-node``) we still
+    # need to forward the resulting value as ``--gpus-per-node=N``,
+    # because ParameterSource for ``gpus_per_node`` shows DEFAULT in
+    # that path. Avoid duplication by stripping any earlier entry.
+    if (
+        ctx.get_parameter_source("gres") == ParameterSource.COMMANDLINE
+        and gres is not None
+    ):
+        extra_sbatch_args = [
+            a for a in extra_sbatch_args if not a.startswith("--gpus-per-node")
+        ]
+        extra_sbatch_args.append(f"--gpus-per-node={gpus_per_node}")
 
     with resolve_transport(
         profile=profile,
@@ -1590,14 +1649,10 @@ def sacct(
     try:
         from srunx.db.cli_helpers import list_recent_jobs
 
-        jobs = list_recent_jobs(limit=limit)
-
-        # Client-side filter (matches squeue ``-j`` semantics). Cheap
-        # because list_recent_jobs caps at ``limit`` rows; if perf
-        # becomes an issue, push the filter into the SQL query.
-        if job_filter:
-            wanted = {int(j) for j in job_filter}
-            jobs = [j for j in jobs if int(j["job_id"]) in wanted]
+        # ``-j`` is pushed down into the SQL query so it finds jobs
+        # older than ``--limit``. Codex follow-up #2 on PR #134.
+        wanted_ids = [int(j) for j in job_filter] if job_filter else None
+        jobs = list_recent_jobs(limit=limit, job_ids=wanted_ids)
 
         if not jobs:
             console = Console()

--- a/src/srunx/cli/submission_plan.py
+++ b/src/srunx/cli/submission_plan.py
@@ -1,0 +1,229 @@
+"""Compute how an ``srunx sbatch`` invocation should reach the cluster.
+
+Given a script path + SSH profile, we need to answer three questions
+before any sbatch call happens:
+
+1. **Is this script under a configured mount?**  If yes, we can
+   translate its path to the remote filesystem and execute it
+   *in place* (no tmp copy).
+2. **Should we sync the mount first?**  Governed by the effective
+   ``--sync / --no-sync / config.sync.auto`` resolution.
+3. **What remote working directory should sbatch run from?**  Matters
+   because SSH sessions start in ``$HOME``; relative paths inside the
+   script (e.g. ``#SBATCH --output=./logs/%j.out``) only make sense
+   when we ``cd`` somewhere meaningful first.
+
+Encapsulating this as a planner keeps the CLI command handler
+readable and leaves a clean seam for Phase 2 (workflow) and Phase 3
+(web) to reuse the same logic. The planner itself does no IO — it
+inspects paths and returns a dataclass — so it's trivial to unit
+test.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from pathlib import Path
+
+from srunx.ssh.core.config import MountConfig, ServerProfile
+
+
+class SubmissionMode(enum.StrEnum):
+    """How the rendered sbatch script reaches the cluster."""
+
+    IN_PLACE = "in_place"
+    """Execute the script at its already-on-remote path (post-rsync).
+
+    Used when the script source sits under a mount's ``local`` root,
+    no Jinja rendering is required (source bytes == rendered bytes),
+    and the user allowed the file to be synced. The cluster runs
+    exactly the file the user edits — no tmp copy, no surprise
+    rewrites.
+    """
+
+    TEMP_UPLOAD = "temp_upload"
+    """Upload a generated script into ``$SRUNX_TEMP_DIR`` on the remote.
+
+    Used for ``--wrap`` (no source file), ``--template`` (rendered
+    artifact), workflow jobs whose Jinja rendering differs from the
+    source, or any script that isn't under a configured mount.
+    """
+
+
+@dataclass(frozen=True)
+class SubmissionPlan:
+    """Decision record for a single sbatch submission.
+
+    Attributes:
+        mode: Which execution path to take.
+        mount: The mount that owns the script (``None`` when
+            ``mode == TEMP_UPLOAD``).
+        remote_script_path: Absolute remote path to ``sbatch`` against.
+            ``None`` when the script hasn't been rendered-and-uploaded
+            yet — that's ``TEMP_UPLOAD``'s job at submit time.
+        submit_cwd: Remote directory to ``cd`` into before sbatch.
+            ``None`` means "let SSH default" (== remote ``$HOME``).
+        sync_required: Whether the caller must invoke rsync before
+            submitting. True only for IN_PLACE with sync enabled.
+        warnings: Human-readable notes the CLI should surface to the
+            user (e.g. "running without syncing local edits").
+    """
+
+    mode: SubmissionMode
+    mount: MountConfig | None = None
+    remote_script_path: str | None = None
+    submit_cwd: str | None = None
+    sync_required: bool = False
+    warnings: tuple[str, ...] = ()
+
+
+def resolve_mount_for_path(path: Path, profile: ServerProfile) -> MountConfig | None:
+    """Return the profile mount whose ``local`` root contains *path*.
+
+    Uses longest-prefix match so nested mounts (unusual but legal)
+    resolve to the deepest one. Resolves symlinks on *path* first to
+    avoid leaking outside the mount via symlink traversal — the same
+    convention the web router's shell-script guard uses.
+    """
+    if not profile.mounts:
+        return None
+
+    resolved = path.resolve()
+    best: MountConfig | None = None
+    best_len = -1
+    for mount in profile.mounts:
+        mount_root = Path(mount.local).expanduser().resolve()
+        try:
+            resolved.relative_to(mount_root)
+        except ValueError:
+            continue
+        root_len = len(str(mount_root))
+        if root_len > best_len:
+            best = mount
+            best_len = root_len
+    return best
+
+
+def translate_local_to_remote(path: Path, mount: MountConfig) -> str:
+    """Translate a local path under *mount* into its remote equivalent.
+
+    Preconditions:
+        *path* must already be under ``mount.local`` (caller should
+        have verified via :func:`resolve_mount_for_path`).
+
+    The remote side is POSIX-only, so we join with ``/`` explicitly
+    rather than relying on ``Path`` (which would pick up the host's
+    separator on Windows workstations).
+    """
+    local_root = Path(mount.local).expanduser().resolve()
+    rel = path.resolve().relative_to(local_root)
+    remote_root = mount.remote.rstrip("/")
+    rel_posix = str(rel).replace("\\", "/")
+    if rel_posix in ("", "."):
+        return remote_root
+    return f"{remote_root}/{rel_posix}"
+
+
+def plan_sbatch_submission(
+    *,
+    script_path: Path | None,
+    profile: ServerProfile | None,
+    cwd: Path | None,
+    sync_enabled: bool,
+    is_rendered_artifact: bool,
+) -> SubmissionPlan:
+    """Decide how to submit a single sbatch script.
+
+    Args:
+        script_path: The user's positional script path, or ``None``
+            when ``--wrap`` / ``--template`` were used (no source
+            file).
+        profile: The resolved SSH profile, or ``None`` for a local
+            SLURM submission (no mount concept there).
+        cwd: The workstation's current working directory, used to
+            derive ``submit_cwd`` when ``cwd`` also lives under a
+            mount. ``None`` skips the cwd translation.
+        sync_enabled: Effective value of the ``--sync / --no-sync /
+            config.sync.auto`` resolution.
+        is_rendered_artifact: Caller already rendered the script
+            (e.g. ``--template`` expanded a Jinja file); the result
+            is a generated artifact and must not be treated as a
+            source file even if ``script_path`` sits under a mount.
+    """
+    if script_path is None or profile is None or is_rendered_artifact:
+        return SubmissionPlan(
+            mode=SubmissionMode.TEMP_UPLOAD,
+            submit_cwd=_translate_cwd(cwd, profile),
+        )
+
+    mount = resolve_mount_for_path(script_path, profile)
+    if mount is None:
+        return SubmissionPlan(
+            mode=SubmissionMode.TEMP_UPLOAD,
+            submit_cwd=_translate_cwd(cwd, profile),
+        )
+
+    remote_path = translate_local_to_remote(script_path, mount)
+    warnings: list[str] = []
+    if not sync_enabled:
+        warnings.append(
+            f"Running without syncing '{mount.name}'. The remote may "
+            f"be out of date; re-run with --sync or rerun "
+            f"'srunx ssh sync' to refresh."
+        )
+
+    return SubmissionPlan(
+        mode=SubmissionMode.IN_PLACE,
+        mount=mount,
+        remote_script_path=remote_path,
+        submit_cwd=_preferred_submit_cwd(script_path, cwd, mount),
+        sync_required=sync_enabled,
+        warnings=tuple(warnings),
+    )
+
+
+def _preferred_submit_cwd(
+    script_path: Path, cwd: Path | None, mount: MountConfig
+) -> str:
+    """Pick a remote cwd for sbatch when the script is in a mount.
+
+    Order of preference:
+
+    1. If the caller's ``cwd`` sits under the same mount, translate it.
+       This preserves relative paths a user might have typed in
+       interactively (``#SBATCH -o ./logs/%j.out``).
+    2. Otherwise fall back to the script's enclosing directory on the
+       remote. That's still strictly better than the SSH default
+       ``$HOME``.
+    """
+    if cwd is not None:
+        mount_root = Path(mount.local).expanduser().resolve()
+        resolved_cwd = cwd.resolve()
+        try:
+            resolved_cwd.relative_to(mount_root)
+        except ValueError:
+            pass
+        else:
+            return translate_local_to_remote(resolved_cwd, mount)
+
+    # Script's parent directory on the remote.
+    remote_script = translate_local_to_remote(script_path, mount)
+    parent, _, _ = remote_script.rpartition("/")
+    return parent or remote_script
+
+
+def _translate_cwd(cwd: Path | None, profile: ServerProfile | None) -> str | None:
+    """Translate *cwd* to its remote equivalent if it lives under any mount.
+
+    Used for ``TEMP_UPLOAD`` submissions (``--wrap``, mount-outside
+    scripts) so that relative paths the wrapped command expects still
+    resolve. Returns ``None`` when no mount matches — the caller
+    should then leave sbatch to default to remote ``$HOME``.
+    """
+    if cwd is None or profile is None:
+        return None
+    mount = resolve_mount_for_path(cwd, profile)
+    if mount is None:
+        return None
+    return translate_local_to_remote(cwd, mount)

--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Sequence
 from importlib.resources import files
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from srunx.callbacks import Callback
 from srunx.logging import get_logger
@@ -301,6 +301,30 @@ class Slurm:
         except UnicodeDecodeError:
             text = data.decode("utf-8", errors="replace")
         return text, offset + len(data)
+
+    def submit_remote_sbatch(
+        self,
+        remote_path: str,
+        *,
+        submit_cwd: str | None = None,
+        job_name: str | None = None,
+        dependency: str | None = None,
+        extra_sbatch_args: list[str] | None = None,
+        callbacks_job: Any = None,
+    ) -> Any:
+        """Conformance stub for :class:`JobOperationsProtocol`.
+
+        Local SLURM has no concept of "mount-resident path" — the
+        whole point of in-place execution is that the script lives on
+        a synced remote mount. The CLI's ``_submit_via_transport``
+        only routes to this method on the SSH transport (the planner
+        always returns ``TEMP_UPLOAD`` for local), so calling this
+        here is a programmer error worth raising loudly.
+        """
+        raise NotImplementedError(
+            "submit_remote_sbatch is SSH-only; local SLURM has no "
+            "mount concept. Use submit() with a Job/ShellJob instead."
+        )
 
     def cancel(self, job_id: int) -> None:
         """Cancel a SLURM job.

--- a/src/srunx/client_protocol.py
+++ b/src/srunx/client_protocol.py
@@ -77,6 +77,44 @@ class JobOperationsProtocol(Protocol):
         """
         ...
 
+    def submit_remote_sbatch(
+        self,
+        remote_path: str,
+        *,
+        submit_cwd: str | None = None,
+        job_name: str | None = None,
+        dependency: str | None = None,
+        extra_sbatch_args: list[str] | None = None,
+        callbacks_job: RunnableJobType | None = None,
+    ) -> RunnableJobType:
+        """Submit a script that already exists on the remote cluster.
+
+        Distinct from :meth:`submit` because the bytes the cluster
+        executes are *user-managed* (typically a synced mount file) —
+        no template render, no SFTP-upload to ``$SRUNX_TEMP_DIR``,
+        no ``-o $SLURM_LOG_DIR/%x_%j.log`` injection. The user's own
+        ``#SBATCH`` directives win.
+
+        ``submit_cwd`` is the remote directory ``sbatch`` runs from;
+        SSH sessions otherwise default to ``$HOME`` and relative
+        paths inside the script (``#SBATCH --output=./logs/%j.out``)
+        would resolve there instead of the mount.
+
+        ``extra_sbatch_args`` are appended to the sbatch command line
+        verbatim, so callers can forward CLI-side flags like
+        ``-N 4`` / ``--mem=32GB`` without modifying the on-disk
+        script. SLURM treats command-line flags as overrides of
+        ``#SBATCH`` directives, matching real ``sbatch``'s precedence.
+
+        ``callbacks_job`` is the in-memory :class:`Job` /
+        :class:`ShellJob` the caller wants the implementation to fire
+        ``Callback.on_job_submitted`` against. Implementations MUST
+        record the submission in the state DB and fire callbacks
+        before returning, the same as :meth:`submit`. Callers must
+        not double-record.
+        """
+        ...
+
     def cancel(self, job_id: int) -> None:
         """Cancel *job_id*. Raises :class:`JobNotFound` if unknown."""
         ...

--- a/src/srunx/config.py
+++ b/src/srunx/config.py
@@ -99,6 +99,50 @@ class CliTransportConfig(BaseModel):
     )
 
 
+class SyncDefaults(BaseModel):
+    """Workspace sync behaviour for job submission.
+
+    srunx can rsync the user's local mount to the remote cluster before
+    invoking sbatch, so that submitted jobs see the freshest source
+    files. This section controls the defaults. Per-invocation overrides
+    (``srunx sbatch --sync`` / ``--no-sync``) always win.
+    """
+
+    auto: bool = Field(
+        default=True,
+        description=(
+            "Run rsync on the script's enclosing mount before sbatch. "
+            "Disable (false) when you manage sync yourself, or when the "
+            "mount sits on shared storage already."
+        ),
+    )
+    lock_timeout_seconds: int = Field(
+        default=120,
+        ge=1,
+        description=(
+            "Maximum time (seconds) to wait for the per-(profile,mount) "
+            "sync lock before aborting. Protects against two concurrent "
+            "rsyncs fighting over the same tree. Increase for huge trees "
+            "or slow networks."
+        ),
+    )
+    warn_dirty: bool = Field(
+        default=True,
+        description=(
+            "Log a concise warning before sync if the mount has "
+            "uncommitted git changes. Informational only — does not "
+            "block submission."
+        ),
+    )
+    require_clean: bool = Field(
+        default=False,
+        description=(
+            "Refuse to sync when the mount has uncommitted git changes. "
+            "Recommended for CI / shared-workstation scenarios."
+        ),
+    )
+
+
 class SrunxConfig(BaseModel):
     """Main srunx configuration."""
 
@@ -106,6 +150,7 @@ class SrunxConfig(BaseModel):
     environment: EnvironmentDefaults = Field(default_factory=EnvironmentDefaults)
     notifications: NotificationConfig = Field(default_factory=NotificationConfig)
     cli: CliTransportConfig = Field(default_factory=CliTransportConfig)
+    sync: SyncDefaults = Field(default_factory=SyncDefaults)
     log_dir: str = Field(default="logs", description="Default log directory")
     work_dir: str | None = Field(default=None, description="Default working directory")
 
@@ -248,6 +293,22 @@ def load_config_from_env() -> dict[str, Any]:
 
     if work_dir := os.getenv("SRUNX_DEFAULT_WORK_DIR"):
         config["work_dir"] = work_dir
+
+    # Sync defaults from environment
+    sync: dict[str, Any] = {}
+    if (auto := os.getenv("SRUNX_SYNC_AUTO")) is not None:
+        sync["auto"] = auto.lower() in ("1", "true", "yes", "on")
+    if (timeout := os.getenv("SRUNX_SYNC_LOCK_TIMEOUT")) is not None:
+        try:
+            sync["lock_timeout_seconds"] = int(timeout)
+        except ValueError:
+            logger.warning(f"Invalid SRUNX_SYNC_LOCK_TIMEOUT value: {timeout}")
+    if (warn := os.getenv("SRUNX_SYNC_WARN_DIRTY")) is not None:
+        sync["warn_dirty"] = warn.lower() in ("1", "true", "yes", "on")
+    if (clean := os.getenv("SRUNX_SYNC_REQUIRE_CLEAN")) is not None:
+        sync["require_clean"] = clean.lower() in ("1", "true", "yes", "on")
+    if sync:
+        config["sync"] = sync
 
     return config
 

--- a/src/srunx/db/cli_helpers.py
+++ b/src/srunx/db/cli_helpers.py
@@ -209,17 +209,23 @@ def record_completion(
         logger.debug(f"record_completion failed: {exc}")
 
 
-def list_recent_jobs(limit: int = 100) -> list[dict[str, Any]]:
+def list_recent_jobs(
+    limit: int = 100,
+    *,
+    job_ids: list[int] | None = None,
+) -> list[dict[str, Any]]:
     """Return the N most recent jobs as legacy-shaped dicts.
 
-    Thin wrapper around :meth:`JobRepository.list_recent_as_dict` that
-    owns the connection; used by the CLI ``history`` command.
+    Thin wrapper around :meth:`JobRepository.list_recent_as_dict`.
+    When ``job_ids`` is supplied, the SQL filter pushes the IDs down
+    and bypasses the ``LIMIT`` so the CLI's ``srunx sacct -j <id>``
+    finds rows that fell outside the most recent ``limit`` page.
     """
     from srunx.db.connection import initialized_connection
     from srunx.db.repositories.jobs import JobRepository
 
     with initialized_connection() as conn:
-        return JobRepository(conn).list_recent_as_dict(limit=limit)
+        return JobRepository(conn).list_recent_as_dict(limit=limit, job_ids=job_ids)
 
 
 def compute_job_stats(

--- a/src/srunx/db/repositories/jobs.py
+++ b/src/srunx/db/repositories/jobs.py
@@ -415,13 +415,57 @@ class JobRepository(BaseRepository):
     # submitted_at, completed_at, log_file, metadata) are passed
     # through unchanged.
 
-    def list_recent_as_dict(self, limit: int = 100) -> list[dict[str, Any]]:
+    def list_recent_as_dict(
+        self,
+        limit: int = 100,
+        *,
+        job_ids: list[int] | None = None,
+    ) -> list[dict[str, Any]]:
         """Return the ``limit`` most recent jobs in the legacy dict shape.
 
-        Used by the ``/api/history`` router + ``srunx history`` CLI to
+        Used by the ``/api/history`` router + ``srunx sacct`` CLI to
         keep the response/display formats stable across the cutover
         from the removed ``srunx.history`` module (P2-4 #A).
+
+        ``job_ids`` filters to a specific subset of jobs and bypasses
+        the ``LIMIT`` so ``srunx sacct -j <id>`` finds the job even
+        when it falls outside the most recent ``limit`` rows. Codex
+        follow-up #2 on PR #134 — without this push-down the CLI
+        would silently report "no history found" for any job older
+        than the page size.
         """
+        if job_ids:
+            placeholders = ",".join("?" * len(job_ids))
+            rows = self.conn.execute(
+                f"""
+                SELECT
+                    j.job_id,
+                    j.name           AS job_name,
+                    j.command,
+                    j.status,
+                    j.nodes,
+                    j.gpus_per_node,
+                    (COALESCE(j.nodes, 0) * COALESCE(j.gpus_per_node, 0)) AS gpus,
+                    NULL             AS cpus_per_task,
+                    j.memory_per_node,
+                    j.time_limit,
+                    j.partition,
+                    j.conda          AS conda_env,
+                    j.submitted_at,
+                    j.completed_at,
+                    j.duration_secs  AS duration_seconds,
+                    wr.workflow_name AS workflow_name,
+                    j.log_file,
+                    j.metadata
+                FROM jobs j
+                LEFT JOIN workflow_runs wr ON wr.id = j.workflow_run_id
+                WHERE j.job_id IN ({placeholders})
+                ORDER BY j.submitted_at DESC
+                """,
+                tuple(job_ids),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
         rows = self.conn.execute(
             """
             SELECT

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -667,6 +667,71 @@ class SSHSlurmClient:
             self.logger.error(f"Job submission failed: {e}")
             return None
 
+    def submit_remote_sbatch_file(
+        self,
+        remote_path: str,
+        *,
+        submit_cwd: str | None = None,
+        job_name: str | None = None,
+        dependency: str | None = None,
+    ) -> SlurmJob | None:
+        """Submit a script that already exists on the remote cluster.
+
+        See :meth:`srunx.ssh.core.slurm.SlurmCommands.submit_remote_sbatch_file`
+        for the full rationale — this facade just forwards the call
+        after validating the remote path, preserving the user's own
+        ``#SBATCH --output=`` / ``--job-name=`` directives and
+        honouring ``submit_cwd`` so relative paths inside the script
+        resolve against the mount root rather than SSH's default
+        ``$HOME``.
+        """
+        try:
+            valid, validation_msg = self.validate_remote_script(remote_path)
+            if not valid:
+                self.logger.error(f"Remote script validation failed: {validation_msg}")
+                return None
+
+            cmd_parts: list[str] = [self._get_slurm_command("sbatch")]
+            if job_name:
+                safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
+                cmd_parts.append(f"--job-name={shlex.quote(safe_name)}")
+            if dependency:
+                if not re.fullmatch(r"[a-z]+:\d+(,[a-z]+:\d+)*", dependency):
+                    raise ValueError(f"Invalid dependency format: {dependency!r}")
+                cmd_parts.append(f"--dependency={dependency}")
+            cmd_parts.append(shlex.quote(remote_path))
+
+            cmd = " ".join(cmd_parts)
+            if submit_cwd:
+                cmd = f"cd {shlex.quote(submit_cwd)} && {cmd}"
+
+            stdout, stderr, exit_code = self._execute_slurm_command(cmd)
+            if exit_code == 0:
+                match = re.search(r"Submitted batch job (\d+)", stdout)
+                if match:
+                    job_id = match.group(1)
+                    resolved_name = (
+                        re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
+                        if job_name
+                        else f"job_{job_id}"
+                    )
+                    job = SlurmJob(job_id=job_id, name=resolved_name)
+                    job.script_path = remote_path
+                    # The remote file is user-managed (under a mount);
+                    # don't let ``cleanup_job_files`` delete it.
+                    job.is_local_script = False
+                    job._cleanup = False
+                    return job
+
+            self.logger.error(
+                f"Failed to submit remote sbatch. stdout: {stdout}, "
+                f"stderr: {stderr}, exit_code: {exit_code}"
+            )
+            return None
+        except Exception as e:
+            self.logger.error(f"Remote sbatch submission failed: {e}")
+            return None
+
     def cleanup_job_files(self, job: SlurmJob) -> None:
         if job.is_local_script and job.script_path and job._cleanup:
             self.cleanup_file(job.script_path)

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -674,6 +674,7 @@ class SSHSlurmClient:
         submit_cwd: str | None = None,
         job_name: str | None = None,
         dependency: str | None = None,
+        extra_sbatch_args: list[str] | None = None,
     ) -> SlurmJob | None:
         """Submit a script that already exists on the remote cluster.
 
@@ -699,6 +700,8 @@ class SSHSlurmClient:
                 if not re.fullmatch(r"[a-z]+:\d+(,[a-z]+:\d+)*", dependency):
                     raise ValueError(f"Invalid dependency format: {dependency!r}")
                 cmd_parts.append(f"--dependency={dependency}")
+            for arg in extra_sbatch_args or ():
+                cmd_parts.append(shlex.quote(arg))
             cmd_parts.append(shlex.quote(remote_path))
 
             cmd = " ".join(cmd_parts)

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -312,6 +312,7 @@ class SlurmRemoteClient:
         submit_cwd: str | None = None,
         job_name: str | None = None,
         dependency: str | None = None,
+        extra_sbatch_args: list[str] | None = None,
     ) -> SlurmJob | None:
         """Submit a script that already exists on the remote cluster.
 
@@ -350,6 +351,13 @@ class SlurmRemoteClient:
                 if not re.fullmatch(r"[a-z]+:\d+(,[a-z]+:\d+)*", dependency):
                     raise ValueError(f"Invalid dependency format: {dependency!r}")
                 cmd_parts.append(f"--dependency={dependency}")
+            # ``extra_sbatch_args`` come from the CLI's resource flags
+            # (-N / -t / --gres=gpu:4 / etc.). SLURM's command-line
+            # flags override matching ``#SBATCH`` directives in the
+            # script — same precedence as real ``sbatch``. Quoted
+            # individually so values containing spaces survive.
+            for arg in extra_sbatch_args or ():
+                cmd_parts.append(shlex.quote(arg))
             cmd_parts.append(shlex.quote(remote_path))
 
             cmd = " ".join(cmd_parts)

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -305,6 +305,80 @@ class SlurmRemoteClient:
             self.logger.error(f"Job submission failed: {e}")
             return None
 
+    def submit_remote_sbatch_file(
+        self,
+        remote_path: str,
+        *,
+        submit_cwd: str | None = None,
+        job_name: str | None = None,
+        dependency: str | None = None,
+    ) -> SlurmJob | None:
+        """Submit a script that already exists on the remote cluster.
+
+        Distinct from :meth:`submit_sbatch_file` so the in-place
+        execution path stays free of that method's two side-effects
+        that would break user expectations here:
+
+        1. ``submit_sbatch_file`` inspects *local* path existence and
+           SFTP-uploads when the file is present locally. For in-place
+           execution we *want* sbatch to target the remote-resident
+           path verbatim, even if a like-named file happens to exist
+           locally.
+        2. ``submit_sbatch_file`` injects ``-o $SLURM_LOG_DIR/%x_%j.log``
+           unconditionally, overriding any ``#SBATCH --output=`` the
+           user wrote in their own script. For a user-authored script
+           on a synced mount, their directives must win.
+
+        The ``submit_cwd`` argument determines where the sbatch
+        invocation runs from. SSH sessions default to the user's
+        remote ``$HOME``; relative paths in the user's ``#SBATCH``
+        directives (e.g. ``--output=./logs/%j.out``) only resolve the
+        way the user expects when we ``cd`` somewhere meaningful
+        first. Pass ``None`` to keep the default.
+        """
+        try:
+            valid, validation_msg = self._files.validate_remote_script(remote_path)
+            if not valid:
+                self.logger.error(f"Remote script validation failed: {validation_msg}")
+                return None
+
+            cmd_parts: list[str] = [self._get_slurm_command("sbatch")]
+            if job_name:
+                safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
+                cmd_parts.append(f"--job-name={shlex.quote(safe_name)}")
+            if dependency:
+                if not re.fullmatch(r"[a-z]+:\d+(,[a-z]+:\d+)*", dependency):
+                    raise ValueError(f"Invalid dependency format: {dependency!r}")
+                cmd_parts.append(f"--dependency={dependency}")
+            cmd_parts.append(shlex.quote(remote_path))
+
+            cmd = " ".join(cmd_parts)
+            if submit_cwd:
+                cmd = f"cd {shlex.quote(submit_cwd)} && {cmd}"
+
+            stdout, stderr, exit_code = self.execute_slurm_command(cmd)
+            if exit_code == 0:
+                match = re.search(r"Submitted batch job (\d+)", stdout)
+                if match:
+                    job_id = match.group(1)
+                    resolved_name = (
+                        re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
+                        if job_name
+                        else f"job_{job_id}"
+                    )
+                    job = SlurmJob(job_id=job_id, name=resolved_name)
+                    job.script_path = remote_path
+                    return job
+
+            self.logger.error(
+                f"Failed to submit remote sbatch. stdout: {stdout}, "
+                f"stderr: {stderr}, exit_code: {exit_code}"
+            )
+            return None
+        except Exception as e:
+            self.logger.error(f"Remote sbatch submission failed: {e}")
+            return None
+
     # ------------------------------------------------------------------
     # Job status / monitoring
     # ------------------------------------------------------------------

--- a/src/srunx/sync/lock.py
+++ b/src/srunx/sync/lock.py
@@ -40,10 +40,16 @@ class SyncLockTimeoutError(RuntimeError):
     """
 
     def __init__(self, lock_path: Path, timeout: float) -> None:
+        # Note: ``--no-sync`` does NOT bypass this lock — we still take
+        # it briefly to make the sbatch handoff race-free against a
+        # concurrent rsync. Tell the user the actual recovery options:
+        # wait for the holder, raise the timeout via config, or remove
+        # the lock file if a previous run crashed without releasing it.
         super().__init__(
             f"Could not acquire sync lock {lock_path} within {timeout:.1f}s. "
             f"Another srunx process is syncing the same mount; wait for it "
-            f"to finish, or override with --no-sync."
+            f"to finish, raise sync.lock_timeout_seconds in config, or "
+            f"delete the lock file if it's stale."
         )
         self.lock_path = lock_path
         self.timeout = timeout

--- a/src/srunx/sync/lock.py
+++ b/src/srunx/sync/lock.py
@@ -1,0 +1,128 @@
+"""Cross-process advisory lock for per-mount sync serialization.
+
+Two concurrent ``srunx sbatch --sync`` invocations targeting the same
+mount must not race: one would see a half-transferred tree the other is
+writing to. A file-based ``fcntl.flock`` provides cheap serialization
+across processes on the same machine, which is the only scope we care
+about (rsync writes from a single workstation).
+
+The lock file lives under ``$XDG_CONFIG_HOME/srunx/locks/`` with a
+sanitised name encoding ``profile`` + ``mount``. It is created on first
+use and left in place afterwards — acquisition is cooperative via
+``flock`` so leaving an empty file around is harmless and avoids
+cleanup races.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import fcntl
+import os
+import re
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+from srunx.config import _user_config_dir
+from srunx.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class SyncLockTimeoutError(RuntimeError):
+    """Raised when the sync lock could not be acquired within the timeout.
+
+    Carries the lock path so callers can surface it to the user; the
+    path itself is the easiest recovery hint ("another process is
+    syncing <mount>; either wait, or inspect/delete the lock file if
+    it's stale").
+    """
+
+    def __init__(self, lock_path: Path, timeout: float) -> None:
+        super().__init__(
+            f"Could not acquire sync lock {lock_path} within {timeout:.1f}s. "
+            f"Another srunx process is syncing the same mount; wait for it "
+            f"to finish, or override with --no-sync."
+        )
+        self.lock_path = lock_path
+        self.timeout = timeout
+
+
+_SANITISE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _sanitise(value: str) -> str:
+    """Return *value* with unsafe filesystem characters replaced.
+
+    Keeps the lock filename readable (``profile-mount.lock``) while
+    defending against path-traversal or shell metacharacters leaking
+    from user-provided names.
+    """
+    cleaned = _SANITISE_RE.sub("_", value).strip("._-")
+    return cleaned or "unnamed"
+
+
+def lock_path_for(profile: str, mount: str) -> Path:
+    """Return the lock file path for a (profile, mount) pair."""
+    return (
+        _user_config_dir() / "locks" / f"{_sanitise(profile)}-{_sanitise(mount)}.lock"
+    )
+
+
+@contextlib.contextmanager
+def acquire_sync_lock(
+    profile: str,
+    mount: str,
+    timeout: float,
+    *,
+    poll_interval: float = 0.25,
+) -> Iterator[Path]:
+    """Block until the per-(profile,mount) lock is held, then yield.
+
+    Implementation: open a lock file and call ``fcntl.flock(LOCK_EX |
+    LOCK_NB)`` in a polling loop until success or ``timeout`` elapses.
+    We prefer polling over blocking ``flock`` because it lets us honour
+    a deadline; the process will spend ``timeout`` mostly idle anyway.
+
+    The returned path is the actual lock file, useful for diagnostics
+    and tests.
+    """
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+
+    path = lock_path_for(profile, mount)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ``open(..., "a+")`` creates on demand and keeps the fd usable for
+    # flock. We close it explicitly on exit to release the lock — even
+    # on POSIX where GC would close it, explicit close keeps the
+    # semantics obvious.
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o644)
+
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as exc:
+                if exc.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    raise
+                if time.monotonic() >= deadline:
+                    os.close(fd)
+                    raise SyncLockTimeoutError(path, timeout) from None
+                time.sleep(poll_interval)
+
+        try:
+            yield path
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                logger.debug("flock(LOCK_UN) failed; fd may already be closed")
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass

--- a/src/srunx/sync/mount_helpers.py
+++ b/src/srunx/sync/mount_helpers.py
@@ -1,0 +1,94 @@
+"""Mount-aware rsync helpers, used by both CLI and Web sync paths.
+
+Originally these lived in :mod:`srunx.web.sync_utils` because the Web
+router was the only caller. Phase 1 of auto-sync (PR #134) made the
+CLI ``srunx sbatch`` path depend on the same helpers, which left
+``srunx.sync.service`` reaching into ``srunx.web``. That dependency
+direction is wrong: ``srunx.sync`` is shared infrastructure, ``srunx.web``
+is one of its consumers. Moved here so the layering reads correctly,
+and the old ``srunx.web.sync_utils`` re-exports for backward
+compatibility.
+
+Two functions live here:
+
+* :func:`build_rsync_client` — translates a :class:`ServerProfile` into
+  an :class:`RsyncClient`, honouring ``ssh_host``-based ``~/.ssh/config``
+  delegation when present.
+* :func:`sync_mount_by_name` — runs ``rsync push`` for the named mount,
+  with a configurable ``delete`` flag (default ``False`` for safety:
+  Phase 1 auto-sync ran with ``delete=True`` and silently ate
+  remote-side outputs/checkpoints inside mounts).
+
+The ``delete`` default change is the user-visible behavioural fix for
+Codex's blocker #4 on PR #134. Callers that explicitly want the old
+mirror-style behaviour pass ``delete=True`` (e.g. the manual
+``srunx ssh sync`` command).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from srunx.ssh.core.config import ServerProfile
+
+from srunx.sync.rsync import RsyncClient
+
+
+def build_rsync_client(profile: ServerProfile) -> RsyncClient:
+    """Create RsyncClient from SSH profile, handling ssh_host vs hostname.
+
+    When *ssh_host* is set, the client delegates all connection
+    parameters (user, key, proxy, port) to ``~/.ssh/config``.
+    Otherwise the explicit profile fields are used directly.
+    """
+    if profile.ssh_host:
+        return RsyncClient(
+            hostname=profile.ssh_host,
+            username="",
+            ssh_config_path=str(Path.home() / ".ssh" / "config"),
+        )
+    return RsyncClient(
+        hostname=profile.hostname,
+        username=profile.username,
+        key_filename=profile.key_filename,
+        port=profile.port,
+        proxy_jump=profile.proxy_jump,
+    )
+
+
+def sync_mount_by_name(
+    profile: ServerProfile,
+    mount_name: str,
+    *,
+    delete: bool = False,
+) -> None:
+    """Sync a named mount's local directory to remote via rsync.
+
+    ``delete`` is **False by default** so callers that don't opt in
+    can't accidentally wipe remote-only outputs. The manual
+    ``srunx ssh sync`` command and any explicit ""mirror this exactly""
+    callers should pass ``delete=True``. Auto-sync paths (PR #134
+    Phase 1) leave the default.
+
+    Raises:
+        ValueError: If *mount_name* does not exist in the profile.
+        RuntimeError: If the rsync process exits with a non-zero code.
+            The error message includes rsync's stderr so the CLI / API
+            layer can surface the underlying cause unchanged.
+    """
+    mount = next((m for m in profile.mounts if m.name == mount_name), None)
+    if mount is None:
+        raise ValueError(f"Mount '{mount_name}' not found in profile")
+    rsync = build_rsync_client(profile)
+    result = rsync.push(
+        mount.local,
+        mount.remote,
+        delete=delete,
+        exclude_patterns=mount.exclude_patterns or None,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"rsync sync failed for mount '{mount_name}': {result.stderr}"
+        )

--- a/src/srunx/sync/service.py
+++ b/src/srunx/sync/service.py
@@ -1,0 +1,141 @@
+"""High-level workspace sync orchestration for CLI submissions.
+
+Ties together the lower-level pieces that each handle one concern:
+
+* :func:`srunx.web.sync_utils.sync_mount_by_name` wraps rsync.
+* :func:`srunx.sync.lock.acquire_sync_lock` serialises concurrent
+  syncs on the same mount.
+* :func:`is_dirty_git_worktree` surfaces uncommitted changes before we
+  push them.
+
+This service layer exists so the CLI command handler stays simple —
+``ensure_mount_synced`` is the only function it needs to call — and so
+Phase 2 (Workflow CLI) / Phase 3 (Web ``/api/jobs`` with
+``script_path`` mode) can reuse the exact same orchestration later.
+
+The service intentionally does not own the rsync client itself; that
+stays in :mod:`srunx.sync.rsync` / :mod:`srunx.web.sync_utils`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from srunx.config import SyncDefaults
+from srunx.logging import get_logger
+from srunx.ssh.core.config import MountConfig, ServerProfile
+from srunx.sync.lock import SyncLockTimeoutError, acquire_sync_lock
+
+logger = get_logger(__name__)
+
+
+class SyncAbortedError(RuntimeError):
+    """Raised when sync is refused — the CLI should abort submission.
+
+    Subclassing :class:`RuntimeError` keeps it distinct from the
+    underlying ``subprocess.CalledProcessError`` / rsync failures, so
+    the CLI layer can pick an appropriate exit code and message.
+    """
+
+
+@dataclass(frozen=True)
+class SyncOutcome:
+    """Result of a single sync attempt surfaced to the CLI."""
+
+    mount_name: str
+    performed: bool
+    """True when rsync actually ran; False when disabled/skipped."""
+
+    warnings: tuple[str, ...] = ()
+
+
+def is_dirty_git_worktree(path: Path) -> tuple[bool, str]:
+    """Return ``(is_dirty, short_summary)`` for the git worktree at *path*.
+
+    Best-effort. Any subprocess failure (``git`` not installed, path
+    not inside a repo, timeout) yields ``(False, "")`` so callers can
+    treat "unknown" as "clean" rather than blocking submission. The
+    ``warn_dirty`` / ``require_clean`` guards only fire on a
+    definitive "dirty" answer.
+
+    ``git status --porcelain`` output is truncated to the first few
+    lines so we can show it in a one-shot warning.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False, ""
+
+    if result.returncode != 0:
+        return False, ""
+
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    if not lines:
+        return False, ""
+
+    summary = ", ".join(ln.strip() for ln in lines[:3])
+    if len(lines) > 3:
+        summary += f", … (+{len(lines) - 3} more)"
+    return True, summary
+
+
+def ensure_mount_synced(
+    *,
+    profile_name: str,
+    profile: ServerProfile,
+    mount: MountConfig,
+    config: SyncDefaults,
+) -> SyncOutcome:
+    """Acquire the lock and rsync *mount* to the remote.
+
+    Called by the CLI on the ``IN_PLACE`` submission path when sync
+    is enabled. Handles the four failure/warning modes we care about:
+
+    * Dirty worktree + ``require_clean=true`` → :class:`SyncAbortedError`
+    * Dirty worktree + ``warn_dirty=true`` → log warning, still sync
+    * Lock contention → :class:`SyncLockTimeoutError` (bubbles up)
+    * rsync non-zero exit → :class:`RuntimeError` (from inner helper)
+
+    We import ``sync_mount_by_name`` lazily to avoid pulling the web
+    sync utilities into non-web CLI invocations on import.
+    """
+    from srunx.web.sync_utils import sync_mount_by_name
+
+    warnings: list[str] = []
+    local_root = Path(mount.local).expanduser()
+    if config.warn_dirty or config.require_clean:
+        dirty, summary = is_dirty_git_worktree(local_root)
+        if dirty:
+            msg = f"Mount '{mount.name}' has uncommitted changes: {summary}"
+            if config.require_clean:
+                raise SyncAbortedError(
+                    f"{msg}. Commit or stash before syncing, or disable "
+                    f"``sync.require_clean``."
+                )
+            if config.warn_dirty:
+                logger.warning(msg)
+                warnings.append(msg)
+
+    logger.info("Syncing mount '%s' before submission", mount.name)
+    try:
+        with acquire_sync_lock(
+            profile_name, mount.name, timeout=config.lock_timeout_seconds
+        ):
+            sync_mount_by_name(profile, mount.name)
+    except SyncLockTimeoutError:
+        raise
+    except RuntimeError:
+        # Raised by sync_mount_by_name with the rsync stderr embedded.
+        # Re-raise as-is; the CLI translates it into a BadParameter
+        # with exit code 2.
+        raise
+
+    return SyncOutcome(mount_name=mount.name, performed=True, warnings=tuple(warnings))

--- a/src/srunx/sync/service.py
+++ b/src/srunx/sync/service.py
@@ -2,31 +2,33 @@
 
 Ties together the lower-level pieces that each handle one concern:
 
-* :func:`srunx.web.sync_utils.sync_mount_by_name` wraps rsync.
+* :func:`srunx.sync.mount_helpers.sync_mount_by_name` wraps rsync.
 * :func:`srunx.sync.lock.acquire_sync_lock` serialises concurrent
   syncs on the same mount.
 * :func:`is_dirty_git_worktree` surfaces uncommitted changes before we
   push them.
 
-This service layer exists so the CLI command handler stays simple —
-``ensure_mount_synced`` is the only function it needs to call — and so
-Phase 2 (Workflow CLI) / Phase 3 (Web ``/api/jobs`` with
-``script_path`` mode) can reuse the exact same orchestration later.
-
-The service intentionally does not own the rsync client itself; that
-stays in :mod:`srunx.sync.rsync` / :mod:`srunx.web.sync_utils`.
+The CLI consumes this module via :func:`mount_sync_session`, which is
+a context manager wrapping the full lock + sync lifetime. Holding the
+lock until ``sbatch`` returns prevents a window where another process
+could rsync the mount between our sync and our submission, which would
+let the cluster execute bytes the user did not approve. This was Codex
+blocker #3 on PR #134.
 """
 
 from __future__ import annotations
 
+import contextlib
 import subprocess
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 
 from srunx.config import SyncDefaults
 from srunx.logging import get_logger
 from srunx.ssh.core.config import MountConfig, ServerProfile
-from srunx.sync.lock import SyncLockTimeoutError, acquire_sync_lock
+from srunx.sync.lock import acquire_sync_lock
+from srunx.sync.mount_helpers import sync_mount_by_name
 
 logger = get_logger(__name__)
 
@@ -56,13 +58,16 @@ def is_dirty_git_worktree(path: Path) -> tuple[bool, str]:
 
     Best-effort. Any subprocess failure (``git`` not installed, path
     not inside a repo, timeout) yields ``(False, "")`` so callers can
-    treat "unknown" as "clean" rather than blocking submission. The
-    ``warn_dirty`` / ``require_clean`` guards only fire on a
-    definitive "dirty" answer.
+    treat "unknown" as "clean" rather than blocking submission.
 
-    ``git status --porcelain`` output is truncated to the first few
-    lines so we can show it in a one-shot warning.
+    Skips the ``git status`` call entirely when there is no ``.git``
+    directory or file (worktree marker) under *path* — keeps the
+    common ""mount is not a git repo"" case free of subprocess
+    overhead. Codex follow-up on #134.
     """
+    if not (path / ".git").exists():
+        return False, ""
+
     try:
         result = subprocess.run(
             ["git", "-C", str(path), "status", "--porcelain"],
@@ -87,6 +92,71 @@ def is_dirty_git_worktree(path: Path) -> tuple[bool, str]:
     return True, summary
 
 
+@contextlib.contextmanager
+def mount_sync_session(
+    *,
+    profile_name: str,
+    profile: ServerProfile,
+    mount: MountConfig,
+    config: SyncDefaults,
+    sync_required: bool,
+) -> Iterator[SyncOutcome]:
+    """Acquire the per-mount lock, optionally rsync, hold lock until exit.
+
+    The lock is held for the entire ``with`` block so callers can
+    submit ``sbatch`` against the just-synced bytes without racing a
+    second sync from another process. Closes Codex blocker #3 on
+    PR #134 (""sync lock released before remote validation and
+    sbatch"").
+
+    When ``sync_required`` is ``False`` (e.g. ``--no-sync``) we still
+    take the lock — that lets concurrent ``--no-sync`` callers safely
+    observe a stable mount root for the brief sbatch handoff — but
+    we skip the rsync invocation itself and return a ``performed=False``
+    outcome.
+
+    Failure modes:
+
+    * Dirty worktree + ``require_clean=true`` → :class:`SyncAbortedError`
+      (rsync does **not** run; lock is released before raising).
+    * Dirty worktree + ``warn_dirty=true`` → log warning, sync proceeds.
+    * Lock contention → :class:`~srunx.sync.lock.SyncLockTimeoutError`
+      bubbles up.
+    * rsync non-zero exit → :class:`RuntimeError` (from inner helper).
+    """
+    warnings: list[str] = []
+    if sync_required:
+        local_root = Path(mount.local).expanduser()
+        if config.warn_dirty or config.require_clean:
+            dirty, summary = is_dirty_git_worktree(local_root)
+            if dirty:
+                msg = f"Mount '{mount.name}' has uncommitted changes: {summary}"
+                if config.require_clean:
+                    raise SyncAbortedError(
+                        f"{msg}. Commit or stash before syncing, or "
+                        f"disable ``sync.require_clean``."
+                    )
+                if config.warn_dirty:
+                    logger.warning(msg)
+                    warnings.append(msg)
+
+    with acquire_sync_lock(
+        profile_name, mount.name, timeout=config.lock_timeout_seconds
+    ):
+        if sync_required:
+            logger.info("Syncing mount '%s' before submission", mount.name)
+            # delete=False (Codex blocker #4): auto-sync must not wipe
+            # remote-only outputs (training checkpoints, run logs).
+            # ``srunx ssh sync`` keeps the historical mirror behaviour.
+            sync_mount_by_name(profile, mount.name, delete=False)
+
+        yield SyncOutcome(
+            mount_name=mount.name,
+            performed=sync_required,
+            warnings=tuple(warnings),
+        )
+
+
 def ensure_mount_synced(
     *,
     profile_name: str,
@@ -94,48 +164,19 @@ def ensure_mount_synced(
     mount: MountConfig,
     config: SyncDefaults,
 ) -> SyncOutcome:
-    """Acquire the lock and rsync *mount* to the remote.
+    """Backwards-compatible entry point that performs a one-shot sync.
 
-    Called by the CLI on the ``IN_PLACE`` submission path when sync
-    is enabled. Handles the four failure/warning modes we care about:
-
-    * Dirty worktree + ``require_clean=true`` → :class:`SyncAbortedError`
-    * Dirty worktree + ``warn_dirty=true`` → log warning, still sync
-    * Lock contention → :class:`SyncLockTimeoutError` (bubbles up)
-    * rsync non-zero exit → :class:`RuntimeError` (from inner helper)
-
-    We import ``sync_mount_by_name`` lazily to avoid pulling the web
-    sync utilities into non-web CLI invocations on import.
+    Prefer :func:`mount_sync_session` for new code that needs to hold
+    the lock across sync + submission. This wrapper exists so the
+    one-call ""just sync this mount"" surface stays available for
+    contexts (workflow precheck, ad-hoc CLI hooks) that don't need the
+    held-lock semantics.
     """
-    from srunx.web.sync_utils import sync_mount_by_name
-
-    warnings: list[str] = []
-    local_root = Path(mount.local).expanduser()
-    if config.warn_dirty or config.require_clean:
-        dirty, summary = is_dirty_git_worktree(local_root)
-        if dirty:
-            msg = f"Mount '{mount.name}' has uncommitted changes: {summary}"
-            if config.require_clean:
-                raise SyncAbortedError(
-                    f"{msg}. Commit or stash before syncing, or disable "
-                    f"``sync.require_clean``."
-                )
-            if config.warn_dirty:
-                logger.warning(msg)
-                warnings.append(msg)
-
-    logger.info("Syncing mount '%s' before submission", mount.name)
-    try:
-        with acquire_sync_lock(
-            profile_name, mount.name, timeout=config.lock_timeout_seconds
-        ):
-            sync_mount_by_name(profile, mount.name)
-    except SyncLockTimeoutError:
-        raise
-    except RuntimeError:
-        # Raised by sync_mount_by_name with the rsync stderr embedded.
-        # Re-raise as-is; the CLI translates it into a BadParameter
-        # with exit code 2.
-        raise
-
-    return SyncOutcome(mount_name=mount.name, performed=True, warnings=tuple(warnings))
+    with mount_sync_session(
+        profile_name=profile_name,
+        profile=profile,
+        mount=mount,
+        config=config,
+        sync_required=True,
+    ) as outcome:
+        return outcome

--- a/src/srunx/web/routers/files.py
+++ b/src/srunx/web/routers/files.py
@@ -322,7 +322,9 @@ async def sync_mount(body: SyncRequest) -> dict[str, str]:
     try:
         from ..sync_utils import sync_mount_by_name
 
-        await anyio.to_thread.run_sync(lambda: sync_mount_by_name(profile, body.mount))
+        await anyio.to_thread.run_sync(
+            lambda: sync_mount_by_name(profile, body.mount, delete=True)
+        )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except RuntimeError as exc:

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -255,7 +255,7 @@ async def submit_job(
         try:
             logger.info("Syncing mount '%s' before job submission", mount_name)
             await anyio.to_thread.run_sync(
-                lambda: sync_mount_by_name(profile, mount_name)
+                lambda: sync_mount_by_name(profile, mount_name, delete=True)
             )
         except ValueError as exc:
             raise HTTPException(

--- a/src/srunx/web/routers/templates.py
+++ b/src/srunx/web/routers/templates.py
@@ -124,7 +124,7 @@ async def apply_template(
             mount_name = req.mount_name
             try:
                 await anyio.to_thread.run_sync(
-                    lambda: sync_mount_by_name(profile, mount_name)
+                    lambda: sync_mount_by_name(profile, mount_name, delete=True)
                 )
             except ValueError as exc:
                 raise HTTPException(

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -799,7 +799,7 @@ async def _sync_mounts(
     for mount_name in mount_names:
         try:
             await anyio.to_thread.run_sync(
-                lambda mn=mount_name: sync_mount_by_name(profile, mn)  # type: ignore[misc]
+                lambda mn=mount_name: sync_mount_by_name(profile, mn, delete=True)  # type: ignore[misc]
             )
         except Exception as exc:
             raise HTTPException(

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -744,7 +744,9 @@ class SlurmSSHAdapter:
         submit_cwd: str | None = None,
         job_name: str | None = None,
         dependency: str | None = None,
-    ) -> dict[str, Any]:
+        extra_sbatch_args: list[str] | None = None,
+        callbacks_job: Any = None,
+    ) -> Any:
         """Submit a script already present on the remote cluster.
 
         Used by the CLI's in-place execution path (mount-resident
@@ -753,7 +755,23 @@ class SlurmSSHAdapter:
         because here the script is user-managed under a synced mount
         and must be executed verbatim without tmp-copy or
         ``-o`` auto-override.
+
+        Records the submission to the state DB and fires the
+        ``on_job_submitted`` callbacks just like :meth:`submit`, so
+        Notification watches and ``srunx sacct`` see the job. Codex
+        blocker #2 on PR #134 — the previous implementation skipped
+        both, leaving in-place submissions invisible to the rest of
+        the system.
+
+        ``callbacks_job`` is the in-memory :class:`ShellJob` /
+        :class:`Job` to record + callback against. When ``None`` we
+        fall back to a synthesised :class:`ShellJob` so the legacy
+        ``dict``-returning call sites keep working, but new callers
+        should pass the real instance so the DB row carries the
+        full job metadata.
         """
+        from srunx.models import JobStatus, ShellJob
+
         with self._io_lock:
             self._ensure_connected()
             result = self._client.submit_remote_sbatch_file(
@@ -761,18 +779,55 @@ class SlurmSSHAdapter:
                 submit_cwd=submit_cwd,
                 job_name=job_name,
                 dependency=dependency,
+                extra_sbatch_args=extra_sbatch_args,
             )
-        if result is None:
+        if result is None or not result.job_id:
             raise RuntimeError("remote sbatch submission failed")
-        return {
-            "name": result.name or job_name or "job",
-            "job_id": int(result.job_id) if result.job_id else None,
-            "status": "PENDING",
-            "script_path": remote_path,
-            "depends_on": [],
-            "command": [],
-            "resources": {},
-        }
+        job_id = int(result.job_id)
+
+        # Bind the result to a Job-shaped object so DB recording +
+        # callbacks have a real object to pass around. When the caller
+        # supplied one we mutate it in place (the CLI uses the returned
+        # job_id + status downstream); otherwise we synthesise a thin
+        # ShellJob.
+        if callbacks_job is None:
+            callbacks_job = ShellJob(
+                name=result.name or job_name or "job",
+                script_path=remote_path,
+            )
+        callbacks_job.job_id = job_id
+        callbacks_job.status = JobStatus.PENDING
+        if isinstance(callbacks_job, ShellJob):
+            callbacks_job.script_path = remote_path
+
+        # Record to DB so `srunx sacct` / poller pick it up. Mirrors
+        # :meth:`submit` step 3.
+        if self._profile_name is not None:
+            self._record_job_submission(
+                callbacks_job,
+                workflow_name=None,
+                workflow_run_id=None,
+                transport_type="ssh",
+                profile_name=self._profile_name,
+                scheduler_key=f"ssh:{self._profile_name}",
+                submission_source=self.submission_source,
+            )
+        else:
+            self._record_job_submission(
+                callbacks_job, workflow_name=None, workflow_run_id=None
+            )
+
+        # Fire on_job_submitted callbacks. Mirrors :meth:`submit` step 4.
+        for callback in self.callbacks:
+            try:
+                callback.on_job_submitted(callbacks_job)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    f"on_job_submitted callback failed for job "
+                    f"{callbacks_job.name}: {exc}"
+                )
+
+        return callbacks_job
 
     def get_job_output(
         self,

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -737,6 +737,43 @@ class SlurmSSHAdapter:
             "resources": {},
         }
 
+    def submit_remote_sbatch(
+        self,
+        remote_path: str,
+        *,
+        submit_cwd: str | None = None,
+        job_name: str | None = None,
+        dependency: str | None = None,
+    ) -> dict[str, Any]:
+        """Submit a script already present on the remote cluster.
+
+        Used by the CLI's in-place execution path (mount-resident
+        ShellJob after rsync). Distinct from :meth:`submit_job` —
+        which ships a fresh ``script_content`` to ``/tmp/srunx/`` —
+        because here the script is user-managed under a synced mount
+        and must be executed verbatim without tmp-copy or
+        ``-o`` auto-override.
+        """
+        with self._io_lock:
+            self._ensure_connected()
+            result = self._client.submit_remote_sbatch_file(
+                remote_path,
+                submit_cwd=submit_cwd,
+                job_name=job_name,
+                dependency=dependency,
+            )
+        if result is None:
+            raise RuntimeError("remote sbatch submission failed")
+        return {
+            "name": result.name or job_name or "job",
+            "job_id": int(result.job_id) if result.job_id else None,
+            "status": "PENDING",
+            "script_path": remote_path,
+            "depends_on": [],
+            "command": [],
+            "resources": {},
+        }
+
     def get_job_output(
         self,
         job_id: int,

--- a/src/srunx/web/sync_utils.py
+++ b/src/srunx/web/sync_utils.py
@@ -1,14 +1,31 @@
-"""Shared rsync sync utilities for web routers."""
+"""Shared rsync sync utilities for web routers.
+
+The mount-rsync helpers (:func:`build_rsync_client`,
+:func:`sync_mount_by_name`) moved to :mod:`srunx.sync.mount_helpers`
+in PR #134's Codex-driven cleanup so the layering reads correctly
+(``srunx.sync`` is shared infra, ``srunx.web`` is one consumer). They
+remain re-exported from here for backward compatibility — every
+existing import site keeps working unchanged.
+
+Web-specific helpers — ``get_current_profile`` (resolves the active
+SSH profile from web config or :class:`ConfigManager`),
+``find_mount`` (404-on-missing lookup), and
+``resolve_mounts_for_workflow`` (longest-prefix mount inference for
+workflow jobs) — stay here.
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from srunx.ssh.core.config import ServerProfile
 
-from srunx.sync.rsync import RsyncClient
+# Re-exports: keep the historical import paths working.
+from srunx.sync.mount_helpers import (
+    build_rsync_client,  # noqa: F401  (re-exported)
+    sync_mount_by_name,  # noqa: F401  (re-exported)
+)
 
 
 def get_current_profile() -> ServerProfile | None:
@@ -45,47 +62,6 @@ def find_mount(profile: ServerProfile, mount_name: str):
         if m.name == mount_name:
             return m
     raise ValueError(f"Mount '{mount_name}' not found")
-
-
-def build_rsync_client(profile: ServerProfile) -> RsyncClient:
-    """Create RsyncClient from SSH profile, handling ssh_host vs hostname.
-
-    When *ssh_host* is set the client delegates all connection parameters
-    (user, key, proxy, port) to ``~/.ssh/config``.
-    """
-    if profile.ssh_host:
-        return RsyncClient(
-            hostname=profile.ssh_host,
-            username="",
-            ssh_config_path=str(Path.home() / ".ssh" / "config"),
-        )
-    return RsyncClient(
-        hostname=profile.hostname,
-        username=profile.username,
-        key_filename=profile.key_filename,
-        port=profile.port,
-        proxy_jump=profile.proxy_jump,
-    )
-
-
-def sync_mount_by_name(profile: ServerProfile, mount_name: str) -> None:
-    """Sync a named mount's local directory to remote via rsync.
-
-    Raises:
-        ValueError: If *mount_name* does not exist in the profile.
-        RuntimeError: If the rsync process exits with a non-zero code.
-    """
-    mount = next((m for m in profile.mounts if m.name == mount_name), None)
-    if mount is None:
-        raise ValueError(f"Mount '{mount_name}' not found in profile")
-    rsync = build_rsync_client(profile)
-    result = rsync.push(
-        mount.local, mount.remote, exclude_patterns=mount.exclude_patterns or None
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"rsync sync failed for mount '{mount_name}': {result.stderr}"
-        )
 
 
 def resolve_mounts_for_workflow(

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -1,9 +1,10 @@
 """Integration tests for ``srunx sbatch`` with mount-aware in-place execution.
 
 These exercise the CLI command end-to-end with the SSH adapter +
-sync service mocked out, so we never spawn paramiko or rsync. The
-goal is to lock in the *routing* logic: which adapter method gets
-called, with what remote path, after which sync invocation.
+the rsync helper mocked out, so we never spawn paramiko or rsync.
+The lock layer is left real (``XDG_CONFIG_HOME`` is sandboxed by the
+autouse fixture) so the lock-held-across-submit invariant from
+Codex blocker #3 is exercised by the same code path it protects.
 """
 
 from __future__ import annotations
@@ -21,7 +22,6 @@ from srunx.ssh.core.config import MountConfig, ServerProfile
 @pytest.fixture(autouse=True)
 def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
-    # Ensure CLI doesn't accidentally pick up the developer's local config.
     monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
 
 
@@ -41,36 +41,38 @@ def _patch_transport(
     profile: ServerProfile,
     profile_name: str = "ml-cluster",
 ):
-    """Wire up an SSH-flavoured ResolvedTransport with mock job_ops + adapter.
+    """Wire up an SSH-flavoured ResolvedTransport with mock job_ops.
 
-    Returns ``(adapter_mock, job_ops_mock)`` so individual tests can
-    assert exactly which adapter method was called.
+    The mock ``job_ops`` exposes both the legacy ``submit`` (tmp-upload
+    path) and the new ``submit_remote_sbatch`` (in-place path) so each
+    test can assert exactly which one fired. ``submit_remote_sbatch``
+    mutates and returns the supplied ``callbacks_job`` to mimic the
+    real adapter's contract.
     """
+    from srunx.models import JobStatus
     from srunx.rendering import SubmissionRenderContext
     from srunx.transport.registry import TransportHandle
 
-    adapter = MagicMock(name="SlurmSSHAdapter")
-    adapter.submit_remote_sbatch.return_value = {
-        "name": "job",
-        "job_id": 42,
-        "status": "PENDING",
-        "script_path": None,
-        "depends_on": [],
-        "command": [],
-        "resources": {},
-    }
     job_ops = MagicMock(name="JobOperations")
-    job_ops._adapter = adapter
     job_ops.submit.side_effect = lambda j, **_: type(j)(
         **{**j.model_dump(), "job_id": 99}
     )
+
+    def _fake_remote_submit(remote_path, *, callbacks_job, **_kwargs):
+        callbacks_job.job_id = 42
+        callbacks_job.status = JobStatus.PENDING
+        if hasattr(callbacks_job, "script_path"):
+            callbacks_job.script_path = remote_path
+        return callbacks_job
+
+    job_ops.submit_remote_sbatch.side_effect = _fake_remote_submit
 
     handle = TransportHandle(
         scheduler_key=f"ssh:{profile_name}",
         profile_name=profile_name,
         transport_type="ssh",
         job_ops=job_ops,
-        queue_client=adapter,
+        queue_client=job_ops,
         executor_factory=None,
         submission_context=SubmissionRenderContext(
             mount_name=None,
@@ -91,14 +93,11 @@ def _patch_transport(
 
     monkeypatch.setattr("srunx.transport.registry._build_ssh_handle", _fake_build)
 
-    # Make ConfigManager.get_profile return our stub regardless of
-    # the on-disk config (the CLI looks the profile up to feed mounts
-    # into the planner).
     from srunx.ssh.core.config import ConfigManager
 
     monkeypatch.setattr(ConfigManager, "get_profile", lambda self, name: profile)
 
-    return adapter, job_ops
+    return job_ops
 
 
 def test_sbatch_in_place_under_mount_calls_remote_submit(
@@ -113,29 +112,30 @@ def test_sbatch_in_place_under_mount_calls_remote_submit(
     profile = _stub_profile(
         tmp_path, mount_local=mount_local, remote="/cluster/share/ml-project"
     )
-    adapter, job_ops = _patch_transport(monkeypatch, profile)
+    job_ops = _patch_transport(monkeypatch, profile)
 
-    sync_called: list[dict] = []
+    rsync_calls: list[tuple] = []
 
-    def _record_sync(**kw):  # type: ignore[no-untyped-def]
-        sync_called.append(kw)
-        return _ok_outcome(kw["mount"])
+    def _record_rsync(prof, name, *, delete=False):  # type: ignore[no-untyped-def]
+        rsync_calls.append((prof, name, delete))
 
-    monkeypatch.setattr("srunx.sync.service.ensure_mount_synced", _record_sync)
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record_rsync)
 
     runner = CliRunner()
     result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
 
     assert result.exit_code == 0, result.stdout + result.stderr
 
-    # sync ran for the right mount.
-    assert len(sync_called) == 1
-    assert sync_called[0]["mount"].name == "ml"
+    # rsync ran for the right mount, and used delete=False (auto-sync
+    # must not wipe remote-only outputs — Codex blocker #4).
+    assert len(rsync_calls) == 1
+    assert rsync_calls[0][1] == "ml"
+    assert rsync_calls[0][2] is False
 
-    # adapter.submit_remote_sbatch was invoked with the translated
-    # remote path and a remote cwd that sits under the mount.
-    adapter.submit_remote_sbatch.assert_called_once()
-    call_kwargs = adapter.submit_remote_sbatch.call_args
+    # Protocol method (no _adapter reach-in) was invoked with the
+    # translated remote path and a remote cwd under the mount.
+    job_ops.submit_remote_sbatch.assert_called_once()
+    call_kwargs = job_ops.submit_remote_sbatch.call_args
     assert call_kwargs.args[0] == "/cluster/share/ml-project/train.sbatch"
     assert call_kwargs.kwargs["submit_cwd"].startswith("/cluster/share/ml-project")
 
@@ -156,7 +156,7 @@ def test_sbatch_outside_mount_falls_back_to_temp_upload(
     profile = _stub_profile(
         tmp_path, mount_local=mount_local, remote="/cluster/share/ml-project"
     )
-    adapter, job_ops = _patch_transport(monkeypatch, profile)
+    job_ops = _patch_transport(monkeypatch, profile)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -164,30 +164,23 @@ def test_sbatch_outside_mount_falls_back_to_temp_upload(
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    # Legacy path: rt.job_ops.submit (not submit_remote_sbatch).
     job_ops.submit.assert_called_once()
-    adapter.submit_remote_sbatch.assert_not_called()
+    job_ops.submit_remote_sbatch.assert_not_called()
 
 
 def test_no_sync_skips_rsync_but_still_runs_in_place(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``--no-sync`` skips rsync but does NOT downgrade to tmp upload.
-
-    The translated remote path is still used so the user's own
-    ``#SBATCH --output=`` directives keep working — they may just be
-    running against an older copy of the script if the workstation
-    has unsynced edits.
-    """
+    """``--no-sync`` skips rsync but does NOT downgrade to tmp upload."""
     mount_local = tmp_path / "ml-project"
     mount_local.mkdir()
     script = mount_local / "train.sbatch"
     script.write_text("#!/bin/bash\necho hi\n")
 
     profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
-    adapter, _ = _patch_transport(monkeypatch, profile)
+    job_ops = _patch_transport(monkeypatch, profile)
 
-    with patch("srunx.sync.service.ensure_mount_synced") as fake_sync:
+    with patch("srunx.sync.service.sync_mount_by_name") as fake_rsync:
         runner = CliRunner()
         result = runner.invoke(
             app,
@@ -201,8 +194,9 @@ def test_no_sync_skips_rsync_but_still_runs_in_place(
         )
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    fake_sync.assert_not_called()
-    adapter.submit_remote_sbatch.assert_called_once()
+    # rsync skipped, but the in-place sbatch still ran.
+    fake_rsync.assert_not_called()
+    job_ops.submit_remote_sbatch.assert_called_once()
 
 
 def test_template_flag_forces_temp_upload(
@@ -212,7 +206,7 @@ def test_template_flag_forces_temp_upload(
     mount_local = tmp_path / "ml-project"
     mount_local.mkdir()
     profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
-    adapter, job_ops = _patch_transport(monkeypatch, profile)
+    job_ops = _patch_transport(monkeypatch, profile)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -229,10 +223,8 @@ def test_template_flag_forces_temp_upload(
     )
 
     assert result.exit_code == 0, result.stdout + result.stderr
-    # --template forces TEMP_UPLOAD even though --wrap had no source
-    # file to consider.
     job_ops.submit.assert_called_once()
-    adapter.submit_remote_sbatch.assert_not_called()
+    job_ops.submit_remote_sbatch.assert_not_called()
 
 
 def test_sync_failure_aborts_submission(
@@ -245,12 +237,12 @@ def test_sync_failure_aborts_submission(
     script.write_text("#!/bin/bash\necho hi\n")
 
     profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
-    adapter, _ = _patch_transport(monkeypatch, profile)
+    job_ops = _patch_transport(monkeypatch, profile)
 
-    def _boom(**_kwargs):  # type: ignore[no-untyped-def]
+    def _boom(profile_arg, mount_name, *, delete=False):  # type: ignore[no-untyped-def]
         raise RuntimeError("rsync exited 23: permission denied")
 
-    monkeypatch.setattr("srunx.sync.service.ensure_mount_synced", _boom)
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _boom)
 
     runner = CliRunner()
     result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
@@ -258,12 +250,69 @@ def test_sync_failure_aborts_submission(
     assert result.exit_code != 0
     combined = (result.stdout or "") + (result.stderr or "")
     assert "rsync" in combined.lower()
-    # Must NOT have submitted anything after rsync failed.
-    adapter.submit_remote_sbatch.assert_not_called()
+    job_ops.submit_remote_sbatch.assert_not_called()
 
 
-def _ok_outcome(mount):  # type: ignore[no-untyped-def]
-    """Build a synthetic SyncOutcome for the mock to return."""
-    from srunx.sync.service import SyncOutcome
+def test_extra_sbatch_args_forwarded_in_place(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI resource flags reach sbatch in IN_PLACE mode (Codex blocker #1)."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
 
-    return SyncOutcome(mount_name=mount.name, performed=True, warnings=())
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "sbatch",
+            str(script),
+            "--profile",
+            "ml-cluster",
+            "-N",
+            "4",
+            "--gres",
+            "gpu:2",
+            "-t",
+            "1:00:00",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    extra = job_ops.submit_remote_sbatch.call_args.kwargs["extra_sbatch_args"]
+    assert "--nodes=4" in extra
+    assert "--gpus-per-node=2" in extra  # --gres parsed into gpus_per_node
+    assert "--time=1:00:00" in extra
+
+
+def test_default_resource_flags_not_forwarded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unstated CLI flags don't shadow the script's own ``#SBATCH`` directives.
+
+    The script may set ``#SBATCH --nodes=8``; we must not stomp on that
+    just because the CLI defaults to ``--nodes=1``.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\n#SBATCH --nodes=8\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    extra = job_ops.submit_remote_sbatch.call_args.kwargs["extra_sbatch_args"]
+    # ``extra_sbatch_args`` is None or empty when no flags were typed.
+    assert not extra

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -1,0 +1,269 @@
+"""Integration tests for ``srunx sbatch`` with mount-aware in-place execution.
+
+These exercise the CLI command end-to-end with the SSH adapter +
+sync service mocked out, so we never spawn paramiko or rsync. The
+goal is to lock in the *routing* logic: which adapter method gets
+called, with what remote path, after which sync invocation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+from srunx.ssh.core.config import MountConfig, ServerProfile
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    # Ensure CLI doesn't accidentally pick up the developer's local config.
+    monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+
+
+def _stub_profile(tmp_path: Path, mount_local: Path, remote: str) -> ServerProfile:
+    key = tmp_path / "id_rsa"
+    key.write_text("dummy")
+    return ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename=str(key),
+        mounts=(MountConfig(name="ml", local=str(mount_local), remote=remote),),
+    )
+
+
+def _patch_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    profile: ServerProfile,
+    profile_name: str = "ml-cluster",
+):
+    """Wire up an SSH-flavoured ResolvedTransport with mock job_ops + adapter.
+
+    Returns ``(adapter_mock, job_ops_mock)`` so individual tests can
+    assert exactly which adapter method was called.
+    """
+    from srunx.rendering import SubmissionRenderContext
+    from srunx.transport.registry import TransportHandle
+
+    adapter = MagicMock(name="SlurmSSHAdapter")
+    adapter.submit_remote_sbatch.return_value = {
+        "name": "job",
+        "job_id": 42,
+        "status": "PENDING",
+        "script_path": None,
+        "depends_on": [],
+        "command": [],
+        "resources": {},
+    }
+    job_ops = MagicMock(name="JobOperations")
+    job_ops._adapter = adapter
+    job_ops.submit.side_effect = lambda j, **_: type(j)(
+        **{**j.model_dump(), "job_id": 99}
+    )
+
+    handle = TransportHandle(
+        scheduler_key=f"ssh:{profile_name}",
+        profile_name=profile_name,
+        transport_type="ssh",
+        job_ops=job_ops,
+        queue_client=adapter,
+        executor_factory=None,
+        submission_context=SubmissionRenderContext(
+            mount_name=None,
+            mounts=tuple(profile.mounts),
+            default_work_dir=None,
+        ),
+    )
+
+    def _fake_build(
+        profile_name_arg,
+        *,
+        callbacks=None,
+        submission_source="web",
+        mount_name=None,
+        pool_size=2,
+    ):
+        return handle, MagicMock(name="pool")
+
+    monkeypatch.setattr("srunx.transport.registry._build_ssh_handle", _fake_build)
+
+    # Make ConfigManager.get_profile return our stub regardless of
+    # the on-disk config (the CLI looks the profile up to feed mounts
+    # into the planner).
+    from srunx.ssh.core.config import ConfigManager
+
+    monkeypatch.setattr(ConfigManager, "get_profile", lambda self, name: profile)
+
+    return adapter, job_ops
+
+
+def test_sbatch_in_place_under_mount_calls_remote_submit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``srunx sbatch <mount-resident-script> --profile X`` runs in place."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\n#SBATCH --job-name=train\necho hi\n")
+
+    profile = _stub_profile(
+        tmp_path, mount_local=mount_local, remote="/cluster/share/ml-project"
+    )
+    adapter, job_ops = _patch_transport(monkeypatch, profile)
+
+    sync_called: list[dict] = []
+
+    def _record_sync(**kw):  # type: ignore[no-untyped-def]
+        sync_called.append(kw)
+        return _ok_outcome(kw["mount"])
+
+    monkeypatch.setattr("srunx.sync.service.ensure_mount_synced", _record_sync)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    # sync ran for the right mount.
+    assert len(sync_called) == 1
+    assert sync_called[0]["mount"].name == "ml"
+
+    # adapter.submit_remote_sbatch was invoked with the translated
+    # remote path and a remote cwd that sits under the mount.
+    adapter.submit_remote_sbatch.assert_called_once()
+    call_kwargs = adapter.submit_remote_sbatch.call_args
+    assert call_kwargs.args[0] == "/cluster/share/ml-project/train.sbatch"
+    assert call_kwargs.kwargs["submit_cwd"].startswith("/cluster/share/ml-project")
+
+    # The legacy temp-upload path must NOT have fired.
+    job_ops.submit.assert_not_called()
+
+
+def test_sbatch_outside_mount_falls_back_to_temp_upload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A script outside any mount continues to use the legacy upload path."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    outside_script = tmp_path / "scratch" / "throwaway.sbatch"
+    outside_script.parent.mkdir()
+    outside_script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(
+        tmp_path, mount_local=mount_local, remote="/cluster/share/ml-project"
+    )
+    adapter, job_ops = _patch_transport(monkeypatch, profile)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["sbatch", str(outside_script), "--profile", "ml-cluster"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # Legacy path: rt.job_ops.submit (not submit_remote_sbatch).
+    job_ops.submit.assert_called_once()
+    adapter.submit_remote_sbatch.assert_not_called()
+
+
+def test_no_sync_skips_rsync_but_still_runs_in_place(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--no-sync`` skips rsync but does NOT downgrade to tmp upload.
+
+    The translated remote path is still used so the user's own
+    ``#SBATCH --output=`` directives keep working — they may just be
+    running against an older copy of the script if the workstation
+    has unsynced edits.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    adapter, _ = _patch_transport(monkeypatch, profile)
+
+    with patch("srunx.sync.service.ensure_mount_synced") as fake_sync:
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "sbatch",
+                str(script),
+                "--profile",
+                "ml-cluster",
+                "--no-sync",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    fake_sync.assert_not_called()
+    adapter.submit_remote_sbatch.assert_called_once()
+
+
+def test_template_flag_forces_temp_upload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--template`` produces a generated artifact, never in-place."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    adapter, job_ops = _patch_transport(monkeypatch, profile)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "sbatch",
+            "--wrap",
+            "echo hi",
+            "--template",
+            "base",
+            "--profile",
+            "ml-cluster",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # --template forces TEMP_UPLOAD even though --wrap had no source
+    # file to consider.
+    job_ops.submit.assert_called_once()
+    adapter.submit_remote_sbatch.assert_not_called()
+
+
+def test_sync_failure_aborts_submission(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rsync failure must abort — never silently submit a stale workspace."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    adapter, _ = _patch_transport(monkeypatch, profile)
+
+    def _boom(**_kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("rsync exited 23: permission denied")
+
+    monkeypatch.setattr("srunx.sync.service.ensure_mount_synced", _boom)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "rsync" in combined.lower()
+    # Must NOT have submitted anything after rsync failed.
+    adapter.submit_remote_sbatch.assert_not_called()
+
+
+def _ok_outcome(mount):  # type: ignore[no-untyped-def]
+    """Build a synthetic SyncOutcome for the mock to return."""
+    from srunx.sync.service import SyncOutcome
+
+    return SyncOutcome(mount_name=mount.name, performed=True, warnings=())

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -291,6 +291,95 @@ def test_extra_sbatch_args_forwarded_in_place(
     assert "--time=1:00:00" in extra
 
 
+def test_lock_is_held_during_submit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The per-mount sync lock is held while ``submit_remote_sbatch`` runs.
+
+    Codex follow-up #4 on PR #134: the previous review pointed out
+    that no test directly proves this. We assert the contract by
+    checking that, *during* the adapter call, a parallel
+    ``acquire_sync_lock`` would time out — i.e. the file lock is
+    actually held the whole time the submission is in flight.
+    """
+    from srunx.sync.lock import SyncLockTimeoutError, acquire_sync_lock
+
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    held_during_submit: dict[str, bool] = {}
+
+    def _check_lock_held(remote_path, *, callbacks_job, **_kwargs):
+        # Try to acquire the same lock with a tiny timeout. If the
+        # outer mount_sync_session is honouring the contract this
+        # second acquire MUST time out, because the OS lock is held.
+        try:
+            with acquire_sync_lock("ml-cluster", "ml", timeout=0.2):
+                held_during_submit["acquired"] = True
+        except SyncLockTimeoutError:
+            held_during_submit["acquired"] = False
+
+        callbacks_job.job_id = 99
+        from srunx.models import JobStatus
+
+        callbacks_job.status = JobStatus.PENDING
+        return callbacks_job
+
+    job_ops.submit_remote_sbatch.side_effect = _check_lock_held
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # The contended acquire timed out → the outer lock was held the
+    # entire time submit_remote_sbatch was running.
+    assert held_during_submit["acquired"] is False, (
+        "mount_sync_session released the lock before submit_remote_sbatch "
+        "finished — a concurrent invocation could rsync stale bytes "
+        "during the sbatch handoff window. (Codex blocker #3 regressed.)"
+    )
+
+
+def test_sbatch_failure_after_sync_uses_distinct_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A sbatch failure must NOT wear an "rsync failed" error message.
+
+    Codex follow-up regression #1 on PR #134: the original fix
+    wrapped both the sync and the submit in one ``except RuntimeError
+    as exc: raise BadParameter(f"rsync failed: ...")`` block, so a
+    sbatch error claimed the rsync failed.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    job_ops.submit_remote_sbatch.side_effect = RuntimeError(
+        "remote sbatch submission failed"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "sbatch failed" in combined.lower()
+    assert "rsync failed" not in combined.lower()
+
+
 def test_default_resource_flags_not_forwarded(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -316,3 +405,86 @@ def test_default_resource_flags_not_forwarded(
     extra = job_ops.submit_remote_sbatch.call_args.kwargs["extra_sbatch_args"]
     # ``extra_sbatch_args`` is None or empty when no flags were typed.
     assert not extra
+
+
+def test_explicit_default_override_is_forwarded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``-N 1`` typed explicitly must override a script's ``#SBATCH --nodes=8``.
+
+    Codex follow-up #1 to PR #134's first round: the original
+    "default !=" check would skip explicit default-valued flags
+    because the typed value matches the default. The new
+    ``get_parameter_source``-based check fixes that.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\n#SBATCH --nodes=8\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["sbatch", str(script), "--profile", "ml-cluster", "-N", "1"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    extra = job_ops.submit_remote_sbatch.call_args.kwargs["extra_sbatch_args"]
+    # The user typed ``-N 1`` explicitly. It must be forwarded so
+    # SLURM overrides the script's ``#SBATCH --nodes=8``.
+    assert "--nodes=1" in extra
+
+
+def test_config_workdir_does_not_inject_chdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Config-default ``work_dir`` must NOT be forwarded as ``--chdir``.
+
+    Codex follow-up #1 (continued): without ParameterSource, a
+    config-injected ``work_dir`` looked indistinguishable from a
+    user-typed ``-D``, so the script's own ``#SBATCH --chdir=`` got
+    silently overridden. ``ParameterSource`` distinguishes the two.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text(
+        "#!/bin/bash\n#SBATCH --chdir=/cluster/share/ml-project\necho hi\n"
+    )
+
+    # Inject a config-default work_dir that differs from the script's
+    # explicit value. Without the fix the planner forwards the config
+    # default and clobbers the script's choice.
+    # ``srunx.cli/__init__.py`` re-exports the ``main`` function as
+    # ``srunx.cli.main``, shadowing the module attribute lookup
+    # so ``import srunx.cli.main as X`` returns the function. Reach
+    # for the module via ``sys.modules`` directly so the patch lands
+    # on the module's namespace where ``get_config`` is rebound.
+    import sys
+
+    from srunx.config import SrunxConfig
+
+    cli_main_module = sys.modules["srunx.cli.main"]
+    monkeypatch.setattr(
+        cli_main_module,
+        "get_config",
+        lambda: SrunxConfig.model_validate({"work_dir": "/some/config/default"}),
+    )
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    extra = job_ops.submit_remote_sbatch.call_args.kwargs["extra_sbatch_args"]
+    assert not any(a.startswith("--chdir") for a in (extra or [])), (
+        "Config-default work_dir leaked into sbatch CLI args, would have "
+        "overridden the script's own #SBATCH --chdir=."
+    )

--- a/tests/cli/test_submission_plan.py
+++ b/tests/cli/test_submission_plan.py
@@ -1,0 +1,290 @@
+"""Unit tests for the submission planner.
+
+The planner is intentionally pure (no IO), so these tests just feed it
+synthetic ``ServerProfile`` / ``MountConfig`` objects and assert on the
+returned :class:`SubmissionPlan`. Real-world sync + sbatch behaviour
+is covered by the integration tests under ``tests/cli/test_sbatch_in_place.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from srunx.cli.submission_plan import (
+    SubmissionMode,
+    plan_sbatch_submission,
+    resolve_mount_for_path,
+    translate_local_to_remote,
+)
+from srunx.ssh.core.config import MountConfig, ServerProfile
+
+
+def _make_profile(tmp_path: Path, mounts: list[MountConfig]) -> ServerProfile:
+    """Build a minimal ServerProfile with no real SSH credentials.
+
+    Only the ``mounts`` field matters for planner tests, but
+    ``ServerProfile`` requires hostname/username/key_filename. We
+    point key_filename at a writable tmp location so Pydantic's
+    validators (which expand ``~``) don't reject it.
+    """
+    key_path = tmp_path / "id_rsa"
+    key_path.write_text("dummy")
+    return ServerProfile(
+        hostname="test.example.com",
+        username="alice",
+        key_filename=str(key_path),
+        mounts=tuple(mounts),
+    )
+
+
+def _make_mount(local: Path, remote: str = "/cluster/share/ml") -> MountConfig:
+    return MountConfig(name="ml", local=str(local), remote=remote)
+
+
+class TestResolveMountForPath:
+    def test_returns_none_when_no_mounts(self, tmp_path: Path) -> None:
+        profile = _make_profile(tmp_path, mounts=[])
+        assert resolve_mount_for_path(tmp_path / "x.sh", profile) is None
+
+    def test_returns_mount_when_path_under_root(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml-project"
+        local.mkdir()
+        mount = _make_mount(local)
+        profile = _make_profile(tmp_path, mounts=[mount])
+
+        result = resolve_mount_for_path(local / "train.sh", profile)
+        assert result == mount
+
+    def test_returns_none_when_outside(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml-project"
+        local.mkdir()
+        outside = tmp_path / "other"
+        outside.mkdir()
+        profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+        assert resolve_mount_for_path(outside / "x.sh", profile) is None
+
+    def test_longest_prefix_wins_for_nested_mounts(self, tmp_path: Path) -> None:
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        inner.mkdir(parents=True)
+        outer_mount = MountConfig(name="outer", local=str(outer), remote="/r/outer")
+        inner_mount = MountConfig(name="inner", local=str(inner), remote="/r/inner")
+        profile = _make_profile(tmp_path, mounts=[outer_mount, inner_mount])
+
+        # Nested file should bind to the deeper mount.
+        result = resolve_mount_for_path(inner / "x.sh", profile)
+        assert result == inner_mount
+
+    def test_resolves_through_symlinks(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml-project"
+        local.mkdir()
+        target = local / "real.sh"
+        target.write_text("#!/bin/bash\n")
+        link = tmp_path / "link.sh"
+        link.symlink_to(target)
+        profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+        # Symlink leaving / entering the mount should still bind to it.
+        result = resolve_mount_for_path(link, profile)
+        assert result is not None
+        assert result.name == "ml"
+
+
+class TestTranslateLocalToRemote:
+    def test_basic_translation(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml-project"
+        local.mkdir()
+        mount = _make_mount(local, remote="/cluster/share/ml")
+        out = translate_local_to_remote(local / "runs/exp1/train.sh", mount)
+        assert out == "/cluster/share/ml/runs/exp1/train.sh"
+
+    def test_root_returns_remote_root(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml-project"
+        local.mkdir()
+        mount = _make_mount(local, remote="/cluster/share/ml")
+        assert translate_local_to_remote(local, mount) == "/cluster/share/ml"
+
+    def test_strips_trailing_slash(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml"
+        local.mkdir()
+        mount = MountConfig(name="ml", local=str(local), remote="/r/ml/")
+        assert translate_local_to_remote(local / "x.sh", mount) == "/r/ml/x.sh"
+
+
+class TestPlanSbatchSubmission:
+    def test_no_script_means_temp_upload(self, tmp_path: Path) -> None:
+        # ``--wrap`` case: script_path is None.
+        profile = _make_profile(tmp_path, mounts=[])
+        plan = plan_sbatch_submission(
+            script_path=None,
+            profile=profile,
+            cwd=None,
+            sync_enabled=True,
+            is_rendered_artifact=False,
+        )
+        assert plan.mode == SubmissionMode.TEMP_UPLOAD
+        assert plan.mount is None
+        assert plan.sync_required is False
+
+    def test_no_profile_means_temp_upload(self, tmp_path: Path) -> None:
+        # Local SLURM has no SSH profile / mount concept.
+        plan = plan_sbatch_submission(
+            script_path=tmp_path / "x.sh",
+            profile=None,
+            cwd=None,
+            sync_enabled=True,
+            is_rendered_artifact=False,
+        )
+        assert plan.mode == SubmissionMode.TEMP_UPLOAD
+
+    def test_template_artifact_means_temp_upload(self, tmp_path: Path) -> None:
+        # Even when the script path lives under a mount, a freshly
+        # rendered template is a generated artifact and must not run
+        # in place — running the on-disk source would discard the
+        # template's substitutions.
+        local = tmp_path / "ml"
+        local.mkdir()
+        script = local / "train.sh"
+        script.write_text("#!/bin/bash\n")
+        profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+        plan = plan_sbatch_submission(
+            script_path=script,
+            profile=profile,
+            cwd=None,
+            sync_enabled=True,
+            is_rendered_artifact=True,
+        )
+        assert plan.mode == SubmissionMode.TEMP_UPLOAD
+
+    def test_outside_mount_is_temp_upload(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml"
+        local.mkdir()
+        outside = tmp_path / "scratch"
+        outside.mkdir()
+        script = outside / "x.sh"
+        script.write_text("#!/bin/bash\n")
+        profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+        plan = plan_sbatch_submission(
+            script_path=script,
+            profile=profile,
+            cwd=None,
+            sync_enabled=True,
+            is_rendered_artifact=False,
+        )
+        assert plan.mode == SubmissionMode.TEMP_UPLOAD
+
+    def test_in_place_with_sync_required(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml"
+        local.mkdir()
+        script = local / "train.sh"
+        script.write_text("#!/bin/bash\n")
+        mount = _make_mount(local, remote="/cluster/share/ml")
+        profile = _make_profile(tmp_path, mounts=[mount])
+
+        plan = plan_sbatch_submission(
+            script_path=script,
+            profile=profile,
+            cwd=None,
+            sync_enabled=True,
+            is_rendered_artifact=False,
+        )
+        assert plan.mode == SubmissionMode.IN_PLACE
+        assert plan.mount == mount
+        assert plan.remote_script_path == "/cluster/share/ml/train.sh"
+        assert plan.sync_required is True
+        assert plan.warnings == ()
+
+    def test_in_place_with_sync_disabled_warns(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml"
+        local.mkdir()
+        script = local / "train.sh"
+        script.write_text("#!/bin/bash\n")
+        profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+        plan = plan_sbatch_submission(
+            script_path=script,
+            profile=profile,
+            cwd=None,
+            sync_enabled=False,
+            is_rendered_artifact=False,
+        )
+        assert plan.mode == SubmissionMode.IN_PLACE
+        assert plan.sync_required is False
+        # User asked for --no-sync but is invoking against a mount;
+        # plan must surface the "remote may be stale" caveat.
+        assert any("without syncing" in w for w in plan.warnings)
+
+    def test_submit_cwd_uses_translated_cwd_when_under_mount(
+        self, tmp_path: Path
+    ) -> None:
+        local = tmp_path / "ml"
+        runs = local / "runs/exp1"
+        runs.mkdir(parents=True)
+        script = runs / "train.sh"
+        script.write_text("#!/bin/bash\n")
+        mount = _make_mount(local, remote="/cluster/share/ml")
+        profile = _make_profile(tmp_path, mounts=[mount])
+
+        plan = plan_sbatch_submission(
+            script_path=script,
+            profile=profile,
+            cwd=runs,
+            sync_enabled=True,
+            is_rendered_artifact=False,
+        )
+        # cwd was the same dir as the script — translated cwd should
+        # match script's parent on the remote.
+        assert plan.submit_cwd == "/cluster/share/ml/runs/exp1"
+
+    def test_submit_cwd_falls_back_to_script_parent(self, tmp_path: Path) -> None:
+        local = tmp_path / "ml"
+        local.mkdir()
+        script = local / "runs" / "train.sh"
+        script.parent.mkdir()
+        script.write_text("#!/bin/bash\n")
+        outside_cwd = tmp_path / "outside"
+        outside_cwd.mkdir()
+        mount = _make_mount(local, remote="/cluster/share/ml")
+        profile = _make_profile(tmp_path, mounts=[mount])
+
+        plan = plan_sbatch_submission(
+            script_path=script,
+            profile=profile,
+            cwd=outside_cwd,
+            sync_enabled=True,
+            is_rendered_artifact=False,
+        )
+        # cwd is outside any mount, so submit_cwd should fall back to
+        # the script's enclosing directory on the remote.
+        assert plan.submit_cwd == "/cluster/share/ml/runs"
+
+
+@pytest.mark.parametrize("sync_enabled", [True, False])
+def test_in_place_preserves_remote_path_regardless_of_sync(
+    tmp_path: Path, sync_enabled: bool
+) -> None:
+    """The remote path translation is independent of sync_enabled.
+
+    Disabling sync only changes whether rsync runs and whether we add
+    a "running stale" warning — it must not change the remote path
+    we end up sbatching against.
+    """
+    local = tmp_path / "ml"
+    local.mkdir()
+    script = local / "train.sh"
+    script.write_text("#!/bin/bash\n")
+    profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+    plan = plan_sbatch_submission(
+        script_path=script,
+        profile=profile,
+        cwd=None,
+        sync_enabled=sync_enabled,
+        is_rendered_artifact=False,
+    )
+    assert plan.remote_script_path == "/cluster/share/ml/train.sh"

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -1,0 +1,132 @@
+"""Tests for the per-mount sync lock.
+
+The lock is the only thing standing between two concurrent
+``srunx sbatch --sync`` invocations and a half-transferred mount.
+We need to verify three behaviours:
+
+* Single-process acquire/release works.
+* A second acquirer respects the timeout and raises
+  :class:`SyncLockTimeoutError` (with the lock path embedded so the
+  user can locate / inspect it).
+* Names with shell metacharacters / path separators are sanitised
+  before they hit the filesystem.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import time
+from pathlib import Path
+
+import pytest
+
+from srunx.sync.lock import (
+    SyncLockTimeoutError,
+    _sanitise,
+    acquire_sync_lock,
+    lock_path_for,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force ``$XDG_CONFIG_HOME`` into tmp so locks land in a sandbox."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+
+def test_acquire_release_basic() -> None:
+    """A clean acquire creates the lock file and releases on exit."""
+    with acquire_sync_lock("alice", "ml", timeout=1.0) as path:
+        assert path.exists()
+        assert path.parent.name == "locks"
+
+    # After the with-block, a second acquirer should grab it
+    # immediately — no leftover OS-level lock.
+    with acquire_sync_lock("alice", "ml", timeout=0.5) as path2:
+        assert path2 == path
+
+
+def test_lock_path_sanitises_special_chars() -> None:
+    """Profile / mount names with slashes or shell chars are flattened.
+
+    Otherwise, ``profile="../../etc/passwd"`` would let a malicious
+    name escape the locks directory or collide with a sibling lock.
+    """
+    p = lock_path_for("../etc/passwd", "&|;")
+    assert ".." not in p.name
+    assert "/" not in p.name
+    assert ";" not in p.name
+    # Sanitised parts still produce a non-empty filename.
+    assert p.name.endswith(".lock")
+
+
+def test_sanitise_empty_value_falls_back() -> None:
+    assert _sanitise("") == "unnamed"
+    assert _sanitise("___") == "unnamed"  # Strip-able chars only.
+
+
+def test_zero_timeout_rejected() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        with acquire_sync_lock("alice", "ml", timeout=0):
+            pass
+
+
+def _hold_lock(profile: str, mount: str, hold_for: float) -> None:
+    """Worker process: hold the lock for *hold_for* seconds."""
+    with acquire_sync_lock(profile, mount, timeout=5.0):
+        time.sleep(hold_for)
+
+
+def test_contended_acquire_times_out(tmp_path: Path) -> None:
+    """A second acquirer waits up to ``timeout`` then raises with the path.
+
+    Spawn a child that holds the lock for longer than the parent's
+    timeout, then assert the parent gets a timely
+    :class:`SyncLockTimeoutError` carrying the exact lock file.
+    """
+    # multiprocessing on macOS defaults to spawn; ensure children pick
+    # up the same XDG_CONFIG_HOME we set in the autouse fixture.
+    ctx = multiprocessing.get_context("spawn")
+    holder = ctx.Process(target=_hold_lock, args=("alice", "ml", 2.0))
+    holder.start()
+    try:
+        # Give the holder a beat to actually take the lock.
+        time.sleep(0.3)
+
+        start = time.monotonic()
+        with pytest.raises(SyncLockTimeoutError) as exc_info:
+            with acquire_sync_lock("alice", "ml", timeout=0.5):
+                pytest.fail("should not have acquired contended lock")
+        elapsed = time.monotonic() - start
+
+        # We honoured the timeout (within a generous slack for CI
+        # scheduling jitter).
+        assert 0.4 < elapsed < 1.5
+
+        err = exc_info.value
+        assert err.timeout == pytest.approx(0.5)
+        assert err.lock_path == lock_path_for("alice", "ml")
+    finally:
+        holder.join(timeout=5)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join()
+
+
+def test_acquire_after_holder_exits(tmp_path: Path) -> None:
+    """Once a holder exits, a fresh acquirer succeeds promptly."""
+    ctx = multiprocessing.get_context("spawn")
+    holder = ctx.Process(target=_hold_lock, args=("alice", "ml", 0.4))
+    holder.start()
+    try:
+        time.sleep(0.1)
+
+        # Block long enough that the holder definitely exits during
+        # our wait. The acquire should succeed without raising.
+        with acquire_sync_lock("alice", "ml", timeout=2.0) as path:
+            assert path.exists()
+    finally:
+        holder.join(timeout=5)
+        if holder.is_alive():
+            holder.terminate()
+            holder.join()

--- a/tests/sync/test_service.py
+++ b/tests/sync/test_service.py
@@ -1,0 +1,159 @@
+"""Tests for :mod:`srunx.sync.service`.
+
+Covers the service layer that ties dirty-tree detection, locking, and
+the underlying rsync helper into a single ``ensure_mount_synced`` call
+that the CLI consumes. We mock both ``sync_mount_by_name`` (rsync) and
+``is_dirty_git_worktree`` (git) so the tests stay deterministic and
+don't fight the repo-wide autouse ``subprocess.run`` patch in
+``tests/conftest.py``. The git inspector itself is exercised by
+``ensure_mount_synced``'s integration tests via the ``warn_dirty`` /
+``require_clean`` paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from srunx.config import SyncDefaults
+from srunx.ssh.core.config import MountConfig, ServerProfile
+from srunx.sync.service import SyncAbortedError, ensure_mount_synced
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+
+def _profile(tmp_path: Path, mount_local: Path) -> ServerProfile:
+    key = tmp_path / "id_rsa"
+    key.write_text("dummy")
+    return ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename=str(key),
+        mounts=(MountConfig(name="ml", local=str(mount_local), remote="/r/ml"),),
+    )
+
+
+class TestEnsureMountSynced:
+    def test_happy_path_invokes_rsync(self, tmp_path: Path) -> None:
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        profile = _profile(tmp_path, mount_local)
+        config = SyncDefaults()  # auto=True, defaults
+
+        with (
+            patch("srunx.web.sync_utils.sync_mount_by_name") as fake_rsync,
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            outcome = ensure_mount_synced(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=config,
+            )
+
+        fake_rsync.assert_called_once_with(profile, "ml")
+        assert outcome.performed is True
+        assert outcome.warnings == ()
+
+    def test_dirty_warn_does_not_block(self, tmp_path: Path) -> None:
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        profile = _profile(tmp_path, mount_local)
+        config = SyncDefaults(warn_dirty=True, require_clean=False)
+
+        with (
+            patch("srunx.web.sync_utils.sync_mount_by_name"),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(True, "?? untracked.txt"),
+            ),
+        ):
+            outcome = ensure_mount_synced(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=config,
+            )
+
+        # Sync should still happen, but the warning surfaces back to
+        # the caller so the CLI can echo it.
+        assert outcome.performed is True
+        assert any("uncommitted changes" in w for w in outcome.warnings)
+
+    def test_dirty_with_require_clean_aborts(self, tmp_path: Path) -> None:
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        profile = _profile(tmp_path, mount_local)
+        config = SyncDefaults(warn_dirty=False, require_clean=True)
+
+        with (
+            patch("srunx.web.sync_utils.sync_mount_by_name") as fake_rsync,
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(True, "?? untracked.txt"),
+            ),
+        ):
+            with pytest.raises(SyncAbortedError, match="uncommitted changes"):
+                ensure_mount_synced(
+                    profile_name="alice",
+                    profile=profile,
+                    mount=profile.mounts[0],
+                    config=config,
+                )
+
+        # rsync must NOT have been invoked when require_clean fires.
+        fake_rsync.assert_not_called()
+
+    def test_clean_repo_no_warning(self, tmp_path: Path) -> None:
+        """A clean tree produces no warning even when ``warn_dirty=True``."""
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        profile = _profile(tmp_path, mount_local)
+        config = SyncDefaults(warn_dirty=True)
+
+        with (
+            patch("srunx.web.sync_utils.sync_mount_by_name"),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            outcome = ensure_mount_synced(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=config,
+            )
+
+        assert outcome.warnings == ()
+
+    def test_rsync_failure_propagates(self, tmp_path: Path) -> None:
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        profile = _profile(tmp_path, mount_local)
+
+        def _boom(_profile, _name):  # type: ignore[no-untyped-def]
+            raise RuntimeError("rsync exited 23: permission denied")
+
+        with (
+            patch("srunx.web.sync_utils.sync_mount_by_name", side_effect=_boom),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="permission denied"):
+                ensure_mount_synced(
+                    profile_name="alice",
+                    profile=profile,
+                    mount=profile.mounts[0],
+                    config=SyncDefaults(),
+                )

--- a/tests/sync/test_service.py
+++ b/tests/sync/test_service.py
@@ -46,7 +46,7 @@ class TestEnsureMountSynced:
         config = SyncDefaults()  # auto=True, defaults
 
         with (
-            patch("srunx.web.sync_utils.sync_mount_by_name") as fake_rsync,
+            patch("srunx.sync.service.sync_mount_by_name") as fake_rsync,
             patch(
                 "srunx.sync.service.is_dirty_git_worktree",
                 return_value=(False, ""),
@@ -59,7 +59,9 @@ class TestEnsureMountSynced:
                 config=config,
             )
 
-        fake_rsync.assert_called_once_with(profile, "ml")
+        # Auto-sync calls rsync with delete=False (Codex blocker #4):
+        # mount-resident outputs/checkpoints must survive a sync.
+        fake_rsync.assert_called_once_with(profile, "ml", delete=False)
         assert outcome.performed is True
         assert outcome.warnings == ()
 
@@ -70,7 +72,7 @@ class TestEnsureMountSynced:
         config = SyncDefaults(warn_dirty=True, require_clean=False)
 
         with (
-            patch("srunx.web.sync_utils.sync_mount_by_name"),
+            patch("srunx.sync.service.sync_mount_by_name"),
             patch(
                 "srunx.sync.service.is_dirty_git_worktree",
                 return_value=(True, "?? untracked.txt"),
@@ -95,7 +97,7 @@ class TestEnsureMountSynced:
         config = SyncDefaults(warn_dirty=False, require_clean=True)
 
         with (
-            patch("srunx.web.sync_utils.sync_mount_by_name") as fake_rsync,
+            patch("srunx.sync.service.sync_mount_by_name") as fake_rsync,
             patch(
                 "srunx.sync.service.is_dirty_git_worktree",
                 return_value=(True, "?? untracked.txt"),
@@ -120,7 +122,7 @@ class TestEnsureMountSynced:
         config = SyncDefaults(warn_dirty=True)
 
         with (
-            patch("srunx.web.sync_utils.sync_mount_by_name"),
+            patch("srunx.sync.service.sync_mount_by_name"),
             patch(
                 "srunx.sync.service.is_dirty_git_worktree",
                 return_value=(False, ""),
@@ -140,11 +142,11 @@ class TestEnsureMountSynced:
         mount_local.mkdir()
         profile = _profile(tmp_path, mount_local)
 
-        def _boom(_profile, _name):  # type: ignore[no-untyped-def]
+        def _boom(_profile, _name, *, delete=False):  # type: ignore[no-untyped-def]
             raise RuntimeError("rsync exited 23: permission denied")
 
         with (
-            patch("srunx.web.sync_utils.sync_mount_by_name", side_effect=_boom),
+            patch("srunx.sync.service.sync_mount_by_name", side_effect=_boom),
             patch(
                 "srunx.sync.service.is_dirty_git_worktree",
                 return_value=(False, ""),

--- a/tests/web/test_ssh_adapter_remote_sbatch.py
+++ b/tests/web/test_ssh_adapter_remote_sbatch.py
@@ -1,0 +1,204 @@
+"""Tests for :meth:`SlurmSSHAdapter.submit_remote_sbatch`.
+
+Codex follow-up #1 on PR #134 flagged that the existing CLI tests
+mock the adapter, leaving no direct proof that ``submit_remote_sbatch``
+actually records to the state DB and fires ``on_job_submitted``
+callbacks. These tests pin both contracts down at the adapter
+boundary.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from srunx.callbacks import Callback
+from srunx.models import ShellJob
+from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+
+def _bare_adapter(
+    callbacks: list[Callback] | None = None,
+    *,
+    profile_name: str | None = "ml-cluster",
+) -> SlurmSSHAdapter:
+    """Build a fully-populated adapter that bypasses real SSH I/O."""
+    adapter = object.__new__(SlurmSSHAdapter)
+    adapter._io_lock = threading.RLock()
+    adapter._client = MagicMock()
+    adapter.callbacks = list(callbacks) if callbacks else []
+    adapter._profile_name = profile_name
+    adapter._hostname = "testhost"
+    adapter._username = "tester"
+    adapter._key_filename = None
+    adapter._port = 22
+    adapter._proxy_jump = None
+    adapter._env_vars = {}
+    adapter._mounts = ()
+    adapter.submission_source = "cli"
+
+    transport = MagicMock()
+    transport.is_active.return_value = True
+    ssh = MagicMock()
+    ssh.get_transport.return_value = transport
+    adapter._client.ssh_client = ssh
+    return adapter
+
+
+class _RecordingCallback(Callback):
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def on_job_submitted(self, job) -> None:  # type: ignore[override]
+        self.submitted.append(job.name)
+
+
+def _stub_inner_submit(adapter: SlurmSSHAdapter, *, job_id: str, name: str) -> None:
+    """Wire ``adapter._client.submit_remote_sbatch_file`` to a MagicMock.
+
+    The class-level ``_client`` is typed as :class:`SSHSlurmClient`,
+    so mypy refuses ``return_value =`` on a real-typed method. The
+    helper coerces through ``MagicMock`` once and then the typed
+    descriptor doesn't get in the way.
+    """
+    mock_method = MagicMock()
+    submitted_inner = MagicMock()
+    submitted_inner.job_id = job_id
+    submitted_inner.name = name
+    mock_method.return_value = submitted_inner
+    adapter._client.submit_remote_sbatch_file = mock_method  # type: ignore[method-assign]
+
+
+def test_submit_remote_sbatch_fires_on_job_submitted_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``on_job_submitted`` must fire so notification watches see the job.
+
+    Codex follow-up #1: the CLI integration test mocks the whole
+    adapter and never observes this. Pin it directly here.
+    """
+    cb = _RecordingCallback()
+    adapter = _bare_adapter(callbacks=[cb])
+    _stub_inner_submit(adapter, job_id="12345", name="train")
+
+    # Don't bother with the real DB — patch out the recorder helper
+    # so this test stays pure-unit. The recording invariant is
+    # asserted in the next test.
+    monkeypatch.setattr(adapter, "_record_job_submission", lambda *a, **kw: None)
+
+    job = ShellJob(name="train", script_path="/cluster/share/ml/train.sh")
+    result = adapter.submit_remote_sbatch(
+        "/cluster/share/ml/train.sh",
+        submit_cwd="/cluster/share/ml",
+        job_name="train",
+        callbacks_job=job,
+    )
+
+    assert result is job  # mutated in place
+    assert job.job_id == 12345
+    # The callback fired against the real Job object the caller owns.
+    assert cb.submitted == ["train"]
+
+
+def test_submit_remote_sbatch_records_to_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recording goes through ``_record_job_submission`` with the SSH triple."""
+    adapter = _bare_adapter(profile_name="ml-cluster")
+    _stub_inner_submit(adapter, job_id="98765", name="train")
+
+    record_calls: list[dict] = []
+
+    def _capture_record(job, **kwargs):  # type: ignore[no-untyped-def]
+        record_calls.append({"job": job, **kwargs})
+
+    monkeypatch.setattr(adapter, "_record_job_submission", _capture_record)
+
+    job = ShellJob(name="train", script_path="/cluster/share/ml/train.sh")
+    adapter.submit_remote_sbatch(
+        "/cluster/share/ml/train.sh",
+        submit_cwd="/cluster/share/ml",
+        job_name="train",
+        callbacks_job=job,
+    )
+
+    assert len(record_calls) == 1
+    call = record_calls[0]
+    # Recorded under the SSH transport with the right scheduler key
+    # so the active-watch poller picks it up under the same axis the
+    # job was submitted on.
+    assert call["transport_type"] == "ssh"
+    assert call["profile_name"] == "ml-cluster"
+    assert call["scheduler_key"] == "ssh:ml-cluster"
+    assert call["submission_source"] == "cli"
+    assert call["job"] is job
+    assert job.job_id == 98765
+
+
+def test_submit_remote_sbatch_no_profile_falls_back_to_default_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a bound profile we still record, just without the SSH triple.
+
+    Some legacy paths (direct hostname constructor, sweep tests)
+    build the adapter without a profile name. Recording shouldn't
+    fail in that path; it should fall through to the default
+    behaviour the existing ``submit()`` method also uses.
+    """
+    adapter = _bare_adapter(profile_name=None)
+    _stub_inner_submit(adapter, job_id="1", name="x")
+
+    record_calls: list[dict] = []
+
+    def _capture_record(job, **kwargs):  # type: ignore[no-untyped-def]
+        record_calls.append({"job": job, **kwargs})
+
+    monkeypatch.setattr(adapter, "_record_job_submission", _capture_record)
+
+    job = ShellJob(name="x", script_path="/r/x.sh")
+    adapter.submit_remote_sbatch("/r/x.sh", callbacks_job=job)
+
+    assert len(record_calls) == 1
+    # No SSH-triple kwargs in the no-profile path.
+    assert "transport_type" not in record_calls[0]
+    assert "scheduler_key" not in record_calls[0]
+
+
+def test_submit_remote_sbatch_raises_when_inner_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inner failure surfaces as RuntimeError so the CLI catches it cleanly."""
+    adapter = _bare_adapter()
+    fail_method = MagicMock(return_value=None)
+    adapter._client.submit_remote_sbatch_file = fail_method  # type: ignore[method-assign]
+    monkeypatch.setattr(adapter, "_record_job_submission", lambda *a, **kw: None)
+
+    with pytest.raises(RuntimeError, match="remote sbatch submission failed"):
+        adapter.submit_remote_sbatch("/r/x.sh")
+
+
+def test_submit_remote_sbatch_forwards_extra_args() -> None:
+    """``extra_sbatch_args`` reach the inner client unchanged."""
+    adapter = _bare_adapter()
+    inner = MagicMock()
+    # ``MagicMock(name=...)`` sets the mock's *display* name, not the
+    # ``.name`` attribute we want pydantic to read. Set it explicitly.
+    inner_result = MagicMock(spec=["job_id", "name"])
+    inner_result.job_id = "7"
+    inner_result.name = "j"
+    inner.return_value = inner_result
+    adapter._client.submit_remote_sbatch_file = inner  # type: ignore[method-assign]
+
+    adapter.submit_remote_sbatch(
+        "/r/x.sh",
+        submit_cwd="/r",
+        job_name="j",
+        dependency=None,
+        extra_sbatch_args=["--nodes=4", "--gpus-per-node=2"],
+    )
+
+    call_kwargs = inner.call_args.kwargs
+    assert call_kwargs["extra_sbatch_args"] == ["--nodes=4", "--gpus-per-node=2"]
+    assert call_kwargs["submit_cwd"] == "/r"


### PR DESCRIPTION
> Re-opened replacement for #134 (auto-closed when its base branch was deleted after #133 merged). Same commits, same diff against main.

## Summary

Two interlocking improvements to ``srunx sbatch``:

1. **Auto-sync the script's enclosing mount before submission.** Default ON, opt-out via ``--no-sync`` or ``[sync] auto = false``.
2. **Execute mount-resident scripts in place — no more tmp copy.** The script is rsynced to the cluster, then ``sbatch`` runs against ``mount.remote/...`` directly. The user's own ``#SBATCH`` directives (``--output=`` etc.) win — no more silent ``-o $SLURM_LOG_DIR/%x_%j.log`` override.

## Behavioural matrix

| Invocation | Path | Behaviour |
|---|---|---|
| ``sbatch <mount-resident> --profile X`` | rsync mount → ``sbatch /cluster/share/...`` directly, ``cd`` into translated cwd | **NEW** in-place execution |
| ``sbatch <mount-resident> --profile X --no-sync`` | skip rsync → ``sbatch /cluster/share/...`` directly | **NEW**, warns "remote may be stale" |
| ``sbatch <outside-mount> --profile X`` | SFTP upload to ``$SRUNX_TEMP_DIR`` → ``sbatch /tmp/srunx/...`` | unchanged |
| ``sbatch --wrap "..." --profile X`` | render → write to remote tmp → sbatch | unchanged |
| ``sbatch <mount> --template T --profile X`` | render template → tmp upload | unchanged (template = generated artifact) |
| ``sbatch <script> --local`` | local SLURM | unchanged (no SSH, no mounts) |

## Failure modes

| Condition | Behaviour |
|---|---|
| rsync exits non-zero | CLI exit 2, rsync stderr surfaced. **No fallback to tmp** (would silently submit a stale workspace) |
| In-place sbatch fails | CLI exit 2, **distinct** ``sbatch failed:`` message (not ``rsync failed:``) |
| Lock contention beyond ``lock_timeout_seconds`` (default 120) | CLI exit 2, ``SyncLockTimeoutError`` carries the lock file path |
| ``require_clean=true`` + uncommitted git changes | ``SyncAbortedError``, rsync **does not run** |
| ``warn_dirty=true`` (default) + uncommitted changes | log warning, rsync still runs |
| ``git`` not installed | treat as clean (don't block submission) |

## Config

```json
{
  "sync": {
    "auto": true,
    "lock_timeout_seconds": 120,
    "warn_dirty": true,
    "require_clean": false
  }
}
```

Env overrides: ``SRUNX_SYNC_AUTO``, ``SRUNX_SYNC_LOCK_TIMEOUT``, ``SRUNX_SYNC_WARN_DIRTY``, ``SRUNX_SYNC_REQUIRE_CLEAN``.

Per-invocation: ``--sync`` / ``--no-sync``.

## Architecture

Three pure-ish modules, each with one job:

- **``srunx.cli.submission_plan``** — pure planner. Returns ``SubmissionPlan(mode=IN_PLACE|TEMP_UPLOAD, mount, remote_script_path, submit_cwd, sync_required, warnings)``. No IO. Trivially unit-testable.
- **``srunx.sync.lock``** — ``flock``-backed per-(profile, mount) serialization. Sanitises names so ``profile=../../etc`` can't escape the locks dir. Lock path embedded in the timeout exception for diagnostics.
- **``srunx.sync.service.mount_sync_session``** — context manager that holds the per-mount lock across rsync + sbatch handoff. Closes the race where a concurrent invocation could rsync different bytes after our sync but before our submission.

Layering cleanup:

- ``srunx.sync.mount_helpers`` (new) owns rsync helpers; ``srunx.web.sync_utils`` re-exports for backward compatibility. Fixes the wrong dependency direction (``srunx.sync`` → ``srunx.web``).

Adapter layer:

- **``JobOperationsProtocol.submit_remote_sbatch``** — dedicated method (no ``_adapter`` reach-in). The SSH adapter implementation records the job in the state DB and fires ``on_job_submitted`` callbacks. Local ``Slurm`` keeps Protocol conformance via ``NotImplementedError`` (CLI dispatch never routes there for in-place).
- **``submit_remote_sbatch_file`` on ``SSHSlurmClient`` / ``SlurmCommands``** — distinct from ``submit_sbatch_file`` so the in-place path doesn't inherit the tmp path's local-existence check or forced ``-o`` injection. Accepts ``extra_sbatch_args`` so CLI-typed flags (``-N`` / ``--gres=gpu:N`` / etc.) reach the cluster.

CLI side:

- ``_build_extra_sbatch_args`` uses Click's ``ParameterSource.COMMANDLINE`` so explicit default-valued overrides (``-N 1``) still propagate, and config-injected ``work_dir`` does NOT silently inject ``--chdir``.

## Phased rollout

This PR is **Phase 1**: CLI ``srunx sbatch`` only. Follow-ups tracked in:

- #135 Phase 2: workflow ShellJob in-place execution
- #136 Phase 3: `POST /api/jobs` script_path mode
- #137 Phase 4: hardening (owner marker, remote hash, dry-run sync diff)
- #138 `sbatch --wrap` parity with real sbatch
- #139 sinfo / sacct / squeue full SSH parity (`-j` filter for sacct/squeue is in this PR)

## Codex review history

The branch has been through two rounds of @codex review. Both rounds' findings are addressed in commits ``126e189`` and ``9fd28e4``:

- Blocker #1: silent CLI flag drop in ShellJob mode → forwarded as ``extra_sbatch_args``.
- Blocker #2: in-place skipped DB record + callbacks → Protocol method + adapter recording.
- Blocker #3: lock released before sbatch → ``mount_sync_session`` holds lock through submit.
- Blocker #4: rsync ``--delete`` default destroys remote outputs → auto-sync uses ``delete=False``; web routers explicitly opt into ``delete=True``.
- Round 2 blocker: defaults heuristic was unsound → ``ParameterSource.COMMANDLINE``.
- Round 2 regressions: distinct ``rsync failed:`` / ``sbatch failed:`` messages, web routers explicit on ``delete``, lock timeout message no longer suggests ``--no-sync``.

Original PR thread: #134.

## Test plan

- [x] ``uv run ruff check .`` clean
- [x] ``uv run mypy .`` clean (249 source files)
- [x] ``uv run pytest`` — 1837 passed (1792 base + 45 new across planner/lock/service/sbatch integration/adapter unit)
- [x] Concurrent lock contention test uses real ``multiprocessing.Process``
- [x] Lock-held-during-submit ordering test contests the lock from inside the submit side-effect
- [ ] Reviewer: try ``srunx sbatch <a-mount-script> --profile X`` end-to-end and confirm the script's own ``#SBATCH --output=`` directive is honoured
- [ ] Reviewer: try ``srunx sbatch script.sh -N 1 --profile X`` and confirm the explicit ``-N 1`` is forwarded (overrides any ``#SBATCH --nodes=8`` in the script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)