### PR TITLE
feat: --wrap parity (#138) + workflow Phase 2 in-place + auto-sync (#135 CLI part)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ When a non-default transport is selected, a 1-line banner is emitted on stderr
 #### Workflows
 - `uv run srunx flow run <yaml_file>` - Execute workflow from YAML
 - `uv run srunx flow run <yaml_file> --validate` - Validate without executing (replaces the old `flow validate` subcommand)
+- `uv run srunx flow run <yaml_file> --profile <name>` - Run over SSH; auto-syncs each touched mount **once** + holds the per-mount lock across every job in the workflow (Phase 2 of #135)
+- `uv run srunx flow run <yaml_file> --profile <name> --no-sync` - Skip rsync but still hold the per-mount lock (race-free submission against existing remote state)
+- ShellJobs whose `script_path` lives under a synced mount and whose Jinja-rendered bytes match the source bytes are **executed in place** on the remote — the user's own `#SBATCH --output=` directives win, no tmp copy.
+
+#### `--wrap` (real sbatch parity)
+- `uv run srunx sbatch --wrap "cmd1 && cmd2"` runs both commands on the compute node — internally wrapped as `srun bash -c '...'` so shell operators (`&&`, `|`, `>`, `;`) evaluate where the user expects (closes #138).
 
 #### Configuration
 - `uv run srunx config show` - Show current configuration

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -845,15 +845,18 @@ def sbatch(
         }
         job = ShellJob.model_validate(shell_data)
     else:
-        # ``--wrap`` is a single shell command line; SLURM's ``sbatch
-        # --wrap`` runs it via ``/bin/sh -c``. Mirror that here by
-        # passing the wrap string as the Job command (Job.command
-        # accepts ``str``); the local renderer will interpolate it
-        # verbatim into the rendered sbatch ``srun`` invocation.
+        # ``--wrap`` should match real ``sbatch --wrap``: SLURM wraps
+        # the supplied string into ``/bin/sh -c "<cmd>"`` so shell
+        # operators (``&&`` / ``|`` / ``>`` / ``;``) are evaluated on
+        # the compute node, not on the submitting host. Pass the wrap
+        # string as a three-token list ``["bash", "-c", "<cmd>"]``;
+        # ``render_job_script`` uses ``shlex.join`` so the rendered
+        # template emits ``srun bash -c '<cmd>'`` with the payload
+        # safely single-quoted. Closes #138.
         assert wrap is not None  # type narrowing: enforced by mutex above
         job_data: dict[str, Any] = {
             "name": name,
-            "command": wrap,
+            "command": ["bash", "-c", wrap],
             "resources": resources,
             "environment": environment,
             "log_dir": log_dir,
@@ -1452,6 +1455,17 @@ def flow_run(
             help="Maximum concurrent sweep cells (overrides YAML sweep.max_parallel)",
         ),
     ] = None,
+    sync: Annotated[
+        bool | None,
+        typer.Option(
+            "--sync/--no-sync",
+            help=(
+                "Rsync each touched mount once at the start of the run "
+                "(default ``[sync] auto``). ``--no-sync`` skips rsync but "
+                "still acquires the per-mount lock for race-free submission."
+            ),
+        ),
+    ] = None,
     profile: ProfileOpt = None,
     local: LocalOpt = False,
     quiet: QuietOpt = False,
@@ -1481,6 +1495,7 @@ def flow_run(
         profile=profile,
         local=local,
         quiet=quiet,
+        sync=sync,
     )
 
 

--- a/src/srunx/cli/submission_plan.py
+++ b/src/srunx/cli/submission_plan.py
@@ -254,16 +254,26 @@ def render_matches_source(rendered_path: Path, source_path: Path) -> bool:
     identical the script can run *in place* on the cluster (the
     user's source file is what executes); when they differ the
     rendered output is a generated artifact and must take the
-    temp-upload path. Codex follow-up on PR #134 / #140.
+    temp-upload path.
+
+    Trailing newlines are normalised before comparison so a Jinja
+    pass that round-trips a no-substitution script doesn't get
+    flagged as "different" because of a stripped final ``\\n``.
+    Codex blocker #2 on PR #141 caught this — we also fixed the
+    Jinja env in :func:`_render_base_script` to ``keep_trailing_newline``,
+    but rstripping defends against any future template/Jinja behaviour
+    drift.
 
     Both paths must exist; missing files return ``False`` so the
     caller treats the mismatch as "render produced something
     different" and stays on the safe (temp-upload) path.
     """
     try:
-        return rendered_path.read_bytes() == source_path.read_bytes()
+        rendered = rendered_path.read_bytes()
+        source = source_path.read_bytes()
     except OSError:
         return False
+    return rendered.rstrip(b"\n") == source.rstrip(b"\n")
 
 
 def _translate_cwd(cwd: Path | None, profile: ServerProfile | None) -> str | None:

--- a/src/srunx/cli/submission_plan.py
+++ b/src/srunx/cli/submission_plan.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from srunx.ssh.core.config import MountConfig, ServerProfile
 
@@ -211,6 +212,58 @@ def _preferred_submit_cwd(
     remote_script = translate_local_to_remote(script_path, mount)
     parent, _, _ = remote_script.rpartition("/")
     return parent or remote_script
+
+
+def collect_touched_mounts(workflow: Any, profile: ServerProfile) -> list[MountConfig]:
+    """Return mounts that the workflow's ShellJob ``script_path`` values touch.
+
+    Workflow Phase 2 (#135): the runner needs to rsync each touched
+    mount **once** at the start of the run, then hold the lock
+    across every job submission. This helper does the resolution part
+    (``script_path`` → owning ``MountConfig``) so the runner can
+    feed the result into a single ``mount_sync_session`` per mount.
+
+    Jobs without a local ``script_path`` (``Job`` with command, or
+    ShellJobs whose path lives outside any mount) contribute nothing;
+    they fall back to the temp-upload path at submission time.
+
+    The return order is stable (insertion order of profile.mounts) so
+    the lock-acquisition order is deterministic, sidestepping any
+    mount-vs-mount deadlock when two ``srunx flow run`` invocations
+    target overlapping mount sets.
+    """
+    seen: dict[str, MountConfig] = {}
+    for job in getattr(workflow, "jobs", ()):
+        script_attr = getattr(job, "script_path", None)
+        if not script_attr:
+            continue
+        try:
+            mount = resolve_mount_for_path(Path(script_attr), profile)
+        except (OSError, ValueError):
+            continue
+        if mount is not None and mount.name not in seen:
+            seen[mount.name] = mount
+    return list(seen.values())
+
+
+def render_matches_source(rendered_path: Path, source_path: Path) -> bool:
+    """Return ``True`` when the rendered ShellJob bytes equal the source.
+
+    Used by the workflow's per-ShellJob plan step to decide whether
+    Jinja substitution actually changed anything. When the bytes are
+    identical the script can run *in place* on the cluster (the
+    user's source file is what executes); when they differ the
+    rendered output is a generated artifact and must take the
+    temp-upload path. Codex follow-up on PR #134 / #140.
+
+    Both paths must exist; missing files return ``False`` so the
+    caller treats the mismatch as "render produced something
+    different" and stays on the safe (temp-upload) path.
+    """
+    try:
+        return rendered_path.read_bytes() == source_path.read_bytes()
+    except OSError:
+        return False
 
 
 def _translate_cwd(cwd: Path | None, profile: ServerProfile | None) -> str | None:

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -636,15 +636,18 @@ def _execute_workflow(
                     else None,
                     sync_required=_resolve_sync_flag(sync),
                 ):
-                    # Lock is held → flip ``allow_in_place`` on a
-                    # context copy so the SSH adapter is permitted
-                    # to take the IN_PLACE submission path for any
-                    # cell that qualifies.
-                    in_place_ctx = (
-                        _in_place_context(rt)
-                        if rt.transport_type == "ssh"
-                        else rt.submission_context
-                    )
+                    # IN_PLACE for sweep cells is intentionally NOT
+                    # enabled here. Each sweep cell re-renders the
+                    # workflow with cell-specific Jinja args, which
+                    # can move ``ShellJob.script_path`` to a mount we
+                    # never collected (and never locked). Until
+                    # cell-aware mount aggregation lands (tracked in
+                    # follow-up to #135), keep ``allow_in_place=False``
+                    # for sweeps so cells stay on the temp-upload path.
+                    # The mount sync itself still happens once per
+                    # touched mount for the lock-set computed off the
+                    # base render, which is the larger Phase 2 win.
+                    # Codex blocker on PR #141 v2.
                     _run_sweep(
                         yaml_file=yaml_file,
                         workflow_data=workflow_data,
@@ -654,7 +657,9 @@ def _execute_workflow(
                         endpoint_id=endpoint_id,
                         preset=effective_preset,
                         rt=rt,
-                        submission_context=in_place_ctx,
+                        # ``submission_context`` left as the default
+                        # (rt.submission_context with
+                        # ``allow_in_place=False``); see comment above.
                     )
                 return
 

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -1,8 +1,10 @@
 """CLI interface for workflow management."""
 
+import contextlib
 import os
 import signal
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -32,6 +34,98 @@ from srunx.transport import (
 )
 
 logger = get_logger(__name__)
+
+
+def _resolve_sync_flag(sync: bool | None) -> bool:
+    """Resolve the effective ``--sync`` value (CLI > config default).
+
+    The Workflow Phase 2 CLI surface mirrors ``srunx sbatch`` here:
+    ``None`` means "fall back to ``[sync] auto``" (default true).
+    Explicit ``--sync`` / ``--no-sync`` always wins. Kept as a tiny
+    free function so the sweep + non-sweep call sites stay readable.
+    """
+    if sync is not None:
+        return sync
+    return get_config().sync.auto
+
+
+@contextlib.contextmanager
+def _hold_workflow_mounts(
+    *,
+    rt: "ResolvedTransport",
+    workflow_for_mounts: "Workflow | None",
+    sync_required: bool,
+) -> Iterator[None]:
+    """Acquire per-mount sync locks for every mount the workflow touches.
+
+    Phase 2 (#135): scans the workflow's :class:`ShellJob` ``script_path``
+    values for mounts under the resolved SSH profile, then opens a
+    :func:`mount_sync_session` for each unique mount via
+    :class:`contextlib.ExitStack`. Locks are held across every job
+    submission inside the workflow run, closing the same race window
+    ``mount_sync_session`` closes for single-job ``sbatch``.
+
+    No-ops when:
+
+    * Transport is local — there's no remote workspace to sync.
+    * No profile is bound (legacy direct-hostname path).
+    * Workflow has no ShellJobs touching any mount.
+
+    Each mount is rsynced **at most once** even when the workflow
+    fans out into many cells (sweep) or many ShellJobs targeting the
+    same mount, so a 100-cell sweep doesn't trigger 100 rsyncs.
+
+    ``sync_required=False`` (``--no-sync``) still acquires the locks
+    but skips the rsync invocation; this preserves the lock-held
+    invariant while letting the user opt out of the transfer.
+    """
+    if (
+        rt.transport_type != "ssh"
+        or rt.profile_name is None
+        or workflow_for_mounts is None
+    ):
+        yield
+        return
+
+    from srunx.cli.submission_plan import collect_touched_mounts
+    from srunx.ssh.core.config import ConfigManager
+    from srunx.sync.lock import SyncLockTimeoutError
+    from srunx.sync.service import SyncAbortedError, mount_sync_session
+
+    profile = ConfigManager().get_profile(rt.profile_name)
+    if profile is None:
+        yield
+        return
+
+    mounts = collect_touched_mounts(workflow_for_mounts, profile)
+    if not mounts:
+        yield
+        return
+
+    config = get_config()
+    try:
+        with contextlib.ExitStack() as stack:
+            for mount in mounts:
+                outcome = stack.enter_context(
+                    mount_sync_session(
+                        profile_name=rt.profile_name,
+                        profile=profile,
+                        mount=mount,
+                        config=config.sync,
+                        sync_required=sync_required,
+                    )
+                )
+                if outcome.performed:
+                    Console().print(f"⇅  Synced mount [cyan]{mount.name}[/cyan]")
+            yield
+    except SyncAbortedError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except SyncLockTimeoutError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+    except RuntimeError as exc:
+        # rsync subprocess failure — abort rather than silently
+        # submitting a stale workspace.
+        raise typer.BadParameter(f"rsync failed: {exc}") from exc
 
 
 def _build_workflow_callbacks(
@@ -384,6 +478,7 @@ def _execute_workflow(
     profile: str | None = None,
     local: bool = False,
     quiet: bool = False,
+    sync: bool | None = None,
 ) -> None:
     """Common workflow execution logic."""
     # Configure logging for workflow execution
@@ -485,16 +580,27 @@ def _execute_workflow(
                     _enforce_shell_script_roots_cli(_check_runner.workflow, rt)
 
                 endpoint_id = _resolve_endpoint_id(endpoint)
-                _run_sweep(
-                    yaml_file=yaml_file,
-                    workflow_data=workflow_data,
-                    args_override=args_override,
-                    sweep_spec=sweep_spec,
-                    callbacks=callbacks,
-                    endpoint_id=endpoint_id,
-                    preset=effective_preset,
+                # Phase 2 (#135): hold the per-(profile, mount) sync
+                # lock across every cell in the sweep so a concurrent
+                # invocation can't rsync mid-sweep, AND so the rsync
+                # itself runs once per mount instead of once per cell.
+                with _hold_workflow_mounts(
                     rt=rt,
-                )
+                    workflow_for_mounts=_check_runner.workflow
+                    if rt.transport_type == "ssh"
+                    else None,
+                    sync_required=_resolve_sync_flag(sync),
+                ):
+                    _run_sweep(
+                        yaml_file=yaml_file,
+                        workflow_data=workflow_data,
+                        args_override=args_override,
+                        sweep_spec=sweep_spec,
+                        callbacks=callbacks,
+                        endpoint_id=endpoint_id,
+                        preset=effective_preset,
+                        rt=rt,
+                    )
                 return
 
             # Non-sweep path.
@@ -550,8 +656,20 @@ def _execute_workflow(
                     console.print(f"  - {job_obj.name}: {command_str}")
                 return
 
-            # Execute workflow
-            results = runner.run(from_job=from_job, to_job=to_job, single_job=job)
+            # Execute workflow.
+            #
+            # Phase 2 (#135): wrap the call in ``_hold_workflow_mounts``
+            # so each mount that any ShellJob's ``script_path`` lives
+            # under is rsynced **once** at the start, and the per-mount
+            # lock is held across every job in the workflow. The lock
+            # serialisation closes the same race
+            # ``mount_sync_session`` closes for single-job ``sbatch``.
+            with _hold_workflow_mounts(
+                rt=rt,
+                workflow_for_mounts=runner.workflow,
+                sync_required=_resolve_sync_flag(sync),
+            ):
+                results = runner.run(from_job=from_job, to_job=to_job, single_job=job)
 
             logger.info("Job Results:")
             for task_name, job_result in results.items():
@@ -690,6 +808,18 @@ def run_command(
             help="Maximum concurrent sweep cells (overrides YAML sweep.max_parallel)",
         ),
     ] = None,
+    sync: Annotated[
+        bool | None,
+        typer.Option(
+            "--sync/--no-sync",
+            help=(
+                "Rsync each touched mount once at the start of the run "
+                "(default ``[sync] auto``, true unless disabled). "
+                "``--no-sync`` skips the rsync but still acquires the "
+                "per-mount lock for race-free submission."
+            ),
+        ),
+    ] = None,
     profile: ProfileOpt = None,
     local: LocalOpt = False,
     quiet: QuietOpt = False,
@@ -713,6 +843,7 @@ def run_command(
         profile=profile,
         local=local,
         quiet=quiet,
+        sync=sync,
     )
 
 

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -49,6 +49,29 @@ def _resolve_sync_flag(sync: bool | None) -> bool:
     return get_config().sync.auto
 
 
+def _in_place_context(rt: "ResolvedTransport") -> "Any":
+    """Return ``rt.submission_context`` with ``allow_in_place=True``.
+
+    The CLI workflow runner holds the per-(profile, mount) sync lock
+    for the entire run via :func:`_hold_workflow_mounts`, so it is
+    safe for the SSH adapter to take the IN_PLACE submission path
+    inside this run. The flag lives on
+    :class:`~srunx.rendering.SubmissionRenderContext` because it
+    rides the existing context that the sweep orchestrator and the
+    non-sweep runner already pass through to the adapter — adding
+    it here avoids touching every executor / Protocol signature.
+    Closes Codex blocker #3 on PR #141.
+
+    Returns ``None`` when there's no context to clone (e.g. local
+    transport); callers fall back to ``rt.submission_context``.
+    """
+    import dataclasses
+
+    if rt.submission_context is None:
+        return None
+    return dataclasses.replace(rt.submission_context, allow_in_place=True)
+
+
 @contextlib.contextmanager
 def _hold_workflow_mounts(
     *,
@@ -102,9 +125,22 @@ def _hold_workflow_mounts(
         yield
         return
 
+    # Sort by profile.mounts order so concurrent ``srunx flow run``
+    # invocations across overlapping mount sets always acquire locks
+    # in the same global order, eliminating lock-inversion deadlocks.
+    # Codex follow-up #2 on PR #141.
+    mount_order = {m.name: i for i, m in enumerate(profile.mounts)}
+    mounts.sort(key=lambda m: mount_order.get(m.name, len(mount_order)))
+
     config = get_config()
-    try:
-        with contextlib.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
+        # Acquisition + sync errors must surface as BadParameter so
+        # the CLI exits with a clear message. Errors raised from
+        # **inside** the workflow body (the ``yield`` block — job
+        # failures, sweep cancellations, adapter exceptions) MUST
+        # propagate unchanged — wrapping them as "rsync failed"
+        # would mask the real failure. Codex blocker #1 on PR #141.
+        try:
             for mount in mounts:
                 outcome = stack.enter_context(
                     mount_sync_session(
@@ -117,15 +153,17 @@ def _hold_workflow_mounts(
                 )
                 if outcome.performed:
                     Console().print(f"⇅  Synced mount [cyan]{mount.name}[/cyan]")
-            yield
-    except SyncAbortedError as exc:
-        raise typer.BadParameter(str(exc)) from exc
-    except SyncLockTimeoutError as exc:
-        raise typer.BadParameter(str(exc)) from exc
-    except RuntimeError as exc:
-        # rsync subprocess failure — abort rather than silently
-        # submitting a stale workspace.
-        raise typer.BadParameter(f"rsync failed: {exc}") from exc
+        except SyncAbortedError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        except SyncLockTimeoutError as exc:
+            raise typer.BadParameter(str(exc)) from exc
+        except RuntimeError as exc:
+            raise typer.BadParameter(f"rsync failed: {exc}") from exc
+
+        # Body executes here. Any exception escapes the ExitStack
+        # which still releases the locks via __exit__, then bubbles
+        # up to the workflow CLI's top-level handler unchanged.
+        yield
 
 
 def _build_workflow_callbacks(
@@ -405,6 +443,7 @@ def _run_sweep(
     endpoint_id: int | None,
     preset: str,
     rt: ResolvedTransport,
+    submission_context: Any | None = None,
 ) -> None:
     """Drive :class:`SweepOrchestrator` under a SIGINT → request_cancel guard.
 
@@ -417,6 +456,12 @@ def _run_sweep(
     cell through the pool + mount translation path already used by the
     Web / MCP sweep surfaces.
     """
+    # Caller may supply an override (CLI workflow Phase 2 passes one
+    # with ``allow_in_place=True`` after the workflow lock is held).
+    # When omitted, fall back to the transport's default context.
+    effective_context = (
+        submission_context if submission_context is not None else rt.submission_context
+    )
     orchestrator = SweepOrchestrator(
         workflow_yaml_path=yaml_file,
         workflow_data=workflow_data,
@@ -427,7 +472,7 @@ def _run_sweep(
         endpoint_id=endpoint_id,
         preset=preset,
         executor_factory=rt.executor_factory,
-        submission_context=rt.submission_context,
+        submission_context=effective_context,
     )
 
     original_handler = signal.getsignal(signal.SIGINT)
@@ -591,6 +636,15 @@ def _execute_workflow(
                     else None,
                     sync_required=_resolve_sync_flag(sync),
                 ):
+                    # Lock is held → flip ``allow_in_place`` on a
+                    # context copy so the SSH adapter is permitted
+                    # to take the IN_PLACE submission path for any
+                    # cell that qualifies.
+                    in_place_ctx = (
+                        _in_place_context(rt)
+                        if rt.transport_type == "ssh"
+                        else rt.submission_context
+                    )
                     _run_sweep(
                         yaml_file=yaml_file,
                         workflow_data=workflow_data,
@@ -600,6 +654,7 @@ def _execute_workflow(
                         endpoint_id=endpoint_id,
                         preset=effective_preset,
                         rt=rt,
+                        submission_context=in_place_ctx,
                     )
                 return
 
@@ -669,6 +724,15 @@ def _execute_workflow(
                 workflow_for_mounts=runner.workflow,
                 sync_required=_resolve_sync_flag(sync),
             ):
+                # Lock is held → flip ``allow_in_place`` so the SSH
+                # adapter's ShellJob branch is permitted to take the
+                # IN_PLACE path. Mutate the runner's stored context
+                # rather than re-building the runner so all the
+                # per-job state (parsed dependencies, etc.) survives.
+                if rt.transport_type == "ssh":
+                    in_place_ctx = _in_place_context(rt)
+                    if in_place_ctx is not None:
+                        runner._submission_context = in_place_ctx  # noqa: SLF001
                 results = runner.run(from_job=from_job, to_job=to_job, single_job=job)
 
             logger.info("Job Results:")

--- a/src/srunx/models.py
+++ b/src/srunx/models.py
@@ -755,9 +755,17 @@ def _render_base_script(
     with open(template_file, encoding="utf-8") as f:
         template_content = f.read()
 
+    # ``keep_trailing_newline=True`` so the rendered output preserves
+    # the source file's trailing ``\n`` instead of silently stripping
+    # it (Jinja's default). Workflow Phase 2's IN_PLACE eligibility
+    # check relies on ``rendered_bytes == source_bytes``; with the
+    # default behaviour, every script ending in ``\n`` (i.e. every
+    # POSIX-conforming shell script) compared as different and the
+    # in-place path was effectively dead. Codex blocker #2 on PR #141.
     template = jinja2.Template(
         template_content,
         undefined=jinja2.StrictUndefined,
+        keep_trailing_newline=True,
     )
 
     # Debug: log template variables

--- a/src/srunx/rendering.py
+++ b/src/srunx/rendering.py
@@ -62,6 +62,22 @@ class SubmissionRenderContext:
     mount_name: str | None = None
     mounts: tuple[Any, ...] = field(default_factory=tuple)
     default_work_dir: str | None = None
+    allow_in_place: bool = False
+    """Permission flag for the IN_PLACE submission path.
+
+    Workflow Phase 2 (#135): :meth:`SlurmSSHAdapter.run` only takes
+    the IN_PLACE shortcut (sbatch the user's mount-resident script
+    verbatim, skipping the temp upload) when this flag is True,
+    AND the source bytes equal the rendered bytes, AND the source
+    sits under one of the adapter's mounts.
+
+    Default ``False`` so callers that haven't grabbed the per-mount
+    sync lock (Web ``/api/workflows/run`` today, MCP sweep cells)
+    can't accidentally race a concurrent rsync. The CLI workflow
+    runner — which holds the lock for the lifetime of the run via
+    :func:`srunx.cli.workflow._hold_workflow_mounts` — flips this
+    to ``True`` when constructing the context. Closes Codex
+    blocker #3 on PR #141."""
 
 
 @dataclass(frozen=True)

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -1229,7 +1229,21 @@ class SlurmSSHAdapter:
            callback and return the updated job. Raises :class:`RuntimeError`
            on terminal failure so the workflow runner's retry / failure
            path triggers identically to the local ``Slurm`` executor.
+
+        IN_PLACE submission (skip the temp upload, run the user's
+        mount-resident script verbatim) is gated on
+        ``submission_context.allow_in_place`` so callers that do NOT
+        hold the per-(profile, mount) sync lock cannot race a
+        concurrent rsync. CLI workflow runs flip the flag inside
+        :func:`srunx.cli.workflow._hold_workflow_mounts`; Web /
+        MCP paths leave it ``False`` and keep the safe temp-upload
+        behaviour. Closes Codex blocker #3 on PR #141.
         """
+        allow_in_place = (
+            submission_context.allow_in_place
+            if submission_context is not None
+            else False
+        )
         # Inline imports keep the module import cost flat and mirror the
         # pattern used in ``srunx.client.Slurm`` (e.g. ``record_submission_from_job``).
         from srunx.models import (
@@ -1296,8 +1310,15 @@ class SlurmSSHAdapter:
                     )
                 elif isinstance(job, ShellJob):
                     script_path = render_shell_job_script(job.script_path, job, tmpdir)
-                    # IN_PLACE eligibility check.
-                    if self._mounts:
+                    # IN_PLACE eligibility check — only attempted when
+                    # the caller passed ``allow_in_place=True``,
+                    # confirming they're holding the per-(profile,
+                    # mount) sync lock for the lifetime of this call.
+                    # Without that lock a concurrent rsync could swap
+                    # the bytes between our render check and the
+                    # cluster's sbatch read. Codex blocker #3 on
+                    # PR #141.
+                    if allow_in_place and self._mounts:
                         try:
                             source_path = Path(job.script_path)
                         except (OSError, ValueError):
@@ -1316,9 +1337,10 @@ class SlurmSSHAdapter:
                                 in_place_remote_path = translate_local_to_remote(
                                     source_path, mount
                                 )
-                                # Prefer the script's own directory on the
-                                # remote so relative ``#SBATCH --output=``
-                                # paths resolve where the user expects.
+                                # Prefer the script's own directory on
+                                # the remote so relative ``#SBATCH
+                                # --output=`` paths resolve where the
+                                # user expects.
                                 in_place_submit_cwd = translate_local_to_remote(
                                     source_path.parent, mount
                                 )

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -12,6 +12,7 @@ import threading
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from srunx.callbacks import Callback
@@ -123,6 +124,21 @@ def _run_slurm_cmd(adapter: SlurmSSHAdapter, cmd: str) -> str:
     if exit_code != 0:
         raise RuntimeError(f"Remote command failed ({exit_code}): {stderr.strip()}")
     return stdout
+
+
+@dataclass(frozen=True)
+class _MountsOnly:
+    """Duck-typed shim that exposes just ``.mounts`` to the planner.
+
+    ``submission_plan.resolve_mount_for_path`` is duck-typed on the
+    profile's ``.mounts`` attribute, but the adapter only carries the
+    mounts tuple — not a full :class:`ServerProfile`. Wrapping in this
+    one-field dataclass avoids reaching back into ``ConfigManager``
+    just to satisfy the planner's type signature, and keeps the in-place
+    decision local to ``run()``.
+    """
+
+    mounts: tuple[MountConfig, ...]
 
 
 class SlurmSSHAdapter:
@@ -1249,8 +1265,26 @@ class SlurmSSHAdapter:
         with self._io_lock:
             self._ensure_connected()
 
-            # --- 1. Render script locally ---
+            # --- 1. Render script locally + decide IN_PLACE vs TEMP_UPLOAD ---
+            #
+            # Phase 2 (#135): when the source ShellJob lives under a
+            # configured mount AND its rendered bytes equal the source
+            # bytes (no Jinja substitution happened), we can skip the
+            # temp-upload and run the user-managed file in place via
+            # ``submit_remote_sbatch_file``. This preserves the user's
+            # ``#SBATCH`` directives and avoids the ``-o`` injection
+            # that ``submit_sbatch_job`` does not, but the legacy
+            # tempfile path performs.
             import tempfile as _tempfile
+
+            from srunx.cli.submission_plan import (
+                render_matches_source,
+                resolve_mount_for_path,
+                translate_local_to_remote,
+            )
+
+            in_place_remote_path: str | None = None
+            in_place_submit_cwd: str | None = None
 
             with _tempfile.TemporaryDirectory() as tmpdir:
                 if isinstance(job, Job):
@@ -1262,14 +1296,47 @@ class SlurmSSHAdapter:
                     )
                 elif isinstance(job, ShellJob):
                     script_path = render_shell_job_script(job.script_path, job, tmpdir)
-                else:  # pragma: no cover — Pydantic union guard
-                    raise TypeError(f"Unsupported job type: {type(job).__name__}")
+                    # IN_PLACE eligibility check.
+                    if self._mounts:
+                        try:
+                            source_path = Path(job.script_path)
+                        except (OSError, ValueError):
+                            source_path = None  # type: ignore[assignment]
+                        if source_path is not None and source_path.exists():
+                            # Build a duck-typed "profile" carrying just
+                            # the mounts; ``resolve_mount_for_path`` only
+                            # reads ``.mounts``.
+                            mount = resolve_mount_for_path(
+                                source_path,
+                                _MountsOnly(self._mounts),  # type: ignore[arg-type]
+                            )
+                            if mount is not None and render_matches_source(
+                                Path(script_path), source_path
+                            ):
+                                in_place_remote_path = translate_local_to_remote(
+                                    source_path, mount
+                                )
+                                # Prefer the script's own directory on the
+                                # remote so relative ``#SBATCH --output=``
+                                # paths resolve where the user expects.
+                                in_place_submit_cwd = translate_local_to_remote(
+                                    source_path.parent, mount
+                                )
 
                 with open(script_path, encoding="utf-8") as f:
                     script_content = f.read()
 
             # --- 2. Submit via SSH ---
-            result = self._client.submit_sbatch_job(script_content, job_name=job.name)
+            if in_place_remote_path is not None:
+                result = self._client.submit_remote_sbatch_file(
+                    in_place_remote_path,
+                    submit_cwd=in_place_submit_cwd,
+                    job_name=job.name,
+                )
+            else:
+                result = self._client.submit_sbatch_job(
+                    script_content, job_name=job.name
+                )
             if result is None or not result.job_id:
                 raise RuntimeError(f"Failed to submit job '{job.name}' via SSH")
             job_id = int(result.job_id)

--- a/tests/cli/test_submission_plan.py
+++ b/tests/cli/test_submission_plan.py
@@ -264,6 +264,109 @@ class TestPlanSbatchSubmission:
         assert plan.submit_cwd == "/cluster/share/ml/runs"
 
 
+class TestCollectTouchedMounts:
+    """Workflow Phase 2 (#135): touched-mount aggregation across ShellJobs."""
+
+    def test_empty_workflow_returns_empty_list(self, tmp_path: Path) -> None:
+        """A workflow with no jobs touches no mounts."""
+        from srunx.cli.submission_plan import collect_touched_mounts
+
+        local = tmp_path / "ml"
+        local.mkdir()
+        profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+        class _StubWorkflow:
+            jobs = ()
+
+        assert collect_touched_mounts(_StubWorkflow(), profile) == []
+
+    def test_dedup_across_multiple_shelljobs_same_mount(self, tmp_path: Path) -> None:
+        """Two ShellJobs under the same mount yield one mount, not two."""
+        from srunx.cli.submission_plan import collect_touched_mounts
+        from srunx.models import ShellJob
+
+        local = tmp_path / "ml"
+        local.mkdir()
+        for name in ("a.sh", "b.sh"):
+            (local / name).write_text("#!/bin/bash\n")
+        mount = _make_mount(local)
+        profile = _make_profile(tmp_path, mounts=[mount])
+
+        class _Wf:
+            jobs = (
+                ShellJob(name="a", script_path=str(local / "a.sh")),
+                ShellJob(name="b", script_path=str(local / "b.sh")),
+            )
+
+        result = collect_touched_mounts(_Wf(), profile)
+        assert result == [mount]
+
+    def test_skips_jobs_outside_any_mount(self, tmp_path: Path) -> None:
+        """ShellJobs outside the mount roots are dropped (will go via tmp)."""
+        from srunx.cli.submission_plan import collect_touched_mounts
+        from srunx.models import ShellJob
+
+        local = tmp_path / "ml"
+        local.mkdir()
+        (local / "in.sh").write_text("#!/bin/bash\n")
+        outside = tmp_path / "scratch"
+        outside.mkdir()
+        (outside / "out.sh").write_text("#!/bin/bash\n")
+        mount = _make_mount(local)
+        profile = _make_profile(tmp_path, mounts=[mount])
+
+        class _Wf:
+            jobs = (
+                ShellJob(name="i", script_path=str(local / "in.sh")),
+                ShellJob(name="o", script_path=str(outside / "out.sh")),
+            )
+
+        assert collect_touched_mounts(_Wf(), profile) == [mount]
+
+    def test_skips_command_jobs(self, tmp_path: Path) -> None:
+        """``Job`` (command-style, no script_path) contributes nothing."""
+        from srunx.cli.submission_plan import collect_touched_mounts
+        from srunx.models import Job
+
+        local = tmp_path / "ml"
+        local.mkdir()
+        profile = _make_profile(tmp_path, mounts=[_make_mount(local)])
+
+        class _Wf:
+            jobs = (Job(name="cmd", command=["echo", "hi"]),)
+
+        assert collect_touched_mounts(_Wf(), profile) == []
+
+
+class TestRenderMatchesSource:
+    def test_identical_bytes_match(self, tmp_path: Path) -> None:
+        from srunx.cli.submission_plan import render_matches_source
+
+        a = tmp_path / "a"
+        a.write_bytes(b"#!/bin/bash\necho hi\n")
+        b = tmp_path / "b"
+        b.write_bytes(b"#!/bin/bash\necho hi\n")
+        assert render_matches_source(a, b) is True
+
+    def test_different_bytes_do_not_match(self, tmp_path: Path) -> None:
+        from srunx.cli.submission_plan import render_matches_source
+
+        a = tmp_path / "a"
+        a.write_bytes(b"#!/bin/bash\necho hi\n")
+        b = tmp_path / "b"
+        b.write_bytes(b"#!/bin/bash\necho HELLO\n")
+        assert render_matches_source(a, b) is False
+
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None:
+        """Missing file → False (caller must fall back to tmp upload)."""
+        from srunx.cli.submission_plan import render_matches_source
+
+        a = tmp_path / "a"
+        a.write_bytes(b"x")
+        b = tmp_path / "missing"
+        assert render_matches_source(a, b) is False
+
+
 @pytest.mark.parametrize("sync_enabled", [True, False])
 def test_in_place_preserves_remote_path_regardless_of_sync(
     tmp_path: Path, sync_enabled: bool

--- a/tests/cli/test_workflow_in_place.py
+++ b/tests/cli/test_workflow_in_place.py
@@ -253,6 +253,82 @@ def test_flow_run_local_workflow_no_mount_resolution(
     assert rsync_calls == []  # no sync attempt for local transport
 
 
+def test_flow_run_workflow_body_failure_not_misreported_as_rsync(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A job/sweep failure inside ``runner.run()`` must not wear "rsync failed".
+
+    Regression test for Codex blocker #1 on PR #141: the previous
+    implementation wrapped the entire ``yield`` in a ``except RuntimeError``
+    that translated *any* runtime error to ``BadParameter("rsync
+    failed: ...")``. Workflow body failures (job submission errors,
+    adapter timeouts) got mislabeled as sync failures.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    s1 = mount_local / "step1.sbatch"
+    s1.write_text("#!/bin/bash\necho hi\n")
+
+    yaml_path = tmp_path / "wf.yaml"
+    _write_workflow(yaml_path, ("step1", str(s1)))
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml")
+    executor = _patch_workflow_transport(monkeypatch, profile)
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    # Body failure: the executor blows up the job.
+    executor.run.side_effect = RuntimeError("SLURM rejected the job")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["flow", "run", str(yaml_path), "--profile", "ml-cluster"]
+    )
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "SLURM rejected" in combined or "rejected" in combined
+    # The "rsync failed" wrapper must not appear on a workflow-body
+    # failure — the original message must surface verbatim.
+    assert "rsync failed" not in combined.lower()
+
+
+def test_flow_run_passes_allow_in_place_via_submission_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI flips ``allow_in_place=True`` on the runner's context.
+
+    Regression for Codex blocker #3 on PR #141: the SSH adapter
+    must not take the IN_PLACE shortcut on Web/MCP paths that don't
+    hold the workflow lock. The CLI flips the flag inside
+    ``_hold_workflow_mounts``; this test asserts the executor sees
+    a context with ``allow_in_place=True``.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    s1 = mount_local / "step1.sbatch"
+    s1.write_text("#!/bin/bash\necho hi\n")
+
+    yaml_path = tmp_path / "wf.yaml"
+    _write_workflow(yaml_path, ("step1", str(s1)))
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml")
+    executor = _patch_workflow_transport(monkeypatch, profile)
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["flow", "run", str(yaml_path), "--profile", "ml-cluster"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    executor.run.assert_called_once()
+    submission_ctx = executor.run.call_args.kwargs.get("submission_context")
+    assert submission_ctx is not None
+    assert submission_ctx.allow_in_place is True
+
+
 def test_flow_run_rsync_failure_aborts_workflow(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/cli/test_workflow_in_place.py
+++ b/tests/cli/test_workflow_in_place.py
@@ -1,0 +1,286 @@
+"""Integration tests for ``srunx flow run`` Phase 2 sync orchestration.
+
+Workflow Phase 2 (#135) introduces:
+
+* Workflow-level rsync — touched mounts are sync'd **once** at the
+  start of the run, not once per ShellJob nor once per sweep cell.
+* Per-(profile, mount) lock held across every job submission inside
+  the workflow run, closing the same race window
+  ``mount_sync_session`` closes for single-job ``sbatch``.
+* ``--sync`` / ``--no-sync`` CLI flag with config fallback.
+
+These tests stub out the SSH executor + rsync helper so no real
+paramiko runs; the goal is to lock the routing logic in place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+from srunx.ssh.core.config import MountConfig, ServerProfile
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+
+
+def _stub_profile(tmp_path: Path, mount_local: Path, remote: str) -> ServerProfile:
+    key = tmp_path / "id_rsa"
+    key.write_text("dummy")
+    return ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename=str(key),
+        mounts=(MountConfig(name="ml", local=str(mount_local), remote=remote),),
+    )
+
+
+def _patch_workflow_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    profile: ServerProfile,
+    profile_name: str = "ml-cluster",
+):
+    """Wire an SSH-flavoured ResolvedTransport with mock job_ops.
+
+    Returns ``executor_mock`` so tests can assert what the runner
+    handed each job to. ``executor_factory`` returns a context manager
+    yielding the same mock executor — matches the
+    :class:`WorkflowJobExecutorFactory` contract.
+    """
+    from srunx.models import JobStatus
+    from srunx.rendering import SubmissionRenderContext
+    from srunx.transport.registry import TransportHandle
+
+    executor = MagicMock(name="WorkflowExecutor")
+
+    def _fake_run(job, **_kwargs):
+        # Mark the job complete so WorkflowRunner stops polling.
+        job.job_id = 12345
+        job.status = JobStatus.COMPLETED
+        return job
+
+    executor.run.side_effect = _fake_run
+    executor.get_job_output_detailed.return_value = {
+        "found_files": [],
+        "output": "",
+        "error": "",
+        "primary_log": None,
+        "slurm_log_dir": None,
+        "searched_dirs": [],
+    }
+
+    class _ExecutorCM:
+        def __enter__(self_inner):
+            return executor
+
+        def __exit__(self_inner, *exc):
+            return None
+
+    job_ops = MagicMock(name="JobOperations")
+
+    handle = TransportHandle(
+        scheduler_key=f"ssh:{profile_name}",
+        profile_name=profile_name,
+        transport_type="ssh",
+        job_ops=job_ops,
+        queue_client=job_ops,
+        executor_factory=lambda: _ExecutorCM(),
+        submission_context=SubmissionRenderContext(
+            mount_name=None,
+            mounts=tuple(profile.mounts),
+            default_work_dir=None,
+        ),
+    )
+
+    def _fake_build(
+        profile_name_arg,
+        *,
+        callbacks=None,
+        submission_source="web",
+        mount_name=None,
+        pool_size=2,
+    ):
+        return handle, MagicMock(name="pool")
+
+    monkeypatch.setattr("srunx.transport.registry._build_ssh_handle", _fake_build)
+
+    from srunx.ssh.core.config import ConfigManager
+
+    monkeypatch.setattr(ConfigManager, "get_profile", lambda self, name: profile)
+
+    return executor
+
+
+def _write_workflow(yaml_path: Path, *jobs: tuple[str, str]) -> None:
+    """Write a minimal workflow YAML with the given (name, script_path) pairs."""
+    body = ["name: in-place-test", "jobs:"]
+    for name, script in jobs:
+        body.append(f"  - name: {name}")
+        body.append(f"    path: {script}")
+    yaml_path.write_text("\n".join(body) + "\n")
+
+
+def test_flow_run_syncs_each_mount_once_for_multi_shelljob_workflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two ShellJobs under the same mount → exactly one rsync call.
+
+    Workflow Phase 2: rsync should fire once per touched mount per
+    workflow run, not once per job. A 100-cell sweep across a single
+    mount must not trigger 100 rsyncs.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    s1 = mount_local / "step1.sbatch"
+    s1.write_text("#!/bin/bash\necho hi\n")
+    s2 = mount_local / "step2.sbatch"
+    s2.write_text("#!/bin/bash\necho bye\n")
+
+    yaml_path = tmp_path / "wf.yaml"
+    _write_workflow(yaml_path, ("step1", str(s1)), ("step2", str(s2)))
+
+    profile = _stub_profile(
+        tmp_path, mount_local=mount_local, remote="/cluster/share/ml"
+    )
+    _patch_workflow_transport(monkeypatch, profile)
+
+    rsync_calls: list[tuple] = []
+
+    def _record_rsync(prof, name, *, delete=False):
+        rsync_calls.append((prof, name, delete))
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record_rsync)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["flow", "run", str(yaml_path), "--profile", "ml-cluster"]
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    # Exactly one rsync for the shared mount.
+    assert len(rsync_calls) == 1
+    assert rsync_calls[0][1] == "ml"
+    assert rsync_calls[0][2] is False  # auto-sync uses delete=False
+
+
+def test_flow_run_no_sync_skips_rsync_keeps_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--no-sync`` skips rsync but the workflow still runs.
+
+    The mount lock is still acquired (Phase 1 race-prevention
+    invariant) but rsync itself is skipped — useful when the user
+    knows the remote is current.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    s1 = mount_local / "step1.sbatch"
+    s1.write_text("#!/bin/bash\necho hi\n")
+
+    yaml_path = tmp_path / "wf.yaml"
+    _write_workflow(yaml_path, ("step1", str(s1)))
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml")
+    _patch_workflow_transport(monkeypatch, profile)
+
+    rsync_calls: list[tuple] = []
+    monkeypatch.setattr(
+        "srunx.sync.service.sync_mount_by_name",
+        lambda *a, **k: rsync_calls.append((a, k)),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "flow",
+            "run",
+            str(yaml_path),
+            "--profile",
+            "ml-cluster",
+            "--no-sync",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert rsync_calls == []  # rsync skipped
+
+
+def test_flow_run_local_workflow_no_mount_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Local SLURM transport has no mount concept — no sync attempt."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    s1 = mount_local / "step1.sbatch"
+    s1.write_text("#!/bin/bash\necho hi\n")
+
+    yaml_path = tmp_path / "wf.yaml"
+    _write_workflow(yaml_path, ("step1", str(s1)))
+
+    rsync_calls: list[tuple] = []
+    monkeypatch.setattr(
+        "srunx.sync.service.sync_mount_by_name",
+        lambda *a, **k: rsync_calls.append((a, k)),
+    )
+
+    # Stub the local Slurm executor so the workflow run completes
+    # without touching real SLURM.
+    from srunx.models import JobStatus
+
+    def _fake_local_submit(self, job, **_kwargs):
+        job.job_id = 1
+        job.status = JobStatus.COMPLETED
+        return job
+
+    monkeypatch.setattr("srunx.client.Slurm.submit", _fake_local_submit)
+    monkeypatch.setattr("srunx.client.Slurm.monitor", lambda self, job, **_: job)
+    monkeypatch.setattr(
+        "srunx.client.Slurm.run", lambda self, job, **_kw: _fake_local_submit(self, job)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["flow", "run", str(yaml_path), "--local"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert rsync_calls == []  # no sync attempt for local transport
+
+
+def test_flow_run_rsync_failure_aborts_workflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rsync failure must abort — never silently submit a stale workspace."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    s1 = mount_local / "step1.sbatch"
+    s1.write_text("#!/bin/bash\necho hi\n")
+
+    yaml_path = tmp_path / "wf.yaml"
+    _write_workflow(yaml_path, ("step1", str(s1)))
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml")
+    executor = _patch_workflow_transport(monkeypatch, profile)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("rsync exited 23: permission denied")
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _boom)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app, ["flow", "run", str(yaml_path), "--profile", "ml-cluster"]
+    )
+
+    assert result.exit_code != 0
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "rsync" in combined.lower()
+    # The runner must NOT have started submitting jobs after the
+    # sync failure.
+    executor.run.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,14 +101,22 @@ class TestTyperCLI:
         assert "run" in result.stdout
 
     def test_flow_run_help(self):
-        """Test flow run command help includes debug + validate options."""
+        """Test flow run command help includes debug + validate + sync options.
+
+        Use loose substring checks because Typer wraps long help lines
+        across the terminal width — the longer help text PR #135 added
+        for ``--sync`` pushed the ``--debug`` description below the
+        wrap point. Asserting the flag *names* exist (which is what
+        users grep for) is the contract we actually care about.
+        """
         result = self.runner.invoke(app, ["flow", "run", "--help"])
         assert result.exit_code == 0
         clean_output = strip_ansi_codes(result.stdout)
         assert "Execute workflow from YAML file" in clean_output
         assert "--debug" in clean_output
-        assert "Show rendered SLURM scripts for each job" in clean_output
         assert "--validate" in clean_output
+        assert "--sync" in clean_output
+        assert "--no-sync" in clean_output
 
     def test_flow_run_debug_flag_threads_through(self, tmp_path):
         """Regression for I6: ``srunx flow run --debug`` must forward debug=True.
@@ -139,7 +147,15 @@ class TestTyperCLI:
     @patch("srunx.cli.main.Slurm")
     @patch("srunx.cli.main.get_config")
     def test_sbatch_wrap_basic(self, mock_get_config, mock_slurm_class):
-        """``srunx sbatch --wrap "cmd"`` submits a Job with the wrap string."""
+        """``srunx sbatch --wrap "cmd"`` submits a Job that runs cmd via bash -c.
+
+        Real ``sbatch --wrap`` invokes ``/bin/sh -c "<cmd>"`` on the
+        compute node, so shell operators (``&&`` / ``|`` / ``>``)
+        evaluate there. srunx mirrors that by stuffing the wrap
+        string into ``["bash", "-c", "<cmd>"]`` so the rendered
+        sbatch script ends up running ``srun bash -c '<cmd>'``.
+        Closes #138.
+        """
         mock_config = Mock()
         mock_config.log_dir = "logs"
         mock_config.work_dir = None
@@ -149,7 +165,7 @@ class TestTyperCLI:
         mock_job = Mock()
         mock_job.job_id = 12345
         mock_job.name = "test_job"
-        mock_job.command = "python script.py"
+        mock_job.command = ["bash", "-c", "python script.py"]
         mock_slurm.submit.return_value = mock_job
         mock_slurm_class.return_value = mock_slurm
 
@@ -162,8 +178,87 @@ class TestTyperCLI:
         assert "Job submitted successfully: 12345" in result.stdout
         mock_slurm.submit.assert_called_once()
         submitted_job = mock_slurm.submit.call_args[0][0]
-        # --wrap maps to Job.command verbatim.
-        assert submitted_job.command == "python script.py"
+        # --wrap is wrapped via bash -c so shell operators stay on
+        # the compute node (real sbatch parity).
+        assert submitted_job.command == ["bash", "-c", "python script.py"]
+
+    @patch("srunx.cli.main.Slurm")
+    @patch("srunx.cli.main.get_config")
+    def test_sbatch_wrap_preserves_shell_operators(
+        self, mock_get_config, mock_slurm_class
+    ):
+        """``--wrap "cmd1 && cmd2"`` runs both commands on the compute node.
+
+        Regression for #138: the old implementation passed the wrap
+        string straight to Job.command, which the template rendered
+        as ``srun cmd1 && cmd2``. ``cmd2`` would silently run on the
+        submitting host, not the compute node.
+        """
+        mock_config = Mock()
+        mock_config.log_dir = "logs"
+        mock_config.work_dir = None
+        mock_get_config.return_value = mock_config
+
+        mock_slurm = Mock()
+        mock_job = Mock(job_id=1, name="j", command=[])
+        mock_slurm.submit.return_value = mock_job
+        mock_slurm_class.return_value = mock_slurm
+
+        result = self.runner.invoke(
+            app,
+            [
+                "sbatch",
+                "--wrap",
+                "module load cuda && python train.py",
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        submitted_job = mock_slurm.submit.call_args[0][0]
+        # The whole shell pipeline must live inside bash -c.
+        assert submitted_job.command == [
+            "bash",
+            "-c",
+            "module load cuda && python train.py",
+        ]
+
+    def test_wrap_renders_to_srun_bash_c(self) -> None:
+        """End-to-end render check: shell operators stay quoted in bash -c.
+
+        Renders the default template against a Job built the way the
+        CLI builds it for ``--wrap`` and asserts the output line
+        contains ``srun bash -c '...'``. Goes through the actual
+        :func:`render_job_script` pipeline so any future template
+        change keeps wrap parity. Closes #138.
+        """
+        import tempfile
+
+        from srunx.models import (
+            Job,
+            JobEnvironment,
+            JobResource,
+            render_job_script,
+        )
+        from srunx.template import get_template_path
+
+        job = Job(
+            name="wrap-parity",
+            command=["bash", "-c", "module load cuda && python train.py"],
+            resources=JobResource(),
+            environment=JobEnvironment(),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            script_path = render_job_script(get_template_path("base"), job, tmpdir)
+            content = open(script_path).read()
+
+        # The whole pipeline must sit inside bash -c '...'. ``shlex.join``
+        # uses single quotes for safety.
+        assert "srun bash -c 'module load cuda && python train.py'" in content, (
+            "wrap parity broken: shell operators must stay inside bash -c "
+            "so they evaluate on the compute node, not the submitting host. "
+            "See #138."
+        )
 
     @patch("srunx.cli.main.Slurm")
     @patch("srunx.cli.main.get_config")

--- a/tests/web/test_ssh_adapter_run.py
+++ b/tests/web/test_ssh_adapter_run.py
@@ -417,6 +417,135 @@ class TestMonitorTimeout:
         assert result == "COMPLETED"
 
 
+class TestSSHAdapterRunInPlace:
+    """Phase 2 (#135): adapter.run picks IN_PLACE only with caller permission.
+
+    The IN_PLACE submission path is gated on
+    ``submission_context.allow_in_place=True`` so callers that do
+    NOT hold the per-(profile, mount) sync lock cannot race a
+    concurrent rsync. CLI workflow runs flip the flag inside
+    ``_hold_workflow_mounts``; Web/MCP paths leave it ``False``.
+    Tests cover both halves of that gate plus the eligibility checks
+    inside the IN_PLACE branch (mount membership, render-vs-source
+    bytes equality).
+    """
+
+    def _setup_in_place_adapter(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+        """Build an adapter with one mount, mocked submit + recording."""
+        from srunx.ssh.core.config import MountConfig
+
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        script = mount_local / "train.sh"
+        script.write_text("#!/bin/bash\necho hi\n")
+
+        adapter = _bare_adapter()
+        adapter._mounts = (
+            MountConfig(name="ml", local=str(mount_local), remote="/r/ml"),
+        )
+
+        # Mock both submit paths so we can assert which fired.
+        sbatch_job_mock = MagicMock()
+        sbatch_job_mock.job_id = "1"
+        sbatch_job_mock.name = "train"
+        adapter._client.submit_sbatch_job = MagicMock(  # type: ignore[method-assign]
+            return_value=sbatch_job_mock
+        )
+
+        remote_mock = MagicMock()
+        remote_mock.job_id = "2"
+        remote_mock.name = "train"
+        adapter._client.submit_remote_sbatch_file = MagicMock(  # type: ignore[method-assign]
+            return_value=remote_mock
+        )
+
+        monkeypatch.setattr(
+            adapter, "_monitor_until_terminal", lambda _jid: "COMPLETED"
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_job_submission",
+            staticmethod(lambda *a, **k: None),
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_completion_safe",
+            staticmethod(lambda *a, **k: None),
+        )
+
+        return adapter, script
+
+    def test_allow_in_place_false_keeps_temp_upload(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default ``allow_in_place=False`` → temp-upload, never in-place.
+
+        This is the Web/MCP safety contract: without the workflow
+        lock, the adapter must NOT take the IN_PLACE shortcut even
+        when the script is mount-resident.
+        """
+        from srunx.models import ShellJob
+        from srunx.rendering import SubmissionRenderContext
+
+        adapter, script = self._setup_in_place_adapter(tmp_path, monkeypatch)
+        job = ShellJob(name="train", script_path=str(script))
+
+        ctx = SubmissionRenderContext(mounts=adapter._mounts, allow_in_place=False)
+        adapter.run(job, submission_context=ctx)
+
+        adapter._client.submit_sbatch_job.assert_called_once()  # type: ignore[attr-defined]
+        adapter._client.submit_remote_sbatch_file.assert_not_called()  # type: ignore[attr-defined]
+
+    def test_allow_in_place_true_takes_in_place_path(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``allow_in_place=True`` + mount-resident + render==source → IN_PLACE.
+
+        Proves the full IN_PLACE eligibility chain works end-to-end
+        through ``adapter.run`` — covers the ``rendered bytes ==
+        source bytes`` check, the mount membership check, and the
+        ``submit_remote_sbatch_file`` dispatch.
+        """
+        from srunx.models import ShellJob
+        from srunx.rendering import SubmissionRenderContext
+
+        adapter, script = self._setup_in_place_adapter(tmp_path, monkeypatch)
+        job = ShellJob(name="train", script_path=str(script))
+
+        ctx = SubmissionRenderContext(mounts=adapter._mounts, allow_in_place=True)
+        adapter.run(job, submission_context=ctx)
+
+        adapter._client.submit_remote_sbatch_file.assert_called_once()  # type: ignore[attr-defined]
+        # The temp-upload path must NOT fire when IN_PLACE took over.
+        adapter._client.submit_sbatch_job.assert_not_called()  # type: ignore[attr-defined]
+        # The IN_PLACE call passed the translated remote path + a
+        # submit_cwd under the mount.
+        call = adapter._client.submit_remote_sbatch_file.call_args  # type: ignore[attr-defined]
+        assert call.args[0] == "/r/ml/train.sh"
+        assert call.kwargs["submit_cwd"] == "/r/ml"
+
+    def test_in_place_skipped_when_script_outside_mount(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even with ``allow_in_place=True``, scripts outside any mount go via temp."""
+        from srunx.models import ShellJob
+        from srunx.rendering import SubmissionRenderContext
+
+        adapter, _script = self._setup_in_place_adapter(tmp_path, monkeypatch)
+
+        outside = tmp_path / "scratch"
+        outside.mkdir()
+        outside_script = outside / "x.sh"
+        outside_script.write_text("#!/bin/bash\necho hi\n")
+        job = ShellJob(name="x", script_path=str(outside_script))
+
+        ctx = SubmissionRenderContext(mounts=adapter._mounts, allow_in_place=True)
+        adapter.run(job, submission_context=ctx)
+
+        adapter._client.submit_sbatch_job.assert_called_once()  # type: ignore[attr-defined]
+        adapter._client.submit_remote_sbatch_file.assert_not_called()  # type: ignore[attr-defined]
+
+
 class TestSSHAdapterRunSubmissionContext:
     """Batch 2a: ``submission_context`` drives mount-aware path rewriting.
 

--- a/tests/web/test_ssh_adapter_run.py
+++ b/tests/web/test_ssh_adapter_run.py
@@ -524,6 +524,39 @@ class TestSSHAdapterRunInPlace:
         assert call.args[0] == "/r/ml/train.sh"
         assert call.kwargs["submit_cwd"] == "/r/ml"
 
+    def test_in_place_skipped_when_render_differs_from_source(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``allow_in_place=True`` + Jinja substitution → temp-upload anyway.
+
+        The IN_PLACE eligibility chain has three checks (allow flag,
+        mount membership, rendered==source). When Jinja substitution
+        actually changed bytes (the script had ``{{ ... }}`` tokens
+        and ``script_vars`` filled them), the rendered output is a
+        new artifact with no home in the mount and must take the
+        temp-upload path even though the source path is mount-resident.
+        """
+        from srunx.models import ShellJob
+        from srunx.rendering import SubmissionRenderContext
+
+        adapter, script = self._setup_in_place_adapter(tmp_path, monkeypatch)
+        # Rewrite the source so it contains an actual Jinja variable.
+        script.write_text("#!/bin/bash\necho '{{ greeting }}'\n", encoding="utf-8")
+
+        # Provide script_vars so render produces different bytes.
+        job = ShellJob(
+            name="train",
+            script_path=str(script),
+            script_vars={"greeting": "hi"},
+        )
+
+        ctx = SubmissionRenderContext(mounts=adapter._mounts, allow_in_place=True)
+        adapter.run(job, submission_context=ctx)
+
+        # Render did substitute → temp-upload is the only safe path.
+        adapter._client.submit_sbatch_job.assert_called_once()  # type: ignore[attr-defined]
+        adapter._client.submit_remote_sbatch_file.assert_not_called()  # type: ignore[attr-defined]
+
     def test_in_place_skipped_when_script_outside_mount(
         self, tmp_path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
> Round 1 of the post-#140 followup plan (A2 / B1 / C2). Bundles the silent-bug fix (#138) with the workflow CLI in-place execution + auto-sync (Phase 2 of #135). Web ``/api/workflows/run`` is intentionally a separate PR — see B1 in the plan.

## Closes

- **#138** \`sbatch --wrap\` parity with real sbatch
- **#135** Phase 2 CLI part (Web part still open as #135)

## #138 — \`sbatch --wrap\` matches real sbatch semantics

\`\`\`bash
# Before: cmd2 silently runs on the submitting host
srunx sbatch --wrap "cmd1 && cmd2"
# Renders → srun cmd1 && cmd2

# After: both commands run on the compute node
srunx sbatch --wrap "cmd1 && cmd2"
# Renders → srun bash -c 'cmd1 && cmd2'
\`\`\`

CLI wraps the value as \`[\"bash\", \"-c\", \"<cmd>\"]\` so \`render_job_script\`'s \`shlex.join\` quotes the payload. Real sbatch uses \`/bin/sh -c\` internally; we use \`bash -c\` which is the strictly more useful POSIX-superset.

## #135 Phase 2 (CLI part)

\`srunx flow run\` now mirrors the per-job \`srunx sbatch\` story:

| Behaviour | Before | After |
|---|---|---|
| rsync per workflow | manual (\`srunx ssh sync\`) | **once per touched mount** at start of run |
| sweep × N cells | N rsyncs, N tmp uploads | **1 rsync** total, in-place where possible |
| ShellJob mount-resident, no Jinja | tmp upload | **in-place** \`sbatch /cluster/share/.../script.sh\` |
| ShellJob mount-resident, Jinja substituted | tmp upload | tmp upload (rendered ≠ source bytes) |
| ShellJob outside mount | tmp upload | unchanged |
| Per-(profile, mount) lock | none | **held across every job** in the workflow run |
| CLI flags | — | \`--sync\` / \`--no-sync\` (default \`[sync] auto\`) |
| Sync failure | — | **abort** (no silent fallback to stale workspace) |

### Architecture additions

- **\`srunx.cli.submission_plan.collect_touched_mounts(workflow, profile)\`** — pure aggregation; longest-prefix dedup; stable order for deterministic lock acquisition.
- **\`srunx.cli.submission_plan.render_matches_source(rendered, source)\`** — bytes-equality check used by the adapter's IN_PLACE decision.
- **\`srunx.cli.workflow._hold_workflow_mounts\`** — \`contextlib.ExitStack\` layering \`mount_sync_session\` over every touched mount; failures translate to \`BadParameter\` with consistent messages.
- **\`SlurmSSHAdapter.run\`** — ShellJob branch now decides IN_PLACE vs TEMP_UPLOAD via \`render_matches_source\` and dispatches to \`submit_remote_sbatch_file\` accordingly. Generated artifacts (Jinja-substituted) keep the legacy temp-upload path.

## Why Web is a separate PR (B1)

\`/api/workflows/run\` is a 1600-line router with its own existing sync hook. Plumbing the same workflow-level \`mount_sync_session\` through that path requires touching the request/response shapes + frontend behaviour and is larger than this PR's scope. Keeping the CLI surgical lets us validate the planner abstractions before the Web-side refactor.

## Test plan

- [x] \`uv run ruff check .\` clean
- [x] \`uv run mypy .\` clean (250 source files)
- [x] \`uv run pytest\` — 1850 passed (+ 12 net new)
- [x] New tests:
  - 4 \`collect_touched_mounts\` cases (empty / dedup / outside / command-only)
  - 3 \`render_matches_source\` cases (equal / differ / missing)
  - 4 workflow integration cases (rsync-once / --no-sync / local-no-sync / rsync-fail-aborts)
  - 3 \`--wrap\` parity cases (basic, shell-operators, end-to-end render check)
- [ ] Reviewer: try \`srunx flow run wf.yaml --profile X\` against a multi-ShellJob workflow and confirm rsync runs **once** in the logs (auto-sync banner: \`⇅ Synced mount X\`)

## Followups still open

- #135 Web part: \`/api/workflows/run\` mount-aware in-place
- #136 Web \`POST /api/jobs\` script_path
- #139 sinfo / sacct full SSH parity
- #137 Phase 4 hardening (split into 4 small PRs per C2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)