### PR TITLE
feat(cli): sbatch --dry-run shows in-place sync preview (#137 part 2)

### DIFF
--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -280,6 +280,73 @@ def _parse_gres_gpu(gres: str | None) -> int | None:
     return count
 
 
+def _print_in_place_sync_preview(
+    *,
+    console: Console,
+    script: Path | None,
+    profile_name: str | None,
+    local: bool,
+    sync_flag: bool | None,
+    config: Any,
+) -> None:
+    """Show the rsync ``-n -i`` preview for an SSH in-place dry-run.
+
+    Quietly no-ops in every "this isn't an in-place candidate" case
+    (local transport, no positional script, no resolvable profile, no
+    profile mounts, script not under any mount). Failures from the
+    rsync subprocess itself are caught and surfaced as a single
+    coloured line — the preview is best-effort and must never abort
+    the larger ``--dry-run`` flow.
+    """
+    if local or script is None:
+        return
+
+    from srunx.transport import peek_scheduler_key
+
+    try:
+        sched_key = peek_scheduler_key(profile=profile_name, local=local)
+    except typer.BadParameter:
+        # ``--profile foo --local`` conflict — already surfaced by the
+        # main resolution path; nothing more to add here.
+        return
+
+    if not sched_key.startswith("ssh:"):
+        return
+
+    resolved_profile_name = sched_key[len("ssh:") :]
+
+    from srunx.cli.submission_plan import resolve_mount_for_path
+    from srunx.ssh.core.config import ConfigManager
+
+    profile = ConfigManager().get_profile(resolved_profile_name)
+    if profile is None or not profile.mounts:
+        return
+
+    mount = resolve_mount_for_path(script, profile)
+    if mount is None:
+        return
+
+    sync_enabled = config.sync.auto if sync_flag is None else sync_flag
+    if not sync_enabled:
+        console.print(f"  Sync: skipped (--no-sync) for mount '{mount.name}'")
+        return
+
+    console.print(f"  Sync preview for mount [cyan]{mount.name}[/cyan]:")
+    try:
+        from srunx.sync.mount_helpers import sync_mount_by_name
+
+        output = sync_mount_by_name(profile, mount.name, dry_run=True)
+    except RuntimeError as exc:
+        console.print(f"    [red]rsync preview failed: {exc}[/red]")
+        return
+
+    if not output.strip():
+        console.print("    (no changes — remote already up to date)")
+        return
+    for line in output.splitlines():
+        console.print(f"    {line}")
+
+
 class DebugCallback(Callback):
     """Callback to display rendered SLURM scripts in debug mode."""
 
@@ -910,6 +977,19 @@ def sbatch(
             console.print(f"  GPUs: {job.resources.gpus_per_node}")
         elif isinstance(job, ShellJob):
             console.print(f"  Script: {job.script_path}")
+        # #137 part 2: when the dry run targets an SSH in-place
+        # candidate (positional script under a profile mount), also
+        # show rsync's preview of what *would* transfer. Lets the user
+        # spot a stray ``build/`` or ``.cache/`` they forgot to
+        # gitignore before they trigger an actual sync.
+        _print_in_place_sync_preview(
+            console=console,
+            script=script,
+            profile_name=profile,
+            local=local,
+            sync_flag=sync,
+            config=config,
+        )
         return
 
     # Submit job through the resolved transport.

--- a/src/srunx/sync/mount_helpers.py
+++ b/src/srunx/sync/mount_helpers.py
@@ -63,7 +63,8 @@ def sync_mount_by_name(
     mount_name: str,
     *,
     delete: bool = False,
-) -> None:
+    dry_run: bool = False,
+) -> str:
     """Sync a named mount's local directory to remote via rsync.
 
     ``delete`` is **False by default** so callers that don't opt in
@@ -71,6 +72,15 @@ def sync_mount_by_name(
     ``srunx ssh sync`` command and any explicit ""mirror this exactly""
     callers should pass ``delete=True``. Auto-sync paths (PR #134
     Phase 1) leave the default.
+
+    ``dry_run=True`` runs rsync with ``-n -i`` (no transfer + itemize)
+    and returns rsync's stdout — the human-readable list of files
+    that *would* be touched. The remote is not modified. Used by the
+    CLI ``srunx sbatch --dry-run`` preview path (#137 part 2).
+
+    Returns:
+        rsync stdout — empty for a non-dry-run sync, the itemize lines
+        for a dry-run preview.
 
     Raises:
         ValueError: If *mount_name* does not exist in the profile.
@@ -86,9 +96,15 @@ def sync_mount_by_name(
         mount.local,
         mount.remote,
         delete=delete,
+        dry_run=dry_run,
+        # ``itemize`` tracks ``dry_run`` — for an actual push we don't
+        # want the per-file output spam in the success path, but for
+        # a preview the itemize lines ARE the value.
+        itemize=dry_run,
         exclude_patterns=mount.exclude_patterns or None,
     )
     if result.returncode != 0:
         raise RuntimeError(
             f"rsync sync failed for mount '{mount_name}': {result.stderr}"
         )
+    return result.stdout

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -114,6 +114,7 @@ class RsyncClient:
         *,
         delete: bool = True,
         dry_run: bool = False,
+        itemize: bool = False,
         exclude_patterns: Sequence[str] | None = None,
     ) -> RsyncResult:
         """Sync a local directory/file to the remote server.
@@ -124,6 +125,10 @@ class RsyncClient:
                 If None, uses ``get_default_remote_path()``.
             delete: Remove remote files not present locally (default True).
             dry_run: Perform a trial run with no changes made.
+            itemize: Add ``--itemize-changes`` so the result lists every
+                file rsync *would* (or did) touch, with the standard
+                ``YXcstpoguax`` flag prefix. Required for ``dry_run``
+                callers that want a human-readable preview.
             exclude_patterns: Additional exclude patterns for this call only.
 
         Returns:
@@ -147,7 +152,12 @@ class RsyncClient:
 
         excludes = self._merge_excludes(exclude_patterns)
         cmd = self._build_rsync_cmd(
-            src, dst, delete=delete, dry_run=dry_run, excludes=excludes
+            src,
+            dst,
+            delete=delete,
+            dry_run=dry_run,
+            itemize=itemize,
+            excludes=excludes,
         )
         return self._run_rsync(cmd)
 
@@ -158,6 +168,7 @@ class RsyncClient:
         *,
         delete: bool = False,
         dry_run: bool = False,
+        itemize: bool = False,
         exclude_patterns: Sequence[str] | None = None,
     ) -> RsyncResult:
         """Sync a remote directory/file to the local machine.
@@ -167,6 +178,8 @@ class RsyncClient:
             local_path: Local destination path.
             delete: Remove local files not present on the remote (default False).
             dry_run: Perform a trial run with no changes made.
+            itemize: Add ``--itemize-changes`` so the result enumerates
+                every file rsync *would* (or did) touch.
             exclude_patterns: Additional exclude patterns for this call only.
 
         Returns:
@@ -177,7 +190,12 @@ class RsyncClient:
 
         excludes = self._merge_excludes(exclude_patterns)
         cmd = self._build_rsync_cmd(
-            src, dst, delete=delete, dry_run=dry_run, excludes=excludes
+            src,
+            dst,
+            delete=delete,
+            dry_run=dry_run,
+            itemize=itemize,
+            excludes=excludes,
         )
         return self._run_rsync(cmd)
 
@@ -210,6 +228,7 @@ class RsyncClient:
         *,
         delete: bool,
         dry_run: bool,
+        itemize: bool = False,
         excludes: list[str],
     ) -> list[str]:
         """Build the full rsync command."""
@@ -227,6 +246,11 @@ class RsyncClient:
             cmd.append("--delete")
         if dry_run:
             cmd.append("-n")
+        if itemize:
+            # ``-i`` (``--itemize-changes``) makes rsync emit one line
+            # per file with a ``YXcstpoguax``-style flag prefix so the
+            # CLI dry-run preview can render exactly what would change.
+            cmd.append("-i")
 
         for pattern in excludes:
             cmd.extend(["--exclude", pattern])

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -488,3 +488,133 @@ def test_config_workdir_does_not_inject_chdir(
         "Config-default work_dir leaked into sbatch CLI args, would have "
         "overridden the script's own #SBATCH --chdir=."
     )
+
+
+# ── Dry-run sync preview (#137 part 2) ────────────────────────────
+
+
+def test_dry_run_shows_in_place_sync_preview(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``sbatch --dry-run`` against a mount-resident script previews rsync.
+
+    Lets the user spot a stray ``build/`` they forgot to gitignore
+    BEFORE the actual sync ships it. The preview lines come from
+    rsync's ``-n -i`` output (mocked here so we don't actually shell
+    out).
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    _patch_transport(monkeypatch, profile)
+
+    # Mock the mount-helper rsync to return three itemize lines as
+    # though rsync had real changes to report.
+    fake_output = (
+        ">f.st...... train.sbatch\ncd+++++++++ build/\n>f+++++++++ build/output.bin\n"
+    )
+    sync_calls: list[dict[str, object]] = []
+
+    def _fake_sync(
+        prof: ServerProfile,
+        name: str,
+        *,
+        delete: bool = False,
+        dry_run: bool = False,
+    ) -> str:
+        sync_calls.append({"name": name, "delete": delete, "dry_run": dry_run})
+        return fake_output if dry_run else ""
+
+    monkeypatch.setattr("srunx.sync.mount_helpers.sync_mount_by_name", _fake_sync)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["sbatch", str(script), "--profile", "ml-cluster", "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "Dry run mode" in result.stdout
+    assert "Sync preview for mount" in result.stdout
+    # Each itemize line surfaces verbatim under the preview header.
+    for line in fake_output.splitlines():
+        assert line in result.stdout
+
+    # The preview path uses dry_run=True so nothing is actually pushed.
+    assert sync_calls == [{"name": "ml", "delete": False, "dry_run": True}]
+
+
+def test_dry_run_no_sync_message_when_sync_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--no-sync --dry-run`` skips the rsync subprocess but still tells the user.
+
+    Important so the user knows *why* there's no preview — without
+    the explicit message it'd look like the mount auto-detection
+    failed.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    _patch_transport(monkeypatch, profile)
+
+    sync_called = False
+
+    def _should_not_run(*a: object, **k: object) -> str:
+        nonlocal sync_called
+        sync_called = True
+        return ""
+
+    monkeypatch.setattr("srunx.sync.mount_helpers.sync_mount_by_name", _should_not_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "sbatch",
+            str(script),
+            "--profile",
+            "ml-cluster",
+            "--dry-run",
+            "--no-sync",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "skipped (--no-sync)" in result.stdout
+    assert not sync_called, "rsync must not run when --no-sync is set"
+
+
+def test_dry_run_preview_silent_for_local_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Local sbatch dry-run shows job info only — no SSH/sync chatter.
+
+    The preview is an SSH-only feature; running a local sbatch
+    against a script that *happens* to share a path with some mount
+    must NOT trigger rsync calls or print mount-related lines.
+    """
+    script = tmp_path / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    sync_called = False
+
+    def _record(*a: object, **k: object) -> None:
+        nonlocal sync_called
+        sync_called = True
+
+    monkeypatch.setattr("srunx.sync.mount_helpers.sync_mount_by_name", _record)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--local", "--dry-run"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert "Sync preview" not in result.stdout
+    assert "skipped (--no-sync)" not in result.stdout
+    assert not sync_called

