### PR TITLE
fix(tests): JobMonitor tests patch Protocol method, not legacy alias

### DIFF
--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -51,7 +51,7 @@ class TestJobMonitor:
         job2._status = JobStatus.COMPLETED
 
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(side_effect=[job1, job2])
+        monitor.client.status = MagicMock(side_effect=[job1, job2])
 
         assert monitor.check_condition() is True
 
@@ -66,7 +66,7 @@ class TestJobMonitor:
         job2._status = JobStatus.RUNNING
 
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(side_effect=[job1, job2])
+        monitor.client.status = MagicMock(side_effect=[job1, job2])
 
         assert monitor.check_condition() is False
 
@@ -79,7 +79,7 @@ class TestJobMonitor:
         job._status = JobStatus.FAILED
 
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(return_value=job)
+        monitor.client.status = MagicMock(return_value=job)
 
         assert monitor.check_condition() is True
 
@@ -94,7 +94,7 @@ class TestJobMonitor:
         job2._status = JobStatus.COMPLETED
 
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(side_effect=[job1, job2])
+        monitor.client.status = MagicMock(side_effect=[job1, job2])
 
         state = monitor.get_current_state()
         assert state == {"123": "RUNNING", "456": "COMPLETED"}
@@ -105,7 +105,7 @@ class TestJobMonitor:
 
         # Mock client to raise exception
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(side_effect=Exception("SLURM error"))
+        monitor.client.status = MagicMock(side_effect=Exception("SLURM error"))
 
         jobs = monitor._get_monitored_jobs()
         assert len(jobs) == 1
@@ -198,7 +198,7 @@ class TestJobMonitor:
         # First call: RUNNING
         job_running = Job(name="job1", job_id=123, command=["test"])
         job_running._status = JobStatus.RUNNING
-        monitor.client.retrieve = MagicMock(return_value=job_running)
+        monitor.client.status = MagicMock(return_value=job_running)
 
         monitor._notify_callbacks("state_changed")
         assert callback.on_job_running.call_count == 1
@@ -210,7 +210,7 @@ class TestJobMonitor:
         # Third call: COMPLETED (should notify — clear cache for new mock)
         job_completed = Job(name="job1", job_id=123, command=["test"])
         job_completed._status = JobStatus.COMPLETED
-        monitor.client.retrieve = MagicMock(return_value=job_completed)
+        monitor.client.status = MagicMock(return_value=job_completed)
         monitor._cached_jobs = None
 
         monitor._notify_callbacks("state_changed")
@@ -229,7 +229,7 @@ class TestJobMonitor:
         monitor.client = MagicMock()
         job = Job(name="job1", job_id=123, command=["test"])
         job._status = JobStatus.RUNNING
-        monitor.client.retrieve = MagicMock(return_value=job)
+        monitor.client.status = MagicMock(return_value=job)
 
         # Should not raise exception
         monitor._notify_callbacks("state_changed")
@@ -255,7 +255,7 @@ class TestJobMonitor:
         monitor.client = MagicMock()
         call_count = 0
 
-        def mock_retrieve(job_id):
+        def mock_status(job_id):
             nonlocal call_count
             call_count += 1
             job = Job(name="job1", job_id=123, command=["test"])
@@ -269,7 +269,7 @@ class TestJobMonitor:
                 job._status = JobStatus.RUNNING
             return job
 
-        monitor.client.retrieve = mock_retrieve
+        monitor.client.status = mock_status
 
         # Run watch_continuous in thread with timeout
         thread = threading.Thread(target=monitor.watch_continuous)
@@ -300,7 +300,7 @@ class TestJobMonitor:
         monitor.client = MagicMock()
         call_count = 0
 
-        def mock_retrieve(job_id):
+        def mock_status(job_id):
             nonlocal call_count
             call_count += 1
             job = Job(name="job1", job_id=123, command=["test"])
