### PR TITLE
feat(sweep): cell-aware mount aggregation for IN_PLACE workflow execution (#143)

### DIFF
--- a/src/srunx/cli/submission_plan.py
+++ b/src/srunx/cli/submission_plan.py
@@ -246,6 +246,65 @@ def collect_touched_mounts(workflow: Any, profile: ServerProfile) -> list[MountC
     return list(seen.values())
 
 
+def collect_touched_mounts_across_cells(
+    yaml_path: str | Path,
+    base_args_override: dict[str, Any] | None,
+    cell_args_overrides: list[dict[str, Any]],
+    profile: ServerProfile,
+) -> list[MountConfig]:
+    """Union of mounts touched by every sweep cell's per-cell render.
+
+    Sweep cells re-render the workflow YAML with cell-specific Jinja
+    overrides. When ``ShellJob.script_path`` interpolates a sweep axis
+    (e.g. ``path: "{{ scratch_dir }}/{{ seed }}/run.sh"``), different
+    cells can resolve to different mounts. The base render alone misses
+    those — we'd lock only the mounts the *unparameterised* paths touch
+    and a non-base cell could race a concurrent rsync against a mount
+    we never aggregated. Issue #143.
+
+    This helper expands the cell args into N per-cell renders, resolves
+    each cell's :class:`Workflow` via :meth:`WorkflowRunner.from_yaml`,
+    and unions the per-cell :func:`collect_touched_mounts` results. The
+    union covers every mount any cell could possibly target, so the
+    workflow lock-set is sound for the IN_PLACE submission path.
+
+    Cells whose render explodes (StrictUndefined / template error) are
+    skipped here — the same render runs again under
+    :func:`_validate_all_sweep_cells` (when ``--validate``) and at
+    cell-submission time, so the user still sees the failure. Skipping
+    here means a single broken cell does not derail the lock-set
+    computation for its peers.
+
+    Returns the unioned mounts sorted by ``profile.mounts`` order so
+    the caller can hand them to ``contextlib.ExitStack`` in a globally
+    deterministic order — same property the single-workflow path uses
+    to avoid lock inversion.
+    """
+    from srunx.runner import WorkflowRunner
+
+    base_overrides = dict(base_args_override or {})
+
+    seen: dict[str, MountConfig] = {}
+    for cell_args in cell_args_overrides:
+        merged = {**base_overrides, **cell_args}
+        try:
+            cell_runner = WorkflowRunner.from_yaml(yaml_path, args_override=merged)
+        except Exception:  # noqa: BLE001
+            # Per-cell render failures are surfaced by the validator and
+            # by the orchestrator at cell submission time; we deliberately
+            # do not let one broken cell prevent locking the mounts the
+            # other cells need.
+            continue
+        for mount in collect_touched_mounts(cell_runner.workflow, profile):
+            if mount.name not in seen:
+                seen[mount.name] = mount
+
+    mount_order = {m.name: i for i, m in enumerate(profile.mounts)}
+    return sorted(
+        seen.values(), key=lambda m: mount_order.get(m.name, len(mount_order))
+    )
+
+
 def render_matches_source(rendered_path: Path, source_path: Path) -> bool:
     """Return ``True`` when the rendered ShellJob bytes equal the source.
 

--- a/src/srunx/cli/workflow.py
+++ b/src/srunx/cli/workflow.py
@@ -6,11 +6,14 @@ import signal
 import sys
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 import yaml  # type: ignore
 from rich.console import Console
+
+if TYPE_CHECKING:
+    from srunx.ssh.core.config import MountConfig
 
 from srunx.callbacks import Callback, NotificationWatchCallback, SlackCallback
 from srunx.cli.transport_options import LocalOpt, ProfileOpt, QuietOpt
@@ -49,7 +52,11 @@ def _resolve_sync_flag(sync: bool | None) -> bool:
     return get_config().sync.auto
 
 
-def _in_place_context(rt: "ResolvedTransport") -> "Any":
+def _in_place_context(
+    rt: "ResolvedTransport",
+    *,
+    locked_mount_names: tuple[str, ...] = (),
+) -> "Any":
     """Return ``rt.submission_context`` with ``allow_in_place=True``.
 
     The CLI workflow runner holds the per-(profile, mount) sync lock
@@ -62,6 +69,13 @@ def _in_place_context(rt: "ResolvedTransport") -> "Any":
     it here avoids touching every executor / Protocol signature.
     Closes Codex blocker #3 on PR #141.
 
+    ``locked_mount_names`` (#143) is a defence-in-depth list of the
+    mounts the caller is currently holding the lock for. The SSH
+    adapter rejects IN_PLACE for any mount outside this set,
+    surfacing aggregation bugs as a clear error rather than a
+    silent rsync race. Empty tuple disables enforcement (preserves
+    pre-#143 single-workflow callers verbatim).
+
     Returns ``None`` when there's no context to clone (e.g. local
     transport); callers fall back to ``rt.submission_context``.
     """
@@ -69,7 +83,66 @@ def _in_place_context(rt: "ResolvedTransport") -> "Any":
 
     if rt.submission_context is None:
         return None
-    return dataclasses.replace(rt.submission_context, allow_in_place=True)
+    return dataclasses.replace(
+        rt.submission_context,
+        allow_in_place=True,
+        locked_mount_names=locked_mount_names,
+    )
+
+
+def _expand_sweep_cell_args(
+    workflow_data: dict[str, Any],
+    args_override: dict[str, Any],
+    sweep_spec: SweepSpec,
+) -> list[dict[str, Any]]:
+    """Expand the matrix into per-cell effective arg dicts.
+
+    Mirrors :meth:`SweepOrchestrator._expand_cells` so the CLI's lock
+    aggregation step (#143) sees the same per-cell args the
+    orchestrator will later hand to :meth:`WorkflowRunner.from_yaml`.
+    Returning an empty list means "no cells to expand"; callers
+    should treat that as "fall back to the single-workflow lock-set
+    rather than the per-cell union".
+    """
+    from srunx.sweep.expand import expand_matrix
+
+    base_args: dict[str, Any] = {
+        **(workflow_data.get("args") or {}),
+        **args_override,
+    }
+    return expand_matrix(sweep_spec.matrix, base_args)
+
+
+def _resolve_sweep_locked_mounts(
+    rt: "ResolvedTransport",
+    cell_args_overrides: list[dict[str, Any]],
+    yaml_file: Path,
+) -> "list[MountConfig]":
+    """Return the union of MountConfigs every sweep cell can touch.
+
+    Drives both the lock-acquisition step (``_hold_workflow_mounts``)
+    and the SSH adapter's defence-in-depth check
+    (``locked_mount_names`` on :class:`SubmissionRenderContext`) off
+    the same rendered set, so the two never disagree about which
+    mounts are actually locked. Returns an empty list when no
+    profile is bound or the profile doesn't exist — the SSH adapter
+    treats that as "no enforcement" which matches the legacy
+    pre-#143 behaviour.
+    """
+    from srunx.cli.submission_plan import collect_touched_mounts_across_cells
+    from srunx.ssh.core.config import ConfigManager
+
+    if rt.profile_name is None:
+        return []
+    profile = ConfigManager().get_profile(rt.profile_name)
+    if profile is None:
+        return []
+    return collect_touched_mounts_across_cells(
+        yaml_file,
+        None,
+        cell_args_overrides,
+        profile,
+    )
 
 
 @contextlib.contextmanager
@@ -78,6 +151,7 @@ def _hold_workflow_mounts(
     rt: "ResolvedTransport",
     workflow_for_mounts: "Workflow | None",
     sync_required: bool,
+    explicit_mounts: "list[MountConfig] | None" = None,
 ) -> Iterator[None]:
     """Acquire per-mount sync locks for every mount the workflow touches.
 
@@ -101,6 +175,15 @@ def _hold_workflow_mounts(
     ``sync_required=False`` (``--no-sync``) still acquires the locks
     but skips the rsync invocation; this preserves the lock-held
     invariant while letting the user opt out of the transfer.
+
+    Sweep callers (#143) can pass ``explicit_mounts`` to override the
+    single-workflow scan with a pre-computed union (typically the
+    per-cell mount aggregation from :func:`collect_touched_mounts_across_cells`).
+    This avoids re-rendering every cell here when the caller already
+    rendered them to compute ``locked_mount_names`` for the SSH
+    adapter — both the lock and the safety net see the same mount
+    list. When omitted the helper falls back to the single-workflow
+    scan and existing non-sweep behaviour is preserved bit-for-bit.
     """
     if (
         rt.transport_type != "ssh"
@@ -120,7 +203,10 @@ def _hold_workflow_mounts(
         yield
         return
 
-    mounts = collect_touched_mounts(workflow_for_mounts, profile)
+    if explicit_mounts is not None:
+        mounts = list(explicit_mounts)
+    else:
+        mounts = collect_touched_mounts(workflow_for_mounts, profile)
     if not mounts:
         yield
         return
@@ -629,25 +715,65 @@ def _execute_workflow(
                 # lock across every cell in the sweep so a concurrent
                 # invocation can't rsync mid-sweep, AND so the rsync
                 # itself runs once per mount instead of once per cell.
+                #
+                # Issue #143: when the sweep matrix can influence
+                # ``ShellJob.script_path`` (e.g. ``path: "{{ scratch
+                # }}/{{ seed }}/run.sh"``), the base render alone
+                # misses mounts only a non-base cell can resolve to.
+                # Expand the matrix here, render each cell, and union
+                # the touched mounts so the lock-set covers every
+                # cell. Then it is safe to flip ``allow_in_place=True``
+                # for the sweep path.
+                cell_args_overrides = _expand_sweep_cell_args(
+                    workflow_data, args_override, sweep_spec
+                )
+                # Render every cell once, take the union of touched
+                # mounts, and feed the SAME list to both the lock-
+                # acquisition step and the SSH adapter's defence-in-
+                # depth check. Sharing the resolved list avoids a
+                # second N-cell render pass and guarantees the two
+                # views can never disagree.
+                sweep_locked_mounts = (
+                    _resolve_sweep_locked_mounts(rt, cell_args_overrides, yaml_file)
+                    if rt.transport_type == "ssh"
+                    else []
+                )
+                sweep_locked_names = tuple(m.name for m in sweep_locked_mounts)
                 with _hold_workflow_mounts(
                     rt=rt,
                     workflow_for_mounts=_check_runner.workflow
                     if rt.transport_type == "ssh"
                     else None,
                     sync_required=_resolve_sync_flag(sync),
+                    explicit_mounts=sweep_locked_mounts
+                    if rt.transport_type == "ssh"
+                    else None,
                 ):
-                    # IN_PLACE for sweep cells is intentionally NOT
-                    # enabled here. Each sweep cell re-renders the
-                    # workflow with cell-specific Jinja args, which
-                    # can move ``ShellJob.script_path`` to a mount we
-                    # never collected (and never locked). Until
-                    # cell-aware mount aggregation lands (tracked in
-                    # follow-up to #135), keep ``allow_in_place=False``
-                    # for sweeps so cells stay on the temp-upload path.
-                    # The mount sync itself still happens once per
-                    # touched mount for the lock-set computed off the
-                    # base render, which is the larger Phase 2 win.
-                    # Codex blocker on PR #141 v2.
+                    # Lock-set is now sound for every cell — flip
+                    # ``allow_in_place`` for the sweep so each cell
+                    # whose rendered ShellJob bytes match its source
+                    # can take the IN_PLACE shortcut on the remote.
+                    # The locked-mount tuple rides the context as a
+                    # defence-in-depth rejection signal: a buggy cell
+                    # that escapes the aggregation hits a clear
+                    # "mount X not locked" error in the SSH adapter
+                    # instead of silently racing rsync.
+                    #
+                    # When ``sweep_locked_mounts`` is empty AND we're
+                    # on SSH, we deliberately keep ``allow_in_place``
+                    # at its default ``False``: an empty union means
+                    # either no cell touches a mount (nothing to flip
+                    # for) or the profile lookup failed (in which case
+                    # we never held the lock — flipping the flag here
+                    # would let the adapter race rsync against an
+                    # unsynchronised remote). Both outcomes match the
+                    # safer pre-#143 sweep behaviour.
+                    if rt.transport_type == "ssh" and sweep_locked_mounts:
+                        sweep_submission_context = _in_place_context(
+                            rt, locked_mount_names=sweep_locked_names
+                        )
+                    else:
+                        sweep_submission_context = rt.submission_context
                     _run_sweep(
                         yaml_file=yaml_file,
                         workflow_data=workflow_data,
@@ -657,9 +783,7 @@ def _execute_workflow(
                         endpoint_id=endpoint_id,
                         preset=effective_preset,
                         rt=rt,
-                        # ``submission_context`` left as the default
-                        # (rt.submission_context with
-                        # ``allow_in_place=False``); see comment above.
+                        submission_context=sweep_submission_context,
                     )
                 return
 

--- a/src/srunx/rendering.py
+++ b/src/srunx/rendering.py
@@ -79,6 +79,21 @@ class SubmissionRenderContext:
     to ``True`` when constructing the context. Closes Codex
     blocker #3 on PR #141."""
 
+    locked_mount_names: tuple[str, ...] = ()
+    """Names of mounts the caller is currently holding the sync lock for.
+
+    Defence-in-depth for the sweep IN_PLACE path (#143). The CLI
+    workflow runner already aggregates mounts across every sweep
+    cell via :func:`collect_touched_mounts_across_cells` so the
+    lock-set should contain every mount any cell can touch. This
+    field is the safety-net: if a buggy / racy cell renders to a
+    mount we somehow missed, the SSH adapter rejects the IN_PLACE
+    path with a "mount X not locked" error instead of silently
+    racing rsync. Empty tuple = no enforcement (preserves all
+    pre-#143 callers verbatim, including non-sweep workflows where
+    the lock-set is computed from a single base render and the
+    safety net would just add noise)."""
+
 
 @dataclass(frozen=True)
 class RenderedJob:

--- a/src/srunx/web/ssh_adapter.py
+++ b/src/srunx/web/ssh_adapter.py
@@ -1334,6 +1334,31 @@ class SlurmSSHAdapter:
                             if mount is not None and render_matches_source(
                                 Path(script_path), source_path
                             ):
+                                # Defence-in-depth (#143): when the
+                                # caller declared a locked mount-set,
+                                # refuse IN_PLACE for any mount outside
+                                # it. Sweep mount aggregation should
+                                # already cover every cell; if it
+                                # didn't, a silent race against rsync
+                                # is the worst outcome — fail loud.
+                                # Empty ``locked_mount_names`` keeps
+                                # every pre-#143 caller working
+                                # unchanged.
+                                locked = (
+                                    submission_context.locked_mount_names
+                                    if submission_context is not None
+                                    else ()
+                                )
+                                if locked and mount.name not in locked:
+                                    raise RuntimeError(
+                                        f"IN_PLACE rejected: ShellJob "
+                                        f"'{job.name}' resolves to mount "
+                                        f"'{mount.name}' which is not in the "
+                                        f"locked mount set {sorted(locked)!r}. "
+                                        "This indicates a sweep cell escaped "
+                                        "the per-cell mount aggregation; "
+                                        "please file an srunx bug."
+                                    )
                                 in_place_remote_path = translate_local_to_remote(
                                     source_path, mount
                                 )

--- a/tests/cli/test_workflow_sweep_in_place.py
+++ b/tests/cli/test_workflow_sweep_in_place.py
@@ -1,0 +1,545 @@
+"""Tests for sweep cell-aware mount aggregation + IN_PLACE wiring (#143).
+
+Sweep cells re-render the workflow YAML with cell-specific Jinja
+overrides, so axes that influence ``ShellJob.script_path`` can move a
+cell to a mount the base render never touches. These tests cover:
+
+* The pure helper ``collect_touched_mounts_across_cells`` — verifies
+  matrix expansion + per-cell render + mount union.
+* CLI integration: a sweep whose ``script_path`` depends on a sweep
+  axis runs IN_PLACE for every cell, with one rsync per touched
+  mount (not one per cell).
+* CLI integration: sweep where the cell-resolved ``script_path``
+  lives outside any mount falls back to TEMP_UPLOAD for that cell
+  (the per-job ``_resolve_in_place_target`` logic still applies).
+* The locked_mount_names defence-in-depth: a hypothetical cell that
+  somehow escapes the aggregation hits a clear "mount X not locked"
+  error in the SSH adapter rather than silently racing rsync.
+* The IN_PLACE flag is flipped on the submission_context for sweeps
+  (the executor sees ``allow_in_place=True``), proving #143's net
+  user-visible win.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+from srunx.cli.submission_plan import collect_touched_mounts_across_cells
+from srunx.ssh.core.client_types import SlurmJob
+from srunx.ssh.core.config import MountConfig, ServerProfile
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+    monkeypatch.setenv("SRUNX_SYNC_OWNER_CHECK", "0")
+
+
+def _make_profile(*mounts: MountConfig) -> ServerProfile:
+    """Build a stub profile with the supplied mounts (no real key on disk)."""
+    return ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename="/tmp/never-read",
+        mounts=list(mounts),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Unit tests for collect_touched_mounts_across_cells (no SLURM, no SSH)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestCollectTouchedMountsAcrossCells:
+    """Pure-Python coverage of the per-cell mount aggregation helper."""
+
+    def test_static_script_path_resolves_single_mount(self, tmp_path: Path) -> None:
+        """A non-parameterised script_path → single mount in union."""
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        s = mount_local / "train.sh"
+        s.write_text("#!/bin/bash\n")
+
+        yaml_path = tmp_path / "wf.yaml"
+        yaml_path.write_text(
+            f"name: t\nargs:\n  seed: 1\njobs:\n  - name: j\n    path: {s}\n"
+        )
+
+        profile = _make_profile(
+            MountConfig(name="ml", local=str(mount_local), remote="/r/ml")
+        )
+        cells = [{"seed": 1}, {"seed": 2}, {"seed": 3}]
+
+        mounts = collect_touched_mounts_across_cells(yaml_path, None, cells, profile)
+        assert [m.name for m in mounts] == ["ml"]
+
+    def test_axis_driven_script_path_resolves_same_mount_per_cell(
+        self, tmp_path: Path
+    ) -> None:
+        """``path: ".../{{ seed }}/run.sh"`` under one mount → still 1 entry.
+
+        The canonical positive #143 case: every cell resolves under
+        the *same* mount, so the union has one element. The base
+        render alone would also see this mount — but the helper has
+        to handle it correctly, so prove it.
+        """
+        mount_local = tmp_path / "scratch"
+        mount_local.mkdir()
+        for seed in (1, 2, 3):
+            d = mount_local / str(seed)
+            d.mkdir()
+            (d / "run.sh").write_text("#!/bin/bash\n")
+
+        yaml_path = tmp_path / "wf.yaml"
+        yaml_path.write_text(
+            "name: t\n"
+            "args:\n  seed: 1\n"
+            "jobs:\n  - name: j\n"
+            f'    path: "{mount_local}/{{{{ seed }}}}/run.sh"\n'
+        )
+
+        profile = _make_profile(
+            MountConfig(name="scratch", local=str(mount_local), remote="/r/sc")
+        )
+        cells = [{"seed": 1}, {"seed": 2}, {"seed": 3}]
+
+        mounts = collect_touched_mounts_across_cells(yaml_path, None, cells, profile)
+        assert [m.name for m in mounts] == ["scratch"]
+
+    def test_axis_driven_script_path_unions_multiple_mounts(
+        self, tmp_path: Path
+    ) -> None:
+        """A sweep axis that picks between mounts → both end up in union.
+
+        The bug #143 fixes: without per-cell aggregation we'd lock
+        only one mount; with it both appear and the lock-set is sound.
+        """
+        mount_a = tmp_path / "data_a"
+        mount_a.mkdir()
+        (mount_a / "run.sh").write_text("#!/bin/bash\n")
+        mount_b = tmp_path / "data_b"
+        mount_b.mkdir()
+        (mount_b / "run.sh").write_text("#!/bin/bash\n")
+
+        yaml_path = tmp_path / "wf.yaml"
+        yaml_path.write_text(
+            "name: t\n"
+            "args:\n  dataset: a\n"
+            "jobs:\n  - name: j\n"
+            f'    path: "{tmp_path}/data_{{{{ dataset }}}}/run.sh"\n'
+        )
+
+        profile = _make_profile(
+            MountConfig(name="data_a", local=str(mount_a), remote="/r/a"),
+            MountConfig(name="data_b", local=str(mount_b), remote="/r/b"),
+        )
+        cells = [{"dataset": "a"}, {"dataset": "b"}]
+
+        mounts = collect_touched_mounts_across_cells(yaml_path, None, cells, profile)
+        # Sorted by profile.mounts insertion order.
+        assert [m.name for m in mounts] == ["data_a", "data_b"]
+
+    def test_failing_cell_render_does_not_drop_other_cells(
+        self, tmp_path: Path
+    ) -> None:
+        """A cell whose Jinja render explodes does not hide its peers' mounts.
+
+        The validator + per-cell submission both re-render later, so
+        the user still sees the failure. The aggregation step must
+        not let one broken cell prevent the lock for everyone else.
+        """
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        (mount_local / "run.sh").write_text("#!/bin/bash\n")
+
+        yaml_path = tmp_path / "wf.yaml"
+        # Job's ``path`` interpolates ``{{ optional_var }}``; cell 0
+        # has no ``optional_var`` so StrictUndefined explodes, cell 1
+        # provides it and renders fine. ShellJobs can't combine
+        # ``path`` + ``command`` (mutually exclusive at parse time)
+        # so the divergence has to live inside ``path`` itself.
+        yaml_path.write_text(
+            "name: t\n"
+            "args: {}\n"
+            "jobs:\n  - name: j\n"
+            f'    path: "{mount_local}/{{{{ optional_var }}}}.sh"\n'
+        )
+        # Pre-create the cell-1 script so the post-render path
+        # actually resolves.
+        (mount_local / "ok.sh").write_text("#!/bin/bash\n")
+
+        profile = _make_profile(
+            MountConfig(name="ml", local=str(mount_local), remote="/r/ml")
+        )
+        cells = [{}, {"optional_var": "ok"}]
+
+        mounts = collect_touched_mounts_across_cells(yaml_path, None, cells, profile)
+        # Cell 0 explodes (StrictUndefined on `optional_var`); cell 1
+        # renders fine and contributes the mount.
+        assert [m.name for m in mounts] == ["ml"]
+
+    def test_paths_outside_every_mount_contribute_nothing(self, tmp_path: Path) -> None:
+        """Cells whose script_path lives outside every mount → empty union."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "run.sh").write_text("#!/bin/bash\n")
+
+        yaml_path = tmp_path / "wf.yaml"
+        yaml_path.write_text(
+            "name: t\n"
+            "args:\n  seed: 1\n"
+            "jobs:\n  - name: j\n"
+            f"    path: {outside}/run.sh\n"
+        )
+
+        # Mount points elsewhere — the script doesn't fall under it.
+        elsewhere = tmp_path / "ml"
+        elsewhere.mkdir()
+        profile = _make_profile(
+            MountConfig(name="ml", local=str(elsewhere), remote="/r/ml")
+        )
+
+        mounts = collect_touched_mounts_across_cells(
+            yaml_path, None, [{"seed": 1}], profile
+        )
+        assert mounts == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# CLI integration: sweep flips allow_in_place + sees per-cell mounts
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _patch_sweep_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    profile: ServerProfile,
+    profile_name: str = "ml-cluster",
+):
+    """Stub SSH transport for sweep tests; capture per-cell submission_context.
+
+    Mirrors ``test_workflow_in_place._patch_workflow_transport`` but
+    keeps the executor visible across cells so we can assert how
+    many times each method was called.
+    """
+    from srunx.models import JobStatus
+    from srunx.rendering import SubmissionRenderContext
+    from srunx.transport.registry import TransportHandle
+
+    executor = MagicMock(name="WorkflowExecutor")
+
+    def _fake_run(job, **_kwargs):
+        job.job_id = 9999
+        job.status = JobStatus.COMPLETED
+        return job
+
+    executor.run.side_effect = _fake_run
+    executor.get_job_output_detailed.return_value = {
+        "found_files": [],
+        "output": "",
+        "error": "",
+        "primary_log": None,
+        "slurm_log_dir": None,
+        "searched_dirs": [],
+    }
+
+    class _ExecutorCM:
+        def __enter__(self_inner):
+            return executor
+
+        def __exit__(self_inner, *exc):
+            return None
+
+    job_ops = MagicMock(name="JobOperations")
+
+    handle = TransportHandle(
+        scheduler_key=f"ssh:{profile_name}",
+        profile_name=profile_name,
+        transport_type="ssh",
+        job_ops=job_ops,
+        queue_client=job_ops,
+        executor_factory=lambda: _ExecutorCM(),
+        submission_context=SubmissionRenderContext(
+            mount_name=None,
+            mounts=tuple(profile.mounts),
+            default_work_dir=None,
+        ),
+    )
+
+    def _fake_build(
+        profile_name_arg,
+        *,
+        callbacks=None,
+        submission_source="web",
+        mount_name=None,
+        pool_size=2,
+    ):
+        return handle, MagicMock(name="pool")
+
+    monkeypatch.setattr("srunx.transport.registry._build_ssh_handle", _fake_build)
+
+    from srunx.ssh.core.config import ConfigManager
+
+    monkeypatch.setattr(ConfigManager, "get_profile", lambda self, name: profile)
+
+    return executor
+
+
+def _stub_profile(tmp_path: Path, mount_local: Path, remote: str) -> ServerProfile:
+    key = tmp_path / "id_rsa"
+    key.write_text("dummy")
+    return ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename=str(key),
+        mounts=(MountConfig(name="ml", local=str(mount_local), remote=remote),),
+    )
+
+
+class TestCLISweepInPlace:
+    """End-to-end coverage of the sweep IN_PLACE wiring (#143)."""
+
+    def test_static_script_path_sweep_runs_in_place(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sweep with non-parameterised script_path → IN_PLACE for every cell."""
+        mount_local = tmp_path / "ml-project"
+        mount_local.mkdir()
+        s = mount_local / "step.sbatch"
+        s.write_text("#!/bin/bash\necho hi\n")
+
+        yaml_path = tmp_path / "wf.yaml"
+        yaml_path.write_text(
+            "name: sweep_in_place\n"
+            "args:\n  seed: 1\n"
+            "sweep:\n"
+            "  matrix:\n    seed: [1, 2]\n"
+            "  max_parallel: 2\n"
+            f"jobs:\n  - name: j\n    path: {s}\n"
+        )
+
+        profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml")
+        executor = _patch_sweep_transport(monkeypatch, profile)
+
+        rsync_calls: list[tuple] = []
+        monkeypatch.setattr(
+            "srunx.sync.service.sync_mount_by_name",
+            lambda *a, **k: rsync_calls.append((a, k)),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["flow", "run", str(yaml_path), "--profile", "ml-cluster"]
+        )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        # One rsync for the shared mount, regardless of cell count.
+        assert len(rsync_calls) == 1
+        # Each cell runs once; both saw allow_in_place=True with the
+        # locked mount-set populated.
+        assert executor.run.call_count == 2
+        for call in executor.run.call_args_list:
+            ctx = call.kwargs.get("submission_context")
+            assert ctx is not None
+            assert ctx.allow_in_place is True
+            assert "ml" in ctx.locked_mount_names
+
+    def test_axis_driven_script_path_unions_mounts_and_syncs_each_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sweep across two mounts → one rsync per mount, IN_PLACE everywhere.
+
+        Canonical #143 win: without per-cell aggregation we'd only
+        lock the base-render mount; here both mounts get locked and
+        the executor sees a context that includes both names.
+        """
+        mount_a = tmp_path / "data_a"
+        mount_a.mkdir()
+        (mount_a / "run.sh").write_text("#!/bin/bash\n")
+        mount_b = tmp_path / "data_b"
+        mount_b.mkdir()
+        (mount_b / "run.sh").write_text("#!/bin/bash\n")
+
+        yaml_path = tmp_path / "wf.yaml"
+        yaml_path.write_text(
+            "name: t\n"
+            "args:\n  dataset: a\n"
+            "sweep:\n"
+            "  matrix:\n    dataset: [a, b]\n"
+            "  max_parallel: 2\n"
+            "jobs:\n  - name: j\n"
+            f'    path: "{tmp_path}/data_{{{{ dataset }}}}/run.sh"\n'
+        )
+
+        # Profile carries BOTH mounts so they can be aggregated.
+        key = tmp_path / "id_rsa"
+        key.write_text("dummy")
+        profile = ServerProfile(
+            hostname="h",
+            username="u",
+            key_filename=str(key),
+            mounts=[
+                MountConfig(name="data_a", local=str(mount_a), remote="/r/a"),
+                MountConfig(name="data_b", local=str(mount_b), remote="/r/b"),
+            ],
+        )
+        executor = _patch_sweep_transport(monkeypatch, profile)
+
+        rsync_calls: list[str] = []
+        monkeypatch.setattr(
+            "srunx.sync.service.sync_mount_by_name",
+            lambda prof, name, **kw: rsync_calls.append(name),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app, ["flow", "run", str(yaml_path), "--profile", "ml-cluster"]
+        )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        # Both mounts locked + rsynced exactly once each.
+        assert sorted(rsync_calls) == ["data_a", "data_b"]
+        # Both cells executed; both contexts list both mounts.
+        assert executor.run.call_count == 2
+        for call in executor.run.call_args_list:
+            ctx = call.kwargs.get("submission_context")
+            assert ctx is not None
+            assert ctx.allow_in_place is True
+            assert set(ctx.locked_mount_names) == {"data_a", "data_b"}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Defence-in-depth: SSH adapter rejects IN_PLACE for unlocked mount
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestLockedMountNamesSafetyNet:
+    """The SSH adapter must refuse IN_PLACE for mounts outside the locked set.
+
+    Tests the ``locked_mount_names`` field on
+    :class:`SubmissionRenderContext` — defence-in-depth for the
+    sweep aggregation. A buggy / racy cell that somehow targets a
+    mount we never locked must fail loudly rather than silently
+    race rsync.
+    """
+
+    def test_unlocked_mount_raises_clear_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Adapter rejects IN_PLACE when ``mount.name`` not in locked set."""
+        from srunx.models import JobStatus, ShellJob
+        from srunx.rendering import SubmissionRenderContext
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        # Build a real ShellJob that lives under the adapter's mount.
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        s = mount_local / "run.sh"
+        s.write_text("#!/bin/bash\necho hi\n")
+
+        adapter = SlurmSSHAdapter(
+            hostname="h",
+            username="u",
+            key_filename="/tmp/none",
+            mounts=[MountConfig(name="ml", local=str(mount_local), remote="/r/ml")],
+        )
+
+        # Stop ``_ensure_connected`` from reaching the wire. Use
+        # monkeypatch so the adapter's bound-method type contract is
+        # respected (no type-ignore band-aids on direct attr writes).
+        monkeypatch.setattr(adapter, "_ensure_connected", lambda: None)
+
+        # The locked-mount guard fires before sbatch — if it didn't,
+        # this would assert.
+        def _fake_remote_submit(*a, **kw):
+            raise AssertionError(
+                "submit_remote_sbatch_file must not be called when "
+                "the locked-mount guard rejects the IN_PLACE path"
+            )
+
+        monkeypatch.setattr(
+            adapter._client, "submit_remote_sbatch_file", _fake_remote_submit
+        )
+
+        ctx = SubmissionRenderContext(
+            mounts=(MountConfig(name="ml", local=str(mount_local), remote="/r/ml"),),
+            allow_in_place=True,
+            # Locked set deliberately does NOT include 'ml'.
+            locked_mount_names=("data_a",),
+        )
+
+        job = ShellJob(name="r", script_path=str(s))
+        job.status = JobStatus.PENDING
+
+        with pytest.raises(RuntimeError) as exc_info:
+            adapter.run(job, submission_context=ctx)
+
+        msg = str(exc_info.value)
+        assert "IN_PLACE rejected" in msg
+        assert "ml" in msg  # the offending mount name
+        assert "not in the locked mount set" in msg
+
+    def test_empty_locked_mount_names_disables_enforcement(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty locked-mount tuple = no enforcement (preserves pre-#143).
+
+        Non-sweep workflows compute their lock-set off the base render
+        and don't need the safety net (their lock-set is the only
+        possible lock-set). Empty ``locked_mount_names`` must therefore
+        leave the IN_PLACE path open for them.
+        """
+        from srunx.models import JobStatus, ShellJob
+        from srunx.rendering import SubmissionRenderContext
+        from srunx.web.ssh_adapter import SlurmSSHAdapter
+
+        mount_local = tmp_path / "ml"
+        mount_local.mkdir()
+        s = mount_local / "run.sh"
+        s.write_text("#!/bin/bash\necho hi\n")
+
+        adapter = SlurmSSHAdapter(
+            hostname="h",
+            username="u",
+            key_filename="/tmp/none",
+            mounts=[MountConfig(name="ml", local=str(mount_local), remote="/r/ml")],
+        )
+        monkeypatch.setattr(adapter, "_ensure_connected", lambda: None)
+
+        called: list[tuple] = []
+
+        def _fake_remote_submit(remote_path, **kw):
+            called.append((remote_path, kw))
+            return SlurmJob(job_id="42", name="r")
+
+        monkeypatch.setattr(
+            adapter._client, "submit_remote_sbatch_file", _fake_remote_submit
+        )
+        monkeypatch.setattr(
+            adapter, "_monitor_until_terminal", lambda *a, **kw: "COMPLETED"
+        )
+        monkeypatch.setattr(
+            SlurmSSHAdapter,
+            "_record_job_submission",
+            staticmethod(lambda *a, **kw: None),
+        )
+        monkeypatch.setattr(adapter, "_record_completion_safe", lambda *a, **kw: None)
+
+        ctx = SubmissionRenderContext(
+            mounts=(MountConfig(name="ml", local=str(mount_local), remote="/r/ml"),),
+            allow_in_place=True,
+            locked_mount_names=(),  # empty → no enforcement
+        )
+
+        job = ShellJob(name="r", script_path=str(s))
+        job.status = JobStatus.PENDING
+        adapter.run(job, submission_context=ctx)
+
+        # IN_PLACE took effect (remote_submit called with the mount-translated path).
+        assert len(called) == 1
+        assert called[0][0] == "/r/ml/run.sh"


### PR DESCRIPTION
## Summary

Closes #143. Removes the IN_PLACE-disabled-for-sweeps limitation from PR #141.

Pre-#143, sweep cells were forced onto the temp-upload path because \`_hold_workflow_mounts\` rendered the workflow once with the *base* args and missed any mount a per-cell Jinja substitution would resolve to. Letting the SSH adapter take the IN_PLACE shortcut for such a cell would race a concurrent rsync against a mount the runner never aggregated.

## Solution

1. **Cell-expansion-then-union**: ``collect_touched_mounts_across_cells(yaml_path, base_args, cell_args, profile)`` expands the matrix, renders each cell via \`WorkflowRunner.from_yaml\`, unions the per-cell touched mounts. Returns a deterministically sorted (profile.mounts order) list — same lock-acquisition-order property the single-workflow path uses.
2. **Lock the union**: \`_hold_workflow_mounts\` gains an \`explicit_mounts\` parameter; the sweep dispatch passes the unioned list through.
3. **Flip allow_in_place=True for sweeps** when the union is non-empty (empty = no profile / no touched mounts → keep pre-#143 behaviour, never race).
4. **Defence-in-depth safety net**: SSH adapter's IN_PLACE branch checks \`SubmissionRenderContext.locked_mount_names\` (new field, defaults to \`()\`= no enforcement). A cell whose script_path resolves to a mount NOT in that set fails loudly instead of silently racing.

## Test plan

- [x] \`tests/cli/test_workflow_sweep_in_place.py\` (new, 9 tests):
  - \`collect_touched_mounts_across_cells\` static-path sweep (single mount)
  - axis-driven sweep targeting two distinct mounts (union covers both, profile-order sorted)
  - cell render explosion (StrictUndefined) does NOT drop other cells' mounts
  - paths outside every mount → empty union
  - CLI sweep dispatch wires \`submission_context\` with \`allow_in_place=True\` + \`locked_mount_names\`
  - SSH adapter safety net: cell targeting unlocked mount raises with clear error
  - \`locked_mount_names=()\` disables enforcement (non-sweep regression guard)
- [x] Existing 118 \`tests/cli/\` + \`tests/sync/\` tests pass
- [x] \`uv run mypy .\` clean (252 source files)
- [x] \`uv run ruff check .\` clean

## Out of scope

- Per-cell Jinja that *adds new mounts mid-run* — would require lock acquisition during execution, explicitly excluded by the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)