--- a/tests/test_rsync.py
+++ b/tests/test_rsync.py
@@ -363,6 +363,37 @@ class TestPush:
 
         assert "-n" in mock_run.call_args[0][0]
 
+    def test_push_itemize(self, tmp_path: Path):
+        """``itemize=True`` adds rsync's ``-i`` flag.
+
+        Required for the dry-run preview path (#137 part 2): without
+        ``-i`` rsync emits no per-file output, so the CLI can't show
+        the user what *would* change.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/", dry_run=True, itemize=True)
+
+        cmd = mock_run.call_args[0][0]
+        assert "-n" in cmd and "-i" in cmd
+
+    def test_push_no_itemize_by_default(self, tmp_path: Path):
+        """``-i`` is opt-in — default push doesn't add it.
+
+        A successful real sync should not spam stdout with per-file
+        change lines. ``itemize=True`` is the explicit opt-in for
+        callers that want the listing.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/")
+
+        assert "-i" not in mock_run.call_args[0][0]
+
     def test_push_failure(self, tmp_path: Path):
         client = _make_rsync_client(hostname="h", username="u")
 


### PR DESCRIPTION
## Summary

Part 2 of #137. When \`srunx sbatch --dry-run\` targets a positional script that sits under one of the SSH profile's mounts, also run rsync's \`-n -i\` and surface the per-file listing under the existing dry-run output.

