### PR TITLE
fix(tests): accept verbose kwarg in workflow in-place mock (post-#149 regression)

### DIFF
--- a/tests/cli/test_workflow_in_place.py
+++ b/tests/cli/test_workflow_in_place.py
@@ -157,7 +157,10 @@ def test_flow_run_syncs_each_mount_once_for_multi_shelljob_workflow(
 
     rsync_calls: list[tuple] = []
 
-    def _record_rsync(prof, name, *, delete=False):
+    def _record_rsync(prof, name, *, delete=False, verbose=False):
+        # ``verbose`` kwarg added in PR #149 (rsync streaming progress).
+        # Mock must accept it so ``sync_mount_by_name(..., verbose=...)``
+        # call from ``mount_sync_session`` doesn't raise TypeError.
         rsync_calls.append((prof, name, delete))
 
     monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record_rsync)


### PR DESCRIPTION
## Summary

Post-#149 regression fix. PR #149 added \`verbose: bool = False\` to \`sync_mount_by_name\` but \`tests/cli/test_workflow_in_place.py::test_flow_run_syncs_each_mount_once_for_multi_shelljob_workflow\`'s mock didn't accept it. Surfaced when the full pytest suite ran on main after #149-#152 all landed.

\`uv run pytest tests/cli/test_workflow_in_place.py\` was failing on main; now passes 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)