### PR TITLE
feat(web): script_path mode for POST /api/jobs in-place execution (#136)

### DIFF
--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -84,13 +84,26 @@ async def preview_script(req: ScriptPreviewRequest) -> ScriptPreviewResponse:
 class JobSubmitRequest(BaseModel):
     """Request body for submitting a job via the Web UI.
 
+    Two submission modes are supported, mutually exclusive:
+
+    * ``script_content`` — bytes uploaded to ``/tmp/srunx/`` on the
+      remote (legacy default; same behaviour as before #136).
+    * ``script_path`` — path to a script that already lives under
+      ``mount_name``'s ``mount.local`` root. The Web rsyncs that mount
+      and dispatches sbatch directly against the remote-mount path,
+      mirroring the CLI's in-place execution. Requires ``mount_name``.
+
     ``notify_slack`` (DEPRECATED) is retained for backward compatibility with
     older frontend builds but has no effect beyond logging a warning. Prefer
     the ``notify`` + ``endpoint_id`` + ``preset`` triplet.
     """
 
     name: str
-    script_content: str
+    # Both content and path are optional individually; the
+    # ``_check_script_source`` validator enforces "exactly one set".
+    # Old clients that always send ``script_content`` keep working.
+    script_content: str | None = None
+    script_path: str | None = None
     job_name: str | None = None
     mount_name: str | None = None
 
@@ -107,6 +120,26 @@ class JobSubmitRequest(BaseModel):
     def _check_notify(self) -> JobSubmitRequest:
         if self.notify and self.endpoint_id is None:
             raise ValueError("notify=true requires endpoint_id")
+        return self
+
+    @model_validator(mode="after")
+    def _check_script_source(self) -> JobSubmitRequest:
+        # Exactly one of (script_content, script_path) must be set.
+        # Both → ambiguous; neither → nothing to submit. Pre-#136
+        # clients always set ``script_content`` so the legacy contract
+        # is preserved; ``script_path`` is the opt-in addition.
+        if self.script_content is None and self.script_path is None:
+            raise ValueError("exactly one of script_content / script_path must be set")
+        if self.script_content is not None and self.script_path is not None:
+            raise ValueError("script_content and script_path are mutually exclusive")
+        # ``script_path`` requires ``mount_name`` so the path can be
+        # validated against a known mount root (security) and
+        # translated to the remote filesystem.
+        if self.script_path is not None and not self.mount_name:
+            raise ValueError(
+                "script_path requires mount_name (so the path can be "
+                "validated and translated to its remote equivalent)"
+            )
         return self
 
 
@@ -218,6 +251,171 @@ def _record_and_watch(
         raise
 
 
+def _resolve_in_place_plan(
+    *,
+    profile: Any,
+    mount_name: str,
+    script_path: str,
+) -> tuple[Any, str, str]:
+    """Validate ``script_path`` and translate it to its remote equivalent.
+
+    Pure (no I/O) — validates that ``mount_name`` exists on the
+    profile and that ``script_path`` resolves under that mount's
+    ``local`` root, then returns the matched ``MountConfig`` together
+    with the translated remote path and a sensible ``submit_cwd``.
+
+    Raises :class:`HTTPException` (404 for unknown mount, 403 for path
+    escapes) so the caller doesn't have to translate exception types.
+    """
+    from pathlib import Path
+
+    from srunx.cli.submission_plan import translate_local_to_remote
+
+    matching = [m for m in profile.mounts if m.name == mount_name]
+    if not matching:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Mount '{mount_name}' not configured on the active profile",
+        )
+    mount = matching[0]
+
+    mount_root = Path(mount.local).expanduser().resolve()
+    resolved = Path(script_path).expanduser().resolve()
+    if not resolved.is_relative_to(mount_root):
+        # Mirrors the workflow router's directory-traversal guard
+        # (``_enforce_shell_script_roots``) — same 403 contract so
+        # the Web UI surfaces a single error shape for both routes.
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"script_path '{script_path}' is outside mount "
+                f"'{mount_name}' (root: {mount_root})"
+            ),
+        )
+
+    remote_script = translate_local_to_remote(resolved, mount)
+    # Run sbatch from the script's parent dir on the remote so any
+    # relative paths inside the user's own ``#SBATCH --output=`` etc.
+    # resolve where they would on a head-node ``sbatch ./script.sh``.
+    parent_remote, _, _ = remote_script.rpartition("/")
+    submit_cwd = parent_remote or remote_script
+    return mount, remote_script, submit_cwd
+
+
+def _submit_in_place(
+    req: JobSubmitRequest,
+    adapter: SlurmSSHAdapter,
+) -> dict[str, Any]:
+    """Run script_path mode end-to-end on a worker thread.
+
+    Wrapped behind one ``anyio.to_thread.run_sync`` so the held mount
+    lock + rsync + sbatch all execute under the same OS thread. If we
+    instead awaited each phase separately, the lock could be released
+    between sync and submit by an event-loop context switch — defeating
+    the whole purpose of holding the lock across submission (Codex
+    blocker #3 on PR #134, same shape).
+    """
+    from srunx.config import get_config
+    from srunx.sync.lock import SyncLockTimeoutError
+    from srunx.sync.service import SyncAbortedError, mount_sync_session
+
+    from ..sync_utils import get_current_profile
+
+    assert req.script_path is not None  # validator guarantees this
+    assert req.mount_name is not None  # validator guarantees this
+
+    profile = get_current_profile()
+    if profile is None:
+        raise HTTPException(
+            status_code=503,
+            detail="No SSH profile configured; cannot resolve script_path",
+        )
+    mount, remote_script, submit_cwd = _resolve_in_place_plan(
+        profile=profile,
+        mount_name=req.mount_name,
+        script_path=req.script_path,
+    )
+
+    sync_cfg = get_config().sync
+    try:
+        # Lock held across rsync + sbatch — a concurrent /api/jobs or
+        # CLI invocation can't rsync different bytes between our sync
+        # and our submission.
+        with mount_sync_session(
+            profile_name=adapter.scheduler_key.removeprefix("ssh:"),
+            profile=profile,
+            mount=mount,
+            config=sync_cfg,
+            sync_required=True,
+        ):
+            submitted = adapter.submit_remote_sbatch(
+                remote_script,
+                submit_cwd=submit_cwd,
+                job_name=req.job_name or req.name,
+            )
+    except SyncAbortedError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except SyncLockTimeoutError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Mount sync failed: {exc}",
+        ) from exc
+
+    # ``submit_remote_sbatch`` returns the in-memory job; reshape into
+    # the dict ``submit_job`` produces so the response payload stays
+    # stable for legacy frontend builds. The route does ``record_and
+    # _watch`` itself so we don't double-record here — the adapter
+    # already wrote a ``jobs`` row, and ``_record_and_watch`` uses
+    # ``INSERT OR IGNORE`` so the Web router's call is a no-op for
+    # the row but still creates the notification watch.
+    return {
+        "name": getattr(submitted, "name", None) or req.job_name or req.name,
+        "job_id": int(submitted.job_id) if submitted.job_id else None,
+        "status": "PENDING",
+        "depends_on": [],
+        "command": [],
+        "resources": {},
+    }
+
+
+def _submit_via_tmp_upload(
+    req: JobSubmitRequest,
+    adapter: SlurmSSHAdapter,
+) -> dict[str, Any]:
+    """Legacy script_content path — uploads bytes to ``/tmp/srunx/``.
+
+    Preserves the pre-#136 behaviour bit-for-bit (including
+    ``delete=True`` on the optional mount sync) so existing clients
+    that always send ``script_content`` see no contract change.
+    """
+    from ..sync_utils import get_current_profile, sync_mount_by_name
+
+    if req.mount_name:
+        profile = get_current_profile()
+        if profile is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No SSH profile configured; cannot sync mount",
+            )
+        try:
+            logger.info("Syncing mount '%s' before job submission", req.mount_name)
+            sync_mount_by_name(profile, req.mount_name, delete=True)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Mount '{req.mount_name}' not found",
+            ) from exc
+        except RuntimeError as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Mount sync failed: {exc}"
+            ) from exc
+
+    assert req.script_content is not None  # validator guarantees this
+    return adapter.submit_job(req.script_content, job_name=req.job_name or req.name)
+
+
 @router.post("", status_code=201)
 async def submit_job(
     req: JobSubmitRequest,
@@ -226,8 +424,17 @@ async def submit_job(
 ) -> dict[str, Any]:
     """Submit a new job to SLURM via SSH.
 
-    If *mount_name* is provided, the corresponding mount is synced
-    via rsync before submission.
+    Two modes (mutually exclusive, enforced by the request validator):
+
+    * ``script_content`` (legacy): bytes uploaded to ``/tmp/srunx/``,
+      sbatch runs against the tmp copy. Optional ``mount_name``
+      triggers a pre-submit rsync.
+    * ``script_path`` (#136): script must live under
+      ``mount_name``'s local root. The mount is rsynced under the
+      per-mount lock (held across submission), and sbatch runs
+      directly against the remote-mount path — no tmp copy, the
+      user's own ``#SBATCH`` directives win. Mirrors the CLI's
+      in-place execution on top of PR #141.
     """
     # Legacy-flag diagnostic: surface a soft warning if the frontend still
     # ships ``notify_slack`` without the new trio.
@@ -241,37 +448,17 @@ async def submit_job(
     # results in a leaked SLURM job. (Codex-flagged.)
     _validate_notify_endpoint(conn, req)
 
-    # Sync mount before submission if requested
-    if req.mount_name:
-        from ..sync_utils import get_current_profile, sync_mount_by_name
-
-        mount_name = req.mount_name
-        profile = await anyio.to_thread.run_sync(get_current_profile)
-        if profile is None:
-            raise HTTPException(
-                status_code=503,
-                detail="No SSH profile configured; cannot sync mount",
-            )
-        try:
-            logger.info("Syncing mount '%s' before job submission", mount_name)
-            await anyio.to_thread.run_sync(
-                lambda: sync_mount_by_name(profile, mount_name, delete=True)
-            )
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=404, detail=f"Mount '{mount_name}' not found"
-            ) from exc
-        except RuntimeError as exc:
-            raise HTTPException(
-                status_code=502, detail=f"Mount sync failed: {exc}"
-            ) from exc
-
     try:
-        result = await anyio.to_thread.run_sync(
-            lambda: adapter.submit_job(
-                req.script_content, job_name=req.job_name or req.name
+        if req.script_path is not None:
+            result = await anyio.to_thread.run_sync(
+                lambda: _submit_in_place(req, adapter)
             )
-        )
+        else:
+            result = await anyio.to_thread.run_sync(
+                lambda: _submit_via_tmp_upload(req, adapter)
+            )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"sbatch failed: {e}") from e
 

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -201,6 +201,269 @@ class TestJobsRouter:
         assert resp.status_code == 502
 
 
+class TestJobsRouterScriptPath:
+    """POST /api/jobs ``script_path`` mode (#136 in-place execution).
+
+    Validator-side cases hit the request path before any I/O so the
+    mocks below are deliberately minimal — those tests assert the
+    422 contract without touching the SSH adapter at all.
+
+    The dispatch tests stub :func:`mount_sync_session` so the lock
+    acquisition + rsync no-op out, then assert that
+    :meth:`SlurmSSHAdapter.submit_remote_sbatch` was called with the
+    correctly translated remote path.
+    """
+
+    def test_neither_script_content_nor_path_rejects(self, client: TestClient) -> None:
+        resp = client.post("/api/jobs", json={"name": "x"})
+        assert resp.status_code == 422
+        assert "exactly one of script_content / script_path" in resp.text
+
+    def test_both_script_content_and_path_rejects(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/jobs",
+            json={
+                "name": "x",
+                "script_content": "#!/bin/bash\n",
+                "script_path": "/tmp/run.sh",
+                "mount_name": MOUNT,
+            },
+        )
+        assert resp.status_code == 422
+        assert "mutually exclusive" in resp.text
+
+    def test_script_path_without_mount_rejects(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/jobs",
+            json={"name": "x", "script_path": "/tmp/run.sh"},
+        )
+        assert resp.status_code == 422
+        assert "script_path requires mount_name" in resp.text
+
+    def test_script_path_dispatches_in_place(
+        self,
+        client: TestClient,
+        mock_adapter: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        from srunx.ssh.core.config import MountConfig, ServerProfile
+
+        # Reuse the same mount root the ``client`` fixture set up so
+        # the path validation passes against the real on-disk dir.
+        mount_local = tmp_path / "project"
+        script = mount_local / "run.sh"
+        script.write_text("#!/bin/bash\necho hi\n")
+
+        fake_profile = ServerProfile(
+            hostname="x",
+            username="u",
+            key_filename="~/.ssh/id_rsa",
+            mounts=[
+                MountConfig(
+                    name=MOUNT,
+                    local=str(mount_local),
+                    remote="/home/u/project",
+                )
+            ],
+        )
+
+        # ``adapter.scheduler_key`` becomes the profile name fed into
+        # ``mount_sync_session`` — match the mock to the profile we're
+        # constructing so the assertion below exercises the full
+        # ``ssh:<profile>`` → profile-name unwrap.
+        mock_adapter.scheduler_key = "ssh:test-profile"
+
+        submitted = MagicMock()
+        submitted.job_id = 99001
+        submitted.name = "in-place-job"
+        mock_adapter.submit_remote_sbatch.return_value = submitted
+
+        @contextmanager
+        def fake_session(**kwargs):  # type: ignore[no-untyped-def]
+            yield MagicMock(performed=True, warnings=())
+
+        with (
+            patch(
+                "srunx.web.sync_utils.get_current_profile",
+                return_value=fake_profile,
+            ),
+            patch("srunx.sync.service.mount_sync_session", fake_session),
+        ):
+            resp = client.post(
+                "/api/jobs",
+                json={
+                    "name": "in-place-job",
+                    "script_path": str(script),
+                    "mount_name": MOUNT,
+                },
+            )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["job_id"] == 99001
+        assert body["name"] == "in-place-job"
+
+        # Local→remote translation: ``project/run.sh`` under
+        # ``/home/u/project`` → ``/home/u/project/run.sh``. submit_cwd
+        # is the script's parent dir on the remote.
+        mock_adapter.submit_remote_sbatch.assert_called_once()
+        _, kwargs = mock_adapter.submit_remote_sbatch.call_args
+        args = mock_adapter.submit_remote_sbatch.call_args.args
+        assert args[0] == "/home/u/project/run.sh"
+        assert kwargs["submit_cwd"] == "/home/u/project"
+        assert kwargs["job_name"] == "in-place-job"
+        # Legacy tmp-upload path must NOT have run when script_path
+        # was provided.
+        mock_adapter.submit_job.assert_not_called()
+
+    def test_script_path_outside_mount_returns_403(
+        self,
+        client: TestClient,
+        mock_adapter: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from unittest.mock import patch
+
+        from srunx.ssh.core.config import MountConfig, ServerProfile
+
+        mount_local = tmp_path / "project"
+        # The escape target sits OUTSIDE mount_local — the
+        # ``Path.is_relative_to`` check must reject it.
+        outside = tmp_path / "elsewhere" / "evil.sh"
+        outside.parent.mkdir()
+        outside.write_text("#!/bin/bash\n")
+
+        fake_profile = ServerProfile(
+            hostname="x",
+            username="u",
+            key_filename="~/.ssh/id_rsa",
+            mounts=[
+                MountConfig(
+                    name=MOUNT,
+                    local=str(mount_local),
+                    remote="/home/u/project",
+                )
+            ],
+        )
+
+        with patch(
+            "srunx.web.sync_utils.get_current_profile",
+            return_value=fake_profile,
+        ):
+            resp = client.post(
+                "/api/jobs",
+                json={
+                    "name": "evil",
+                    "script_path": str(outside),
+                    "mount_name": MOUNT,
+                },
+            )
+        assert resp.status_code == 403
+        assert "outside mount" in resp.text
+        # The adapter must never see an off-mount script_path.
+        mock_adapter.submit_remote_sbatch.assert_not_called()
+
+    def test_script_path_unknown_mount_returns_404(
+        self,
+        client: TestClient,
+        mock_adapter: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        from unittest.mock import patch
+
+        from srunx.ssh.core.config import MountConfig, ServerProfile
+
+        mount_local = tmp_path / "project"
+        script = mount_local / "run.sh"
+        script.write_text("#!/bin/bash\n")
+
+        # Profile has a mount, but its name doesn't match the request.
+        fake_profile = ServerProfile(
+            hostname="x",
+            username="u",
+            key_filename="~/.ssh/id_rsa",
+            mounts=[
+                MountConfig(
+                    name="other",
+                    local=str(mount_local),
+                    remote="/home/u/project",
+                )
+            ],
+        )
+
+        with patch(
+            "srunx.web.sync_utils.get_current_profile",
+            return_value=fake_profile,
+        ):
+            resp = client.post(
+                "/api/jobs",
+                json={
+                    "name": "x",
+                    "script_path": str(script),
+                    "mount_name": "missing-mount",
+                },
+            )
+        assert resp.status_code == 404
+        assert "missing-mount" in resp.text
+
+    def test_sync_failure_returns_502(
+        self,
+        client: TestClient,
+        mock_adapter: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """An rsync ``RuntimeError`` (non-zero exit) surfaces as 502."""
+        from contextlib import contextmanager
+        from unittest.mock import patch
+
+        from srunx.ssh.core.config import MountConfig, ServerProfile
+
+        mount_local = tmp_path / "project"
+        script = mount_local / "run.sh"
+        script.write_text("#!/bin/bash\n")
+
+        fake_profile = ServerProfile(
+            hostname="x",
+            username="u",
+            key_filename="~/.ssh/id_rsa",
+            mounts=[
+                MountConfig(
+                    name=MOUNT,
+                    local=str(mount_local),
+                    remote="/home/u/project",
+                )
+            ],
+        )
+
+        @contextmanager
+        def boom_session(**kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("rsync exited with status 23")
+            yield  # unreachable; satisfies type checker
+
+        with (
+            patch(
+                "srunx.web.sync_utils.get_current_profile",
+                return_value=fake_profile,
+            ),
+            patch("srunx.sync.service.mount_sync_session", boom_session),
+        ):
+            resp = client.post(
+                "/api/jobs",
+                json={
+                    "name": "fails",
+                    "script_path": str(script),
+                    "mount_name": MOUNT,
+                },
+            )
+        assert resp.status_code == 502
+        assert "Mount sync failed" in resp.text
+        mock_adapter.submit_remote_sbatch.assert_not_called()
+
+
 # ── Resources Router ──────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes #136. Adds an opt-in `script_path` field to `JobSubmitRequest` so the Web UI can submit a mount-resident script directly — no tmp upload, the user's own `#SBATCH` directives win — mirroring what `srunx sbatch <script>` already does on the CLI after PR #141.

## Schema

| field | mode |
|------|-----|
| `script_content` only (default) | Legacy: bytes uploaded to `/tmp/srunx/`, behaviour identical to pre-#136 |
| `script_path` only | New: must live under `mount_name`'s `mount.local` root |
| both / neither | 422 (validator rejects ambiguity) |
| `script_path` without `mount_name` | 422 (path can't be translated) |

## Routing

- **`script_path` →** validate path under mount root (`Path.is_relative_to`; 403 on escape, mirroring `_enforce_shell_script_roots` shape) → `mount_sync_session` (rsync + per-mount lock held across submission) → `adapter.submit_remote_sbatch(remote_path, submit_cwd, job_name)`.
- **`script_content` →** legacy `adapter.submit_job(content, ...)` (with optional pre-submit mount sync, unchanged).

Both helpers run under a single `anyio.to_thread.run_sync` so the held mount lock + rsync + sbatch all execute on the same OS thread — otherwise an event-loop context switch could release the lock between sync and submit (Codex blocker #3 on #134, same shape).

## Test plan

- [x] `tests/web/test_routers.py::TestJobsRouterScriptPath` — 7 tests:
  - validator: neither / both / script_path-without-mount → 422
  - dispatch: in-place call hits `submit_remote_sbatch` with correctly translated remote path + submit_cwd, legacy `submit_job` not called
  - security: off-mount script_path → 403, adapter never sees the path
  - error mapping: unknown mount_name → 404, rsync `RuntimeError` → 502
- [x] Existing 91 router tests still pass (legacy `script_content` path unchanged)
- [x] Full suite: 1914 passed (1 pre-existing flaky migration race unrelated)
- [x] `uv run mypy .` / `uv run ruff check .` clean

## Out of scope (Phase 3 follow-ups)

- Web UI submit dialog "Choose mount-resident script" picker — frontend work, separate PR
- Sync warnings surfaced in the response toast — needs return-shape extension; can layer on later

🤖 Generated with [Claude Code](https://claude.com/claude-code)