### PR TITLE
feat(sync): stream rsync progress under sbatch --verbose (#137 part 3)

### DIFF
--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -148,6 +148,7 @@ def _submit_via_transport(
             config=config.sync,
             sync_required=plan.sync_required,
             force_sync=force_sync,
+            verbose=verbose,
         )
         sync_ctx_entered = sync_ctx.__enter__()
     except SyncAbortedError as exc:

--- a/src/srunx/sync/mount_helpers.py
+++ b/src/srunx/sync/mount_helpers.py
@@ -64,6 +64,7 @@ def sync_mount_by_name(
     *,
     delete: bool = False,
     dry_run: bool = False,
+    verbose: bool = False,
 ) -> str:
     """Sync a named mount's local directory to remote via rsync.
 
@@ -77,6 +78,11 @@ def sync_mount_by_name(
     and returns rsync's stdout — the human-readable list of files
     that *would* be touched. The remote is not modified. Used by the
     CLI ``srunx sbatch --dry-run`` preview path (#137 part 2).
+
+    ``verbose=True`` switches the underlying rsync invocation to
+    streaming mode so per-file progress reaches the user's terminal
+    live (#137 part 3). Mutually compatible with ``dry_run`` — the
+    preview output streams the same way.
 
     Returns:
         rsync stdout — empty for a non-dry-run sync, the itemize lines
@@ -101,6 +107,7 @@ def sync_mount_by_name(
         # want the per-file output spam in the success path, but for
         # a preview the itemize lines ARE the value.
         itemize=dry_run,
+        verbose=verbose,
         exclude_patterns=mount.exclude_patterns or None,
     )
     if result.returncode != 0:

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -6,10 +6,12 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
+import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import ClassVar
+from typing import IO, ClassVar
 
 from srunx.logging import get_logger
 
@@ -115,6 +117,7 @@ class RsyncClient:
         delete: bool = True,
         dry_run: bool = False,
         itemize: bool = False,
+        verbose: bool = False,
         exclude_patterns: Sequence[str] | None = None,
     ) -> RsyncResult:
         """Sync a local directory/file to the remote server.
@@ -129,6 +132,10 @@ class RsyncClient:
                 file rsync *would* (or did) touch, with the standard
                 ``YXcstpoguax`` flag prefix. Required for ``dry_run``
                 callers that want a human-readable preview.
+            verbose: Stream rsync's per-file progress to stderr live
+                instead of capturing it silently. Adds
+                ``--info=progress2`` so users with large mounts see
+                progress instead of a frozen terminal.
             exclude_patterns: Additional exclude patterns for this call only.
 
         Returns:
@@ -157,8 +164,11 @@ class RsyncClient:
             delete=delete,
             dry_run=dry_run,
             itemize=itemize,
+            verbose=verbose,
             excludes=excludes,
         )
+        if verbose:
+            return self._run_rsync_streaming(cmd)
         return self._run_rsync(cmd)
 
     def pull(
@@ -229,6 +239,7 @@ class RsyncClient:
         delete: bool,
         dry_run: bool,
         itemize: bool = False,
+        verbose: bool = False,
         excludes: list[str],
     ) -> list[str]:
         """Build the full rsync command."""
@@ -251,6 +262,12 @@ class RsyncClient:
             # per file with a ``YXcstpoguax``-style flag prefix so the
             # CLI dry-run preview can render exactly what would change.
             cmd.append("-i")
+        if verbose:
+            # ``--info=progress2`` is the single-line aggregate progress
+            # form that updates in place (via ``\r``). It's the only
+            # progress mode that doesn't drown the terminal in per-file
+            # output for thousand-file syncs.
+            cmd.append("--info=progress2")
 
         for pattern in excludes:
             cmd.extend(["--exclude", pattern])
@@ -273,6 +290,67 @@ class RsyncClient:
             returncode=proc.returncode,
             stdout=proc.stdout,
             stderr=proc.stderr,
