### PR TITLE
feat(sync): remote hash verification post-sync (#137 part 5)

### DIFF
--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -149,6 +149,12 @@ def _submit_via_transport(
             sync_required=plan.sync_required,
             force_sync=force_sync,
             verbose=verbose,
+            # Per-script hash verification (#137 part 5): the local
+            # source of truth for the file we're about to ``sbatch``.
+            # Gated upstream by ``config.sync.verify_remote_hash``;
+            # passing the path unconditionally keeps the CLI ignorant
+            # of that flag.
+            verify_paths=[str(script_path)] if script_path is not None else None,
         )
         sync_ctx_entered = sync_ctx.__enter__()
     except SyncAbortedError as exc:

--- a/src/srunx/config.py
+++ b/src/srunx/config.py
@@ -151,6 +151,20 @@ class SyncDefaults(BaseModel):
             "globally for solo-machine setups."
         ),
     )
+    verify_remote_hash: bool = Field(
+        default=False,
+        description=(
+            "After auto-sync, SHA-256 the script we're about to "
+            "``sbatch`` on both ends and abort on mismatch (#137 part 5). "
+            "Catches silent rsync failures — a stray exclude rule, a "
+            "path-translation bug, an incremental-algorithm hiccup — "
+            "where rsync exits 0 but the file we cared about never "
+            "actually reached the cluster. Off by default because it "
+            "adds an ssh round-trip per submit; enable for CI / "
+            "shared-cluster setups where silently submitting stale "
+            "bytes is unacceptable."
+        ),
+    )
 
 
 class SrunxConfig(BaseModel):
@@ -319,6 +333,8 @@ def load_config_from_env() -> dict[str, Any]:
         sync["require_clean"] = clean.lower() in ("1", "true", "yes", "on")
     if (owner := os.getenv("SRUNX_SYNC_OWNER_CHECK")) is not None:
         sync["owner_check"] = owner.lower() in ("1", "true", "yes", "on")
+    if (verify := os.getenv("SRUNX_SYNC_VERIFY_REMOTE_HASH")) is not None:
+        sync["verify_remote_hash"] = verify.lower() in ("1", "true", "yes", "on")
     if sync:
         config["sync"] = sync
 