@@ -310,7 +310,7 @@ class TestJobMonitor:
                 monitor._stop_requested = True
             return job
 
-        monitor.client.retrieve = mock_retrieve
+        monitor.client.status = mock_status
 
         # Run watch_continuous in thread
         thread = threading.Thread(target=monitor.watch_continuous)
@@ -337,7 +337,7 @@ class TestJobMonitor:
         monitor.client = MagicMock()
         job = Job(name="job1", job_id=123, command=["test"])
         job._status = JobStatus.RUNNING
-        monitor.client.retrieve = MagicMock(return_value=job)
+        monitor.client.status = MagicMock(return_value=job)
 
         # Start monitoring in thread
         thread = threading.Thread(target=monitor.watch_continuous)
@@ -364,12 +364,12 @@ class TestJobMonitor:
         # Mock client to return completed jobs
         monitor.client = MagicMock()
 
-        def mock_retrieve(job_id):
+        def mock_status(job_id):
             job = Job(name=f"job_{job_id}", job_id=job_id, command=["test"])
             job._status = JobStatus.COMPLETED
             return job
 
-        monitor.client.retrieve = mock_retrieve
+        monitor.client.status = mock_status
 
         # Check all jobs are monitored
         state = monitor.get_current_state()
@@ -411,7 +411,7 @@ class TestJobMonitor:
             JobStatus.COMPLETED,  # Duplicate - should not notify
         ]
 
-        def mock_retrieve(job_id):
+        def mock_status(job_id):
             nonlocal call_count
             job = Job(name="job999", job_id=999, command=["test"])
             if call_count < len(states):
@@ -422,7 +422,7 @@ class TestJobMonitor:
             call_count += 1
             return job
 
-        monitor.client.retrieve = mock_retrieve
+        monitor.client.status = mock_status
 
         # Run monitoring
         thread = threading.Thread(target=monitor.watch_continuous)

--- a/tests/test_monitor_errors.py
+++ b/tests/test_monitor_errors.py
@@ -20,7 +20,7 @@ class TestJobMonitorErrorRecovery:
         # First job succeeds, second fails
         job1 = Job(name="job1", job_id=123, command=["test"])
         job1._status = JobStatus.RUNNING
