### PR TITLE
fix(docs): griffe-parseable Raises block in remote_sha256 docstring

### DIFF
--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -472,11 +472,11 @@ class RsyncClient:
             rsync that just succeeded is the user's main signal).
 
         Raises:
-            RuntimeError: For any other ssh / network failure
-            (connection refused, host key mismatch, host
-            unreachable, …). Callers that want "best effort" can
-            catch and downgrade; the marker-read code in
-            :func:`check_owner` is the prior art for that pattern.
+            RuntimeError: For any other ssh / network failure (connection
+                refused, host key mismatch, host unreachable, …). Callers
+                that want "best effort" can catch and downgrade; the
+                marker-read code in :func:`check_owner` is the prior art
+                for that pattern.
         """
         quoted = shlex.quote(remote_path)
         # Single round-trip: existence check, then prefer sha256sum


### PR DESCRIPTION
## Summary

The Docs workflow has been failing on every main push since PR #152 merged. Root cause: \`RsyncClient.remote_sha256\`'s docstring had a multi-line continuation under \`Raises:\` that wasn't further indented:

\`\`\`
Raises:
    RuntimeError: For any other ssh / network failure
    (connection refused, host key mismatch, host
    unreachable, …). Callers ...
\`\`\`

griffe (under \`mkdocs build --strict\`) treats unindented continuation lines as new exception entries, fails to parse, and \`--strict\` aborts the build:

\`\`\`
WARNING -  griffe: src/srunx/sync/rsync.py:476: Failed to get 'exception: description' pair from '(connection refused, host key mismatch, host'
WARNING -  griffe: src/srunx/sync/rsync.py:477: Failed to get 'exception: description' pair from 'unreachable, …). Callers that want "best effort" can'
WARNING -  griffe: src/srunx/sync/rsync.py:478: Failed to get 'exception: description' pair from 'catch and downgrade; the marker-read code in'
Aborted with 3 warnings in strict mode!
\`\`\`

## Fix

Indent the continuation lines under \`RuntimeError:\` so griffe sees them as part of the same description.

## Verification

\`uv run mkdocs build --strict\` locally now reports \`Documentation built in 1.62 seconds\` with no griffe warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)