--- a/src/srunx/sync/hash_verify.py
+++ b/src/srunx/sync/hash_verify.py
@@ -1,0 +1,187 @@
+"""Per-script SHA-256 verification post-rsync (#137 part 5).
+
+After ``rsync`` returns 0 the user has every reason to assume their
+script reached the cluster intact. Reality has at least three ways to
+break that assumption silently:
+
+* a stray ``--exclude`` rule (project-level or user-level rsyncd config)
+  that filters out the specific file we're about to ``sbatch``,
+* a path-translation bug between ``mount.local`` and ``mount.remote``,
+* an rsync incremental-algorithm hiccup that decided the remote copy
+  was "good enough" but actually wasn't.
+
+Per-script hashing (vs. hashing the entire mount tree) keeps the cost
+to a single ``sha256sum`` round-trip per submission. The caller passes
+in the local script path; we translate it to its remote equivalent
+(``mount.local`` prefix → ``mount.remote`` prefix) and compare local
+hash with remote hash. Mismatch → abort with a :class:`HashMismatch`
+carrying both hashes plus a hint about likely rsync excludes, so the
+user can debug the silent-failure cause instead of submitting stale
+bytes.
+
+The check is opt-in via ``[sync] verify_remote_hash`` (default
+``False``) because it adds an ssh round-trip per submit. Solo-machine
+setups with a known-good rsync config don't need it; CI / shared-cluster
+setups very much do.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from pathlib import Path
+
+from srunx.ssh.core.config import MountConfig, ServerProfile
+from srunx.sync.mount_helpers import build_rsync_client
+from srunx.sync.service import SyncAbortedError
+
+
+class HashMismatch(SyncAbortedError):
+    """Raised when the post-rsync hash does not match the local source.
+
+    Subclasses :class:`SyncAbortedError` so existing CLI / Web error
+    handling — which already catches "we refused to sync" via that
+    base class — surfaces hash mismatches with the same exit code
+    and exception channel as owner-marker mismatches and
+    require-clean failures.
+
+    Carries both hashes and the local + remote paths so a debugging
+    user can ``ls -la`` and ``sha256sum`` each side directly.
+    """
+
+    def __init__(
+        self,
+        *,
+        local_path: Path,
+        remote_path: str,
+        local_hash: str,
+        remote_hash: str | None,
+    ) -> None:
+        if remote_hash is None:
+            detail = (
+                f"Remote file {remote_path!r} not found after rsync. "
+                f"This usually means an rsync exclude rule filtered out "
+                f"the file, or the path translation is wrong. "
+                f"Local: {local_path} (sha256={local_hash})."
+            )
+        else:
+            detail = (
+                f"Hash mismatch for {local_path}:\n"
+                f"  local  ({local_path}) sha256={local_hash}\n"
+                f"  remote ({remote_path}) sha256={remote_hash}\n"
+                f"rsync exited successfully but the remote copy of this "
+                f"file does not match. Most likely an rsync exclude rule "
+                f"is filtering it out (check ~/.rsyncrc, project "
+                f"``.rsync-filter``, and ``mount.exclude_patterns``)."
+            )
+        super().__init__(detail)
+        self.local_path = local_path
+        self.remote_path = remote_path
+        self.local_hash = local_hash
+        self.remote_hash = remote_hash
+
+
+def local_sha256(path: Path) -> str:
+    """Return the SHA-256 hex digest of *path*'s contents.
+
+    Reads the whole file into memory: every caller in scope is a
+    sbatch script, which is kB at most. Chunked reads would be
+    over-engineering for this size class.
+    """
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _local_to_remote(path: Path, mount: MountConfig) -> str:
+    """Translate a local path under *mount* into its remote equivalent.
+
+    Mirrors :func:`srunx.cli.submission_plan.translate_local_to_remote`,
+    duplicated here so the ``srunx.sync`` layer doesn't import upward
+    into ``srunx.cli``. Same contract: caller has already verified
+    *path* lives under ``mount.local`` (e.g. via the planner).
+
+    Joins with ``/`` explicitly because the remote side is POSIX —
+    relying on :class:`Path` would pick up the host separator on
+    Windows workstations.
+    """
+    local_root = Path(mount.local).expanduser().resolve()
+    rel = path.resolve().relative_to(local_root)
+    remote_root = mount.remote.rstrip("/")
+    rel_posix = str(rel).replace("\\", "/")
+    if rel_posix in ("", "."):
+        return remote_root
+    return f"{remote_root}/{rel_posix}"
+
+
+def verify_paths_match(
+    profile: ServerProfile,
+    mount: MountConfig,
+    local_paths: Sequence[Path],
+) -> None:
+    """Hash each *local_path* on both ends; raise on any mismatch.
+
+    Per-path semantics:
+
+    * Local hash + matching remote hash → no-op.
+    * Local hash + remote returns ``None`` because the remote tooling
+      is missing → log debug, skip silently. The rsync that just
+      succeeded is the user's main signal of last resort.
+    * Local hash + remote returns ``None`` because the file is missing
+      → raise :class:`HashMismatch`. This is the most damning silent
+      rsync failure and exactly what the verifier exists to catch.
+    * Local hash != remote hash → raise :class:`HashMismatch`.
+
+    Network / ssh failures from
+    :meth:`RsyncClient.remote_sha256` propagate as
+    :class:`RuntimeError`; the caller (``mount_sync_session``)
+    deliberately does not swallow them so the user sees the
+    underlying connection problem rather than a misleading "hash
+    mismatch" or silent "skip".
+
+    The "no tool" case is intentionally non-fatal: forcing every
+    cluster admin to install ``sha256sum`` to use srunx would be a
+    regression. The check has shipped as opt-in precisely so users
+    who care about it can flip it on; users on toolless clusters
+    can leave it off without penalty.
+    """
+    if not local_paths:
+        return
+
+    client = build_rsync_client(profile)
+
+    for local_path in local_paths:
+        local_hash = local_sha256(local_path)
+        remote_path = _local_to_remote(local_path, mount)
+
+        # ssh / network failures propagate from remote_sha256 so the
+        # user sees the underlying cause instead of a misleading hash
+        # message. Same shape ``check_owner`` uses for marker reads.
+        remote_hash = client.remote_sha256(remote_path)
+
+        if remote_hash is None:
+            # ``remote_sha256`` returns None for both "file missing"
+            # and "no hashing tool". Disambiguate via read_remote_file
+            # (which itself uses ``test -f`` so a None return means
+            # the file is really gone). The extra round-trip only
+            # fires in the rare None branch of an opt-in code path,
+            # which is cheaper than enriching the RsyncClient API
+            # with a tri-state return.
+            exists = client.read_remote_file(remote_path) is not None
+            if not exists:
+                raise HashMismatch(
+                    local_path=local_path,
+                    remote_path=remote_path,
+                    local_hash=local_hash,
+                    remote_hash=None,
+                )
+            # File exists but we got no hash → no remote tooling.
+            # Already logged at debug inside remote_sha256; skip
+            # silently per the opt-in contract.
+            continue
+
+        if remote_hash != local_hash:
+            raise HashMismatch(
+                local_path=local_path,
+                remote_path=remote_path,
+                local_hash=local_hash,
+                remote_hash=remote_hash,
+            )

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -438,6 +439,87 @@ class RsyncClient:
                 f"ssh write to {remote_path!r} failed "
                 f"(exit {result.returncode}): {result.stderr.strip()}"
             )
+
+    # Custom exit codes wired into the remote shell snippet for
+    # remote_sha256. Chosen above the common shell-defined range
+    # (1=generic error, 2=misuse, 126/127=can't exec / not found,
+    # 255=ssh) so they can't be confused with a genuine failure mode
+    # we'd want to surface as RuntimeError.
+    _SHA256_REMOTE_MISSING_EXIT = 10
+    _SHA256_REMOTE_NO_TOOL_EXIT = 11
+
+    # sha256sum / shasum -a 256 prefix every output line with the 64-hex
+    # digest followed by whitespace. Anchored at start of line so we
+    # don't accidentally match a hex-looking substring inside a path.
+    _SHA256_HEX_RE = re.compile(r"^([0-9a-f]{64})\b", re.IGNORECASE)
+
+    def remote_sha256(self, remote_path: str) -> str | None:
+        """Return the SHA-256 hex digest of *remote_path*, or ``None``.
+
+        Used by :func:`srunx.sync.hash_verify.verify_paths_match`
+        (#137 part 5) to detect the silent-rsync-failure case where
+        rsync exits 0 but the specific file we're about to ``sbatch``
+        never reached the cluster (excluded by a stray rule, lost to
+        a path-translation bug, …). A None return defers to the
+        caller, which decides whether "missing" or "no tool" should
+        block submission.
+
+        Returns:
+            The 64-char lowercase hex digest on success.
+            ``None`` when the file does not exist on the remote.
+            ``None`` when neither ``sha256sum`` nor ``shasum -a 256``
+            is available on the remote PATH (logged at debug — the
+            rsync that just succeeded is the user's main signal).
+
+        Raises:
+            RuntimeError: For any other ssh / network failure
+            (connection refused, host key mismatch, host
+            unreachable, …). Callers that want "best effort" can
+            catch and downgrade; the marker-read code in
+            :func:`check_owner` is the prior art for that pattern.
+        """
+        quoted = shlex.quote(remote_path)
+        # Single round-trip: existence check, then prefer sha256sum
+        # (Linux), fall back to shasum -a 256 (macOS / BSD). Custom
+        # exit codes disambiguate "file missing" and "no tool" from
+        # genuine failures so the Python side doesn't have to grep
+        # stderr to make that distinction.
+        script = (
+            f"test -f {quoted} || exit {self._SHA256_REMOTE_MISSING_EXIT}\n"
+            f"if command -v sha256sum >/dev/null 2>&1; then\n"
+            f"  sha256sum -- {quoted}\n"
+            f"elif command -v shasum >/dev/null 2>&1; then\n"
+            f"  shasum -a 256 -- {quoted}\n"
+            f"else\n"
+            f"  exit {self._SHA256_REMOTE_NO_TOOL_EXIT}\n"
+            f"fi"
+        )
+        result = self._ssh_run(script)
+        if result.returncode == 0:
+            match = self._SHA256_HEX_RE.match(result.stdout.strip())
+            if match is None:
+                # Unparseable output is a genuine failure — sha256sum
+                # / shasum surfaced something we don't understand,
+                # better to fail loud than silently fall through to
+                # "no hash".
+                raise RuntimeError(
+                    f"could not parse sha256 output for {remote_path!r}: "
+                    f"{result.stdout.strip()!r}"
+                )
+            return match.group(1).lower()
+        if result.returncode == self._SHA256_REMOTE_MISSING_EXIT:
+            return None
+        if result.returncode == self._SHA256_REMOTE_NO_TOOL_EXIT:
+            logger.debug(
+                "Remote sha256 verification skipped for {}: "
+                "neither sha256sum nor shasum available on remote PATH",
+                remote_path,
+            )
+            return None
+        raise RuntimeError(
+            f"ssh sha256 of {remote_path!r} failed "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
 
     def _merge_excludes(self, extra: Sequence[str] | None) -> list[str]:
         """Merge per-call exclude patterns with instance patterns."""

--- a/src/srunx/sync/service.py
+++ b/src/srunx/sync/service.py
@@ -103,6 +103,7 @@ def mount_sync_session(
     sync_required: bool,
     force_sync: bool = False,
     verbose: bool = False,
+    verify_paths: list[str] | None = None,
 ) -> Iterator[SyncOutcome]:
     """Acquire the per-mount lock, optionally rsync, hold lock until exit.
 
@@ -125,6 +126,16 @@ def mount_sync_session(
     ``verbose=True`` forwards into the underlying rsync call so
     per-file progress streams to stderr (#137 part 3).
 
+    ``verify_paths`` (#137 part 5) is the list of LOCAL paths whose
+    remote SHA-256 should be compared against the local SHA-256
+    after a successful rsync, gated by ``config.verify_remote_hash``.
+    Mismatch → :class:`SyncAbortedError` (a ``HashMismatch`` subtype)
+    with both digests in the message. Skipped silently when the flag
+    is off, the list is empty/None, or the remote lacks
+    ``sha256sum`` / ``shasum``. The check slots in BEFORE the marker
+    write so a corrupt-remote state never claims ownership of bytes
+    we couldn't actually trust.
+
     Failure modes:
 
     * Dirty worktree + ``require_clean=true`` → :class:`SyncAbortedError`
@@ -133,6 +144,8 @@ def mount_sync_session(
     * Owner marker shows a different host + ``owner_check=true`` +
       ``force_sync=False`` → :class:`SyncAbortedError` (rsync does
       **not** run).
+    * Hash mismatch + ``verify_remote_hash=true`` →
+      :class:`SyncAbortedError` (rsync DID run; marker NOT written).
     * Lock contention → :class:`~srunx.sync.lock.SyncLockTimeoutError`
       bubbles up.
     * rsync non-zero exit → :class:`RuntimeError` (from inner helper).
@@ -182,6 +195,23 @@ def mount_sync_session(
             # remote-only outputs (training checkpoints, run logs).
             # ``srunx ssh sync`` keeps the historical mirror behaviour.
             sync_mount_by_name(profile, mount.name, delete=False, verbose=verbose)
+
+            # Per-script hash verification (#137 part 5) runs BEFORE
+            # the marker write so a hash mismatch refuses to take
+            # ownership of corrupt remote state — the next user to
+            # rsync sees "no marker" rather than "this machine just
+            # claimed it" and the silent rsync bug surfaces instead
+            # of compounding. Opt-in: skipped when the config flag is
+            # off OR no specific paths were supplied (e.g. ``srunx
+            # ssh sync`` has nothing specific to verify).
+            if config.verify_remote_hash and verify_paths:
+                # Local import to keep the (small) hash_verify module
+                # off the import path of unrelated callers and to
+                # avoid a circular import — hash_verify imports the
+                # ``SyncAbortedError`` we define above.
+                from srunx.sync.hash_verify import verify_paths_match
+
+                verify_paths_match(profile, mount, [Path(p) for p in verify_paths])
 
             # Stamp the marker AFTER a successful sync so a failed
             # rsync doesn't claim ownership for a tree we couldn't

--- a/tests/sync/test_hash_verify.py
+++ b/tests/sync/test_hash_verify.py
@@ -1,0 +1,426 @@
+"""Tests for the per-script hash verification (#137 part 5).
+
+Two layers exercised here:
+
+* :mod:`srunx.sync.hash_verify` — the policy / helpers themselves,
+  mocked at the :class:`RsyncClient` boundary so we never touch real
+  ssh.
+* :func:`srunx.sync.service.mount_sync_session` integration —
+  asserts that the verify call only fires when the opt-in config flag
+  is on AND ``verify_paths`` was supplied, and that it slots between
+  rsync and the marker write (a hash mismatch must NOT result in a
+  stale ownership marker).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from srunx.config import SyncDefaults
+from srunx.ssh.core.config import MountConfig, ServerProfile
+from srunx.sync.hash_verify import (
+    HashMismatch,
+    local_sha256,
+    verify_paths_match,
+)
+from srunx.sync.service import SyncAbortedError, mount_sync_session
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+
+def _profile(tmp_path: Path) -> tuple[ServerProfile, Path]:
+    """Return a profile with a single 'ml' mount + the local mount root."""
+    key = tmp_path / "id_rsa"
+    key.write_text("dummy")
+    mount_local = tmp_path / "ml"
+    mount_local.mkdir()
+    profile = ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename=str(key),
+        mounts=(MountConfig(name="ml", local=str(mount_local), remote="/r/ml"),),
+    )
+    return profile, mount_local
+
+
+# ── HashMismatch ──────────────────────────────────────────────────
+
+
+class TestHashMismatch:
+    def test_subclasses_sync_aborted_error(self) -> None:
+        """Existing CLI / Web error handling catches one base class.
+
+        ``SyncAbortedError`` is the single ""we refused to sync""
+        channel; a hash mismatch must ride that same channel rather
+        than introducing a parallel exception type the callers would
+        need to know about.
+        """
+        assert issubclass(HashMismatch, SyncAbortedError)
+
+    def test_carries_fields_on_mismatch(self, tmp_path: Path) -> None:
+        local = tmp_path / "train.sbatch"
+        local.write_text("hi")
+        exc = HashMismatch(
+            local_path=local,
+            remote_path="/r/ml/train.sbatch",
+            local_hash="a" * 64,
+            remote_hash="b" * 64,
+        )
+        assert exc.local_path == local
+        assert exc.remote_path == "/r/ml/train.sbatch"
+        assert exc.local_hash == "a" * 64
+        assert exc.remote_hash == "b" * 64
+        # Both hashes must appear in the message so a debugging user
+        # can grep them out of stderr without scraping fields.
+        msg = str(exc)
+        assert "a" * 64 in msg
+        assert "b" * 64 in msg
+        # And a hint about excludes so the most common cause is
+        # signposted rather than left as an exercise.
+        assert "exclude" in msg.lower()
+
+    def test_message_for_missing_remote(self, tmp_path: Path) -> None:
+        """``remote_hash=None`` produces a distinct ""file not found"" message.
+
+        The user needs to know whether the remote bytes are wrong
+        (mismatch) or simply not there (missing) — different debug
+        paths.
+        """
+        local = tmp_path / "train.sbatch"
+        local.write_text("hi")
+        exc = HashMismatch(
+            local_path=local,
+            remote_path="/r/ml/train.sbatch",
+            local_hash="a" * 64,
+            remote_hash=None,
+        )
+        msg = str(exc)
+        assert "not found" in msg.lower()
+        assert "/r/ml/train.sbatch" in msg
+
+
+# ── local_sha256 ──────────────────────────────────────────────────
+
+
+class TestLocalSha256:
+    def test_matches_hashlib(self, tmp_path: Path) -> None:
+        path = tmp_path / "script.sbatch"
+        payload = b"#!/bin/bash\necho hi\n"
+        path.write_bytes(payload)
+        expected = hashlib.sha256(payload).hexdigest()
+        assert local_sha256(path) == expected
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        """sha256 of empty bytes is e3b0c442… — sanity check."""
+        path = tmp_path / "empty"
+        path.write_bytes(b"")
+        assert local_sha256(path) == hashlib.sha256(b"").hexdigest()
+
+
+# ── verify_paths_match ────────────────────────────────────────────
+
+
+class TestVerifyPathsMatch:
+    """The single decision point for hash verification.
+
+    Mocking :func:`build_rsync_client` lets us drive the four cases
+    (match / mismatch / remote missing / no tool) deterministically
+    without standing up an SSH server.
+    """
+
+    def test_empty_paths_is_noop(self, tmp_path: Path) -> None:
+        """No paths → no rsync client built (no ssh round-trip)."""
+        profile, _ = _profile(tmp_path)
+        with patch("srunx.sync.hash_verify.build_rsync_client") as fake_build:
+            verify_paths_match(profile, profile.mounts[0], [])
+        fake_build.assert_not_called()
+
+    def test_matching_hash_returns_silently(self, tmp_path: Path) -> None:
+        """Equal local + remote hash → no exception."""
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        payload = b"#!/bin/bash\necho hi\n"
+        script.write_bytes(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+
+        client = MagicMock()
+        client.remote_sha256.return_value = digest
+
+        with patch("srunx.sync.hash_verify.build_rsync_client", return_value=client):
+            verify_paths_match(profile, profile.mounts[0], [script])
+
+        client.remote_sha256.assert_called_once_with("/r/ml/train.sbatch")
+
+    def test_mismatched_hash_raises(self, tmp_path: Path) -> None:
+        """Distinct local + remote hash → ``HashMismatch`` with both digests."""
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        script.write_bytes(b"local-bytes")
+        local_hash = hashlib.sha256(b"local-bytes").hexdigest()
+        remote_hash = "f" * 64
+
+        client = MagicMock()
+        client.remote_sha256.return_value = remote_hash
+
+        with patch("srunx.sync.hash_verify.build_rsync_client", return_value=client):
+            with pytest.raises(HashMismatch) as exc_info:
+                verify_paths_match(profile, profile.mounts[0], [script])
+
+        assert exc_info.value.local_hash == local_hash
+        assert exc_info.value.remote_hash == remote_hash
+        assert exc_info.value.local_path == script
+        assert exc_info.value.remote_path == "/r/ml/train.sbatch"
+
+    def test_remote_missing_raises(self, tmp_path: Path) -> None:
+        """remote_sha256 → None and read_remote_file → None: file is gone.
+
+        This is the headline failure mode the verifier exists for —
+        rsync exited 0 but the file we cared about never landed.
+        """
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        script.write_bytes(b"hi")
+
+        client = MagicMock()
+        client.remote_sha256.return_value = None
+        client.read_remote_file.return_value = None  # file genuinely gone
+
+        with patch("srunx.sync.hash_verify.build_rsync_client", return_value=client):
+            with pytest.raises(HashMismatch) as exc_info:
+                verify_paths_match(profile, profile.mounts[0], [script])
+
+        assert exc_info.value.remote_hash is None
+        assert "not found" in str(exc_info.value).lower()
+
+    def test_remote_no_tool_skips_silently(self, tmp_path: Path) -> None:
+        """remote_sha256 → None but file exists: no tool on remote PATH.
+
+        Forcing every cluster admin to install ``sha256sum`` to use
+        srunx would be a regression — the check ships opt-in
+        precisely so users who care can flip it on, while users on
+        toolless clusters can leave it off without penalty.
+        """
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        script.write_bytes(b"hi")
+
+        client = MagicMock()
+        client.remote_sha256.return_value = None
+        # File exists, so the disambiguation probe sees content back.
+        client.read_remote_file.return_value = "remote bytes (not None)"
+
+        with patch("srunx.sync.hash_verify.build_rsync_client", return_value=client):
+            verify_paths_match(profile, profile.mounts[0], [script])
+
+        # No raise. read_remote_file was used to disambiguate.
+        client.read_remote_file.assert_called_once_with("/r/ml/train.sbatch")
+
+    def test_ssh_failure_propagates(self, tmp_path: Path) -> None:
+        """RuntimeError from remote_sha256 propagates verbatim.
+
+        Letting it bubble means the user sees ""ssh: connection
+        refused"" instead of a misleading ""hash mismatch"" — the
+        same defensive shape ``check_owner`` uses for marker reads.
+        """
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        script.write_bytes(b"hi")
+
+        client = MagicMock()
+        client.remote_sha256.side_effect = RuntimeError(
+            "ssh: connect to host h: connection refused"
+        )
+
+        with patch("srunx.sync.hash_verify.build_rsync_client", return_value=client):
+            with pytest.raises(RuntimeError, match="connection refused"):
+                verify_paths_match(profile, profile.mounts[0], [script])
+
+    def test_remote_path_translation(self, tmp_path: Path) -> None:
+        """The remote path passed to ``remote_sha256`` is the mount-translated form."""
+        profile, mount_local = _profile(tmp_path)
+        sub = mount_local / "experiments" / "v1"
+        sub.mkdir(parents=True)
+        script = sub / "train.sbatch"
+        script.write_bytes(b"hi")
+
+        client = MagicMock()
+        client.remote_sha256.return_value = hashlib.sha256(b"hi").hexdigest()
+
+        with patch("srunx.sync.hash_verify.build_rsync_client", return_value=client):
+            verify_paths_match(profile, profile.mounts[0], [script])
+
+        client.remote_sha256.assert_called_once_with(
+            "/r/ml/experiments/v1/train.sbatch"
+        )
+
+
+# ── mount_sync_session integration ────────────────────────────────
+
+
+class TestMountSyncSessionVerifyIntegration:
+    """The service layer wires verify_paths_match in at the right point.
+
+    Acceptance criteria:
+    * Default config (``verify_remote_hash=False``) → verify NOT called.
+    * Opt-in + paths supplied → verify called between rsync and
+      marker write.
+    * Opt-in but no paths → verify NOT called.
+    * Hash mismatch → marker NOT written (we don't claim ownership of
+      corrupt remote state).
+    """
+
+    def test_verify_off_by_default_does_not_call_helper(self, tmp_path: Path) -> None:
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        script.write_bytes(b"hi")
+
+        with (
+            patch("srunx.sync.hash_verify.verify_paths_match") as fake_verify,
+            patch("srunx.sync.service.sync_mount_by_name", return_value=""),
+            patch("srunx.sync.service.check_owner"),
+            patch("srunx.sync.service.write_owner_marker"),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with mount_sync_session(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=SyncDefaults(),  # verify_remote_hash defaults to False
+                sync_required=True,
+                verify_paths=[str(script)],
+            ):
+                pass
+
+        fake_verify.assert_not_called()
+
+    def test_verify_on_with_paths_calls_helper_between_rsync_and_marker(
+        self, tmp_path: Path
+    ) -> None:
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        script.write_bytes(b"hi")
+
+        order: list[str] = []
+
+        def _record_rsync(*a: object, **k: object) -> str:
+            order.append("rsync")
+            return ""
+
+        def _record_verify(*a: object, **k: object) -> None:
+            order.append("verify")
+
+        def _record_write(*a: object, **k: object) -> object:
+            order.append("write")
+            return None
+
+        with (
+            patch("srunx.sync.service.sync_mount_by_name", _record_rsync),
+            patch("srunx.sync.hash_verify.verify_paths_match", _record_verify),
+            patch("srunx.sync.service.check_owner"),
+            patch("srunx.sync.service.write_owner_marker", _record_write),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with mount_sync_session(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=SyncDefaults(verify_remote_hash=True),
+                sync_required=True,
+                verify_paths=[str(script)],
+            ):
+                pass
+
+        assert order == ["rsync", "verify", "write"], (
+            "verify must run AFTER rsync (so we hash the post-rsync "
+            "remote state) and BEFORE the marker write (so a hash "
+            "mismatch refuses to claim ownership of corrupt state)."
+        )
+
+    def test_verify_on_no_paths_skips_helper(self, tmp_path: Path) -> None:
+        """Opt-in but no specific paths → still skip.
+
+        ``srunx ssh sync`` and similar callers don't have a single
+        script to verify; the verifier should no-op rather than
+        guess at what to hash.
+        """
+        profile, _ = _profile(tmp_path)
+
+        with (
+            patch("srunx.sync.hash_verify.verify_paths_match") as fake_verify,
+            patch("srunx.sync.service.sync_mount_by_name", return_value=""),
+            patch("srunx.sync.service.check_owner"),
+            patch("srunx.sync.service.write_owner_marker"),
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with mount_sync_session(
+                profile_name="alice",
+                profile=profile,
+                mount=profile.mounts[0],
+                config=SyncDefaults(verify_remote_hash=True),
+                sync_required=True,
+                # Both None and empty list must skip — the absence of
+                # a specific file to verify is the off-switch.
+                verify_paths=None,
+            ):
+                pass
+
+        fake_verify.assert_not_called()
+
+    def test_hash_mismatch_does_not_write_marker(self, tmp_path: Path) -> None:
+        """A failed verify must NOT result in a stale ownership marker.
+
+        If we wrote the marker anyway, the next user to sync would
+        see ""this machine just claimed it"" and skip THEIR sync —
+        compounding the silent-rsync bug instead of letting it
+        surface.
+        """
+        profile, mount_local = _profile(tmp_path)
+        script = mount_local / "train.sbatch"
+        script.write_bytes(b"hi")
+
+        def _verify_boom(*a: object, **k: object) -> None:
+            raise HashMismatch(
+                local_path=script,
+                remote_path="/r/ml/train.sbatch",
+                local_hash="a" * 64,
+                remote_hash="b" * 64,
+            )
+
+        with (
+            patch("srunx.sync.service.sync_mount_by_name", return_value=""),
+            patch("srunx.sync.hash_verify.verify_paths_match", _verify_boom),
+            patch("srunx.sync.service.check_owner"),
+            patch("srunx.sync.service.write_owner_marker") as fake_write,
+            patch(
+                "srunx.sync.service.is_dirty_git_worktree",
+                return_value=(False, ""),
+            ),
+        ):
+            with pytest.raises(SyncAbortedError):
+                with mount_sync_session(
+                    profile_name="alice",
+                    profile=profile,
+                    mount=profile.mounts[0],
+                    config=SyncDefaults(verify_remote_hash=True),
+                    sync_required=True,
+                    verify_paths=[str(script)],
+                ):
+                    pass
+
+        fake_write.assert_not_called()

--- a/tests/test_rsync.py
+++ b/tests/test_rsync.py
@@ -729,3 +729,107 @@ class TestSyncProject:
             )
             with pytest.raises(RuntimeError, match="rsync failed"):
                 client.sync_project()
+
+
+# ---------------------------------------------------------------------------
+# remote_sha256 (#137 part 5)
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteSha256:
+    """``remote_sha256`` is the cluster-side half of post-rsync verification.
+
+    The wire-level shape is a single ssh round-trip running a small
+    shell snippet that:
+
+    1. ``test -f`` — distinct exit code for ""file missing"".
+    2. Tries ``sha256sum`` (Linux), falls back to ``shasum -a 256``
+       (macOS) — distinct exit code for ""no tool available"".
+    3. Otherwise prints the digest followed by the path.
+
+    Each branch maps to a distinct return / raise so the caller in
+    :mod:`srunx.sync.hash_verify` can apply the right policy without
+    grepping stderr.
+    """
+
+    def test_happy_path_parses_sha256sum_output(self) -> None:
+        """Standard ``sha256sum`` output: ``<64 hex>  <path>``."""
+        client = _make_rsync_client(hostname="h", username="u")
+        digest = "a" * 64
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=f"{digest}  /r/ml/train.sbatch\n",
+                stderr="",
+            )
+            result = client.remote_sha256("/r/ml/train.sbatch")
+        assert result == digest
+        # The remote command must have shell-quoted the path.
+        ssh_cmd = mock_run.call_args[0][0]
+        joined = " ".join(ssh_cmd)
+        assert "/r/ml/train.sbatch" in joined
+        assert "sha256sum" in joined
+        assert "shasum" in joined  # fallback also wired in
+
+    def test_uppercase_hex_is_normalised(self) -> None:
+        """``shasum`` on some BSDs prints upper-case — normalise to lower.
+
+        Comparison against :func:`hashlib.sha256().hexdigest()`
+        (always lowercase) needs both sides in the same case.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+        digest_upper = "A" * 64
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=f"{digest_upper}  /r/ml/x\n", stderr=""
+            )
+            assert client.remote_sha256("/r/ml/x") == "a" * 64
+
+    def test_missing_file_returns_none(self) -> None:
+        """Custom exit 10 (``test -f`` failed) → ``None`` (file gone)."""
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=10, stdout="", stderr="")
+            assert client.remote_sha256("/r/ml/missing.sbatch") is None
+
+    def test_missing_tool_returns_none(self) -> None:
+        """Custom exit 11 (no sha256sum, no shasum) → ``None`` (skip).
+
+        The debug-log emission itself isn't asserted (loguru +
+        caplog don't compose without a sink) — the contract that
+        matters is that the caller gets None to feed the
+        ``hash_verify`` skip-silently policy.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=11, stdout="", stderr="")
+            assert client.remote_sha256("/r/ml/script.sbatch") is None
+
+    def test_ssh_failure_raises_runtime_error(self) -> None:
+        """ssh exit 255 (genuine network failure) → ``RuntimeError``."""
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=255,
+                stdout="",
+                stderr="ssh: connect to host h: connection refused",
+            )
+            with pytest.raises(RuntimeError, match="connection refused"):
+                client.remote_sha256("/r/ml/train.sbatch")
+
+    def test_unparseable_output_raises(self) -> None:
+        """Exit 0 but no hex digest in stdout → fail loud, don't fall through.
+
+        sha256sum / shasum surfacing something we don't recognise is
+        more concerning than ""no hash"" — silently returning None
+        would let a buggy remote mask itself as ""tool missing"".
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="garbage not-a-digest\n",
+                stderr="",
+            )
+            with pytest.raises(RuntimeError, match="parse sha256"):
+                client.remote_sha256("/r/ml/train.sbatch")


### PR DESCRIPTION
## Summary

Final part of #137. After ``rsync`` exits 0 the user has every reason to assume the script they're about to sbatch reached the cluster intact. Reality has at least three ways to break that assumption silently:

- a stray ``exclude_patterns`` rule
- a wrong local→remote path translation
- an rsync incremental algorithm hiccup

This PR adds an opt-in SHA-256 verification of the specific script being submitted. Mismatch → abort with diff hint instead of silently submitting stale bytes.

## Design choices worth flagging

| choice | rationale |
|--------|-----------|
| Per-script (not per-tree) hashing | Mount can be GB. One ssh round-trip per submission is bounded; full-tree hash is not. |
| Off by default | Existing callers see bit-for-bit unchanged behaviour. Opt-in via ``[sync] verify_remote_hash = true`` or ``SRUNX_SYNC_VERIFY_REMOTE_HASH=1``. |
| Missing remote tooling → skip silently | Forcing every cluster admin to install ``sha256sum`` is a regression. The verify is opt-in precisely so users who care can flip it on while toolless clusters can leave it off. |
| Hash check INSIDE the lock, BEFORE marker write | A corrupt remote must not claim ownership; next user sees "no marker" and the silent rsync bug surfaces instead of compounding. |
| ``HashMismatch`` subclasses ``SyncAbortedError`` | Existing CLI / Web handlers catch it on the same channel as owner-marker mismatches and require-clean failures. |
| Path translation duplicated in ``hash_verify._local_to_remote`` | Avoids ``srunx.sync`` → ``srunx.cli`` upward import that would invert the established layering (sync = shared infrastructure, cli = consumer). |

## Test plan

- [x] \`tests/sync/test_hash_verify.py\` (new, 16 tests): match / mismatch / remote missing / no-tool skip / ssh-failure propagation, plus integration tests asserting verify is called between rsync and marker write only when opt-in flag is on AND paths supplied, and that a hash mismatch suppresses the marker write.
- [x] \`tests/test_rsync.py::TestRemoteSha256\` — happy path, uppercase normalisation, missing file (exit 10), missing tool (exit 11), ssh failure (exit 255), unparseable output.
- [x] Existing 111 sync / sbatch tests still pass — default \`verify_remote_hash=False\` is bit-for-bit identical behaviour.
- [x] mypy / ruff clean.

## #137 status (all 5 parts)

| part | PR | status |
|------|-----|--------|
| 1 — lock filename collision | #146 | ✅ MERGED |
| 2 — dry-run sync preview | #147 | ✅ MERGED |
| 3 — \`--verbose\` rsync streaming | #149 | ✅ MERGED |
| 4 — owner marker | #148 | ✅ MERGED |
| 5 — remote hash verify | this PR | 🟢 OPEN |

🤖 Generated with [Claude Code](https://claude.com/claude-code)