### PR TITLE
fix(sync): collision-resistant per-mount lock filename (#137 part 1)

### DIFF
--- a/src/srunx/sync/lock.py
+++ b/src/srunx/sync/lock.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import fcntl
+import hashlib
 import os
 import re
 import time
@@ -69,10 +70,42 @@ def _sanitise(value: str) -> str:
     return cleaned or "unnamed"
 
 
+def _disambiguator(profile: str, mount: str) -> str:
+    """Short hash that disambiguates colliding ``(profile, mount)`` pairs.
+
+    The pre-#137 filename ``f"{sanitise(profile)}-{sanitise(mount)}.lock"``
+    collapsed pairs whose split fell at a ``-``: ``("foo-bar", "baz")`` and
+    ``("foo", "bar-baz")`` both produced ``foo-bar-baz.lock``. The
+    consequence was *over-serialisation* (two unrelated mounts queueing
+    on one lock) — safe but wrong. Two unrelated workflows on
+    overlapping name shapes would block each other for no reason.
+
+    Mixing in a short hash of the raw ``(profile, mount)`` pair (a
+    ``\\x00`` separator avoids the same collapse the readable name
+    suffers) restores per-pair uniqueness while keeping the filename
+    diagnosable. 8 hex chars ≈ 32 bits — collision probability is
+    negligible for the handful of mounts a single user will ever
+    register.
+    """
+    payload = f"{profile}\x00{mount}".encode()
+    return hashlib.sha256(payload).hexdigest()[:8]
+
+
 def lock_path_for(profile: str, mount: str) -> Path:
-    """Return the lock file path for a (profile, mount) pair."""
+    """Return the lock file path for a (profile, mount) pair.
+
+    Filename format: ``{sanitised_profile}-{sanitised_mount}-{hash8}.lock``.
+    The ``hash8`` suffix disambiguates pairs whose readable parts
+    collide after sanitisation (``foo-bar / baz`` vs ``foo / bar-baz``).
+    See :func:`_disambiguator`.
+    """
     return (
-        _user_config_dir() / "locks" / f"{_sanitise(profile)}-{_sanitise(mount)}.lock"
+        _user_config_dir()
+        / "locks"
+        / (
+            f"{_sanitise(profile)}-{_sanitise(mount)}"
+            f"-{_disambiguator(profile, mount)}.lock"
+        )
     )
 
 

--- a/tests/sync/test_lock.py
+++ b/tests/sync/test_lock.py
@@ -60,6 +60,42 @@ def test_lock_path_sanitises_special_chars() -> None:
     assert p.name.endswith(".lock")
 
 
+def test_lock_path_disambiguates_dash_collision() -> None:
+    """``foo-bar / baz`` and ``foo / bar-baz`` get distinct lock files.
+
+    Pre-#137 the filename was ``f"{sanitise(p)}-{sanitise(m)}.lock"``
+    which collapsed both pairs into ``foo-bar-baz.lock`` — distinct
+    mounts queued on the same lock for no semantic reason. The hash
+    suffix added in :func:`_disambiguator` restores per-pair
+    uniqueness.
+    """
+    a = lock_path_for("foo-bar", "baz")
+    b = lock_path_for("foo", "bar-baz")
+    assert a != b
+    # Both still live in the locks dir and end in .lock — readability
+    # of the diagnostic prefix is preserved.
+    assert a.parent == b.parent
+    assert a.name.endswith(".lock") and b.name.endswith(".lock")
+
+
+def test_lock_path_is_deterministic() -> None:
+    """Same inputs → same path. The hash suffix is content-derived."""
+    assert lock_path_for("alice", "ml") == lock_path_for("alice", "ml")
+
+
+def test_lock_path_separates_unrelated_pairs_after_sanitise() -> None:
+    """Names that sanitise to the same string still get distinct locks.
+
+    ``"a/b"`` and ``"a_b"`` both flatten to ``a_b`` under sanitisation;
+    without the hash they'd map to the same lock. The disambiguator
+    runs against the *raw* names so each unique input gets its own
+    lock file.
+    """
+    a = lock_path_for("a/b", "ml")
+    b = lock_path_for("a_b", "ml")
+    assert a != b
+
+
 def test_sanitise_empty_value_falls_back() -> None:
     assert _sanitise("") == "unnamed"
     assert _sanitise("___") == "unnamed"  # Strip-able chars only.


### PR DESCRIPTION
## Summary

Part 1 of #137. Fixes the lock-filename collision Codex flagged on the #134 review: pairs whose split fell at a \`-\` collapsed to the same file, so unrelated mounts queued on one lock for no semantic reason.

| pair | pre-#137 lock | post |
|------|--------------|------|
| \`("foo-bar", "baz")\` | \`foo-bar-baz.lock\` | \`foo-bar-baz-3a7e9c1d.lock\` |
| \`("foo", "bar-baz")\` | \`foo-bar-baz.lock\` *(same!)* | \`foo-bar-baz-91cf2008.lock\` |

## Fix

Mix in an 8-hex-char SHA256 of the raw \`(profile, mount)\` pair (with \`\\x00\` separator so the same dash-collapse doesn't bite us inside the hash input). The readable prefix stays for diagnosis; the hash suffix restores per-pair uniqueness.

## Test plan

- [x] \`tests/sync/test_lock.py::test_lock_path_disambiguates_dash_collision\` — proves the two pairs above no longer share a lock
- [x] \`test_lock_path_separates_unrelated_pairs_after_sanitise\` — \`"a/b"\` and \`"a_b"\` (both sanitise to \`a_b\`) get distinct locks
- [x] \`test_lock_path_is_deterministic\` — same input → same path
- [x] Existing 6 lock tests still pass (basic acquire/release, sanitise, timeout)
- [x] Full suite: 1918 passed
- [x] \`uv run mypy .\` / \`uv run ruff check .\` clean

## Out of scope (#137 follow-ups)

- Per-machine ownership marker (\`.srunx-owner.json\` + \`--force-sync\`)
- Remote hash verification post-sync
- \`--dry-run\` sync preview
- \`--verbose\` rsync streaming progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)