### PR TITLE
chore(exceptions): rename JobNotFound call sites (closes #169)

### DIFF
--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -21,7 +21,7 @@ from srunx.config import (
     get_config,
     get_config_paths,
 )
-from srunx.exceptions import JobNotFound, TransportError
+from srunx.exceptions import JobNotFoundError, TransportError
 from srunx.logging import (
     configure_cli_logging,
     get_logger,
@@ -1298,7 +1298,7 @@ def scancel(
         console = Console()
         console.print(f"✅ Job {job_id} cancelled successfully")
 
-    except JobNotFound:
+    except JobNotFoundError:
         typer.secho(
             f"Job {job_id} not found",
             err=True,
@@ -1485,7 +1485,7 @@ def tail(
                         fg=typer.colors.YELLOW,
                     )
 
-    except JobNotFound:
+    except JobNotFoundError:
         typer.secho(
             f"Job {job_id} not found",
             err=True,

--- a/src/srunx/common/exceptions.py
+++ b/src/srunx/common/exceptions.py
@@ -55,8 +55,25 @@ class JobNotFoundError(Exception):
     """
 
 
-# Backward-compat alias (pre-#169 name).
-JobNotFound = JobNotFoundError
+def __getattr__(name: str) -> type:
+    """Surface a DeprecationWarning when the legacy ``JobNotFound`` alias is accessed.
+
+    Pre-#169, the class was ``JobNotFound``; the rename kept a plain
+    module-level binding as an alias, but that silently accepted the old
+    name forever. Route it through ``__getattr__`` so importing
+    ``JobNotFound`` now warns while still resolving to
+    :class:`JobNotFoundError`.
+    """
+    if name == "JobNotFound":
+        import warnings
+
+        warnings.warn(
+            "srunx.exceptions.JobNotFound is deprecated; use JobNotFoundError instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return JobNotFoundError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class SubmissionError(Exception):

--- a/src/srunx/exceptions.py
+++ b/src/srunx/exceptions.py
@@ -3,7 +3,7 @@
 Aliases the canonical module via ``sys.modules`` so attribute access
 and ``isinstance`` checks route through one module object. The star
 import below exists only so that static type-checkers see names like
-``srunx.exceptions.JobNotFound`` resolve statically.
+``srunx.exceptions.JobNotFoundError`` resolve statically.
 """
 
 from __future__ import annotations

--- a/src/srunx/slurm/ssh.py
+++ b/src/srunx/slurm/ssh.py
@@ -1033,7 +1033,7 @@ class SlurmSSHAdapter:
     def cancel(self, job_id: int) -> None:
         """Cancel *job_id* on the remote cluster.
 
-        Raises :class:`~srunx.exceptions.JobNotFound` when ``scancel``
+        Raises :class:`~srunx.exceptions.JobNotFoundError` when ``scancel``
         reports the job is missing, :class:`TransportError` subclasses
         for SSH-layer failures. The legacy :meth:`cancel_job` API is
         preserved below as a no-op alias for backwards compat.
@@ -1042,7 +1042,7 @@ class SlurmSSHAdapter:
         import paramiko
 
         from srunx.exceptions import (
-            JobNotFound,
+            JobNotFoundError,
             RemoteCommandError,
             TransportAuthError,
             TransportConnectionError,
@@ -1060,11 +1060,13 @@ class SlurmSSHAdapter:
         except RuntimeError as exc:
             # ``_run_slurm_cmd`` wraps non-zero-exit stderr into RuntimeError.
             # SLURM's scancel emits "Invalid job id specified" for unknown
-            # ids; surface that as JobNotFound so callers can handle it as
+            # ids; surface that as JobNotFoundError so callers can handle it as
             # a user-level condition rather than a transport failure.
             msg = str(exc).lower()
             if "invalid job id" in msg or "invalid job specification" in msg:
-                raise JobNotFound(f"Job {job_id} not found on remote cluster") from exc
+                raise JobNotFoundError(
+                    f"Job {job_id} not found on remote cluster"
+                ) from exc
             raise RemoteCommandError(str(exc)) from exc
 
     def status(self, job_id: int) -> BaseJob:
@@ -1073,7 +1075,7 @@ class SlurmSSHAdapter:
         Uses :meth:`queue_by_ids` (already Protocol-compliant) so both
         active and terminal jobs resolve through the same code path as
         the notification poller. Raises
-        :class:`~srunx.exceptions.JobNotFound` when SLURM has no record
+        :class:`~srunx.exceptions.JobNotFoundError` when SLURM has no record
         of ``job_id``.
 
         The returned :class:`BaseJob` is a static snapshot — per the
@@ -1086,13 +1088,13 @@ class SlurmSSHAdapter:
         """
         import time as _time
 
-        from srunx.exceptions import JobNotFound
+        from srunx.exceptions import JobNotFoundError
         from srunx.models import BaseJob, JobStatus
 
         info_map = self.queue_by_ids([int(job_id)])
         info = info_map.get(int(job_id))
         if info is None:
-            raise JobNotFound(f"Job {job_id} not found on remote cluster")
+            raise JobNotFoundError(f"Job {job_id} not found on remote cluster")
 
         try:
             status_enum = JobStatus(info.status)

--- a/tests/test_transport_protocols.py
+++ b/tests/test_transport_protocols.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from srunx.client_protocol import JobOperationsProtocol, LogChunk
 from srunx.exceptions import (
-    JobNotFound,
+    JobNotFoundError,
     RemoteCommandError,
     SubmissionError,
     TransportAuthError,
@@ -51,7 +51,7 @@ class TestExceptionHierarchy:
         assert issubclass(RemoteCommandError, TransportError)
 
     def test_job_not_found_independent(self) -> None:
-        assert not issubclass(JobNotFound, TransportError)
+        assert not issubclass(JobNotFoundError, TransportError)
 
     def test_submission_error_independent(self) -> None:
         assert not issubclass(SubmissionError, TransportError)

--- a/tests/test_transport_protocols_phase2.py
+++ b/tests/test_transport_protocols_phase2.py
@@ -31,11 +31,11 @@ class TestSlurmProtocolCompliance:
 
     def test_status_wraps_unknown_id_into_job_not_found(self) -> None:
         """``retrieve`` raises ValueError on missing jobs; status converts it."""
-        from srunx.exceptions import JobNotFound
+        from srunx.exceptions import JobNotFoundError
 
         s = Slurm()
         with patch.object(s, "retrieve", side_effect=ValueError("no such job")):
-            with pytest.raises(JobNotFound):
+            with pytest.raises(JobNotFoundError):
                 s.status(99999)
 
 
@@ -122,13 +122,13 @@ class TestSlurmSSHAdapterProtocolCompliance:
         assert result._status == JobStatus.RUNNING
 
     def test_ssh_adapter_status_raises_job_not_found(self) -> None:
-        """Missing job → JobNotFound, matching the Protocol contract."""
-        from srunx.exceptions import JobNotFound
+        """Missing job → JobNotFoundError, matching the Protocol contract."""
+        from srunx.exceptions import JobNotFoundError
         from srunx.slurm.ssh import SlurmSSHAdapter
 
         with patch.object(SlurmSSHAdapter, "queue_by_ids", return_value={}):
             adapter = SlurmSSHAdapter.__new__(SlurmSSHAdapter)
-            with pytest.raises(JobNotFound):
+            with pytest.raises(JobNotFoundError):
                 adapter.status(99999)
 
     def test_ssh_adapter_queue_returns_list_base_job(self) -> None:


### PR DESCRIPTION
## Summary

Finishes the partial rename from Phase 4 (#173). `JobNotFoundError` already existed, but 10 call sites were still using the pre-rename `JobNotFound` via a plain alias. Completes #169's acceptance criterion: `grep -r "JobNotFound\b" src/` now returns only the alias itself.

### Call-site updates
- `src/srunx/slurm/ssh.py`: 2 `raise` sites + docstrings + import
- `src/srunx/cli/main.py`: 2 `except` sites + import
- `tests/test_transport_protocols.py` + `_phase2.py`: 6 refs

### Alias upgrade
`srunx.common.exceptions.JobNotFound` was a plain module-level binding, silently accepting the old name forever. Replaced with `__getattr__` that emits `DeprecationWarning` on access — existing code keeps working, new code gets a nudge.

### Tests
- [x] `uv run pytest` — 1978/1981 pass (3 pre-existing env failures on `~/.config/srunx/config.json` overriding defaults)
- [x] `uv run pytest tests/test_transport_protocols.py tests/test_transport_protocols_phase2.py` — 20 pass
- [x] `uv run mypy .` — success (289 files)
- [x] `uv run ruff check .` — clean
- [x] `from srunx.exceptions import JobNotFound` emits `DeprecationWarning`

Closes #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)