+        )
+
+    def _run_rsync_streaming(self, cmd: list[str]) -> RsyncResult:
+        """Execute rsync, streaming stdout to stderr live as it arrives.
+
+        Drains both pipes from dedicated threads. A single-thread
+        ``readline()`` loop on Popen.stdout would deadlock once
+        rsync's stderr pipe buffer fills (typically 64 KiB), and
+        ``select`` doesn't work for text-mode pipes on every platform
+        — two blocking threads are the simplest correct shape.
+
+        The streamed lines are also accumulated into the returned
+        :class:`RsyncResult` so callers that read ``result.stdout`` /
+        ``result.stderr`` (e.g. error-message construction) keep
+        working unchanged.
+        """
+        logger.debug("Running rsync (streaming): {}", shlex.join(cmd))
+
+        proc = subprocess.Popen(  # noqa: S603
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+
+        stdout_buf: list[str] = []
+        stderr_buf: list[str] = []
+
+        def _pump(src: IO[str], sink: IO[str], buf: list[str]) -> None:
+            for line in src:
+                buf.append(line)
+                sink.write(line)
+                sink.flush()
+
+        assert proc.stdout is not None and proc.stderr is not None
+        t_out = threading.Thread(
+            target=_pump, args=(proc.stdout, sys.stderr, stdout_buf)
+        )
+        t_err = threading.Thread(
+            target=_pump, args=(proc.stderr, sys.stderr, stderr_buf)
+        )
+        t_out.start()
+        t_err.start()
+
+        returncode = proc.wait()
+        t_out.join()
+        t_err.join()
+
+        stdout_text = "".join(stdout_buf)
+        stderr_text = "".join(stderr_buf)
+
+        if returncode != 0:
+            logger.warning(
+                "rsync exited with code {}: {}", returncode, stderr_text.strip()
+            )
+
+        return RsyncResult(
+            returncode=returncode,
+            stdout=stdout_text,
+            stderr=stderr_text,
         )
 
     def _ensure_remote_dir(self, remote_path: str) -> None:

--- a/src/srunx/sync/service.py
+++ b/src/srunx/sync/service.py
@@ -102,6 +102,7 @@ def mount_sync_session(
     config: SyncDefaults,
     sync_required: bool,
     force_sync: bool = False,
+    verbose: bool = False,
 ) -> Iterator[SyncOutcome]:
     """Acquire the per-mount lock, optionally rsync, hold lock until exit.
 
@@ -121,6 +122,8 @@ def mount_sync_session(
     per-machine ownership marker check (#137 part 4) so the user can
     intentionally take over a mount that another workstation
     previously synced.
+    ``verbose=True`` forwards into the underlying rsync call so
+    per-file progress streams to stderr (#137 part 3).
 
     Failure modes:
 
@@ -178,7 +181,7 @@ def mount_sync_session(
             # delete=False (Codex blocker #4): auto-sync must not wipe
             # remote-only outputs (training checkpoints, run logs).
             # ``srunx ssh sync`` keeps the historical mirror behaviour.
-            sync_mount_by_name(profile, mount.name, delete=False)
+            sync_mount_by_name(profile, mount.name, delete=False, verbose=verbose)
 
             # Stamp the marker AFTER a successful sync so a failed
             # rsync doesn't claim ownership for a tree we couldn't
@@ -213,6 +216,7 @@ def ensure_mount_synced(
     profile: ServerProfile,
     mount: MountConfig,
     config: SyncDefaults,
+    verbose: bool = False,
 ) -> SyncOutcome:
     """Backwards-compatible entry point that performs a one-shot sync.
 
@@ -228,5 +232,6 @@ def ensure_mount_synced(
         mount=mount,
         config=config,
         sync_required=True,
+        verbose=verbose,
     ) as outcome:
         return outcome

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -122,8 +122,8 @@ def test_sbatch_in_place_under_mount_calls_remote_submit(
 
     rsync_calls: list[tuple] = []
 
-    def _record_rsync(prof, name, *, delete=False):  # type: ignore[no-untyped-def]
-        rsync_calls.append((prof, name, delete))
+    def _record_rsync(prof, name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
+        rsync_calls.append((prof, name, delete, verbose))
 
     monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record_rsync)
 
@@ -133,10 +133,12 @@ def test_sbatch_in_place_under_mount_calls_remote_submit(
     assert result.exit_code == 0, result.stdout + result.stderr
 
     # rsync ran for the right mount, and used delete=False (auto-sync
-    # must not wipe remote-only outputs — Codex blocker #4).
+    # must not wipe remote-only outputs — Codex blocker #4). Default
+    # ``verbose=False`` since the user did not pass ``--verbose``.
     assert len(rsync_calls) == 1
     assert rsync_calls[0][1] == "ml"
     assert rsync_calls[0][2] is False
+    assert rsync_calls[0][3] is False
 
     # Protocol method (no _adapter reach-in) was invoked with the
     # translated remote path and a remote cwd under the mount.
@@ -245,7 +247,7 @@ def test_sync_failure_aborts_submission(
     profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
     job_ops = _patch_transport(monkeypatch, profile)
 
-    def _boom(profile_arg, mount_name, *, delete=False):  # type: ignore[no-untyped-def]
+    def _boom(profile_arg, mount_name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
         raise RuntimeError("rsync exited 23: permission denied")
 
     monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _boom)
@@ -603,6 +605,66 @@ def test_dry_run_no_sync_message_when_sync_disabled(
     assert result.exit_code == 0, result.stdout + result.stderr
     assert "skipped (--no-sync)" in result.stdout
     assert not sync_called, "rsync must not run when --no-sync is set"
+
+
+def test_verbose_forwards_to_sync_mount_by_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``srunx sbatch --verbose`` reaches sync_mount_by_name with verbose=True.
+
+    The actual streaming behaviour is exercised in ``tests/test_rsync.py``
+    — here we only assert the wiring from the CLI flag through
+    ``mount_sync_session`` lands on the rsync helper.
+    """
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    _patch_transport(monkeypatch, profile)
+
+    rsync_calls: list[dict[str, object]] = []
+
+    def _record(prof, name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
+        rsync_calls.append({"name": name, "delete": delete, "verbose": verbose})
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["sbatch", str(script), "--profile", "ml-cluster", "--verbose"],
+    )
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert rsync_calls == [{"name": "ml", "delete": False, "verbose": True}]
+
+
+def test_no_verbose_keeps_quiet_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without ``--verbose`` the CLI passes ``verbose=False`` (legacy path)."""
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
+    _patch_transport(monkeypatch, profile)
+
+    rsync_calls: list[dict[str, object]] = []
+
+    def _record(prof, name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
+        rsync_calls.append({"name": name, "delete": delete, "verbose": verbose})
+
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert rsync_calls == [{"name": "ml", "delete": False, "verbose": False}]
 
 
 def test_dry_run_preview_silent_for_local_transport(

--- a/tests/sync/test_service.py
+++ b/tests/sync/test_service.py
@@ -70,7 +70,9 @@ class TestEnsureMountSynced:
 
         # Auto-sync calls rsync with delete=False (Codex blocker #4):
         # mount-resident outputs/checkpoints must survive a sync.
-        fake_rsync.assert_called_once_with(profile, "ml", delete=False)
+        # ``verbose=False`` is the default surfaced by the CLI when the
+        # user did not pass ``--verbose`` (#137 part 3).
+        fake_rsync.assert_called_once_with(profile, "ml", delete=False, verbose=False)
         assert outcome.performed is True
         assert outcome.warnings == ()
 
@@ -151,7 +153,13 @@ class TestEnsureMountSynced:
         mount_local.mkdir()
         profile = _profile(tmp_path, mount_local)
 
-        def _boom(_profile: ServerProfile, _name: str, *, delete: bool = False) -> str:
+        def _boom(
+            _profile: ServerProfile,
+            _name: str,
+            *,
+            delete: bool = False,
+            verbose: bool = False,
+        ) -> str:
             raise RuntimeError("rsync exited 23: permission denied")
 
         with (

--- a/tests/test_rsync.py
+++ b/tests/test_rsync.py
@@ -541,6 +541,121 @@ class TestMkpath:
 
 
 # ---------------------------------------------------------------------------
+# Verbose streaming (#137 part 3)
+# ---------------------------------------------------------------------------
+
+
+class TestVerboseStreaming:
+    """``verbose=True`` switches push() onto the streaming Popen path."""
+
+    def test_verbose_adds_progress_flag(self):
+        """``--info=progress2`` is rsync's single-line progress mode.
+
+        Single-line is the only progress form that doesn't drown the
+        terminal in per-file output for thousand-file syncs.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+        cmd = client._build_rsync_cmd(
+            "s", "d", delete=False, dry_run=False, verbose=True, excludes=[]
+        )
+        assert "--info=progress2" in cmd
+
+    def test_default_does_not_add_progress_flag(self):
+        client = _make_rsync_client(hostname="h", username="u")
+        cmd = client._build_rsync_cmd(
+            "s", "d", delete=False, dry_run=False, excludes=[]
+        )
+        assert "--info=progress2" not in cmd
+
+    def test_default_uses_subprocess_run(self, tmp_path: Path):
+        """``verbose=False`` keeps the historical capture-and-quiet path.
+
+        Bit-for-bit no behaviour change for the default — guarded so we
+        notice if a future refactor accidentally rewires the default
+        path through Popen.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with (
+            patch("srunx.sync.rsync.subprocess.run") as mock_run,
+            patch("srunx.sync.rsync.subprocess.Popen") as mock_popen,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/")
+
+        mock_run.assert_called_once()
+        mock_popen.assert_not_called()
+
+    def test_verbose_uses_popen_and_streams_to_stderr(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        """Streaming path drains both pipes and surfaces lines on stderr."""
+        client = _make_rsync_client(hostname="h", username="u")
+
+        # Fake Popen: stdout yields three progress lines, stderr stays empty.
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter(
+            [
+                "  1,234,567  10%   1.23MB/s    0:00:42\n",
+                "  2,345,678  20%   1.45MB/s    0:00:30\n",
+                "  3,456,789 100%   1.50MB/s    0:00:00 (xfr#1, to-chk=0/1)\n",
+            ]
+        )
+        fake_proc.stderr = iter([])
+        fake_proc.wait.return_value = 0
+
+        with (
+            patch("srunx.sync.rsync.subprocess.run") as mock_run,
+            patch(
+                "srunx.sync.rsync.subprocess.Popen", return_value=fake_proc
+            ) as mock_popen,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = client.push(tmp_path, "~/dst/", verbose=True)
+
+        # Popen was used (not run) for the actual rsync invocation.
+        # ``subprocess.run`` may still be called for the ``_ensure_remote_dir``
+        # fallback when --mkpath isn't supported, so we only assert the
+        # Popen invocation here.
+        mock_popen.assert_called_once()
+        cmd = mock_popen.call_args[0][0]
+        assert "--info=progress2" in cmd
+
+        # Streamed lines reached stderr verbatim.
+        captured = capsys.readouterr()
+        assert "10%" in captured.err
+        assert "100%" in captured.err
+
+        # The accumulated stdout is also returned in the result so
+        # callers that rely on result.stdout (error messages, etc.)
+        # keep working.
+        assert "10%" in result.stdout
+        assert "100%" in result.stdout
+        assert result.success
+
+    def test_verbose_returncode_propagates(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        """Non-zero exit on the streaming path produces an unsuccessful result."""
+        client = _make_rsync_client(hostname="h", username="u")
+
+        fake_proc = MagicMock()
+        fake_proc.stdout = iter([])
+        fake_proc.stderr = iter(["rsync: connection unexpectedly closed\n"])
+        fake_proc.wait.return_value = 12
+
+        with (
+            patch("srunx.sync.rsync.subprocess.run") as mock_run,
+            patch("srunx.sync.rsync.subprocess.Popen", return_value=fake_proc),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = client.push(tmp_path, "~/dst/", verbose=True)
+
+        assert result.returncode == 12
+        assert "connection unexpectedly closed" in result.stderr
+
+
+# ---------------------------------------------------------------------------
 # SSHSlurmClient.sync_project
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Part 3 of #137. When the user passes \`--verbose\` to \`srunx sbatch\`, the rsync subprocess that runs as part of the auto-sync now streams its output live to stderr as files transfer, instead of being captured silently. Lets users with large mounts see progress.

## Design

| change | file |
|--------|------|
| New \`verbose: bool = False\` parameter on \`RsyncClient.push/pull\` | \`sync/rsync.py\` |
| When True, adds \`--info=progress2\` (single-line in-place updating progress) | \`sync/rsync.py\` |
| New \`_run_rsync_streaming\` uses \`Popen(text=True, bufsize=1)\` + 2 \`threading.Thread\` pumps (one per pipe) | \`sync/rsync.py\` |
| Forwarded through \`sync_mount_by_name\` / \`mount_sync_session\` / \`ensure_mount_synced\` | \`sync/mount_helpers.py\`, \`sync/service.py\` |
| CLI sbatch's existing \`--verbose\` flag now reaches the sync layer | \`cli/main.py\` |

### Threading rationale

A single-threaded \`for line in proc.stdout\` loop deadlocks as soon as the stderr pipe buffer fills (~64 KiB on Linux). \`select\` is unreliable for text-mode pipes across platforms. Two blocking \`threading.Thread\` instances — one per pipe — are the simplest correct shape; \`proc.wait()\` then \`thread.join()\` each.

### Bit-for-bit fallback

The default \`verbose=False\` path is unchanged — same \`subprocess.run(capture_output=True)\` call as before. No new flag in the rsync command, no behaviour change for the non-verbose default. Existing 50 rsync tests + the sync / sbatch in-place suites continue to pass unchanged.

## Test plan

- [x] \`tests/test_rsync.py::TestVerboseStreaming\` — 5 new tests:
  - \`--info=progress2\` added when \`verbose=True\`
  - flag absent when \`verbose=False\` (regression guard)
  - default path uses \`subprocess.run\` (never Popen)
  - streamed output reaches both stderr (live) AND \`RsyncResult.stdout\` (return value)
  - non-zero exit propagates correctly through the streaming path
- [x] \`tests/cli/test_sbatch_in_place.py\` — 2 new CLI integration tests:
  - \`sbatch <script> --profile X --verbose\` reaches the rsync helper with \`verbose=True\`
  - \`sbatch <script> --profile X\` (no verbose) keeps \`verbose=False\` default
- [x] Existing 105 sync/sbatch tests still pass
- [x] \`uv run mypy\` / \`uv run ruff check\` clean

## Out of scope (#137 follow-ups)

- Per-machine ownership marker — done in PR #148
- Remote hash verification post-sync (#137 part 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)