### PR TITLE
feat(sync): per-machine ownership marker for synced mounts (#137 part 4)

### DIFF
--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -57,6 +57,7 @@ def _submit_via_transport(
     callbacks: list[Callback],
     config: Any,
     extra_sbatch_args: list[str] | None = None,
+    force_sync: bool = False,
 ) -> Any:
     """Dispatch a submit to the right adapter method + optional mount sync.
 
@@ -146,6 +147,7 @@ def _submit_via_transport(
             mount=plan.mount,
             config=config.sync,
             sync_required=plan.sync_required,
+            force_sync=force_sync,
         )
         sync_ctx_entered = sync_ctx.__enter__()
     except SyncAbortedError as exc:
@@ -800,6 +802,19 @@ def sbatch(
             ),
         ),
     ] = None,
+    force_sync: Annotated[
+        bool,
+        typer.Option(
+            "--force-sync",
+            help=(
+                "Bypass the per-machine ownership check and sync this "
+                "mount even if another workstation last touched it. Use "
+                "after confirming the other machine isn't mid-edit. "
+                "Disable the check globally via ``[sync] owner_check = "
+                "false`` if your setup is solo-machine."
+            ),
+        ),
+    ] = False,
     verbose: Annotated[
         bool, typer.Option("--verbose", "-v", help="Show verbose output")
     ] = False,
@@ -1062,6 +1077,7 @@ def sbatch(
             callbacks=callbacks,
             config=config,
             extra_sbatch_args=extra_sbatch_args,
+            force_sync=force_sync,
         )
         client = Slurm(callbacks=callbacks) if rt.transport_type == "local" else None
 

--- a/src/srunx/config.py
+++ b/src/srunx/config.py
@@ -141,6 +141,16 @@ class SyncDefaults(BaseModel):
             "Recommended for CI / shared-workstation scenarios."
         ),
     )
+    owner_check: bool = Field(
+        default=True,
+        description=(
+            "Refuse to sync when the remote ``.srunx-owner.json`` marker "
+            "shows a different machine last touched the mount. Catches "
+            "the cross-workstation overwrite footgun (#137 part 4). "
+            "Override per-invocation with ``--force-sync`` or disable "
+            "globally for solo-machine setups."
+        ),
+    )
 
 
 class SrunxConfig(BaseModel):
@@ -307,6 +317,8 @@ def load_config_from_env() -> dict[str, Any]:
         sync["warn_dirty"] = warn.lower() in ("1", "true", "yes", "on")
     if (clean := os.getenv("SRUNX_SYNC_REQUIRE_CLEAN")) is not None:
         sync["require_clean"] = clean.lower() in ("1", "true", "yes", "on")
+    if (owner := os.getenv("SRUNX_SYNC_OWNER_CHECK")) is not None:
+        sync["owner_check"] = owner.lower() in ("1", "true", "yes", "on")
     if sync:
         config["sync"] = sync
 

--- a/src/srunx/sync/owner_marker.py
+++ b/src/srunx/sync/owner_marker.py
@@ -1,0 +1,231 @@
+"""Per-machine ownership marker for synced mounts (#137 part 4).
+
+Without this marker srunx can't tell which workstation last pushed to
+a mount, so the following sequence silently destroys work:
+
+    laptop$  cd ~/proj && vim train.sbatch       # edit
+    laptop$  srunx sbatch train.sbatch --profile X    # syncs new bytes
+    desktop$ srunx sbatch train.sbatch --profile X    # different
+                                                      # workstation, syncs
+                                                      # *its own* old bytes
+                                                      # over the laptop's
+
+Both submissions succeed, but the desktop's run executes the laptop's
+old code while overwriting the laptop's new code on the cluster. The
+user has no signal that anything went wrong.
+
+The marker is a tiny JSON file at ``<mount.remote>/.srunx-owner.json``
+recording ``hostname`` + ``mount_name`` + ISO timestamp of the last
+successful sync. Each sync:
+
+1. Reads the marker (best-effort: missing / unparseable → no owner).
+2. If the recorded hostname differs from this machine's
+   :func:`current_machine_id` AND the user has not explicitly opted
+   out (``--force-sync`` CLI flag or ``[sync] owner_check = false``
+   config), aborts with :class:`OwnerMismatch`.
+3. If the rsync succeeds, writes a fresh marker so the next sync sees
+   the up-to-date owner.
+
+The check is deliberately conservative — when the marker can't be
+fetched (ssh failure, malformed JSON, …) we treat it as "no owner"
+rather than blocking, so a transient network blip doesn't strand the
+user. The protection it provides is "two known machines competing";
+arbitrary corruption is out of scope.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from srunx.logging import get_logger
+from srunx.ssh.core.config import MountConfig, ServerProfile
+from srunx.sync.mount_helpers import build_rsync_client
+
+logger = get_logger(__name__)
+
+
+_MARKER_FILENAME = ".srunx-owner.json"
+
+
+class OwnerMismatch(RuntimeError):
+    """Raised when the remote marker shows a different owning machine.
+
+    Carries the recorded hostname + mount + timestamp so the caller's
+    error message can tell the user *which* workstation currently
+    owns the mount and *when* it last touched it. Recovery is
+    explicit: re-run with ``--force-sync`` after confirming the
+    other workstation isn't mid-edit, or set
+    ``[sync] owner_check = false`` to disable the check globally.
+    """
+
+    def __init__(
+        self,
+        *,
+        mount_name: str,
+        local_machine: str,
+        recorded_machine: str,
+        recorded_at: str | None,
+    ) -> None:
+        when = f" at {recorded_at}" if recorded_at else ""
+        super().__init__(
+            f"Mount '{mount_name}' was last synced from '{recorded_machine}'"
+            f"{when}, not '{local_machine}'. Syncing now would overwrite "
+            f"the other machine's edits. Re-run with --force-sync to "
+            f"override, or disable the check via "
+            f"``[sync] owner_check = false``."
+        )
+        self.mount_name = mount_name
+        self.local_machine = local_machine
+        self.recorded_machine = recorded_machine
+        self.recorded_at = recorded_at
+
+
+@dataclass(frozen=True)
+class OwnerMarker:
+    """In-memory representation of ``.srunx-owner.json``."""
+
+    hostname: str
+    mount_name: str
+    last_sync_at: str  # ISO-8601 UTC
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "hostname": self.hostname,
+                "mount_name": self.mount_name,
+                "last_sync_at": self.last_sync_at,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> OwnerMarker | None:
+        """Parse a marker payload; return ``None`` for any malformed input.
+
+        Defensive on every field: a marker that's missing or wrong-shape
+        is treated as "no owner" rather than as an error so a one-off
+        corruption doesn't block legitimate syncs forever. The user's
+        next successful sync overwrites it with a fresh marker anyway.
+        """
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        hostname = data.get("hostname")
+        mount_name = data.get("mount_name")
+        last = data.get("last_sync_at")
+        if not isinstance(hostname, str) or not isinstance(mount_name, str):
+            return None
+        if not isinstance(last, str):
+            return None
+        return cls(hostname=hostname, mount_name=mount_name, last_sync_at=last)
+
+
+def current_machine_id() -> str:
+    """Return a stable identifier for *this* machine.
+
+    Uses :func:`socket.gethostname` as the cheapest readily-available
+    identifier — matches what most users would type to describe their
+    workstation, and survives reboots / DHCP IP churn (unlike
+    something MAC-address based). Per-user tests can monkeypatch
+    this.
+    """
+    return socket.gethostname()
+
+
+def _marker_remote_path(mount: MountConfig) -> str:
+    """Return the absolute remote path of the marker for *mount*.
+
+    Joining with ``/`` explicitly because the remote side is POSIX —
+    ``Path`` would pick up the host separator on Windows workstations.
+    """
+    return f"{mount.remote.rstrip('/')}/{_MARKER_FILENAME}"
+
+
+def read_owner_marker(profile: ServerProfile, mount: MountConfig) -> OwnerMarker | None:
+    """Read the remote marker for *mount*; return ``None`` if missing/invalid.
+
+    "Missing" is the legitimate first-sync case and must not raise.
+    Genuine ssh failures DO raise via :class:`RuntimeError` from the
+    underlying :meth:`RsyncClient.read_remote_file` so the caller can
+    decide whether a network problem warrants blocking the sync.
+    """
+    client = build_rsync_client(profile)
+    raw = client.read_remote_file(_marker_remote_path(mount))
+    if raw is None:
+        return None
+    marker = OwnerMarker.from_json(raw)
+    if marker is None:
+        # Malformed marker — log so it's visible in --verbose, but
+        # don't raise. The next successful sync overwrites it.
+        logger.debug(
+            "Owner marker at %s is malformed; ignoring",
+            _marker_remote_path(mount),
+        )
+    return marker
+
+
+def write_owner_marker(
+    profile: ServerProfile, mount: MountConfig, *, hostname: str | None = None
+) -> OwnerMarker:
+    """Write a fresh marker for *mount*; return the value that was written.
+
+    ``hostname`` defaults to :func:`current_machine_id`; tests pass
+    an explicit value to avoid leaking the real hostname into
+    fixtures.
+    """
+    machine = hostname or current_machine_id()
+    marker = OwnerMarker(
+        hostname=machine,
+        mount_name=mount.name,
+        last_sync_at=datetime.now(UTC).isoformat(),
+    )
+    client = build_rsync_client(profile)
+    client.write_remote_file(_marker_remote_path(mount), marker.to_json())
+    return marker
+
+
+def check_owner(
+    profile: ServerProfile,
+    mount: MountConfig,
+    *,
+    enabled: bool,
+    force: bool,
+    hostname: str | None = None,
+) -> None:
+    """Raise :class:`OwnerMismatch` if the remote marker names a different host.
+
+    No-ops when ``enabled=False`` (config opt-out) or ``force=True``
+    (CLI ``--force-sync`` opt-out) so the caller can run the same
+    function in every code path without branching at the call site.
+    Marker read failures are logged at debug and treated as "no
+    owner" — see module docstring for the rationale.
+    """
+    if not enabled or force:
+        return
+    try:
+        marker = read_owner_marker(profile, mount)
+    except RuntimeError as exc:
+        # Network / ssh failure: don't block the sync; the user is
+        # already in trouble and silently aborting would just hide it.
+        # The rsync that follows will surface the same connection
+        # problem with its own error.
+        logger.debug("Owner marker read failed (treating as absent): %s", exc)
+        return
+    if marker is None:
+        return
+    me = hostname or current_machine_id()
+    if marker.hostname == me:
+        return
+    raise OwnerMismatch(
+        mount_name=mount.name,
+        local_machine=me,
+        recorded_machine=marker.hostname,
+        recorded_at=marker.last_sync_at,
+    )

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -277,19 +277,89 @@ class RsyncClient:
 
     def _ensure_remote_dir(self, remote_path: str) -> None:
         """Create the remote directory via ssh mkdir -p (fallback for rsync without --mkpath)."""
-        ssh_cmd = self._build_ssh_cmd()
+        self._ssh_run(f"mkdir -p {shlex.quote(remote_path.rstrip('/'))}")
+
+    def _ssh_dest(self) -> str:
+        """Return the ``user@host`` (or just ``host``) string for ssh."""
         if self.username:
-            dest = f"{self.username}@{self.hostname}"
-        else:
-            dest = self.hostname
-        quoted_path = shlex.quote(remote_path.rstrip("/"))
-        mkdir_cmd = [
-            *ssh_cmd,
-            dest,
-            f"mkdir -p {quoted_path}",
-        ]
-        logger.debug("Ensuring remote dir: {}", shlex.join(mkdir_cmd))
-        subprocess.run(mkdir_cmd, capture_output=True, text=True)  # noqa: S603
+            return f"{self.username}@{self.hostname}"
+        return self.hostname
+
+    def _ssh_run(
+        self,
+        remote_cmd: str,
+        *,
+        stdin: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run *remote_cmd* on the configured host via ssh.
+
+        Reuses the same SSH options rsync uses (key, port, ProxyJump,
+        ssh_config) so that anything rsync can reach, this can reach
+        too. ``stdin`` is piped through to the remote process — used
+        by the owner-marker writer to send JSON via ``tee``.
+        """
+        ssh_cmd = [*self._build_ssh_cmd(), self._ssh_dest(), remote_cmd]
+        logger.debug("ssh: {}", shlex.join(ssh_cmd))
+        return subprocess.run(  # noqa: S603
+            ssh_cmd,
+            input=stdin,
+            capture_output=True,
+            text=True,
+        )
+
+    def read_remote_file(self, remote_path: str) -> str | None:
+        """Return the remote file's contents, or ``None`` if it doesn't exist.
+
+        Used by the per-machine ownership marker (#137 part 4) to read
+        ``.srunx-owner.json`` before each sync. The check needs to
+        distinguish "file missing" (legitimate first sync, returns
+        ``None``) from "ssh / network failed" (raise so the caller
+        knows the marker can't be trusted).
+
+        Implementation: ``ssh ... cat -- <path>`` with a per-file
+        existence test wrapped in a single shell command — keeps the
+        round-trip count to one per check.
+        """
+        # ``test -f X && cat X`` returns:
+        #   * 0 + stdout: file exists, content returned
+        #   * 1 + empty stdout: file does not exist
+        #   * 2+ : actual error (permission denied, ssh failure, …)
+        # We disambiguate via the exit code so transient failures
+        # don't get silently treated as "no marker".
+        quoted = shlex.quote(remote_path)
+        result = self._ssh_run(f"test -f {quoted} && cat -- {quoted}")
+        if result.returncode == 0:
+            return result.stdout
+        if result.returncode == 1:
+            # ``test -f`` returned false — file does not exist.
+            return None
+        raise RuntimeError(
+            f"ssh read of {remote_path!r} failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+
+    def write_remote_file(self, remote_path: str, content: str) -> None:
+        """Atomically write *content* to *remote_path* via ssh + tee.
+
+        ``tee`` (without ``-a``) truncates and rewrites the destination
+        in one shell op so a concurrent reader either sees the old
+        content or the new content — never a half-written file. The
+        parent directory is assumed to exist (the rsync that just ran
+        guarantees it for the owner-marker case).
+
+        Raises :class:`RuntimeError` if ssh / tee exits non-zero so the
+        caller can surface the failure rather than silently leaving a
+        stale marker on disk.
+        """
+        quoted = shlex.quote(remote_path)
+        # Use ``> /dev/null`` so tee's stdout doesn't echo the JSON
+        # back through ssh (waste of bytes + stdout pollution).
+        result = self._ssh_run(f"tee -- {quoted} > /dev/null", stdin=content)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"ssh write to {remote_path!r} failed "
+                f"(exit {result.returncode}): {result.stderr.strip()}"
+            )
 
     def _merge_excludes(self, extra: Sequence[str] | None) -> list[str]:
         """Merge per-call exclude patterns with instance patterns."""

--- a/src/srunx/sync/service.py
+++ b/src/srunx/sync/service.py
@@ -29,6 +29,7 @@ from srunx.logging import get_logger
 from srunx.ssh.core.config import MountConfig, ServerProfile
 from srunx.sync.lock import acquire_sync_lock
 from srunx.sync.mount_helpers import sync_mount_by_name
+from srunx.sync.owner_marker import OwnerMismatch, check_owner, write_owner_marker
 
 logger = get_logger(__name__)
 
@@ -100,6 +101,7 @@ def mount_sync_session(
     mount: MountConfig,
     config: SyncDefaults,
     sync_required: bool,
+    force_sync: bool = False,
 ) -> Iterator[SyncOutcome]:
     """Acquire the per-mount lock, optionally rsync, hold lock until exit.
 
@@ -115,15 +117,24 @@ def mount_sync_session(
     we skip the rsync invocation itself and return a ``performed=False``
     outcome.
 
+    ``force_sync=True`` (CLI ``--force-sync``) bypasses the
+    per-machine ownership marker check (#137 part 4) so the user can
+    intentionally take over a mount that another workstation
+    previously synced.
+
     Failure modes:
 
     * Dirty worktree + ``require_clean=true`` → :class:`SyncAbortedError`
       (rsync does **not** run; lock is released before raising).
     * Dirty worktree + ``warn_dirty=true`` → log warning, sync proceeds.
+    * Owner marker shows a different host + ``owner_check=true`` +
+      ``force_sync=False`` → :class:`SyncAbortedError` (rsync does
+      **not** run).
     * Lock contention → :class:`~srunx.sync.lock.SyncLockTimeoutError`
       bubbles up.
     * rsync non-zero exit → :class:`RuntimeError` (from inner helper).
     """
+
     warnings: list[str] = []
     if sync_required:
         local_root = Path(mount.local).expanduser()
@@ -144,11 +155,50 @@ def mount_sync_session(
         profile_name, mount.name, timeout=config.lock_timeout_seconds
     ):
         if sync_required:
+            # Owner-marker check runs INSIDE the lock so two racing
+            # workstations can't both pass the check and then both
+            # write conflicting markers. The lock guarantees that at
+            # most one of them is ever in the read-marker → rsync →
+            # write-marker window at a time.
+            try:
+                check_owner(
+                    profile,
+                    mount,
+                    enabled=config.owner_check,
+                    force=force_sync,
+                )
+            except OwnerMismatch as exc:
+                # Re-cast as SyncAbortedError so CLI / Web callers can
+                # catch every "we refused to sync" reason via one
+                # exception type, while preserving the original
+                # message.
+                raise SyncAbortedError(str(exc)) from exc
+
             logger.info("Syncing mount '%s' before submission", mount.name)
             # delete=False (Codex blocker #4): auto-sync must not wipe
             # remote-only outputs (training checkpoints, run logs).
             # ``srunx ssh sync`` keeps the historical mirror behaviour.
             sync_mount_by_name(profile, mount.name, delete=False)
+
+            # Stamp the marker AFTER a successful sync so a failed
+            # rsync doesn't claim ownership for a tree we couldn't
+            # actually push. Gated by ``owner_check``: if the user
+            # opted out of the check, also opt out of writing the
+            # marker — otherwise solo-machine setups would still
+            # accumulate markers nobody reads.
+            #
+            # Best-effort on write failure: a write error produces a
+            # warning but doesn't abort the run that just
+            # successfully shipped its files (network blips at this
+            # exact moment shouldn't fail an otherwise-successful
+            # submission).
+            if config.owner_check:
+                try:
+                    write_owner_marker(profile, mount)
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    msg = f"Could not update owner marker for '{mount.name}': {exc}"
+                    logger.warning(msg)
+                    warnings.append(msg)
 
         yield SyncOutcome(
             mount_name=mount.name,

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -23,6 +23,12 @@ from srunx.ssh.core.config import MountConfig, ServerProfile
 def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+    # Disable the per-machine owner marker check (#137 part 4) for
+    # the existing in-place tests — they predate the marker and only
+    # care about the rsync / sbatch / lock interactions. Owner-marker
+    # behaviour is exercised separately in
+    # ``tests/sync/test_owner_marker.py``.
+    monkeypatch.setenv("SRUNX_SYNC_OWNER_CHECK", "0")
 
 
 def _stub_profile(tmp_path: Path, mount_local: Path, remote: str) -> ServerProfile:
@@ -472,7 +478,15 @@ def test_config_workdir_does_not_inject_chdir(
     monkeypatch.setattr(
         cli_main_module,
         "get_config",
-        lambda: SrunxConfig.model_validate({"work_dir": "/some/config/default"}),
+        lambda: SrunxConfig.model_validate(
+            {
+                "work_dir": "/some/config/default",
+                # Match the autouse env-var override — the injected
+                # config bypasses ``load_config`` so the env var
+                # doesn't reach this construction path.
+                "sync": {"owner_check": False},
+            }
+        ),
     )
 
     profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")

--- a/tests/cli/test_workflow_in_place.py
+++ b/tests/cli/test_workflow_in_place.py
@@ -29,6 +29,10 @@ from srunx.ssh.core.config import MountConfig, ServerProfile
 def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
     monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+    # Owner-marker (#137 part 4) check is exercised in
+    # ``tests/sync/test_owner_marker.py``; keep it off here so the
+    # workflow-level mocks don't have to cover ssh round-trips.
+    monkeypatch.setenv("SRUNX_SYNC_OWNER_CHECK", "0")
 
 
 def _stub_profile(tmp_path: Path, mount_local: Path, remote: str) -> ServerProfile:

--- a/tests/sync/test_owner_marker.py
+++ b/tests/sync/test_owner_marker.py
@@ -1,0 +1,453 @@
+"""Tests for the per-machine ownership marker (#137 part 4).
+
+Two layers exercised here:
+
+* :mod:`srunx.sync.owner_marker` — pure parse/serialise + the
+  :func:`check_owner` policy gate, mocked at the
+  :class:`RsyncClient` boundary so we never touch a real ssh.
+* :func:`srunx.sync.service.mount_sync_session` integration —
+  asserts the marker check fires before rsync, that rsync's
+  successful return triggers a marker write, and that
+  ``--force-sync`` (``force_sync=True``) bypasses the check
+  without skipping the write.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from srunx.config import SyncDefaults
+from srunx.ssh.core.config import MountConfig, ServerProfile
+from srunx.sync.owner_marker import (
+    OwnerMarker,
+    OwnerMismatch,
+    check_owner,
+    current_machine_id,
+    read_owner_marker,
+    write_owner_marker,
+)
+from srunx.sync.service import SyncAbortedError, mount_sync_session
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+
+def _profile(tmp_path: Path) -> ServerProfile:
+    key = tmp_path / "id_rsa"
+    key.write_text("dummy")
+    mount_local = tmp_path / "ml"
+    mount_local.mkdir()
+    return ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename=str(key),
+        mounts=(MountConfig(name="ml", local=str(mount_local), remote="/r/ml"),),
+    )
+
+
+# ── OwnerMarker JSON parse/serialise ──────────────────────────────
+
+
+class TestOwnerMarkerJSON:
+    def test_round_trip(self) -> None:
+        m = OwnerMarker(
+            hostname="alice", mount_name="ml", last_sync_at="2026-04-23T00:00:00+00:00"
+        )
+        round_tripped = OwnerMarker.from_json(m.to_json())
+        assert round_tripped == m
+
+    def test_unparseable_returns_none(self) -> None:
+        """Defensive: garbage input must not raise.
+
+        A corrupted marker should be treated as absent (next sync
+        overwrites it) — not as a hard error that locks the user
+        out.
+        """
+        assert OwnerMarker.from_json("not json") is None
+        assert OwnerMarker.from_json("[1,2,3]") is None
+        assert OwnerMarker.from_json("{}") is None  # missing fields
+
+    def test_wrong_field_types_returns_none(self) -> None:
+        bad = json.dumps({"hostname": 42, "mount_name": "ml", "last_sync_at": "now"})
+        assert OwnerMarker.from_json(bad) is None
+
+    def test_serialised_format_is_stable(self) -> None:
+        """The on-disk format is a contract — sort_keys + indent.
+
+        Operators may grep / tail these markers manually; surprising
+        them with reordered keys after a refactor would be unkind.
+        """
+        m = OwnerMarker(hostname="h", mount_name="m", last_sync_at="t")
+        serialised = m.to_json()
+        # Sort order = hostname < last_sync_at < mount_name
+        assert (
+            serialised.index('"hostname"')
+            < serialised.index('"last_sync_at"')
+            < serialised.index('"mount_name"')
+        )
+
+
+# ── check_owner policy gate ───────────────────────────────────────
+
+
+class TestCheckOwnerPolicy:
+    """``check_owner`` should be the single decision point.
+
+    Every code path (CLI auto-sync, Web one-shot sync, future MCP
+    sync) routes the same inputs through this function; the tests
+    cover the full truth table of the four flags
+    (enabled, force, marker present, hostname match).
+    """
+
+    def test_disabled_skips_check(self, tmp_path: Path) -> None:
+        """``enabled=False`` is the global config opt-out.
+
+        Should NOT call ``read_owner_marker`` at all — that would
+        force a needless ssh round-trip per sync for users who
+        opted out.
+        """
+        profile = _profile(tmp_path)
+        with patch("srunx.sync.owner_marker.read_owner_marker") as fake_read:
+            check_owner(
+                profile,
+                profile.mounts[0],
+                enabled=False,
+                force=False,
+            )
+        fake_read.assert_not_called()
+
+    def test_force_skips_check(self, tmp_path: Path) -> None:
+        """``--force-sync`` bypasses even when ``enabled=True``."""
+        profile = _profile(tmp_path)
+        with patch("srunx.sync.owner_marker.read_owner_marker") as fake_read:
+            check_owner(
+                profile,
+                profile.mounts[0],
+                enabled=True,
+                force=True,
+            )
+        fake_read.assert_not_called()
+
+    def test_no_marker_passes(self, tmp_path: Path) -> None:
+        """First sync (no marker exists) must succeed."""
+        profile = _profile(tmp_path)
+        with patch("srunx.sync.owner_marker.read_owner_marker", return_value=None):
+            check_owner(
+                profile,
+                profile.mounts[0],
+                enabled=True,
+                force=False,
+            )
+
+    def test_matching_hostname_passes(self, tmp_path: Path) -> None:
+        profile = _profile(tmp_path)
+        marker = OwnerMarker(hostname="me", mount_name="ml", last_sync_at="t")
+        with patch("srunx.sync.owner_marker.read_owner_marker", return_value=marker):
+            check_owner(
+                profile,
+                profile.mounts[0],
+                enabled=True,
+                force=False,
+                hostname="me",
+            )
+
+    def test_different_hostname_raises(self, tmp_path: Path) -> None:
+        profile = _profile(tmp_path)
+        marker = OwnerMarker(
+            hostname="alice-laptop",
+            mount_name="ml",
+            last_sync_at="2026-04-23T00:00:00+00:00",
+        )
+        with (
+            patch("srunx.sync.owner_marker.read_owner_marker", return_value=marker),
+            pytest.raises(OwnerMismatch) as exc_info,
+        ):
+            check_owner(
+                profile,
+                profile.mounts[0],
+                enabled=True,
+                force=False,
+                hostname="bob-desktop",
+            )
+
+        # Error carries the recorded + local hostnames so the user
+        # knows WHO last touched it. Plain pytest.raises message
+        # match would be fragile; reach for the structured fields.
+        assert exc_info.value.local_machine == "bob-desktop"
+        assert exc_info.value.recorded_machine == "alice-laptop"
+        assert "alice-laptop" in str(exc_info.value)
+        assert "--force-sync" in str(exc_info.value)
+
+    def test_ssh_failure_does_not_block(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A transient ssh failure during the marker read should NOT abort.
+
+        The user is already in trouble; silently aborting would
+        only hide the problem. The rsync that follows will surface
+        the same connection failure with its own error message.
+        """
+        profile = _profile(tmp_path)
+
+        def _boom(*a: object, **k: object) -> None:
+            raise RuntimeError("ssh: connect to host h: connection refused")
+
+        with patch("srunx.sync.owner_marker.read_owner_marker", side_effect=_boom):
+            check_owner(
+                profile,
+                profile.mounts[0],
+                enabled=True,
+                force=False,
+            )
+
+
+# ── current_machine_id ────────────────────────────────────────────
+
+
+class TestCurrentMachineId:
+    def test_returns_socket_hostname(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import socket
+
+        monkeypatch.setattr(socket, "gethostname", lambda: "test-host")
+        assert current_machine_id() == "test-host"
+
+
+# ── Read / write marker via mocked RsyncClient ────────────────────
+
+
+class TestReadWriteMarker:
+    def test_read_returns_none_when_file_missing(self, tmp_path: Path) -> None:
+        """``read_remote_file`` returning ``None`` propagates as ``None``."""
+        profile = _profile(tmp_path)
+        with patch("srunx.sync.owner_marker.build_rsync_client") as fake_build:
+            fake_build.return_value.read_remote_file.return_value = None
+            assert read_owner_marker(profile, profile.mounts[0]) is None
+
+    def test_read_parses_valid_json(self, tmp_path: Path) -> None:
+        profile = _profile(tmp_path)
+        marker = OwnerMarker(
+            hostname="alice", mount_name="ml", last_sync_at="2026-04-23T00:00:00+00:00"
+        )
+        with patch("srunx.sync.owner_marker.build_rsync_client") as fake_build:
+            fake_build.return_value.read_remote_file.return_value = marker.to_json()
+            assert read_owner_marker(profile, profile.mounts[0]) == marker
+
+    def test_read_returns_none_for_malformed_json(self, tmp_path: Path) -> None:
+        """Corrupted marker → treat as absent, don't raise."""
+        profile = _profile(tmp_path)
+        with patch("srunx.sync.owner_marker.build_rsync_client") as fake_build:
+            fake_build.return_value.read_remote_file.return_value = "{broken"
+            assert read_owner_marker(profile, profile.mounts[0]) is None
+
+    def test_write_calls_remote_with_marker_json(self, tmp_path: Path) -> None:
+        profile = _profile(tmp_path)
+        with patch("srunx.sync.owner_marker.build_rsync_client") as fake_build:
+            written = write_owner_marker(profile, profile.mounts[0], hostname="alice")
+
+        # The returned marker is what was written — caller can use it
+        # for logging / state without re-reading.
+        assert written.hostname == "alice"
+        assert written.mount_name == "ml"
+
+        # And the underlying client was given the JSON form at the
+        # canonical remote path.
+        fake_build.return_value.write_remote_file.assert_called_once()
+        args, _ = fake_build.return_value.write_remote_file.call_args
+        assert args[0] == "/r/ml/.srunx-owner.json"
+        assert json.loads(args[1])["hostname"] == "alice"
+
+
+# ── mount_sync_session integration ────────────────────────────────
+
+
+class TestMountSyncSessionWithOwnerMarker:
+    """End-to-end: the service layer calls check + write at the right times.
+
+    These assert the *integration* contract; the policy / parse
+    behaviour is exercised in the focused classes above.
+    """
+
+    def test_owner_check_runs_before_rsync(self, tmp_path: Path) -> None:
+        profile = _profile(tmp_path)
+        order: list[str] = []
+
+        def _record_check(*a: object, **k: object) -> None:
+            order.append("check")
+
+        def _record_rsync(*a: object, **k: object) -> str:
+            order.append("rsync")
+            return ""
+
+        def _record_write(*a: object, **k: object) -> OwnerMarker:
+            order.append("write")
+            return OwnerMarker(hostname="h", mount_name="m", last_sync_at="t")
+
+        with (
+            patch("srunx.sync.service.check_owner", _record_check),
+            patch("srunx.sync.service.write_owner_marker", _record_write),
+            patch("srunx.sync.service.sync_mount_by_name", _record_rsync),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with mount_sync_session(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=SyncDefaults(),  # owner_check defaults to True
+                sync_required=True,
+            ):
+                pass
+
+        assert order == ["check", "rsync", "write"], (
+            "Owner check must run BEFORE rsync (so a mismatch aborts "
+            "without touching the remote), and the marker write must "
+            "run AFTER rsync (so a failed sync doesn't claim ownership)."
+        )
+
+    def test_owner_mismatch_re_raises_as_sync_aborted(self, tmp_path: Path) -> None:
+        """``OwnerMismatch`` is wrapped so callers catch one exception type.
+
+        CLI / Web both already handle ``SyncAbortedError`` as the
+        single ""we refused to sync"" signal — owner_marker errors
+        ride the same channel.
+        """
+        profile = _profile(tmp_path)
+
+        def _mismatch(*a: object, **k: object) -> None:
+            raise OwnerMismatch(
+                mount_name="ml",
+                local_machine="bob",
+                recorded_machine="alice",
+                recorded_at="2026-04-23T00:00:00+00:00",
+            )
+
+        with (
+            patch("srunx.sync.service.check_owner", _mismatch),
+            patch("srunx.sync.service.sync_mount_by_name") as fake_rsync,
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with pytest.raises(SyncAbortedError, match="alice"):
+                with mount_sync_session(
+                    profile_name="alice",
+                    profile=profile,
+                    mount=profile.mounts[0],
+                    config=SyncDefaults(),
+                    sync_required=True,
+                ):
+                    pass
+
+        # rsync must NOT have run when the marker rejected the sync.
+        fake_rsync.assert_not_called()
+
+    def test_owner_check_off_skips_check_and_write(self, tmp_path: Path) -> None:
+        """``owner_check=False`` skips BOTH the check AND the write.
+
+        A solo-machine setup that opted out shouldn't accumulate
+        markers nobody reads — keep the remote tree clean.
+        """
+        profile = _profile(tmp_path)
+
+        with (
+            patch("srunx.sync.service.check_owner") as fake_check,
+            patch("srunx.sync.service.write_owner_marker") as fake_write,
+            patch("srunx.sync.service.sync_mount_by_name", return_value=""),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with mount_sync_session(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=SyncDefaults(owner_check=False),
+                sync_required=True,
+            ):
+                pass
+
+        # check_owner is still called (it's the policy gate that
+        # itself short-circuits on enabled=False) — but write must
+        # not fire.
+        fake_check.assert_called_once()
+        assert fake_check.call_args.kwargs["enabled"] is False
+        fake_write.assert_not_called()
+
+    def test_force_sync_bypasses_check_but_still_writes(self, tmp_path: Path) -> None:
+        """``force_sync=True`` (CLI ``--force-sync``) takes ownership.
+
+        The user is intentionally taking the mount over from
+        another machine — they SHOULD write a fresh marker so they
+        become the recorded owner from now on.
+        """
+        profile = _profile(tmp_path)
+
+        with (
+            patch("srunx.sync.service.check_owner") as fake_check,
+            patch("srunx.sync.service.write_owner_marker") as fake_write,
+            patch("srunx.sync.service.sync_mount_by_name", return_value=""),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with mount_sync_session(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=SyncDefaults(),
+                sync_required=True,
+                force_sync=True,
+            ):
+                pass
+
+        # check_owner is still called with force=True (it's the
+        # policy gate; the no-op decision happens inside).
+        assert fake_check.call_args.kwargs["force"] is True
+        # And the write fires so the takeover is recorded.
+        fake_write.assert_called_once()
+
+    def test_marker_write_failure_warns_but_does_not_abort(
+        self, tmp_path: Path
+    ) -> None:
+        """A failed marker write must NOT roll back a successful rsync.
+
+        Network blips at the exact write moment shouldn't fail an
+        otherwise-good submission — the user's bytes already shipped.
+        Surface the warning via the SyncOutcome instead.
+        """
+        profile = _profile(tmp_path)
+
+        with (
+            patch("srunx.sync.service.check_owner"),
+            patch(
+                "srunx.sync.service.write_owner_marker",
+                side_effect=RuntimeError("ssh write timeout"),
+            ),
+            patch("srunx.sync.service.sync_mount_by_name", return_value=""),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with mount_sync_session(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=SyncDefaults(),
+                sync_required=True,
+            ) as outcome:
+                pass
+
+        assert outcome.performed is True
+        assert any("owner marker" in w for w in outcome.warnings)

--- a/tests/sync/test_service.py
+++ b/tests/sync/test_service.py
@@ -39,11 +39,20 @@ def _profile(tmp_path: Path, mount_local: Path) -> ServerProfile:
 
 
 class TestEnsureMountSynced:
+    """Pre-#137-part-4 behaviours: dirty-tree handling, lock + rsync wiring.
+
+    These tests deliberately set ``owner_check=False`` because the
+    owner-marker subsystem has its own test class
+    (:class:`TestOwnerMarkerIntegration`) below — keeping the two
+    concerns separate makes the dirty-tree / rsync assertions easier
+    to read.
+    """
+
     def test_happy_path_invokes_rsync(self, tmp_path: Path) -> None:
         mount_local = tmp_path / "ml"
         mount_local.mkdir()
         profile = _profile(tmp_path, mount_local)
-        config = SyncDefaults()  # auto=True, defaults
+        config = SyncDefaults(owner_check=False)
 
         with (
             patch("srunx.sync.service.sync_mount_by_name") as fake_rsync,
@@ -69,7 +78,7 @@ class TestEnsureMountSynced:
         mount_local = tmp_path / "ml"
         mount_local.mkdir()
         profile = _profile(tmp_path, mount_local)
-        config = SyncDefaults(warn_dirty=True, require_clean=False)
+        config = SyncDefaults(warn_dirty=True, require_clean=False, owner_check=False)
 
         with (
             patch("srunx.sync.service.sync_mount_by_name"),
@@ -94,7 +103,7 @@ class TestEnsureMountSynced:
         mount_local = tmp_path / "ml"
         mount_local.mkdir()
         profile = _profile(tmp_path, mount_local)
-        config = SyncDefaults(warn_dirty=False, require_clean=True)
+        config = SyncDefaults(warn_dirty=False, require_clean=True, owner_check=False)
 
         with (
             patch("srunx.sync.service.sync_mount_by_name") as fake_rsync,
@@ -119,7 +128,7 @@ class TestEnsureMountSynced:
         mount_local = tmp_path / "ml"
         mount_local.mkdir()
         profile = _profile(tmp_path, mount_local)
-        config = SyncDefaults(warn_dirty=True)
+        config = SyncDefaults(warn_dirty=True, owner_check=False)
 
         with (
             patch("srunx.sync.service.sync_mount_by_name"),
@@ -142,7 +151,7 @@ class TestEnsureMountSynced:
         mount_local.mkdir()
         profile = _profile(tmp_path, mount_local)
 
-        def _boom(_profile, _name, *, delete=False):  # type: ignore[no-untyped-def]
+        def _boom(_profile: ServerProfile, _name: str, *, delete: bool = False) -> str:
             raise RuntimeError("rsync exited 23: permission denied")
 
         with (
@@ -157,5 +166,5 @@ class TestEnsureMountSynced:
                     profile_name="alice",
                     profile=profile,
                     mount=profile.mounts[0],
-                    config=SyncDefaults(),
+                    config=SyncDefaults(owner_check=False),
                 )


### PR DESCRIPTION
## Summary

Part 4 of #137. Catches the cross-workstation overwrite footgun: without an ownership marker, syncing the same mount from two different machines silently overwrites each other's edits with no signal to the user.

## The footgun

\`\`\`
laptop$  vim train.sbatch && srunx sbatch ...   # syncs new bytes
desktop$ srunx sbatch train.sbatch ...          # syncs ITS old bytes
                                                # over the laptop's
\`\`\`

Both submissions return success; the cluster runs the desktop's old code while overwriting the laptop's new code on the remote tree. The user never knows.

## Solution

| component | change |
|----------|--------|
| \`srunx.sync.owner_marker\` (new) | reads/writes \`.srunx-owner.json\` at remote mount root (hostname + mount_name + ISO timestamp) via ssh + cat/tee |
| \`RsyncClient.read_remote_file\` / \`write_remote_file\` | thin wrappers around the existing \`_build_ssh_cmd\` so anything rsync can reach the marker can too |
| \`mount_sync_session\` | reads marker → \`OwnerMismatch\` if different host → re-cast as \`SyncAbortedError\`; writes fresh marker after successful rsync |
| Config: \`[sync] owner_check: bool = True\` + \`SRUNX_SYNC_OWNER_CHECK\` | global opt-out for solo-machine setups |
| CLI: \`srunx sbatch --force-sync\` | per-invocation bypass when intentionally taking over from another machine |

The check runs INSIDE the per-mount lock so two racing workstations can't both pass and then both write conflicting markers.

## Defensive behaviour

- **Missing marker** (first sync): pass — write a fresh one
- **Malformed marker**: log debug, treat as absent (next sync overwrites it) — don't lock the user out
- **SSH read failure during check**: log debug, don't block — rsync that follows surfaces the same connection error with its own message
- **SSH write failure after rsync succeeds**: warning in \`SyncOutcome.warnings\` but doesn't roll back the submission — the user's bytes already shipped

## Test plan

- [x] \`tests/sync/test_owner_marker.py\` — 20 tests across 5 classes:
  - JSON round-trip + malformed/wrong-type defense
  - \`check_owner\` policy gate (4-way truth table: enabled × force × marker × hostname)
  - SSH failure during check doesn't block
  - read/write via mocked RsyncClient
  - **integration**: check runs BEFORE rsync, write runs AFTER, mismatch re-casts as \`SyncAbortedError\`, force_sync bypasses check but still writes, owner_check=false skips both, write failure surfaces as warning only
- [x] Existing \`test_service.py\` / \`test_sbatch_in_place.py\` / \`test_workflow_in_place.py\` updated to disable owner_check (their scope is rsync/dirty-tree/lock, not the marker)
- [x] Full suite: 1942 passed (1 pre-existing flaky multiprocessing-timing test unrelated)
- [x] \`uv run mypy .\` / \`uv run ruff check .\` clean

## Out of scope (#137 follow-ups)

- \`--verbose\` rsync streaming progress (#137 part 3)
- Remote SHA256 hash verification post-sync (#137 part 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)