-        monitor.client.retrieve = MagicMock(
+        monitor.client.status = MagicMock(
             side_effect=[job1, Exception("SLURM connection error")]
         )
 
@@ -37,7 +37,7 @@ class TestJobMonitorErrorRecovery:
         """Test that all jobs get placeholders when all retrievals fail."""
         monitor = JobMonitor(job_ids=[123, 456, 789])
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(side_effect=Exception("SLURM down"))
+        monitor.client.status = MagicMock(side_effect=Exception("SLURM down"))
 
         jobs = monitor._get_monitored_jobs()
 
@@ -49,7 +49,7 @@ class TestJobMonitorErrorRecovery:
         """Test that check_condition doesn't crash on SLURM errors."""
         monitor = JobMonitor(job_ids=[123])
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(side_effect=Exception("Network error"))
+        monitor.client.status = MagicMock(side_effect=Exception("Network error"))
 
         # Should not raise, should return False (UNKNOWN not in target statuses)
         result = monitor.check_condition()
@@ -62,7 +62,7 @@ class TestJobMonitorErrorRecovery:
 
         job1 = Job(name="job1", job_id=123, command=["test"])
         job1._status = JobStatus.COMPLETED
-        monitor.client.retrieve = MagicMock(side_effect=[job1, Exception("Timeout")])
+        monitor.client.status = MagicMock(side_effect=[job1, Exception("Timeout")])
 
         state = monitor.get_current_state()
 
@@ -213,7 +213,7 @@ class TestCallbackErrorHandling:
 
         job = Job(name="job1", job_id=123, command=["test"])
         job._status = JobStatus.RUNNING
-        monitor.client.retrieve = MagicMock(return_value=job)
+        monitor.client.status = MagicMock(return_value=job)
 
         # Callback raises exception
         callback = MagicMock()

--- a/tests/test_monitor_timeout.py
+++ b/tests/test_monitor_timeout.py
@@ -23,7 +23,7 @@ class TestJobMonitorTimeout:
         job = Job(name="job1", job_id=123, command=["test"])
         job._status = JobStatus.RUNNING
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(return_value=job)
+        monitor.client.status = MagicMock(return_value=job)
 
         start_time = time.time()
         with pytest.raises(TimeoutError):
@@ -42,7 +42,7 @@ class TestJobMonitorTimeout:
         job = Job(name="job1", job_id=123, command=["test"])
         job._status = JobStatus.COMPLETED
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(return_value=job)
+        monitor.client.status = MagicMock(return_value=job)
 
         start_time = time.time()
         monitor.watch_until()
@@ -63,7 +63,7 @@ class TestJobMonitorTimeout:
 
         call_count = 0
 
-        def mock_retrieve(job_id):
+        def mock_status(job_id):
             nonlocal call_count
             call_count += 1
             if call_count >= 3:
@@ -71,7 +71,7 @@ class TestJobMonitorTimeout:
                 monitor._stop_requested = True
             return job
 
-        monitor.client.retrieve = mock_retrieve
+        monitor.client.status = mock_status
 
         start_time = time.time()
         monitor.watch_until()
@@ -89,7 +89,7 @@ class TestJobMonitorTimeout:
         job = Job(name="job1", job_id=123, command=["test"])
         job._status = JobStatus.RUNNING
         monitor.client = MagicMock()
-        monitor.client.retrieve = MagicMock(return_value=job)
+        monitor.client.status = MagicMock(return_value=job)
 
         start_time = time.time()
         with pytest.raises(TimeoutError):
@@ -207,7 +207,7 @@ class TestContinuousModeTimeout:
 
         call_count = 0
 
-        def mock_retrieve(job_id):
+        def mock_status(job_id):
             nonlocal call_count
             call_count += 1
             if call_count >= 5:
@@ -215,7 +215,7 @@ class TestContinuousModeTimeout:
                 monitor._stop_requested = True
             return job
 
-        monitor.client.retrieve = mock_retrieve
+        monitor.client.status = mock_status
 
         start_time = time.time()
         monitor.watch_continuous()
@@ -240,13 +240,13 @@ class TestPollIntervalTiming:
 
         poll_times = []
 
-        def mock_retrieve(job_id):
+        def mock_status(job_id):
             poll_times.append(time.time())
             if len(poll_times) >= 3:
                 monitor._stop_requested = True
             return job
 
-        monitor.client.retrieve = mock_retrieve
+        monitor.client.status = mock_status
 
         monitor.watch_until()
 


### PR DESCRIPTION
## Summary

The pre-existing test failures in \`test_job_monitor.py\`, \`test_monitor_errors.py\`, and \`test_monitor_timeout.py\` (45 cases total) were caused by the tests patching \`monitor.client.retrieve\` but production code calling \`monitor.client.status\` since the transport unification (P5a). The MagicMock default for \`status\` returned a MagicMock instance instead of a real Job, so any assertion on the returned object's attributes failed.

This PR patches the right attribute (\`status\`) and renames the inner helper \`mock_retrieve\` → \`mock_status\` to match. No production code changes.

## Why this matters

These three test files have been excluded from \`pytest\` runs (via \`--ignore\`) for several PRs because they were known-broken-but-unrelated. Fixing them now lets us drop the \`--ignore\` flags from CI and from the PR template.

## Test plan

- [x] \`uv run pytest tests/test_job_monitor.py tests/test_monitor_errors.py tests/test_monitor_timeout.py\` — 45 passed
- [x] Full \`uv run pytest\` (no \`--ignore\`) — 1881 passed; 1 unrelated flaky migration test (passes on retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)