### PR TITLE
refactor(lifecycle): extract JobLifecycleSink from slurm/local.py (#161)

### DIFF
--- a/src/srunx/client.py
+++ b/src/srunx/client.py
@@ -1,17 +1,76 @@
 """Backward-compat shim. Canonical home: :mod:`srunx.slurm.local`.
 
-``Slurm`` is preserved as an alias for :class:`LocalClient` during
-the migration (#156). New code should import ``LocalClient`` directly.
+Preserves the legacy ``Slurm(callbacks=[...])`` signature by wiring the
+supplied callbacks + the default DB recorder into a
+:class:`~srunx.runtime.lifecycle.CompositeSink` and passing it to the
+canonical :class:`~srunx.slurm.local.LocalClient`. New code should
+construct a sink chain directly and instantiate ``LocalClient`` with
+``sink=``.
 """
 
-from srunx.slurm.local import (
-    LocalClient,
-    cancel_job,
-    retrieve_job,
-    submit_job,
-)
+from __future__ import annotations
 
-# Backward-compat alias
-Slurm = LocalClient
+from collections.abc import Sequence
+
+from srunx.callbacks import Callback
+from srunx.domain import BaseJob, RunnableJobType
+from srunx.observability import CallbackSink, DBRecorderSink
+from srunx.runtime.lifecycle import CompositeSink, JobLifecycleSink
+from srunx.slurm.local import LocalClient
+
+
+class Slurm(LocalClient):
+    """Legacy wrapper around :class:`LocalClient` honouring ``callbacks=``.
+
+    The legacy constructor accepted a list of :class:`Callback`
+    instances; this subclass translates them into a
+    :class:`~srunx.observability.CallbackSink` chain, appends the
+    default :class:`~srunx.observability.DBRecorderSink`, and forwards
+    the composed sink to the canonical ``LocalClient`` constructor.
+    """
+
+    def __init__(
+        self,
+        default_template: str | None = None,
+        callbacks: Sequence[Callback] | None = None,
+        sink: JobLifecycleSink | None = None,
+    ):
+        if sink is None:
+            # Order matches legacy behaviour: DB row is written first so
+            # callbacks can safely query ``srunx.db`` for their own job
+            # (e.g. a future Slack message that links back to the history
+            # table). Changing this order is a breaking contract change.
+            sinks: list[JobLifecycleSink] = [DBRecorderSink()]
+            sinks.extend(CallbackSink(cb) for cb in (callbacks or []))
+            sink = CompositeSink(sinks)
+        super().__init__(default_template=default_template, sink=sink)
+        # Preserve ``self.callbacks`` for callers that introspect it.
+        self.callbacks = list(callbacks) if callbacks else []
+
+
+def submit_job(
+    job: RunnableJobType,
+    template_path: str | None = None,
+    callbacks: Sequence[Callback] | None = None,
+    verbose: bool = False,
+) -> RunnableJobType:
+    """Submit a job to SLURM (convenience function).
+
+    Routes through :class:`Slurm` so DB recording + legacy callbacks are
+    wired by default, matching pre-#161 behaviour.
+    """
+    client = Slurm(callbacks=callbacks)
+    return client.submit(job, template_path=template_path, verbose=verbose)
+
+
+def retrieve_job(job_id: int) -> BaseJob:
+    """Get job status (convenience function)."""
+    return Slurm().retrieve(job_id)
+
+
+def cancel_job(job_id: int) -> None:
+    """Cancel a job (convenience function)."""
+    Slurm().cancel(job_id)
+
 
 __all__ = ["LocalClient", "Slurm", "cancel_job", "retrieve_job", "submit_job"]

--- a/src/srunx/observability/__init__.py
+++ b/src/srunx/observability/__init__.py
@@ -1,0 +1,13 @@
+"""Observability layer — state persistence, notifications, monitoring.
+
+Exposes concrete :class:`~srunx.runtime.lifecycle.JobLifecycleSink`
+implementations (:class:`DBRecorderSink`, :class:`CallbackSink`) that the
+slurm/ clients consume via the protocol, plus downstream pieces
+(pollers, notifications, storage) that Phase 8 (#164) will relocate
+into this package.
+"""
+
+from srunx.observability.callbacks import CallbackSink
+from srunx.observability.recorder import DBRecorderSink
+
+__all__ = ["CallbackSink", "DBRecorderSink"]

--- a/src/srunx/observability/callbacks.py
+++ b/src/srunx/observability/callbacks.py
@@ -1,0 +1,36 @@
+"""Legacy ``Callback`` → :class:`JobLifecycleSink` adapter.
+
+The legacy ``srunx.callbacks.Callback`` class predates the lifecycle-sink
+abstraction. This adapter lets existing ``Slurm(callbacks=[SlackCallback(),
+...])`` invocations keep working while ``slurm/local.py`` only sees the
+sink Protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from srunx.callbacks import Callback
+from srunx.domain import BaseJob
+from srunx.domain.jobs import JobStatus
+
+
+class CallbackSink:
+    """Routes sink events to the equivalent ``Callback`` hook method."""
+
+    def __init__(self, callback: Callback) -> None:
+        self._cb = callback
+
+    def on_submit(self, job: BaseJob, **_: Any) -> None:
+        self._cb.on_job_submitted(job)
+
+    def on_terminal(self, job: BaseJob) -> None:
+        match job.status:
+            case JobStatus.COMPLETED:
+                self._cb.on_job_completed(job)
+            case JobStatus.FAILED:
+                self._cb.on_job_failed(job)
+            case JobStatus.CANCELLED | JobStatus.TIMEOUT:
+                self._cb.on_job_cancelled(job)
+            case _:
+                pass  # Non-terminal / unknown — nothing to dispatch.

--- a/src/srunx/observability/recorder.py
+++ b/src/srunx/observability/recorder.py
@@ -1,0 +1,51 @@
+"""DB-recorder sink — persists job lifecycle events into the srunx state DB.
+
+Previously this logic was inlined in ``srunx.client.Slurm.submit`` /
+``._record_completion``; extracted here so ``slurm/local.py`` no longer
+imports ``srunx.db`` (#161).
+"""
+
+from typing import Literal
+
+from srunx.domain import BaseJob
+
+
+class DBRecorderSink:
+    """Writes submission and terminal-state rows to ``srunx.db``.
+
+    DB writes are best-effort — exceptions are logged and swallowed
+    inside the underlying ``record_submission_from_job`` /
+    ``record_completion`` helpers, preserving the behaviour the old
+    inlined code had.
+    """
+
+    def on_submit(
+        self,
+        job: BaseJob,
+        *,
+        workflow_name: str | None = None,
+        workflow_run_id: int | None = None,
+        transport_type: Literal["local", "ssh"] = "local",
+        profile_name: str | None = None,
+        scheduler_key: str = "local",
+        record_history: bool = True,
+    ) -> None:
+        if not record_history:
+            return
+        from srunx.db.cli_helpers import record_submission_from_job
+
+        record_submission_from_job(
+            job,
+            workflow_name=workflow_name,
+            workflow_run_id=workflow_run_id,
+            transport_type=transport_type,
+            profile_name=profile_name,
+            scheduler_key=scheduler_key,
+        )
+
+    def on_terminal(self, job: BaseJob) -> None:
+        if job.job_id is None:
+            return
+        from srunx.db.cli_helpers import record_completion
+
+        record_completion(int(job.job_id), job.status)

--- a/src/srunx/runtime/lifecycle.py
+++ b/src/srunx/runtime/lifecycle.py
@@ -1,0 +1,73 @@
+"""Job lifecycle sinks — the interface slurm/ clients emit events through
+without reaching into ``observability/`` directly.
+
+Concrete sinks (``DBRecorderSink``, ``CallbackSink``) live under
+``observability/``. The ``slurm/`` layer only sees this protocol, keeping
+execution transport independent of persistence / notification concerns
+(#156 Phase 5 / #161).
+"""
+
+from typing import Any, Literal, Protocol, runtime_checkable
+
+from srunx.domain import BaseJob
+
+
+@runtime_checkable
+class JobLifecycleSink(Protocol):
+    """Receives job lifecycle events from a SLURM client.
+
+    Two events are emitted today:
+
+    - ``on_submit`` — after a successful ``sbatch`` returns a job id.
+    - ``on_terminal`` — when ``monitor()`` observes a terminal SLURM
+      state (``COMPLETED`` / ``FAILED`` / ``CANCELLED`` / ``TIMEOUT``).
+
+    ``on_transition`` (non-terminal state changes) is deliberately not
+    part of the protocol yet — the local client has no place it would
+    fire from. Added when Phase 8 pollers gain push-based state.
+    """
+
+    def on_submit(
+        self,
+        job: BaseJob,
+        *,
+        workflow_name: str | None = None,
+        workflow_run_id: int | None = None,
+        transport_type: Literal["local", "ssh"] = "local",
+        profile_name: str | None = None,
+        scheduler_key: str = "local",
+        record_history: bool = True,
+    ) -> None: ...
+
+    def on_terminal(self, job: BaseJob) -> None: ...
+
+
+class NoOpSink:
+    """Default sink that records nothing — used when the caller opts out."""
+
+    def on_submit(self, job: BaseJob, **kwargs: Any) -> None:
+        pass
+
+    def on_terminal(self, job: BaseJob) -> None:
+        pass
+
+
+class CompositeSink:
+    """Fan-out to multiple sinks in declared order.
+
+    Exceptions propagate to the caller — this preserves the legacy
+    callback-invocation contract where a buggy ``SlackCallback`` surfaced
+    its traceback instead of silently disappearing. Sinks that want
+    best-effort semantics (the DB recorder) swallow internally.
+    """
+
+    def __init__(self, sinks: list[JobLifecycleSink]) -> None:
+        self._sinks: list[JobLifecycleSink] = list(sinks)
+
+    def on_submit(self, job: BaseJob, **kwargs: Any) -> None:
+        for sink in self._sinks:
+            sink.on_submit(job, **kwargs)
+
+    def on_terminal(self, job: BaseJob) -> None:
+        for sink in self._sinks:
+            sink.on_terminal(job)

--- a/src/srunx/slurm/local.py
+++ b/src/srunx/slurm/local.py
@@ -1,17 +1,17 @@
 """Local SLURM client — in-process ``sbatch`` / ``squeue`` / ``scancel``."""
 
+from __future__ import annotations
+
 import glob
 import os
 import re
 import subprocess
 import tempfile
 import time
-from collections.abc import Sequence
 from importlib.resources import files
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from srunx.callbacks import Callback
 from srunx.logging import get_logger
 from srunx.models import (
     BaseJob,
@@ -23,6 +23,7 @@ from srunx.models import (
     render_job_script,
     render_shell_job_script,
 )
+from srunx.runtime.lifecycle import JobLifecycleSink, NoOpSink
 from srunx.slurm.parsing import GPU_TRES_RE
 from srunx.utils import get_job_status, job_status_msg
 
@@ -39,37 +40,48 @@ class LocalClient:
     def __init__(
         self,
         default_template: str | None = None,
-        callbacks: Sequence[Callback] | None = None,
+        sink: JobLifecycleSink | None = None,
     ):
         """Initialize the local SLURM client.
 
         Args:
             default_template: Path to default job template.
-            callbacks: List of callbacks.
+            sink: Receives submit / terminal lifecycle events. ``None``
+                means no observability side effects are performed — DB
+                recording and callback dispatch live behind concrete
+                sinks in :mod:`srunx.observability`. The backward-compat
+                :class:`~srunx.client.Slurm` shim wires the default
+                ``CallbackSink`` + ``DBRecorderSink`` chain from its
+                own ``callbacks=`` parameter.
         """
         self.default_template = default_template or self._get_default_template()
-        self.callbacks = list(callbacks) if callbacks else []
+        self._sink: JobLifecycleSink = sink if sink is not None else NoOpSink()
 
     def submit(
         self,
         job: RunnableJobType,
         template_path: str | None = None,
-        callbacks: Sequence[Callback] | None = None,
+        sink: JobLifecycleSink | None = None,
         verbose: bool = False,
         record_history: bool = True,
         workflow_name: str | None = None,
         workflow_run_id: int | None = None,
         *,
-        submission_context: "SubmissionRenderContext | None" = None,
+        submission_context: SubmissionRenderContext | None = None,
     ) -> RunnableJobType:
         """Submit a job to SLURM.
 
         Args:
             job: Job configuration.
             template_path: Optional template path (uses default if not provided).
-            callbacks: List of callbacks.
+            sink: Optional per-call lifecycle sink; when given its
+                ``on_submit`` fires *in addition* to the instance sink
+                configured at construction. Use to attach a one-off
+                listener without mutating the client's default chain.
             verbose: Whether to print the rendered content.
-            record_history: Whether to record job in history database.
+            record_history: Whether to record job in history database
+                (passed through to the sink — the default
+                :class:`~srunx.observability.DBRecorderSink` respects it).
             workflow_name: Name of the workflow if part of a workflow.
             workflow_run_id: ``workflow_runs.id`` when the job was
                 submitted from a workflow; persisted on the ``jobs`` row
@@ -159,29 +171,31 @@ class LocalClient:
 
         logger.debug(f"Successfully submitted job '{job.name}' with ID {job_id}")
 
-        # Record in the state DB (best-effort; failures log at debug
-        # and never surface to the caller — see cli_helpers.py).
-        # Local ``LocalClient`` only ever writes the local-transport triple;
-        # SSH submissions take the ``SlurmSSHAdapter.submit`` path which
-        # passes its own (transport_type='ssh', profile_name=...,
-        # scheduler_key='ssh:<profile>') values.
-        if record_history:
-            from srunx.db.cli_helpers import record_submission_from_job
-
-            record_submission_from_job(
+        # Lifecycle events fan out through the instance sink (+ optional
+        # per-call sink). The default :class:`DBRecorderSink` persists the
+        # local-transport triple; SSH submissions take the
+        # ``SlurmSSHAdapter.submit`` path which builds its own sink chain
+        # with ``(transport_type='ssh', profile_name=...,
+        # scheduler_key='ssh:<profile>')``.
+        self._sink.on_submit(
+            job,
+            workflow_name=workflow_name,
+            workflow_run_id=workflow_run_id,
+            transport_type="local",
+            profile_name=None,
+            scheduler_key="local",
+            record_history=record_history,
+        )
+        if sink is not None:
+            sink.on_submit(
                 job,
                 workflow_name=workflow_name,
                 workflow_run_id=workflow_run_id,
                 transport_type="local",
                 profile_name=None,
                 scheduler_key="local",
+                record_history=record_history,
             )
-
-        all_callbacks = self.callbacks[:]
-        if callbacks:
-            all_callbacks.extend(callbacks)
-        for callback in all_callbacks:
-            callback.on_job_submitted(job)
 
         return job
 
@@ -228,7 +242,7 @@ class LocalClient:
         job_id: int,
         stdout_offset: int = 0,
         stderr_offset: int = 0,
-    ) -> "LogChunk":
+    ) -> LogChunk:
         """Return new log content since the given byte offsets.
 
         Reads local log files using ``open`` + ``seek`` instead of a
@@ -419,7 +433,7 @@ class LocalClient:
 
         return jobs
 
-    def queue_by_ids(self, job_ids: list[int]) -> dict[int, "JobSnapshot"]:
+    def queue_by_ids(self, job_ids: list[int]) -> dict[int, JobSnapshot]:
         """Return a mapping of ``job_id`` -> :class:`JobSnapshot` for active jobs.
 
         Active jobs are read from ``squeue``. Jobs that have already left
@@ -525,14 +539,15 @@ class LocalClient:
         self,
         job_obj_or_id: JobType | int,
         poll_interval: int = 5,
-        callbacks: Sequence[Callback] | None = None,
+        sink: JobLifecycleSink | None = None,
     ) -> JobType:
         """Wait for a job to complete.
 
         Args:
             job_obj_or_id: Job object or job ID.
             poll_interval: Polling interval in seconds.
-            callbacks: List of callbacks.
+            sink: Optional per-call sink for a one-off listener in
+                addition to the instance sink.
 
         Returns:
             Completed job object.
@@ -544,10 +559,6 @@ class LocalClient:
             job = self.retrieve(job_obj_or_id)
         else:
             job = job_obj_or_id
-
-        all_callbacks = self.callbacks[:]
-        if callbacks:
-            all_callbacks.extend(callbacks)
 
         msg = f"👀 {'MONITORING':<12} Job {job.name:<12} (ID: {job.job_id})"
         logger.info(msg)
@@ -566,32 +577,21 @@ class LocalClient:
             match job.status:
                 case JobStatus.COMPLETED:
                     logger.info(job_status_msg(job))
-                    self._record_completion(job)
-                    for callback in all_callbacks:
-                        callback.on_job_completed(job)
+                    self._emit_terminal(job, sink)
                     return job
                 case JobStatus.FAILED:
-                    self._record_completion(job)
-                    err_msg = self._build_error_msg(job)
-                    for callback in all_callbacks:
-                        callback.on_job_failed(job)
-                    raise RuntimeError(err_msg)
+                    self._emit_terminal(job, sink)
+                    raise RuntimeError(self._build_error_msg(job))
                 case JobStatus.CANCELLED | JobStatus.TIMEOUT:
-                    self._record_completion(job)
-                    err_msg = self._build_error_msg(job)
-                    for callback in all_callbacks:
-                        callback.on_job_cancelled(job)
-                    raise RuntimeError(err_msg)
+                    self._emit_terminal(job, sink)
+                    raise RuntimeError(self._build_error_msg(job))
             time.sleep(poll_interval)
 
-    @staticmethod
-    def _record_completion(job: BaseJob) -> None:
-        """Record job completion in the state DB."""
-        if job.job_id is None:
-            return
-        from srunx.db.cli_helpers import record_completion
-
-        record_completion(int(job.job_id), job.status)
+    def _emit_terminal(self, job: BaseJob, extra_sink: JobLifecycleSink | None) -> None:
+        """Fire on_terminal on the instance sink (+ optional per-call sink)."""
+        self._sink.on_terminal(job)
+        if extra_sink is not None:
+            extra_sink.on_terminal(job)
 
     @staticmethod
     def _build_error_msg(job: BaseJob) -> str:
@@ -611,13 +611,13 @@ class LocalClient:
         self,
         job: RunnableJobType,
         template_path: str | None = None,
-        callbacks: Sequence[Callback] | None = None,
+        sink: JobLifecycleSink | None = None,
         poll_interval: int = 5,
         verbose: bool = False,
         workflow_name: str | None = None,
         workflow_run_id: int | None = None,
         *,
-        submission_context: "SubmissionRenderContext | None" = None,
+        submission_context: SubmissionRenderContext | None = None,
     ) -> RunnableJobType:
         """Submit a job and wait for completion.
 
@@ -632,13 +632,13 @@ class LocalClient:
         submitted_job = self.submit(
             job,
             template_path=template_path,
-            callbacks=callbacks,
+            sink=sink,
             verbose=verbose,
             workflow_name=workflow_name,
             workflow_run_id=workflow_run_id,
         )
         monitored_job = self.monitor(
-            submitted_job, poll_interval=poll_interval, callbacks=callbacks
+            submitted_job, poll_interval=poll_interval, sink=sink
         )
 
         # Ensure the return type matches the expected type
@@ -926,44 +926,3 @@ class LocalClient:
     def _get_default_template(self) -> str:
         """Get the default job template path."""
         return str(files("srunx.runtime").joinpath("_jinja", "base.slurm.jinja"))
-
-
-# Convenience functions for backward compatibility
-def submit_job(
-    job: RunnableJobType,
-    template_path: str | None = None,
-    callbacks: Sequence[Callback] | None = None,
-    verbose: bool = False,
-) -> RunnableJobType:
-    """Submit a job to SLURM (convenience function).
-
-    Args:
-        job: Job configuration.
-        template_path: Optional template path (uses default if not provided).
-        callbacks: List of callbacks.
-        verbose: Whether to print the rendered content.
-    """
-    client = LocalClient()
-    return client.submit(
-        job, template_path=template_path, callbacks=callbacks, verbose=verbose
-    )
-
-
-def retrieve_job(job_id: int) -> BaseJob:
-    """Get job status (convenience function).
-
-    Args:
-        job_id: SLURM job ID.
-    """
-    client = LocalClient()
-    return client.retrieve(job_id)
-
-
-def cancel_job(job_id: int) -> None:
-    """Cancel a job (convenience function).
-
-    Args:
-        job_id: SLURM job ID.
-    """
-    client = LocalClient()
-    client.cancel(job_id)

--- a/tests/architecture/test_import_layers.py
+++ b/tests/architecture/test_import_layers.py
@@ -3,7 +3,7 @@
 Scans every ``src/srunx/**/*.py`` file statically and asserts that cross-layer
 imports respect the target 6-layer architecture:
 
-    interfaces -> runtime / slurm / observability / integrations -> domain -> support
+    interfaces -> runtime / slurm / observability / integrations -> domain -> common
 
 Files have not moved yet (Phases 2-8 do that). Each top-level module is mapped
 to the layer it will belong to post-migration via ``MODULE_LAYERS``. Imports
@@ -27,11 +27,11 @@ SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "srunx"
 # Map each top-level package/module under ``srunx/`` to its TARGET layer.
 # Source files move in later phases; the layer name is stable.
 MODULE_LAYERS: dict[str, str] = {
-    # support
-    "_version": "support",
-    "config": "support",
-    "exceptions": "support",
-    "logging": "support",
+    # common (Phase 8 / #164 will move these under src/srunx/common/)
+    "_version": "common",
+    "config": "common",
+    "exceptions": "common",
+    "logging": "common",
     # domain (Phase 3 / #159 splits models.py into domain/)
     "domain": "domain",
     "models": "domain",
@@ -48,7 +48,8 @@ MODULE_LAYERS: dict[str, str] = {
     "slurm": "slurm",
     "transport": "slurm",
     "utils": "slurm",
-    # observability (Phase 8 / #164)
+    # observability (Phase 5 / #161 + Phase 8 / #164)
+    "observability": "observability",
     "callbacks": "observability",
     "db": "observability",
     "formatters": "observability",
@@ -67,14 +68,14 @@ MODULE_LAYERS: dict[str, str] = {
 
 # Allowed cross-layer edges per target architecture (#156).
 ALLOWED: dict[str, set[str]] = {
-    "support": {"domain"},
-    "domain": {"support"},
-    "integrations": {"support", "domain"},
-    "runtime": {"support", "domain", "integrations", "slurm"},
-    "slurm": {"support", "domain", "integrations", "runtime"},
-    "observability": {"support", "domain", "integrations", "slurm"},
+    "common": {"domain"},
+    "domain": {"common"},
+    "integrations": {"common", "domain"},
+    "runtime": {"common", "domain", "integrations", "slurm"},
+    "slurm": {"common", "domain", "integrations", "runtime"},
+    "observability": {"common", "domain", "integrations", "slurm"},
     "interfaces": {
-        "support",
+        "common",
         "domain",
         "integrations",
         "slurm",
@@ -94,15 +95,17 @@ KNOWN_VIOLATIONS: dict[tuple[str, str], str] = {
         "Phase 5 (#161) / Phase 8 (#164): callbacks absorbed into observability; "
         "CLI-side notification helper inverted so interfaces -> observability."
     ),
-    # slurm -> observability (local client writes DB rows and invokes callbacks).
-    (
-        "slurm",
-        "callbacks",
-    ): "Phase 5 (#161): extract JobLifecycleSink from slurm/local.py.",
-    (
-        "slurm",
-        "db",
-    ): "Phase 5 (#161): route slurm/local.py DB writes through observability.recorder sink.",
+    # slurm -> observability (legacy ``Slurm`` shim wires the default sink chain).
+    ("client", "callbacks"): (
+        "Shim-only: ``srunx.client.Slurm`` imports ``Callback`` for its legacy "
+        "``callbacks=`` type hint. Removed when the shim is deleted."
+    ),
+    ("client", "observability"): (
+        "Shim-only: ``srunx.client.Slurm`` composes ``CallbackSink`` + "
+        "``DBRecorderSink`` into the default sink chain so legacy "
+        "``Slurm(callbacks=[...])`` keeps working. Removed when the shim "
+        "is deleted."
+    ),
     # domain -> runtime (models.py is a backward-compat shim re-exporting renderers).
     ("models", "runtime"): (
         "Shim re-exports from :mod:`srunx.runtime.rendering`. Remove when "


### PR DESCRIPTION
## Summary
Phase 5 of #156. Extracts DB writes + callback dispatch from `slurm/local.py` into a new `JobLifecycleSink` Protocol. The slurm transport layer no longer imports from observability.

**New**
- `runtime/lifecycle.py` — `JobLifecycleSink` (Protocol), `NoOpSink`, `CompositeSink`
- `observability/` — package with `CallbackSink` (legacy `Callback` adapter) + `DBRecorderSink`

**Behavioural guarantees preserved**
- DB row written BEFORE callbacks fire (legacy order)
- Callback exceptions propagate (legacy contract)
- DB writes remain best-effort (swallowed inside the helpers)
- `Slurm(callbacks=[...])` unchanged from caller perspective
- Convenience functions (`submit_job` / `retrieve_job` / `cancel_job`) still route through `Slurm()` so observability wires by default

**Architecture guard**
- `support` layer label renamed to `common` (user preference)
- `observability` added as first-class layer
- Stale whitelist entries removed, shim-only entries added

## Test plan
- [x] `uv run pytest tests/architecture/` — 2 passed, 0.62s
- [x] `uv run pytest --ignore=tests/test_mcp_server.py --ignore=tests/test_mcp_sweep.py` — 1903 passed, 2 skipped
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [x] Code review: 4 findings addressed (order inversion, exception swallowing, dead code, forward-ref quoting)

Closes #161. Part of #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)