Lets the user spot a stray \`build/\` they forgot to gitignore BEFORE the actual sync ships it — the whole point of issue #137 #3.

## Sample output

\`\`\`
🔍 Dry run mode - would submit job:
  Name: train
  Script: /home/me/proj/train.sbatch
  Sync preview for mount proj:
    >f.st...... train.sbatch
    cd+++++++++ build/
    >f+++++++++ build/output.bin
\`\`\`

## Plumbing

| layer | change |
|------|--------|
| \`RsyncClient.push/pull\` | new \`itemize: bool = False\` → adds \`-i\` (default off so successful real syncs run silently) |
| \`sync_mount_by_name\` | new \`dry_run: bool = False\`, returns rsync stdout (empty for non-dry-run, itemize lines for preview); auto-enables \`itemize\` when \`dry_run\` |
| CLI sbatch | new \`_print_in_place_sync_preview\` helper called from the existing \`if dry_run:\` branch — quietly no-ops on every "not an in-place candidate" case |

The other \`sync_mount_by_name\` callers (Web routers, \`mount_sync_session\`) ignore the new \`str\` return, so the legacy \`None\` → \`str\` change is a no-op for them.

## Test plan

- [x] \`tests/test_rsync.py\`: \`test_push_itemize\`, \`test_push_no_itemize_by_default\`
- [x] \`tests/cli/test_sbatch_in_place.py\`:
  - \`test_dry_run_shows_in_place_sync_preview\` — itemize lines surface verbatim
  - \`test_dry_run_no_sync_message_when_sync_disabled\` — \`--no-sync\` skips rsync subprocess but tells the user
  - \`test_dry_run_preview_silent_for_local_transport\` — local sbatch dry-run never triggers SSH/rsync
- [x] Existing 70 sync/sbatch tests still pass
- [x] Full suite: 1919 passed (1 pre-existing flaky migration race unrelated)
- [x] \`uv run mypy .\` / \`uv run ruff check .\` clean

## Out of scope (#137 follow-ups)

- Per-machine ownership marker (\`.srunx-owner.json\` + \`--force-sync\`)
- Remote hash verification post-sync
- \`--verbose\` rsync streaming progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)