### PR TITLE
feat(cli): SSH parity for sinfo / sacct / sreport (#139)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,14 @@ counterpart.
 - `uv run srunx squeue --show-gpus` - Include GPU allocation column
 - `uv run srunx squeue --format json` - Emit JSON instead of a table
 - `uv run srunx scancel <job_id>` - Cancel a job
-- `uv run srunx sinfo` - Display current GPU/node resource availability (local-only in this release; see #139)
+- `uv run srunx sinfo` - Display current GPU/node resource availability
+- `uv run srunx sinfo --profile <name>` - Query a remote cluster via SSH adapter (#139)
 - `uv run srunx sinfo --partition gpu --format json` - Partition resources as JSON
 - `uv run srunx sacct` - DB-backed job execution history (uses srunx.db, not real sacct)
 - `uv run srunx sacct -j <job_id>` - Filter history to a specific job (replaces `srunx status` for finished jobs)
+- `uv run srunx sacct --profile <name>` - Scope history to a single cluster's jobs (`scheduler_key` filter)
 - `uv run srunx sreport` - Aggregated execution report from srunx.db
+- `uv run srunx sreport --profile <name>` - Aggregate only jobs that ran on the given cluster
 - `uv run srunx tail <job_id> --follow` - Stream job logs (use `--profile` for SSH)
 
 `sbatch` accepts the standard SLURM short flags (`-J` / `-N` / `-n` / `-c` /

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -38,7 +38,9 @@ from srunx.models import (
 )
 from srunx.ssh.cli.commands import ssh_app
 from srunx.template import get_template_info, get_template_path, list_templates
-from srunx.transport import resolve_transport
+from srunx.transport import (
+    resolve_transport,
+)
 
 logger = get_logger(__name__)
 
@@ -1217,30 +1219,56 @@ def sinfo(
         str,
         typer.Option("--format", "-f", help="Output format: table or json"),
     ] = "table",
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
     """Display current GPU resource availability.
 
-    .. note::
-
-       Local-only in this release. Unlike ``sbatch`` / ``squeue`` /
-       ``scancel`` / ``tail``, ``sinfo`` does not yet accept
-       ``--profile`` — :class:`ResourceMonitor` always queries the
-       local cluster's ``sinfo`` / ``squeue``. SSH parity is tracked in
-       https://github.com/ksterx/srunx/issues/139.
+    With ``--profile <name>`` (or ``$SRUNX_SSH_PROFILE`` / current
+    profile) the query runs against the remote cluster via the SSH
+    adapter. Local mode keeps the legacy ``sinfo`` / ``squeue``
+    subprocess path so a head-node user sees no behaviour change.
 
     Examples:
         srunx sinfo
         srunx sinfo --partition gpu
         srunx sinfo --format json
         srunx sinfo --partition gpu --format json
+        srunx sinfo --profile dgx-server --partition gpu
     """
     import json
+    from typing import cast
 
     from srunx.monitor.resource_monitor import ResourceMonitor
+    from srunx.monitor.resource_source import ResourceSource, SSHAdapterResourceSource
+    from srunx.transport import resolve_transport
 
     try:
-        monitor = ResourceMonitor(min_gpus=0, partition=partition)
-        snapshot = monitor.get_partition_resources()
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            # SSH path delegates to the existing
+            # ``SSHAdapterResourceSource`` so cluster-wide vs
+            # per-partition dedup, error propagation, and dict→snapshot
+            # coercion all match what the resource snapshotter / Web
+            # ``/api/resources`` already use. Local stays on the
+            # subprocess fallback (source=None) — head-node behaviour
+            # is byte-for-byte identical to pre-#139.
+            source: ResourceSource | None = None
+            if rt.transport_type == "ssh":
+                # ``rt.job_ops`` is the live ``SlurmSSHAdapter`` for
+                # this profile (see ``_build_ssh_handle``). Cast away
+                # the Protocol → concrete narrowing — the Protocol
+                # doesn't expose ``get_resources`` /
+                # ``get_cluster_snapshot`` because those are SSH-only,
+                # and bouncing through a fresh Protocol adds no value
+                # over the existing ``SSHAdapterResourceSource``.
+                from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+                adapter = cast(SlurmSSHAdapter, rt.job_ops)
+                source = SSHAdapterResourceSource(lambda: adapter)
+
+            monitor = ResourceMonitor(min_gpus=0, partition=partition, source=source)
+            snapshot = monitor.get_partition_resources()
 
         if format == "json":
             data = {
@@ -1644,15 +1672,39 @@ def sacct(
     limit: Annotated[
         int, typer.Option("--limit", "-n", help="Number of jobs to show")
     ] = 50,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
-    """Show job execution history."""
+    """Show job execution history.
+
+    With ``--profile <name>`` (or ``$SRUNX_SSH_PROFILE`` / current
+    profile), results are filtered to jobs that ran against that
+    cluster. Without a transport selector, history from every
+    transport is shown — matching legacy behaviour.
+    """
     try:
         from srunx.db.cli_helpers import list_recent_jobs
+        from srunx.transport import (
+            emit_transport_banner,
+            peek_scheduler_key,
+            resolve_transport_source,
+        )
+
+        # sacct is a pure DB query — no SSH connection needed even
+        # for SSH profiles. ``peek_scheduler_key`` gives us the WHERE
+        # filter without paying the round-trip cost of opening an
+        # SSH adapter just to read the local SQLite history.
+        source = resolve_transport_source(profile=profile, local=local)
+        scheduler_key = peek_scheduler_key(profile=profile, local=local)
+        emit_transport_banner(label=scheduler_key, source=source, quiet=quiet)
 
         # ``-j`` is pushed down into the SQL query so it finds jobs
         # older than ``--limit``. Codex follow-up #2 on PR #134.
         wanted_ids = [int(j) for j in job_filter] if job_filter else None
-        jobs = list_recent_jobs(limit=limit, job_ids=wanted_ids)
+        jobs = list_recent_jobs(
+            limit=limit, job_ids=wanted_ids, scheduler_key=scheduler_key
+        )
 
         if not jobs:
             console = Console()
@@ -1715,13 +1767,33 @@ def sreport(
     workflow: Annotated[
         str | None, typer.Option("--workflow", help="Workflow name")
     ] = None,
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
 ) -> None:
-    """Generate job execution report."""
+    """Generate job execution report.
+
+    With ``--profile <name>`` (or ``$SRUNX_SSH_PROFILE`` / current
+    profile), aggregates are scoped to jobs that ran on that
+    cluster. Without a transport selector, every transport is
+    aggregated together — matching legacy behaviour.
+    """
     try:
         from srunx.db.cli_helpers import compute_job_stats, compute_workflow_stats
+        from srunx.transport import (
+            emit_transport_banner,
+            peek_scheduler_key,
+            resolve_transport_source,
+        )
+
+        # sreport is a pure DB query — see ``sacct`` for the rationale
+        # behind the ``peek_scheduler_key`` shortcut.
+        source = resolve_transport_source(profile=profile, local=local)
+        scheduler_key = peek_scheduler_key(profile=profile, local=local)
+        emit_transport_banner(label=scheduler_key, source=source, quiet=quiet)
 
         if workflow:
-            stats = compute_workflow_stats(workflow)
+            stats = compute_workflow_stats(workflow, scheduler_key=scheduler_key)
 
             console = Console()
             console.print(f"\n[bold cyan]Workflow Report: {workflow}[/bold cyan]")
@@ -1733,7 +1805,11 @@ def sreport(
             console.print(f"Last Submitted: {stats['last_submitted']}\n")
 
         else:
-            stats = compute_job_stats(from_date=from_date, to_date=to_date)
+            stats = compute_job_stats(
+                from_date=from_date,
+                to_date=to_date,
+                scheduler_key=scheduler_key,
+            )
 
             console = Console()
             console.print("\n[bold cyan]Job Execution Report[/bold cyan]")

--- a/src/srunx/db/cli_helpers.py
+++ b/src/srunx/db/cli_helpers.py
@@ -213,6 +213,7 @@ def list_recent_jobs(
     limit: int = 100,
     *,
     job_ids: list[int] | None = None,
+    scheduler_key: str | None = None,
 ) -> list[dict[str, Any]]:
     """Return the N most recent jobs as legacy-shaped dicts.
 
@@ -220,43 +221,70 @@ def list_recent_jobs(
     When ``job_ids`` is supplied, the SQL filter pushes the IDs down
     and bypasses the ``LIMIT`` so the CLI's ``srunx sacct -j <id>``
     finds rows that fell outside the most recent ``limit`` page.
+
+    ``scheduler_key`` (``"local"`` / ``"ssh:<profile>"``) scopes to
+    a single transport — passed through to the SQL ``WHERE`` so
+    ``srunx sacct --profile X`` only sees that cluster's jobs.
     """
     from srunx.db.connection import initialized_connection
     from srunx.db.repositories.jobs import JobRepository
 
     with initialized_connection() as conn:
-        return JobRepository(conn).list_recent_as_dict(limit=limit, job_ids=job_ids)
+        return JobRepository(conn).list_recent_as_dict(
+            limit=limit, job_ids=job_ids, scheduler_key=scheduler_key
+        )
 
 
 def compute_job_stats(
     from_date: str | None = None,
     to_date: str | None = None,
+    *,
+    scheduler_key: str | None = None,
 ) -> dict[str, Any]:
     """Return aggregate job stats in the legacy ``get_job_stats`` shape.
 
     Thin wrapper around :meth:`JobRepository.compute_stats` that owns
     the connection; used by the CLI ``report`` command.
+
+    ``scheduler_key`` filters to a single transport for SSH parity
+    on ``srunx sreport --profile X``.
     """
     from srunx.db.connection import initialized_connection
     from srunx.db.repositories.jobs import JobRepository
 
     with initialized_connection() as conn:
-        return JobRepository(conn).compute_stats(from_date=from_date, to_date=to_date)
+        return JobRepository(conn).compute_stats(
+            from_date=from_date, to_date=to_date, scheduler_key=scheduler_key
+        )
 
 
-def compute_workflow_stats(workflow_name: str) -> dict[str, Any]:
+def compute_workflow_stats(
+    workflow_name: str,
+    *,
+    scheduler_key: str | None = None,
+) -> dict[str, Any]:
     """Return workflow-scoped stats in the legacy ``get_workflow_stats`` shape.
 
     Joins ``jobs`` with ``workflow_runs`` on ``workflow_name`` and
     aggregates. Fields: ``workflow_name``, ``total_jobs``,
     ``avg_duration_seconds``, ``first_submitted``, ``last_submitted``.
     Used by the CLI ``report --workflow`` command.
+
+    ``scheduler_key`` scopes the join to jobs that ran on a given
+    transport so ``--profile X`` reports only that cluster's runs
+    of the workflow.
     """
     from srunx.db.connection import initialized_connection
 
+    scheduler_clause = ""
+    params: tuple[Any, ...] = (workflow_name,)
+    if scheduler_key is not None:
+        scheduler_clause = " AND j.scheduler_key = ?"
+        params = (workflow_name, scheduler_key)
+
     with initialized_connection() as conn:
         row = conn.execute(
-            """
+            f"""
             SELECT
                 COUNT(*)                          AS total_jobs,
                 AVG(j.duration_secs)              AS avg_duration_seconds,
@@ -264,9 +292,9 @@ def compute_workflow_stats(workflow_name: str) -> dict[str, Any]:
                 MAX(j.submitted_at)               AS last_submitted
             FROM jobs j
             JOIN workflow_runs wr ON wr.id = j.workflow_run_id
-            WHERE wr.workflow_name = ?
+            WHERE wr.workflow_name = ?{scheduler_clause}
             """,
-            (workflow_name,),
+            params,
         ).fetchone()
 
     return {

--- a/src/srunx/db/repositories/jobs.py
+++ b/src/srunx/db/repositories/jobs.py
@@ -420,6 +420,7 @@ class JobRepository(BaseRepository):
         limit: int = 100,
         *,
         job_ids: list[int] | None = None,
+        scheduler_key: str | None = None,
     ) -> list[dict[str, Any]]:
         """Return the ``limit`` most recent jobs in the legacy dict shape.
 
@@ -433,7 +434,18 @@ class JobRepository(BaseRepository):
         follow-up #2 on PR #134 — without this push-down the CLI
         would silently report "no history found" for any job older
         than the page size.
+
+        ``scheduler_key`` (e.g. ``"local"`` / ``"ssh:dgx"``) scopes
+        the query to a single transport so ``srunx sacct --profile X``
+        only sees jobs that ran against that cluster. ``None`` keeps
+        the legacy "all transports" behaviour for the Web UI history.
         """
+        scheduler_clause = ""
+        scheduler_param: tuple[Any, ...] = ()
+        if scheduler_key is not None:
+            scheduler_clause = " AND j.scheduler_key = ?"
+            scheduler_param = (scheduler_key,)
+
         if job_ids:
             placeholders = ",".join("?" * len(job_ids))
             rows = self.conn.execute(
@@ -459,15 +471,16 @@ class JobRepository(BaseRepository):
                     j.metadata
                 FROM jobs j
                 LEFT JOIN workflow_runs wr ON wr.id = j.workflow_run_id
-                WHERE j.job_id IN ({placeholders})
+                WHERE j.job_id IN ({placeholders}){scheduler_clause}
                 ORDER BY j.submitted_at DESC
                 """,
-                tuple(job_ids),
+                tuple(job_ids) + scheduler_param,
             ).fetchall()
             return [dict(r) for r in rows]
 
+        where_clause = " WHERE j.scheduler_key = ?" if scheduler_key is not None else ""
         rows = self.conn.execute(
-            """
+            f"""
             SELECT
                 j.job_id,
                 j.name           AS job_name,
@@ -495,11 +508,11 @@ class JobRepository(BaseRepository):
                 j.log_file,
                 j.metadata
             FROM jobs j
-            LEFT JOIN workflow_runs wr ON wr.id = j.workflow_run_id
+            LEFT JOIN workflow_runs wr ON wr.id = j.workflow_run_id{where_clause}
             ORDER BY j.submitted_at DESC
             LIMIT ?
             """,
-            (limit,),
+            scheduler_param + (limit,),
         ).fetchall()
         return [dict(r) for r in rows]
 
@@ -507,12 +520,18 @@ class JobRepository(BaseRepository):
         self,
         from_date: str | None = None,
         to_date: str | None = None,
+        *,
+        scheduler_key: str | None = None,
     ) -> dict[str, Any]:
         """Return aggregate stats in the legacy ``JobHistory.get_job_stats`` shape.
 
         ``from_date`` / ``to_date`` are inclusive ISO-8601 dates (e.g.
         ``"2026-04-01"``). ``to_date`` is interpreted as ``<= day-end``,
         matching the legacy behaviour.
+
+        ``scheduler_key`` (e.g. ``"local"`` / ``"ssh:dgx"``) scopes the
+        aggregate to a single transport so ``srunx sreport --profile X``
+        reflects only that cluster.
         """
         conditions: list[str] = []
         params: list[Any] = []
@@ -523,6 +542,9 @@ class JobRepository(BaseRepository):
             conditions.append("submitted_at < ?")
             # Match legacy behaviour: include the full ``to_date`` day.
             params.append(to_date + "T23:59:59" if "T" not in to_date else to_date)
+        if scheduler_key is not None:
+            conditions.append("scheduler_key = ?")
+            params.append(scheduler_key)
         where_clause = (" WHERE " + " AND ".join(conditions)) if conditions else ""
 
         total = int(

--- a/tests/db/test_cli_helpers.py
+++ b/tests/db/test_cli_helpers.py
@@ -12,11 +12,124 @@ from __future__ import annotations
 import pytest
 
 from srunx.db.cli_helpers import (
+    compute_job_stats,
     compute_workflow_stats,
     create_cli_workflow_run,
+    list_recent_jobs,
     record_submission_from_job,
 )
 from srunx.models import Job, JobEnvironment, JobResource
+
+
+def _record_ssh_job(
+    job: Job,
+    *,
+    profile: str,
+    workflow_run_id: int | None = None,
+) -> None:
+    """Record a job under the SSH transport triple.
+
+    JobRepository validates ``(transport_type, profile_name,
+    scheduler_key)`` together so callers can't drift one without the
+    others — this helper bundles the trio for SSH-tagged tests.
+    """
+    record_submission_from_job(
+        job,
+        transport_type="ssh",
+        profile_name=profile,
+        scheduler_key=f"ssh:{profile}",
+        workflow_run_id=workflow_run_id,
+    )
+
+
+class TestSchedulerKeyFilter:
+    """SSH-parity for ``sacct`` / ``sreport``: scheduler_key push-down.
+
+    The CLI passes ``scheduler_key="ssh:<profile>"`` (or ``"local"``)
+    into the helpers; the SQL ``WHERE`` filter must scope rows to that
+    transport so cross-cluster jobs don't bleed into each other's
+    history / aggregates. ``scheduler_key=None`` keeps the legacy
+    behaviour (every transport).
+    """
+
+    def test_list_recent_jobs_filters_by_scheduler_key(self, _isolated_db):
+        record_submission_from_job(_make_job("local_job", 10, gpus=2))
+        _record_ssh_job(_make_job("dgx_job", 11, gpus=4), profile="dgx")
+        _record_ssh_job(_make_job("aws_job", 12, gpus=8), profile="aws")
+
+        local_jobs = list_recent_jobs(scheduler_key="local")
+        assert {j["job_name"] for j in local_jobs} == {"local_job"}
+
+        dgx_jobs = list_recent_jobs(scheduler_key="ssh:dgx")
+        assert {j["job_name"] for j in dgx_jobs} == {"dgx_job"}
+
+        # No filter → every transport surfaces (legacy Web UI behaviour).
+        all_jobs = list_recent_jobs()
+        assert {j["job_name"] for j in all_jobs} == {
+            "local_job",
+            "dgx_job",
+            "aws_job",
+        }
+
+    def test_list_recent_jobs_id_filter_respects_scheduler_key(self, _isolated_db):
+        """``-j <id>`` push-down still scopes to the requested transport.
+
+        Without the AND-clause, ``srunx sacct -j 100 --profile dgx``
+        would happily return a local job that happens to share the
+        SLURM ``job_id`` (different clusters reuse the int counter).
+        """
+        record_submission_from_job(_make_job("local_100", 100))
+        _record_ssh_job(_make_job("dgx_100", 100), profile="dgx")
+
+        # No scope — both rows surface (composite uniqueness on
+        # (scheduler_key, job_id) means both can coexist).
+        both = list_recent_jobs(job_ids=[100])
+        assert {j["job_name"] for j in both} == {"local_100", "dgx_100"}
+
+        only_ssh = list_recent_jobs(job_ids=[100], scheduler_key="ssh:dgx")
+        assert {j["job_name"] for j in only_ssh} == {"dgx_100"}
+
+    def test_compute_job_stats_filters_by_scheduler_key(self, _isolated_db):
+        record_submission_from_job(_make_job("local_a", 1))
+        record_submission_from_job(_make_job("local_b", 2))
+        _record_ssh_job(_make_job("ssh_a", 3), profile="dgx")
+
+        assert compute_job_stats(scheduler_key="local")["total_jobs"] == 2
+        assert compute_job_stats(scheduler_key="ssh:dgx")["total_jobs"] == 1
+        assert compute_job_stats()["total_jobs"] == 3  # legacy: all
+
+    def test_compute_workflow_stats_filters_by_scheduler_key(self, _isolated_db):
+        """Same workflow can run on multiple clusters — stats scope per key."""
+        run_id = create_cli_workflow_run(workflow_name="multi_cluster")
+        assert run_id is not None
+
+        # Workflow run rows aren't transport-tagged; the per-job
+        # ``scheduler_key`` is what scopes the JOIN.
+        record_submission_from_job(
+            _make_job("local_step", 50),
+            workflow_name="multi_cluster",
+            workflow_run_id=run_id,
+        )
+        _record_ssh_job(
+            _make_job("dgx_step", 51),
+            profile="dgx",
+            workflow_run_id=run_id,
+        )
+        _record_ssh_job(
+            _make_job("dgx_step_2", 52),
+            profile="dgx",
+            workflow_run_id=run_id,
+        )
+
+        local_stats = compute_workflow_stats("multi_cluster", scheduler_key="local")
+        assert local_stats["total_jobs"] == 1
+
+        dgx_stats = compute_workflow_stats("multi_cluster", scheduler_key="ssh:dgx")
+        assert dgx_stats["total_jobs"] == 2
+
+        # Legacy (no scope): both clusters' rows aggregate together.
+        all_stats = compute_workflow_stats("multi_cluster")
+        assert all_stats["total_jobs"] == 3
 
 
 @pytest.fixture

--- a/tests/test_cli_sinfo.py
+++ b/tests/test_cli_sinfo.py
@@ -100,7 +100,9 @@ class TestResourcesCommand:
             assert "0" in result.stdout  # nodes_down
 
             # Verify ResourceMonitor was created with correct partition
-            mock_monitor_class.assert_called_once_with(min_gpus=0, partition="gpu")
+            mock_monitor_class.assert_called_once_with(
+                min_gpus=0, partition="gpu", source=None
+            )
 
     def test_resources_json_format_default(self, runner, mock_snapshot_all_partitions):
         """Test resources command with JSON format."""
@@ -151,7 +153,9 @@ class TestResourcesCommand:
             assert data["nodes_down"] == 0
 
             # Verify ResourceMonitor was created with correct partition
-            mock_monitor_class.assert_called_once_with(min_gpus=0, partition="gpu")
+            mock_monitor_class.assert_called_once_with(
+                min_gpus=0, partition="gpu", source=None
+            )
 
     def test_resources_zero_gpus_available(self, runner):
         """Test resources command when no GPUs available."""
@@ -271,7 +275,9 @@ class TestResourcesCommand:
             assert data["partition"] == "gpu"
 
             # Verify ResourceMonitor was created correctly
-            mock_monitor_class.assert_called_once_with(min_gpus=0, partition="gpu")
+            mock_monitor_class.assert_called_once_with(
+                min_gpus=0, partition="gpu", source=None
+            )
 
     def test_resources_high_utilization(self, runner):
         """Test resources command with high GPU utilization."""
@@ -300,3 +306,135 @@ class TestResourcesCommand:
             # 95% utilization
             assert data["gpus_in_use"] / data["gpus_total"] == 0.95
             assert data["gpus_available"] == 5
+
+
+class TestSinfoSshParity:
+    """#139: ``--profile`` routes ``sinfo`` through the SSH adapter.
+
+    SSH path uses :class:`SSHAdapterResourceSource` (the same backend
+    the resource snapshotter / Web ``/api/resources`` already use), so
+    these tests mock the SSH transport handle and assert the cluster
+    snapshot path runs against the adapter — never the local
+    ``subprocess.run('sinfo')`` fallback.
+    """
+
+    def test_profile_routes_through_ssh_adapter_cluster_snapshot(self, runner):
+        from srunx.transport.registry import TransportHandle
+
+        fake_adapter = MagicMock()
+        fake_adapter.get_cluster_snapshot.return_value = {
+            "partition": None,
+            "total_gpus": 64,
+            "gpus_in_use": 16,
+            "gpus_available": 48,
+            "jobs_running": 4,
+            "nodes_total": 8,
+            "nodes_idle": 4,
+            "nodes_down": 0,
+        }
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=fake_adapter,
+            queue_client=fake_adapter,
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ):
+            result = runner.invoke(
+                app, ["sinfo", "--profile", "dgx", "--format", "json"]
+            )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        data = json.loads(result.stdout)
+        assert data["gpus_total"] == 64
+        assert data["gpus_available"] == 48
+        # The whole point of #139 — local sinfo must NOT have run.
+        fake_adapter.get_cluster_snapshot.assert_called_once()
+        fake_adapter.get_resources.assert_not_called()
+
+    def test_profile_with_partition_uses_per_partition_query(self, runner):
+        from srunx.transport.registry import TransportHandle
+
+        fake_adapter = MagicMock()
+        fake_adapter.get_resources.return_value = [
+            {
+                "partition": "gpu",
+                "total_gpus": 32,
+                "gpus_in_use": 8,
+                "gpus_available": 24,
+                "jobs_running": 2,
+                "nodes_total": 4,
+                "nodes_idle": 2,
+                "nodes_down": 0,
+            }
+        ]
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=fake_adapter,
+            queue_client=fake_adapter,
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "sinfo",
+                    "--profile",
+                    "dgx",
+                    "--partition",
+                    "gpu",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        data = json.loads(result.stdout)
+        assert data["partition"] == "gpu"
+        assert data["gpus_total"] == 32
+        # Per-partition path: get_resources('gpu') called, NOT
+        # get_cluster_snapshot.
+        fake_adapter.get_resources.assert_called_once_with("gpu")
+        fake_adapter.get_cluster_snapshot.assert_not_called()
+
+    def test_local_path_unchanged_when_no_profile(
+        self, runner, mock_snapshot_all_partitions
+    ):
+        """Regression guard: local default still uses ResourceMonitor subprocess.
+
+        Without ``--profile``/``$SRUNX_SSH_PROFILE`` the SSH branch
+        must NOT activate — the existing
+        :class:`TestResourcesCommand` tests already cover the table
+        path, this one explicitly asserts ``source=None`` so the
+        subprocess fallback stays the default.
+        """
+        with patch(
+            "srunx.monitor.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = (
+                mock_snapshot_all_partitions
+            )
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["sinfo", "--local", "--format", "json"])
+
+        assert result.exit_code == 0
+        # ``source=None`` means the local subprocess path runs — see
+        # the docstring on ``ResourceMonitor.get_partition_resources``.
+        mock_monitor_class.assert_called_once_with(
+            min_gpus=0, partition=None, source=None
+        )


### PR DESCRIPTION
## Summary

Closes #139. Wires `--profile` / `--local` / `--quiet` into the three
remaining job-management commands so a SLURM user driving multiple
clusters can see per-cluster history and aggregates without swapping
`\$SRUNX_SSH_PROFILE` for every invocation.

| command | SSH path |
|---------|---------|
| `srunx sinfo --profile <name>` | Delegates to existing `SSHAdapterResourceSource` (same backend as the resource snapshotter and `/api/resources`) |
| `srunx sacct --profile <name>` | Pure DB query — `peek_scheduler_key` + WHERE push-down, no SSH connection |
| `srunx sreport --profile <name>` | Same pattern as sacct |

## Design

- **sinfo** reuses `SSHAdapterResourceSource` so cluster-wide vs per-partition dedup, error propagation, and dict→snapshot coercion all match what's already battle-tested. Local stays on `source=None` — head-node behaviour byte-for-byte identical to pre-#139.
- **sacct/sreport** never open an SSH connection — they're pure local SQLite queries. `peek_scheduler_key` resolves the WHERE filter, `emit_transport_banner` shows the user which scope was applied, and `scheduler_key` is pushed down into `list_recent_as_dict` / `compute_stats` / `compute_workflow_stats`.
- `scheduler_key=None` keeps the legacy "all transports" behaviour on the helper API, so the Web UI `/api/history` (intentionally cross-cluster) is unchanged.

## Test plan

- [x] `tests/db/test_cli_helpers.py::TestSchedulerKeyFilter` — list/stats/workflow_stats scheduler_key push-down (4 tests)
- [x] `tests/test_cli_sinfo.py::TestSinfoSshParity` — SSH adapter dispatch + local fallback regression (3 tests)
- [x] Existing 1888 tests still pass (1 pre-existing flaky `test_apply_migrations_concurrent_callers_do_not_duplicate` confirmed unrelated)
- [x] `uv run mypy .` / `uv run ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)