### PR TITLE
refactor(web): slim workflows.py via service extraction (#167)

### DIFF
--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -13,7 +13,6 @@ import contextlib
 import functools
 import re
 import sqlite3
-import tempfile
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -61,6 +60,7 @@ from ..schemas.workflows import (
 )
 from ..services import _submission_common
 from ..services.workflow_storage import WorkflowStorageService
+from ..services.workflow_validation import WorkflowValidationService
 
 # Re-exports for backward compatibility — external callers and tests that
 # ``from srunx.web.routers.workflows import WorkflowJobInput`` (etc.) keep
@@ -312,28 +312,7 @@ async def cancel_run(
 
 @router.post("/validate")
 async def validate_workflow(body: dict[str, str]) -> dict[str, Any]:
-    yaml_content = body.get("yaml", "")
-    if not yaml_content:
-        return {"valid": False, "errors": ["Empty YAML content"]}
-
-    _reject_python_prefix_in_yaml_args(yaml_content)
-
-    with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
-        f.write(yaml_content)
-        tmp_path = f.name
-
-    try:
-        runner = await anyio.to_thread.run_sync(
-            lambda: WorkflowRunner.from_yaml(tmp_path)
-        )
-        await anyio.to_thread.run_sync(runner.workflow.validate)
-        return {"valid": True}
-    except WorkflowValidationError as e:
-        return {"valid": False, "errors": [str(e)]}
-    except Exception as e:
-        return {"valid": False, "errors": [str(e)]}
-    finally:
-        Path(tmp_path).unlink(missing_ok=True)
+    return await WorkflowValidationService().validate_yaml(body.get("yaml", ""))
 
 
 @router.post("/upload")

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -9,45 +9,21 @@ aggregates child job statuses into the workflow run via an internal
 
 from __future__ import annotations
 
-import contextlib
-import functools
 import re
 import sqlite3
-from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
 
-import anyio
-import yaml
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from srunx.db.connection import transaction
-from srunx.db.repositories.base import now_iso
-from srunx.db.repositories.job_state_transitions import (
-    JobStateTransitionRepository,
-)
-from srunx.db.repositories.jobs import JobRepository
-from srunx.db.repositories.watches import WatchRepository
-from srunx.db.repositories.workflow_run_jobs import WorkflowRunJobRepository
-from srunx.db.repositories.workflow_runs import WorkflowRunRepository
-from srunx.exceptions import SweepExecutionError, WorkflowValidationError
 from srunx.logging import get_logger
-from srunx.models import (
-    Job,
-    ShellJob,
-    Workflow,
-)
-from srunx.rendering import (
-    RenderedWorkflow,
-    SubmissionRenderContext,
-    render_workflow_for_submission,
-)
 from srunx.runner import WorkflowRunner
 from srunx.slurm.ssh import SlurmSSHAdapter
-from srunx.slurm.ssh_executor import SlurmSSHExecutorPool
+from srunx.slurm.ssh_executor import (
+    SlurmSSHExecutorPool as SlurmSSHExecutorPool,  # re-export for test patches
+)
 from srunx.sweep import SweepSpec
 from srunx.sweep.orchestrator import SweepOrchestrator
-from srunx.sweep.state_service import WorkflowRunStateService
 
 from ..deps import get_adapter, get_db_conn
 from ..schemas.workflows import (
@@ -57,6 +33,7 @@ from ..schemas.workflows import (
     WorkflowRunRequest,
 )
 from ..services import _submission_common
+from ..services.sweep_submission import SweepSubmissionService
 from ..services.workflow_run_cancellation import WorkflowRunCancellationService
 from ..services.workflow_run_query import (
     WorkflowRunQueryService,
@@ -71,16 +48,27 @@ from ..services.workflow_run_query import (
     serialize_run as _serialize_run,  # noqa: F401 — preserved for import parity
 )
 from ..services.workflow_storage import WorkflowStorageService
+from ..services.workflow_submission import WorkflowSubmissionService
 from ..services.workflow_validation import WorkflowValidationService
 
 # Re-exports for backward compatibility — external callers and tests that
 # ``from srunx.web.routers.workflows import WorkflowJobInput`` (etc.) keep
 # working. The canonical home is now ``srunx.web.schemas.workflows``.
+#
+# ``WorkflowRunner`` / ``SweepSpec`` / ``SweepOrchestrator`` /
+# ``SlurmSSHExecutorPool`` are listed so
+# ``unittest.mock.patch('srunx.web.routers.workflows.<name>')`` test
+# targets keep a live attribute to replace — services receive these
+# classes via constructor args so the patches flow through.
 __all__ = [
+    "SlurmSSHExecutorPool",
+    "SweepOrchestrator",
+    "SweepSpec",
     "SweepSpecRequest",
     "WorkflowCreateRequest",
     "WorkflowJobInput",
     "WorkflowRunRequest",
+    "WorkflowRunner",
     "router",
 ]
 
@@ -204,587 +192,10 @@ async def create_workflow(body: WorkflowCreateRequest) -> dict[str, Any]:
 _WORKFLOW_RUN_PRESETS = ("terminal", "running_and_terminal", "all")
 
 
-def _filter_workflow_jobs(
-    workflow: Workflow,
-    from_job: str | None,
-    to_job: str | None,
-    single_job: str | None,
-) -> list[Job | ShellJob]:
-    """Filter workflow jobs based on execution control parameters."""
-    all_jobs = {job.name: job for job in workflow.jobs}
-
-    if single_job:
-        if single_job not in all_jobs:
-            raise HTTPException(422, f"Job '{single_job}' not found in workflow")
-        job = all_jobs[single_job]
-        # Create a copy-like job with no dependencies for standalone execution
-        return [job]
-
-    names = [job.name for job in workflow.jobs]
-
-    start_idx = 0
-    end_idx = len(names)
-
-    if from_job:
-        if from_job not in all_jobs:
-            raise HTTPException(422, f"Job '{from_job}' not found in workflow")
-        start_idx = names.index(from_job)
-
-    if to_job:
-        if to_job not in all_jobs:
-            raise HTTPException(422, f"Job '{to_job}' not found in workflow")
-        end_idx = names.index(to_job) + 1
-
-    if from_job and to_job and start_idx >= end_idx:
-        raise HTTPException(
-            422,
-            f"from_job '{from_job}' must appear before to_job '{to_job}' in the workflow",
-        )
-
-    selected_names = set(names[start_idx:end_idx])
-    return [job for job in workflow.jobs if job.name in selected_names]
-
-
-@contextlib.asynccontextmanager
-async def _hold_workflow_mounts_web(
-    workflow: Workflow,
-    runner: WorkflowRunner,
-    *,
-    sync_required: bool = True,
-) -> AsyncIterator[Any]:
-    """Hold the per-mount sync lock across the whole workflow submission.
-
-    Workflow Phase 2 (#135) — web parity with the CLI's
-    :func:`srunx.cli.workflow._hold_workflow_mounts`. Each unique
-    mount touched by the workflow's :class:`ShellJob` ``script_path``
-    values is rsynced **once** under
-    :func:`~srunx.sync.service.mount_sync_session`, and the
-    per-(profile, mount) lock is held for the entire ``async with``
-    block so a concurrent ``srunx flow run`` / ``/api/workflows/run``
-    can't rsync different bytes between our sync and our submission.
-
-    Sort order matches the profile's ``mounts`` list so two web
-    requests touching overlapping mount sets always acquire locks
-    in the same global order — eliminates lock-inversion deadlock,
-    same fix as Codex follow-up #2 on PR #141.
-
-    Yields the resolved :class:`ServerProfile` so the caller can use
-    it for path translation / submission-context construction. Yields
-    ``None`` when no SSH profile is configured (legacy local path).
-
-    Lock acquisition + rsync errors surface as
-    :class:`HTTPException(502)`. Exceptions raised from the body
-    (sbatch failures, render errors) propagate **unchanged** so the
-    caller can route them through the existing per-phase ``_fail``
-    bookkeeping. Mirrors the CLI exception-scoping rationale (Codex
-    blocker #1 on PR #141).
-
-    ``sync_required=False`` skips the rsync but still acquires the
-    lock — preserves the race-free submission invariant for callers
-    that opted out of the transfer.
-    """
-    from srunx.config import get_config
-    from srunx.runtime.submission_plan import collect_touched_mounts
-    from srunx.ssh.core.config import ConfigManager
-    from srunx.sync.lock import SyncLockTimeoutError
-    from srunx.sync.service import SyncAbortedError, mount_sync_session
-
-    from ..config import get_web_config
-    from ..sync_utils import get_current_profile
-
-    def _resolve_profile_with_name() -> tuple[Any, str | None]:
-        # Mirrors ``sync_utils.get_current_profile`` but returns the
-        # name too — :func:`acquire_sync_lock` keys the lock file on
-        # ``(profile_name, mount_name)`` so we need both halves.
-        web_cfg = get_web_config()
-        cm = ConfigManager()
-        name = web_cfg.ssh_profile or cm.get_current_profile_name()
-        if not name:
-            return None, None
-        return cm.get_profile(name), name
-
-    profile, profile_name = await anyio.to_thread.run_sync(_resolve_profile_with_name)
-    if profile is None:
-        # Fall back to the patched-in ``get_current_profile`` so tests
-        # that mock the helper directly (without seeding the
-        # ``ConfigManager`` registry) still see a profile here.
-        profile = await anyio.to_thread.run_sync(get_current_profile)
-        if profile is None:
-            yield None
-            return
-        profile_name = profile_name or runner.default_project or ""
-
-    mounts = collect_touched_mounts(workflow, profile)
-    if not mounts:
-        yield profile
-        return
-
-    mount_order = {m.name: i for i, m in enumerate(profile.mounts)}
-    mounts.sort(key=lambda m: mount_order.get(m.name, len(mount_order)))
-
-    config = get_config()
-    # Lock-file key — falls back to the workflow's default_project so
-    # we never hand an empty string to acquire_sync_lock.
-    effective_profile_name = profile_name or runner.default_project or "default"
-
-    def _enter_all_mounts() -> contextlib.ExitStack:
-        # ExitStack lifetime spans the ``async with`` body; constructed
-        # off-thread because mount_sync_session is a synchronous CM
-        # (file lock + subprocess rsync). The stack is closed back in
-        # ``_close_stack`` after the body exits.
-        stack = contextlib.ExitStack()
-        try:
-            for mount in mounts:
-                outcome = stack.enter_context(
-                    mount_sync_session(
-                        profile_name=effective_profile_name,
-                        profile=profile,
-                        mount=mount,
-                        config=config.sync,
-                        sync_required=sync_required,
-                    )
-                )
-                if outcome.performed:
-                    logger.info("Synced mount '%s'", mount.name)
-        except BaseException:
-            stack.close()
-            raise
-        return stack
-
-    try:
-        stack = await anyio.to_thread.run_sync(_enter_all_mounts)
-    except SyncAbortedError as exc:
-        raise HTTPException(
-            status_code=502, detail=f"Mount sync failed: {exc}"
-        ) from exc
-    except SyncLockTimeoutError as exc:
-        raise HTTPException(
-            status_code=502, detail=f"Mount sync failed: {exc}"
-        ) from exc
-    except RuntimeError as exc:
-        raise HTTPException(
-            status_code=502, detail=f"Mount sync failed: {exc}"
-        ) from exc
-
-    try:
-        # Body exceptions MUST propagate as-is (sbatch failures vs sync
-        # failures must stay distinguishable to the caller's per-phase
-        # _fail bookkeeping). Codex blocker #1 on PR #141.
-        yield profile
-    finally:
-        await anyio.to_thread.run_sync(stack.close)
-
-
-def _build_submission_context(
-    mount_name: str | None,
-    profile: Any,
-) -> SubmissionRenderContext:
-    """Construct a :class:`SubmissionRenderContext` from the Web profile + mount.
-
-    - ``mount_name`` is the selected ``?mount=<name>`` query parameter.
-      When ``None``, no mount translation is performed.
-    - ``profile`` is the configured :class:`ServerProfile` (or ``None``
-      when no SSH profile is set up). Its ``mounts`` list is frozen into
-      a tuple so the context stays hashable / immutable.
-    - ``default_work_dir`` is the selected mount's remote path (so jobs
-      whose ``work_dir`` is empty inherit the mount root).
-    """
-    mounts: tuple[Any, ...] = tuple(profile.mounts) if profile is not None else ()
-    default_work_dir: str | None = None
-    if mount_name is not None and profile is not None:
-        for m in profile.mounts:
-            if m.name == mount_name:
-                default_work_dir = m.remote
-                break
-    return SubmissionRenderContext(
-        mount_name=mount_name,
-        mounts=mounts,
-        default_work_dir=default_work_dir,
-    )
-
-
-def _render_workflow(
-    yaml_path: Path,
-    *,
-    submission_context: SubmissionRenderContext,
-    args_override: dict[str, Any] | None = None,
-    single_job: str | None = None,
-) -> RenderedWorkflow:
-    """Thin wrapper around :func:`render_workflow_for_submission`.
-
-    The previous ``_prepare_render_context`` / ``_render_scripts`` pair
-    re-implemented a mount-aware render local to the Web router; this
-    delegates to the canonical helper so Web non-sweep, Web sweep, and
-    MCP all share identical semantics.
-    """
-    return render_workflow_for_submission(
-        yaml_path,
-        args_override=args_override,
-        context=submission_context,
-        single_job=single_job,
-    )
-
-
-def _enforce_shell_script_roots(
-    workflow: Workflow,
-    mount: str,
-    profile: Any,
-) -> None:
-    """Guard that every :class:`ShellJob`'s script_path stays under allowed roots.
-
-    The canonical render helper reads :class:`ShellJob` scripts verbatim
-    (``render_shell_job_script`` uses ``script_path`` as the template); we
-    still need the directory-traversal check that the old ``_render_scripts``
-    performed before the file was opened. Called before render so bogus
-    paths surface as 403 with no partial render side effects.
-    """
-    from srunx.security import find_shell_script_violation
-
-    allowed_roots = [_workflow_dir(mount).resolve()]
-    if profile:
-        allowed_roots.extend(Path(m.local).resolve() for m in profile.mounts)
-    violation = find_shell_script_violation(workflow, allowed_roots)
-    if violation is not None:
-        raise HTTPException(
-            403,
-            f"Script path '{violation.script_path}' is outside allowed directories",
-        )
-
-
-def _resolve_in_place_target(
-    job: Job | ShellJob,
-    rendered_text: str,
-    profile: Any,
-) -> tuple[str, str] | None:
-    """Decide whether *job* qualifies for the in-place sbatch path.
-
-    Workflow Phase 2 (#135): only :class:`ShellJob` instances whose
-    ``script_path`` resolves under one of the SSH profile's mount
-    ``local`` roots, and whose Jinja-rendered bytes still equal the
-    on-disk source bytes, can run the user's file verbatim on the
-    cluster. Anything else (``Job`` with ``command``, ShellJob outside
-    every mount, or rendered output that diverged from source) must
-    fall back to the legacy temp-upload path so the rendered artifact
-    actually reaches the cluster.
-
-    Returns ``(remote_path, submit_cwd)`` when the in-place path is
-    safe, otherwise ``None``. ``submit_cwd`` is the script's parent
-    directory on the remote so relative paths inside the user's
-    ``#SBATCH`` directives resolve as they would on a head-node
-    ``sbatch ./script.sh``. Same ``parent_remote or remote_script``
-    fallback the single-job /api/jobs path uses.
-
-    Path security: the workflow's ``_enforce_shell_script_roots``
-    guard already rejected scripts outside every allowed root before
-    render, so reaching here means the path is safe to translate.
-    The mount lookup is a longest-prefix match via
-    :func:`resolve_mount_for_path` so nested mounts pick the deepest
-    owner.
-    """
-    from srunx.runtime.submission_plan import (
-        render_text_matches_source,
-        resolve_mount_for_path,
-        translate_local_to_remote,
-    )
-
-    if profile is None or not isinstance(job, ShellJob):
-        return None
-
-    script_attr = getattr(job, "script_path", None)
-    if not script_attr:
-        return None
-
-    try:
-        source_path = Path(script_attr)
-    except (TypeError, ValueError):
-        return None
-
-    mount = resolve_mount_for_path(source_path, profile)
-    if mount is None:
-        return None
-
-    if not render_text_matches_source(rendered_text, source_path):
-        return None
-
-    remote_path = translate_local_to_remote(source_path, mount)
-    parent_remote, _, _ = remote_path.rpartition("/")
-    submit_cwd = parent_remote or remote_path
-    return remote_path, submit_cwd
-
-
-async def _submit_jobs_bfs(
-    workflow: Workflow,
-    scripts: dict[str, str],
-    run_opts: WorkflowRunRequest,
-    adapter: SlurmSSHAdapter,
-    *,
-    conn: sqlite3.Connection,
-    run_id: int,
-    profile: Any = None,
-    unrendered_jobs_by_name: dict[str, Job | ShellJob] | None = None,
-) -> dict[str, str]:
-    """Submit jobs in topological order via BFS, returning {name: slurm_id}.
-
-    Each successful submit is persisted atomically:
-
-    1. ``jobs`` row via :meth:`JobRepository.record_submission` (with
-       ``submission_source='workflow'`` + ``workflow_run_id``).
-    2. Seed ``job_state_transitions`` with ``PENDING`` so the active
-       watch poller's first observation produces a real transition.
-    3. Link to the workflow via :meth:`WorkflowRunJobRepository.create`.
-
-    On sbatch failure we record a membership row with ``job_id=None`` so
-    the response can still reflect the attempted job set, then raise.
-
-    Per-job dispatch (workflow Phase 2 / #135 web parity): when
-    *profile* is supplied AND a job is a :class:`ShellJob` whose
-    rendered bytes match the on-disk source AND that source lives
-    under one of the profile's mounts, sbatch runs against the
-    already-on-remote path via :meth:`SlurmSSHAdapter.submit_remote_sbatch`
-    (no tmp upload, the user's own ``#SBATCH`` directives win).
-    Everything else stays on the legacy temp-upload path —
-    :meth:`SlurmSSHAdapter.submit_job` ships the rendered bytes to
-    ``$SRUNX_TEMP_DIR`` so the cluster runs what srunx generated.
-    """
-    from collections import deque
-
-    job_repo = JobRepository(conn)
-    wrj_repo = WorkflowRunJobRepository(conn)
-    transition_repo = JobStateTransitionRepository(conn)
-
-    filtered_names = {job.name for job in workflow.jobs}
-    job_map: dict[str, Job | ShellJob] = {job.name: job for job in workflow.jobs}
-    dependents: dict[str, list[str]] = {job.name: [] for job in workflow.jobs}
-    in_degree: dict[str, int] = {
-        job.name: len(
-            [d for d in job.parsed_dependencies if d.job_name in filtered_names]
-        )
-        for job in workflow.jobs
-    }
-
-    for job in workflow.jobs:
-        for dep in job.parsed_dependencies:
-            if dep.job_name in filtered_names:
-                dependents[dep.job_name].append(job.name)
-
-    queue: deque[str] = deque(
-        job.name for job in workflow.jobs if in_degree[job.name] == 0
-    )
-    submitted: dict[str, str] = {}
-
-    while queue:
-        current_name = queue.popleft()
-        current_job = job_map[current_name]
-
-        dep_parts: list[str] = []
-        if not run_opts.single_job:
-            for dep in current_job.parsed_dependencies:
-                if dep.job_name in submitted:
-                    parent_id = submitted[dep.job_name]
-                    dep_parts.append(f"{dep.dep_type}:{parent_id}")
-        dependency = ",".join(dep_parts) if dep_parts else None
-
-        depends_on = [
-            d.job_name
-            for d in current_job.parsed_dependencies
-            if d.job_name in filtered_names
-        ]
-
-        # The rendered ``current_job`` may have its ``script_path`` already
-        # translated to remote form by ``_normalize_paths_for_mount``, which
-        # makes the in-place mount lookup miss. Use the unrendered job (with
-        # its original local path) when the caller threaded one through.
-        # See #150 root cause.
-        in_place_job = (
-            unrendered_jobs_by_name.get(current_name, current_job)
-            if unrendered_jobs_by_name is not None
-            else current_job
-        )
-        in_place = _resolve_in_place_target(
-            in_place_job, scripts[current_name], profile
-        )
-
-        try:
-            if in_place is not None:
-                remote_path, submit_cwd = in_place
-
-                def _in_place_submit(
-                    rp: str = remote_path,
-                    cwd: str = submit_cwd,
-                    n: str = current_name,
-                    d: str | None = dependency,
-                ) -> int:
-                    submitted_obj = adapter.submit_remote_sbatch(
-                        rp,
-                        submit_cwd=cwd,
-                        job_name=n,
-                        dependency=d,
-                    )
-                    if submitted_obj is None or submitted_obj.job_id is None:
-                        raise RuntimeError("remote sbatch returned no job_id")
-                    return int(submitted_obj.job_id)
-
-                slurm_id = await anyio.to_thread.run_sync(_in_place_submit)
-            else:
-                result = await anyio.to_thread.run_sync(
-                    lambda s=scripts[current_name],  # type: ignore[misc]
-                    n=current_name,
-                    d=dependency: adapter.submit_job(s, job_name=n, dependency=d)
-                )
-                slurm_id = int(result["job_id"])
-            submitted[current_name] = str(slurm_id)
-        except Exception as exc:
-            # R3: record a membership row with ``job_id=None`` so the
-            # GET /runs/{id} response still shows the failed node.
-            # Best-effort — a write failure must not mask the original
-            # sbatch exception.
-            try:
-
-                def _record_failed(
-                    jname: str = current_name,
-                    deps: list[str] = depends_on,
-                ) -> None:
-                    wrj_repo.create(
-                        workflow_run_id=run_id,
-                        job_name=jname,
-                        depends_on=deps or None,
-                        job_id=None,
-                    )
-
-                await anyio.to_thread.run_sync(_record_failed)
-            except Exception:
-                logger.debug(
-                    "Failed to record membership for the failed job",
-                    exc_info=True,
-                )
-            raise HTTPException(
-                status_code=502,
-                detail=f"sbatch failed for '{current_name}': {exc}",
-            ) from exc
-
-        # R1: persist the three related rows atomically. On autocommit
-        # connections (isolation_level=None) each ``execute`` would
-        # otherwise commit on its own — a mid-sequence failure would
-        # leave e.g. the jobs row inserted with no transition or
-        # membership to match it, breaking poller dedup downstream.
-        #
-        # Transport axis: pick up the adapter's scheduler_key so SSH-
-        # submitted workflow jobs land on the correct (ssh, profile,
-        # scheduler_key) triple — otherwise the poller would query
-        # local SLURM for remote job ids.
-        wf_scheduler_key = adapter.scheduler_key
-        if wf_scheduler_key.startswith("ssh:"):
-            wf_transport_type = "ssh"
-            wf_profile_name: str | None = wf_scheduler_key[len("ssh:") :]
-        else:
-            wf_transport_type = "local"
-            wf_profile_name = None
-
-        def _persist(
-            jid: int = slurm_id,
-            jname: str = current_name,
-            job_obj: Job | ShellJob = current_job,
-            deps: list[str] = depends_on,
-            tt: str = wf_transport_type,
-            pn: str | None = wf_profile_name,
-            sk: str = wf_scheduler_key,
-        ) -> None:
-            resources = getattr(job_obj, "resources", None)
-            environment = getattr(job_obj, "environment", None)
-            command_val = getattr(job_obj, "command", None)
-            with transaction(conn, "IMMEDIATE"):
-                job_repo.record_submission(
-                    job_id=jid,
-                    name=jname,
-                    status="PENDING",
-                    submission_source="workflow",
-                    transport_type=tt,  # type: ignore[arg-type]
-                    profile_name=pn,
-                    scheduler_key=sk,
-                    workflow_run_id=run_id,
-                    command=command_val if isinstance(command_val, list) else None,
-                    nodes=getattr(resources, "nodes", None) if resources else None,
-                    gpus_per_node=(
-                        getattr(resources, "gpus_per_node", None) if resources else None
-                    ),
-                    memory_per_node=(
-                        getattr(resources, "memory_per_node", None)
-                        if resources
-                        else None
-                    ),
-                    time_limit=(
-                        getattr(resources, "time_limit", None) if resources else None
-                    ),
-                    partition=(
-                        getattr(resources, "partition", None) if resources else None
-                    ),
-                    nodelist=(
-                        getattr(resources, "nodelist", None) if resources else None
-                    ),
-                    conda=getattr(environment, "conda", None) if environment else None,
-                    venv=getattr(environment, "venv", None) if environment else None,
-                    env_vars=(
-                        getattr(environment, "env_vars", None) if environment else None
-                    ),
-                )
-                transition_repo.insert(
-                    job_id=jid,
-                    from_status=None,
-                    to_status="PENDING",
-                    source="webhook",
-                    scheduler_key=sk,
-                )
-                wrj_repo.create(
-                    workflow_run_id=run_id,
-                    job_name=jname,
-                    depends_on=deps or None,
-                    job_id=jid,
-                    scheduler_key=sk,
-                )
-
-        await anyio.to_thread.run_sync(_persist)
-
-        for dep_name in dependents[current_name]:
-            in_degree[dep_name] -= 1
-            if in_degree[dep_name] == 0:
-                queue.append(dep_name)
-
-    return submitted
-
-
-async def _run_sweep_background(
-    orchestrator: SweepOrchestrator,
-    sweep_run_id: int,
-    pool: SlurmSSHExecutorPool | None = None,
-) -> None:
-    """Background task body: drive already-materialized cells to completion.
-
-    Exceptions are logged and swallowed — the sweep's status columns in
-    the DB are authoritative, and the aggregator will converge the sweep
-    to a terminal state even if this task crashes mid-flight.
-
-    When a ``pool`` is supplied, every pooled SSH adapter is torn down
-    after the orchestrator returns (success or crash) so a completed
-    sweep never leaks SSH sessions against the cluster.
-    """
-    try:
-        await orchestrator.arun_from_materialized(sweep_run_id)
-    except Exception:  # noqa: BLE001
-        logger.warning(
-            "Background sweep task for sweep_run_id=%s raised",
-            sweep_run_id,
-            exc_info=True,
-        )
-    finally:
-        if pool is not None:
-            try:
-                await anyio.to_thread.run_sync(pool.close)
-            except Exception:  # noqa: BLE001 — pool cleanup is best-effort
-                logger.warning(
-                    "Failed to close SSH executor pool for sweep_run_id=%s",
-                    sweep_run_id,
-                    exc_info=True,
-                )
+# ── Sweep shims — preserved as module-level entry points so
+# ``tests/sweep/test_sweep_ssh_integration.py`` can call
+# ``wf_mod._dispatch_sweep(...)`` / ``wf_mod._run_sweep_background(...)``
+# directly. Real logic lives in ``SweepSubmissionService``.
 
 
 async def _dispatch_sweep(
@@ -796,176 +207,33 @@ async def _dispatch_sweep(
     adapter: SlurmSSHAdapter,
     mount: str | None = None,
 ) -> dict[str, Any]:
-    """Materialize synchronously + spawn the orchestrator as a background task.
-
-    Returns 202 as soon as the cells exist in the DB so HTTP clients
-    don't block on the full sweep. Matrix validation (non-scalar
-    values, reserved axis names, oversize matrices) is routed through
-    :class:`WorkflowValidationError` by ``expand_matrix`` and surfaced
-    as HTTP 422.
-
-    Sweep cells run through a per-sweep :class:`SlurmSSHExecutorPool`
-    bounded by ``min(max_parallel, 8)`` so concurrent cells share a small
-    set of pooled SSH sessions against the cluster. The pool is closed in
-    :func:`_run_sweep_background` once the orchestrator returns.
-    """
-    assert body.sweep is not None  # narrowed by caller
-    # ``SweepSpec`` / ``SweepOrchestrator`` are module-imported so
-    # tests can patch them via ``srunx.web.routers.workflows.*``.
-
-    # Read raw YAML once so the orchestrator can see base ``args`` and
-    # the workflow name. ``from_yaml`` would redundantly parse it.
-    def _load_raw() -> dict[str, Any]:
-        raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-        return raw if isinstance(raw, dict) else {}
-
-    workflow_data = await anyio.to_thread.run_sync(_load_raw)
-
-    try:
-        sweep_spec = SweepSpec(
-            matrix=body.sweep.matrix,
-            fail_fast=body.sweep.fail_fast,
-            max_parallel=body.sweep.max_parallel,
-        )
-    except Exception as exc:  # noqa: BLE001 — Pydantic / value errors
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-    # C3 (security): apply the same ShellJob script-root guard the
-    # non-sweep path runs, before any DB materialize side effect. The
-    # matrix axes in ``sweep.matrix`` are scalars (validated by
-    # ``expand_matrix``) so a per-cell check would only be redundant;
-    # the base workflow's ShellJob ``script_path`` is the entire attack
-    # surface. ``mount`` is required by the caller (``run_workflow``)
-    # so it is non-None in practice; keep the guard defensive for
-    # direct callers.
-    profile = await anyio.to_thread.run_sync(_get_current_profile)
-    base_runner: WorkflowRunner | None = None
-    if mount is not None:
-        try:
-            base_runner = await anyio.to_thread.run_sync(
-                lambda: WorkflowRunner.from_yaml(
-                    yaml_path,
-                    args_override=body.args_override or None,
-                )
-            )
-        except WorkflowValidationError as exc:
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
-        except Exception as exc:  # noqa: BLE001 — YAML load / Jinja errors
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
-        assert base_runner is not None  # narrowed by the from_yaml call above
-        runner_for_guard = base_runner
-        await anyio.to_thread.run_sync(
-            lambda: _enforce_shell_script_roots(
-                runner_for_guard.workflow, mount, profile
-            )
-        )
-
-        # Workflow Phase 2 (#135 web parity): rsync each touched mount
-        # **once** at dispatch time, even when the sweep expands into
-        # many cells targeting the same mount. The lock is released as
-        # soon as the rsync completes — sweep cells then take the
-        # legacy temp-upload path (the CLI keeps ``allow_in_place=False``
-        # for sweeps because cell-specific Jinja args can move
-        # ``script_path`` to a mount the base render didn't touch).
-        async with _hold_workflow_mounts_web(
-            runner_for_guard.workflow, runner_for_guard, sync_required=True
-        ):
-            pass
-
-    endpoint_id: int | None = None
-    if body.notify and body.endpoint_id is not None:
-        endpoint_id = body.endpoint_id
-    elif body.notify and body.endpoint_id is None:
-        # Non-fatal — matches the non-sweep path's contract: the sweep
-        # still runs, but no external deliveries are wired.
-        logger.warning("sweep run: notify=true with no endpoint_id; skipping")
-
-    # Build a per-sweep SSH executor pool so each cell's runner submits
-    # through the configured cluster adapter instead of the local
-    # :class:`Slurm` client. Size is capped at 8 to avoid opening more
-    # SSH sessions than most clusters comfortably accept from a single
-    # web host. ``pool.lease`` matches ``WorkflowJobExecutorFactory`` so
-    # it can be handed to the orchestrator without further wrapping.
-    pool_size = max(1, min(sweep_spec.max_parallel, 8))
-    pool = SlurmSSHExecutorPool(
-        adapter.connection_spec,
-        callbacks=[],
-        size=pool_size,
+    """Dispatch shim — see :meth:`SweepSubmissionService.dispatch`."""
+    sweep_service = SweepSubmissionService(
+        sweep_spec_cls=SweepSpec,
+        orchestrator_cls=SweepOrchestrator,
+        profile_resolver=_get_current_profile,
+        workflow_runner_cls=WorkflowRunner,
+        executor_pool_cls=SlurmSSHExecutorPool,
+    )
+    return await sweep_service.dispatch(
+        yaml_path=yaml_path,
+        name=name,
+        body=body,
+        request=request,
+        adapter=adapter,
+        mount=mount,
     )
 
-    # Hand the mount-aware render context through to the orchestrator so
-    # every sweep cell's ``WorkflowRunner`` sees the same ``work_dir`` /
-    # ``log_dir`` translation as the non-sweep path. ``profile`` was
-    # already resolved above for the ShellJob script-root guard.
-    submission_context = _build_submission_context(mount, profile)
 
-    orchestrator = SweepOrchestrator(
-        workflow_yaml_path=yaml_path,
-        workflow_data={"name": name, **workflow_data},
-        args_override=body.args_override or None,
-        sweep_spec=sweep_spec,
-        submission_source="web",
-        endpoint_id=endpoint_id,
-        preset=body.preset,
-        executor_factory=pool.lease,
-        submission_context=submission_context,
-    )
+async def _run_sweep_background(
+    orchestrator: Any,
+    sweep_run_id: int,
+    pool: SlurmSSHExecutorPool | None = None,
+) -> None:
+    """Background-task shim — see :func:`run_sweep_background`."""
+    from ..services.sweep_submission import run_sweep_background
 
-    try:
-        sweep_run_id = await anyio.to_thread.run_sync(orchestrator.materialize)
-    except WorkflowValidationError as exc:
-        pool.close()
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    except SweepExecutionError as exc:
-        pool.close()
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-    except BaseException:
-        pool.close()
-        raise
-
-    # Spawn the execution loop on the app's lifespan task group so the
-    # HTTP request can return 202 immediately. ``task_group`` is set up
-    # in :func:`srunx.web.app.lifespan`; fall back to a stand-alone
-    # ``asyncio.create_task`` if the app state hasn't been wired (e.g.
-    # a bare ``TestClient`` without lifespan). Either way the pool is
-    # closed inside :func:`_run_sweep_background`.
-    task_group = getattr(request.app.state, "task_group", None)
-    if task_group is not None:
-        task_group.start_soon(_run_sweep_background, orchestrator, sweep_run_id, pool)
-    else:
-        # Fallback for test harnesses that don't run lifespan: keep a
-        # weak-ish reference to the spawned task so it isn't garbage-
-        # collected mid-flight.
-        import asyncio
-
-        pending = getattr(request.app.state, "background_tasks", None)
-        if pending is None:
-            pending = set()
-            request.app.state.background_tasks = pending
-        task = asyncio.create_task(
-            _run_sweep_background(orchestrator, sweep_run_id, pool)
-        )
-        pending.add(task)
-        task.add_done_callback(pending.discard)
-
-    # Read the freshly-materialized row so counters + status reflect the
-    # DB state, not the orchestrator's pre-run view.
-    from srunx.db.connection import open_connection as _open
-    from srunx.db.repositories.sweep_runs import SweepRunRepository
-
-    def _load_sweep() -> Any:
-        db_conn = _open()
-        try:
-            return SweepRunRepository(db_conn).get(sweep_run_id)
-        finally:
-            db_conn.close()
-
-    sweep_row = await anyio.to_thread.run_sync(_load_sweep)
-    return {
-        "sweep_run_id": sweep_run_id,
-        "status": sweep_row.status if sweep_row is not None else "pending",
-        "cell_count": sweep_row.cell_count if sweep_row is not None else 0,
-    }
+    await run_sweep_background(orchestrator, sweep_run_id, pool)
 
 
 @router.post("/{name}/run", status_code=202)
@@ -979,15 +247,11 @@ async def run_workflow(
 ) -> dict[str, Any]:
     """Run a workflow: sync mounts, submit jobs with SLURM dependencies.
 
-    On success, creates a ``kind='workflow_run'`` watch that
+    On success, creates a kind='workflow_run' watch that
     :class:`~srunx.pollers.active_watch_poller.ActiveWatchPoller`
     consumes to drive aggregate status transitions after the request
     returns.
     """
-    # ``request`` is forwarded to ``_dispatch_sweep`` so the sweep
-    # branch can spawn the execution loop on the app's lifespan task
-    # group (avoiding a blocked HTTP response). Non-sweep branches
-    # don't need it.
     if not _SAFE_NAME.match(name):
         raise HTTPException(status_code=422, detail="Invalid workflow name")
     if not mount:
@@ -995,34 +259,24 @@ async def run_workflow(
 
     run_opts = body or WorkflowRunRequest()
 
-    # Validate preset up-front — before mounting, rendering, and
-    # ``sbatch``ing. Deferring this check until Phase 5 (post-submit)
-    # means a bogus preset returns 422 with jobs already queued on
-    # the cluster, leaving orphans behind. The implementation set
-    # matches ``SubscriptionRepository`` + the subscriptions router
-    # guard (P1-3) — ``digest`` has no delivery pipeline yet.
-    if run_opts.notify and run_opts.preset not in _WORKFLOW_RUN_PRESETS:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"Invalid preset '{run_opts.preset}'. Allowed: {_WORKFLOW_RUN_PRESETS}"
-            ),
-        )
-
-    # R7: sanitize structured sweep / args_override payloads. YAML-level
-    # guard still runs on upload; this catches requests that bypass it.
-    if run_opts.args_override:
-        _reject_python_prefix_web(run_opts.args_override, source="args_override")
+    # Sweep-axis python:-prefix guard must run before dispatching into
+    # the sweep service (the matrix is consumed there and wouldn't
+    # re-check). The args_override guard runs inside
+    # WorkflowSubmissionService.run for the non-sweep branch.
     if run_opts.sweep is not None:
         _reject_python_prefix_web(run_opts.sweep.matrix, source="sweep.matrix")
+        if run_opts.args_override:
+            _reject_python_prefix_web(run_opts.args_override, source="args_override")
 
     yaml_path = _find_yaml(name, mount)
 
-    # Sweep branch: materialize synchronously so the 202 response carries
-    # a real ``sweep_run_id``, then spawn the execution loop on the app's
-    # lifespan task group. Per-cell workflow_run rows are created inside
-    # the orchestrator's happy-path TX; the client polls
-    # ``/api/sweep_runs/{id}``.
+    # Sweep branch: materialize synchronously so the 202 response
+    # carries a real sweep_run_id, then spawn the execution loop on the
+    # app's lifespan task group.
+    #
+    # SweepSpec / SweepOrchestrator are passed by reference so that
+    # unittest.mock.patch('srunx.web.routers.workflows.SweepSpec',
+    # ...) continues to affect the materialize call.
     if run_opts.sweep is not None:
         return await _dispatch_sweep(
             yaml_path=yaml_path,
@@ -1033,281 +287,24 @@ async def run_workflow(
             mount=mount,
         )
 
-    # Load and optionally filter workflow
-    runner = await anyio.to_thread.run_sync(
-        lambda: WorkflowRunner.from_yaml(
-            yaml_path,
-            args_override=run_opts.args_override or None,
-        )
+    submission_service = WorkflowSubmissionService(
+        profile_resolver=_get_current_profile,
+        terminal_statuses=_WORKFLOW_TERMINAL_STATUSES,
+        allowed_presets=_WORKFLOW_RUN_PRESETS,
+        # Pass the router's ``WorkflowRunner`` attribute so tests that
+        # patch ``srunx.web.routers.workflows.WorkflowRunner`` reach
+        # the ``from_yaml`` call.
+        workflow_runner_cls=WorkflowRunner,
     )
-    workflow = runner.workflow
-    if run_opts.from_job or run_opts.to_job or run_opts.single_job:
-        filtered_jobs = _filter_workflow_jobs(
-            workflow, run_opts.from_job, run_opts.to_job, run_opts.single_job
-        )
-        workflow = Workflow(name=workflow.name, jobs=filtered_jobs)
-
-    run_repo = WorkflowRunRepository(conn)
-    watch_repo = WatchRepository(conn)
-
-    # Create run record (skip for dry runs)
-    run_id: int | None = None
-    if not run_opts.dry_run:
-        run_id = await anyio.to_thread.run_sync(
-            lambda: run_repo.create(
-                workflow_name=name,
-                yaml_path=str(yaml_path),
-                args=runner.args or None,
-                triggered_by="web",
-            )
-        )
-
-    def _fail(reason: str) -> None:
-        if run_id is None:
-            return
-        # Route through WorkflowRunStateService so a status_changed event
-        # is emitted (subscribers of the auto-created workflow_run watch
-        # then receive a Slack-etc. delivery). Read the current status
-        # fresh — the poller may have already advanced the row before
-        # the failure fires.
-        with transaction(conn, "IMMEDIATE"):
-            latest = run_repo.get(run_id)
-            if latest is None or latest.status in _WORKFLOW_TERMINAL_STATUSES:
-                return
-            WorkflowRunStateService.update(
-                conn=conn,
-                workflow_run_id=run_id,
-                from_status=latest.status,
-                to_status="failed",
-                error=reason,
-                completed_at=now_iso(),
-            )
-
-    # Resolve the SSH profile up-front so render + the shell-script
-    # guard see the same mount registry the lock-and-submit path will
-    # use. ``_hold_workflow_mounts_web`` re-resolves it internally
-    # (matches the CLI structure) — the per-request profile read is
-    # cheap and keeps the render path independent of the lock context.
-    profile = await anyio.to_thread.run_sync(_get_current_profile)
-
-    # Phase 2: Render scripts via the canonical helper. Mount translation
-    # and template resolution live in :mod:`srunx.rendering` so Web
-    # non-sweep, Web sweep, and MCP share identical semantics.
-    #
-    # The shell script-root check runs against the set the helper will
-    # actually read. ``single_job`` restricts the helper to that one
-    # target; ``from_job`` / ``to_job`` are post-render filters so the
-    # helper reads every job in the YAML. Checking the full
-    # ``runner.workflow`` in those cases matches the helper's read set.
-    submission_context = _build_submission_context(mount, profile)
-    shell_check_workflow = (
-        Workflow(
-            name=runner.workflow.name,
-            jobs=[j for j in runner.workflow.jobs if j.name == run_opts.single_job],
-        )
-        if run_opts.single_job
-        else runner.workflow
+    return await submission_service.run(
+        name=name,
+        mount=mount,
+        yaml_path=yaml_path,
+        run_opts=run_opts,
+        request=request,
+        adapter=adapter,
+        conn=conn,
     )
-    try:
-        await anyio.to_thread.run_sync(
-            lambda: _enforce_shell_script_roots(shell_check_workflow, mount, profile)
-        )
-        rendered = await anyio.to_thread.run_sync(
-            lambda: _render_workflow(
-                yaml_path,
-                submission_context=submission_context,
-                args_override=run_opts.args_override or None,
-                single_job=run_opts.single_job,
-            )
-        )
-    except HTTPException:
-        # 403 shell-script-root violation: propagate without _fail side
-        # effects (no jobs queued, no cluster state to roll back).
-        raise
-    except Exception as exc:
-        reason = f"Script rendering failed: {exc}"
-        await anyio.to_thread.run_sync(functools.partial(_fail, reason))
-        raise HTTPException(status_code=500, detail=reason) from exc
-
-    # When ``from_job`` / ``to_job`` are set the canonical helper doesn't
-    # prune; apply the existing filter over the rendered result. The
-    # ``single_job`` case is already handled inside the helper.
-    if run_opts.from_job or run_opts.to_job:
-        filtered_names = {
-            j.name
-            for j in _filter_workflow_jobs(
-                rendered.workflow,
-                run_opts.from_job,
-                run_opts.to_job,
-                None,
-            )
-        }
-        rendered_jobs = tuple(
-            rj for rj in rendered.jobs if rj.job.name in filtered_names
-        )
-    else:
-        rendered_jobs = rendered.jobs
-
-    # The rendered workflow drives everything downstream so ``work_dir`` /
-    # ``log_dir`` translations stay visible to the submit + dry-run paths.
-    submission_workflow = Workflow(
-        name=rendered.workflow.name,
-        jobs=[rj.job for rj in rendered_jobs],
-    )
-    scripts: dict[str, str] = {rj.job.name: rj.script_text for rj in rendered_jobs}
-
-    # Phase 3: Dry run early return
-    if run_opts.dry_run:
-        job_names_in_wf = {job.name for job in submission_workflow.jobs}
-        return {
-            "dry_run": True,
-            "jobs": [
-                {
-                    "name": job.name,
-                    "script": scripts.get(job.name, ""),
-                    "depends_on": [
-                        d.job_name
-                        for d in job.parsed_dependencies
-                        if d.job_name in job_names_in_wf
-                    ],
-                    "resources": job.resources.model_dump()
-                    if isinstance(job, Job)
-                    else {},
-                }
-                for job in submission_workflow.jobs
-            ],
-            "execution_order": [job.name for job in submission_workflow.jobs],
-        }
-
-    # Phase 4: Submit each job + persist + link to workflow_run + seed transition.
-    #
-    # Workflow Phase 2 (#135 web parity): hold the per-(profile, mount)
-    # sync lock across the entire BFS so a concurrent /api/jobs or
-    # ``srunx flow run`` can't rsync different bytes between our sync
-    # and our submissions. Lock acquisition / rsync errors raise
-    # HTTPException(502) tagged "Mount sync failed: …"; sbatch
-    # failures from inside the body keep their existing
-    # "sbatch failed for X" detail so the two failure classes stay
-    # distinguishable in the API response.
-    assert run_id is not None
-    try:
-        # Pass the UNRENDERED workflow to the lock-acquisition helper so
-        # ``collect_touched_mounts`` sees the original local script_paths
-        # (mount.local form) rather than the post-render remote form.
-        # Without this, no mounts get aggregated and the in-place dispatch
-        # never fires for any cell. Same root cause #150 also fixes for
-        # ``_resolve_in_place_target`` — both consumers of script_path
-        # must read from the unrendered side.
-        async with _hold_workflow_mounts_web(
-            runner.workflow, runner, sync_required=True
-        ) as locked_profile:
-            unrendered_by_name: dict[str, Job | ShellJob] = {
-                j.name: j for j in runner.workflow.jobs
-            }
-            try:
-                await _submit_jobs_bfs(
-                    submission_workflow,
-                    scripts,
-                    run_opts,
-                    adapter,
-                    conn=conn,
-                    run_id=run_id,
-                    profile=locked_profile,
-                    unrendered_jobs_by_name=unrendered_by_name,
-                )
-            except HTTPException as exc:
-                reason = (
-                    f"Submission failed: {exc.detail}"
-                    if isinstance(exc.detail, str)
-                    else "Submission failed"
-                )
-
-                # R2: cancel any jobs that were already accepted by sbatch before
-                # the failure. Without this the workflow_run is marked failed
-                # but cluster resources keep running the orphan jobs (and any
-                # independent successors the DAG may have scheduled).
-                def _load_orphan_ids() -> list[int]:
-                    memberships = WorkflowRunJobRepository(conn).list_by_run(run_id)
-                    return [m.job_id for m in memberships if m.job_id is not None]
-
-                orphan_ids = await anyio.to_thread.run_sync(_load_orphan_ids)
-                for jid in orphan_ids:
-                    try:
-                        await anyio.to_thread.run_sync(
-                            lambda x=jid: adapter.cancel_job(int(x))  # type: ignore[misc]
-                        )
-                    except Exception:
-                        logger.warning(
-                            "Failed to cancel orphan SLURM job %s during workflow-run rollback",
-                            jid,
-                            exc_info=True,
-                        )
-
-                await anyio.to_thread.run_sync(functools.partial(_fail, reason))
-                raise
-    except HTTPException as exc:
-        # Lock-acquisition failures land here (raised from
-        # ``_hold_workflow_mounts_web`` before the body runs). Mark
-        # the run as failed with the sync-failure reason. Body-raised
-        # exceptions were already handled inside the inner try/except,
-        # which re-raises after recording — we only need to mark and
-        # rethrow here when the outer raise originates from the lock
-        # acquisition itself.
-        if isinstance(exc.detail, str) and exc.detail.startswith("Mount sync failed"):
-            await anyio.to_thread.run_sync(functools.partial(_fail, exc.detail))
-        raise
-
-    # Phase 5: open the workflow_run watch so the poller can drive
-    # status transitions going forward. ``workflow_runs.status='running'``
-    # is deliberately NOT written here — the run record stays ``pending``
-    # (as created above) until ``ActiveWatchPoller`` observes a child
-    # job in RUNNING state (P1-1). Writing ``running`` eagerly would
-    # race the poller's "otherwise→pending" rule and emit a spurious
-    # ``running → pending`` transition (+ a
-    # ``workflow_run.status_changed`` event to every subscriber) on the
-    # very first cycle, while all children are still PENDING in SLURM.
-    #
-    # When ``notify`` is requested, also pair the watch with a
-    # subscription for the chosen endpoint; the delivery poller then
-    # fans ``workflow_run.status_changed`` events out to Slack/etc.
-    def _open_watch() -> int | None:
-        new_watch_id = watch_repo.create(
-            kind="workflow_run",
-            target_ref=f"workflow_run:{run_id}",
-        )
-        if run_opts.notify and run_opts.endpoint_id is not None:
-            from srunx.db.repositories.endpoints import EndpointRepository
-            from srunx.db.repositories.subscriptions import SubscriptionRepository
-
-            endpoint = EndpointRepository(conn).get(run_opts.endpoint_id)
-            if endpoint is None or endpoint.disabled_at is not None:
-                # Non-fatal: the watch still exists, the run is open,
-                # the user just won't get external notifications. Jobs
-                # are already queued on the cluster — 4xx'ing here
-                # would be misleading.
-                logger.warning(
-                    "workflow_run %s: requested endpoint_id=%s not usable "
-                    "(missing or disabled); skipping subscription",
-                    run_id,
-                    run_opts.endpoint_id,
-                )
-                return new_watch_id
-            SubscriptionRepository(conn).create(
-                watch_id=new_watch_id,
-                endpoint_id=run_opts.endpoint_id,
-                preset=run_opts.preset,
-            )
-        return new_watch_id
-
-    await anyio.to_thread.run_sync(_open_watch)
-
-    def _load_final() -> dict[str, Any]:
-        final_run = run_repo.get(run_id)  # type: ignore[arg-type]
-        if final_run is None:
-            return {"id": str(run_id), "status": "pending"}
-        return _build_run_response(conn, final_run)
-
-    return await anyio.to_thread.run_sync(_load_final)
 
 
 @router.delete("/{name}")

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -37,8 +37,6 @@ from srunx.exceptions import SweepExecutionError, WorkflowValidationError
 from srunx.logging import get_logger
 from srunx.models import (
     Job,
-    JobEnvironment,
-    JobResource,
     ShellJob,
     Workflow,
 )
@@ -48,7 +46,6 @@ from srunx.rendering import (
     render_workflow_for_submission,
 )
 from srunx.runner import WorkflowRunner
-from srunx.security import find_python_prefix
 from srunx.slurm.ssh import SlurmSSHAdapter
 from srunx.slurm.ssh_executor import SlurmSSHExecutorPool
 from srunx.sweep import SweepSpec
@@ -62,6 +59,8 @@ from ..schemas.workflows import (
     WorkflowJobInput,
     WorkflowRunRequest,
 )
+from ..services import _submission_common
+from ..services.workflow_storage import WorkflowStorageService
 
 # Re-exports for backward compatibility — external callers and tests that
 # ``from srunx.web.routers.workflows import WorkflowJobInput`` (etc.) keep
@@ -86,273 +85,53 @@ _SAFE_NAME = re.compile(r"^[\w\-]+$")
 _RESERVED_NAMES = frozenset({"new"})
 
 
-# ── Shared helpers ───────────────────────────────────
+# ── Shared helpers — thin delegates preserved for test patch surface ───
+# Tests patch ``srunx.web.routers.workflows._get_current_profile`` and
+# import ``_build_run_response`` directly. Keeping these as module-level
+# symbols here is load-bearing; the real implementations live in
+# ``services/_submission_common.py``.
 
 
-def _validate_and_build_workflow(data: dict[str, Any]) -> Workflow:
-    """Construct and validate a Workflow from a plain dict.
-
-    Builds Job instances with JobResource / JobEnvironment, then runs
-    cycle-detection via ``Workflow.validate()``.  Raises on any
-    Pydantic or workflow-level validation failure.
-    """
-    name: str = data["name"]
-    jobs_data: list[dict[str, Any]] = data.get("jobs", [])
-
-    jobs: list[Job | ShellJob] = []
-    for jd in jobs_data:
-        resource = JobResource.model_validate(jd.get("resources") or {})
-        environment = JobEnvironment.model_validate(jd.get("environment") or {})
-        job_kwargs: dict[str, Any] = {
-            "name": jd["name"],
-            "command": jd["command"],
-            "depends_on": jd.get("depends_on", []),
-            "exports": jd.get("exports", {}),
-            "resources": resource,
-            "environment": environment,
-        }
-        # Always pass work_dir and log_dir explicitly to prevent Job's
-        # default_factory from calling os.getcwd() (wrong for the web server)
-        # or defaulting to "logs" (meaningless on a remote SLURM host).
-        # Empty strings are falsy and skipped by _workflow_to_yaml and
-        # the SLURM template (#SBATCH --chdir is only emitted when truthy).
-        job_kwargs["work_dir"] = jd.get("work_dir") or ""
-        job_kwargs["log_dir"] = jd.get("log_dir") or ""
-        if jd.get("retry") is not None:
-            job_kwargs["retry"] = jd["retry"]
-        if jd.get("retry_delay") is not None:
-            job_kwargs["retry_delay"] = jd["retry_delay"]
-        job = Job(**job_kwargs)
-        jobs.append(job)
-
-    workflow = Workflow(name=name, jobs=jobs)
-    workflow.validate()
-    return workflow
-
-
-def _workflow_to_yaml(
-    name: str,
-    jobs_data: list[dict[str, Any]],
-    default_project: str | None = None,
-    args: dict[str, Any] | None = None,
-) -> str:
-    """Serialize a workflow to YAML compatible with ``WorkflowRunner.from_yaml``.
-
-    Only includes non-default / non-None resource and environment fields so
-    the resulting file stays clean.
-    """
-    serialized_jobs: list[dict[str, Any]] = []
-    for jd in jobs_data:
-        entry: dict[str, Any] = {
-            "name": jd["name"],
-            "command": jd["command"],
-        }
-
-        depends = jd.get("depends_on", [])
-        if depends:
-            entry["depends_on"] = depends
-
-        exports = jd.get("exports", {})
-        if exports:
-            entry["exports"] = exports
-
-        # Resources — only include non-None values
-        raw_res = jd.get("resources") or {}
-        resources = {k: v for k, v in raw_res.items() if v is not None}
-        if resources:
-            entry["resources"] = resources
-
-        # Environment — only include non-None values
-        raw_env = jd.get("environment") or {}
-        environment = {k: v for k, v in raw_env.items() if v is not None}
-        if environment:
-            entry["environment"] = environment
-
-        # Job-level optional fields
-        if jd.get("template"):
-            entry["template"] = jd["template"]
-        if jd.get("work_dir"):
-            entry["work_dir"] = jd["work_dir"]
-        if jd.get("log_dir"):
-            entry["log_dir"] = jd["log_dir"]
-        if jd.get("retry") is not None:
-            entry["retry"] = jd["retry"]
-        if jd.get("retry_delay") is not None:
-            entry["retry_delay"] = jd["retry_delay"]
-        if jd.get("srun_args"):
-            entry["srun_args"] = jd["srun_args"]
-        if jd.get("launch_prefix"):
-            entry["launch_prefix"] = jd["launch_prefix"]
-
-        serialized_jobs.append(entry)
-
-    doc: dict[str, Any] = {"name": name}
-    if default_project:
-        doc["default_project"] = default_project
-    if args:
-        doc["args"] = args
-    doc["jobs"] = serialized_jobs
-    return yaml.dump(doc, default_flow_style=False, sort_keys=False)
-
-
-def _get_current_profile():
-    """Get the current SSH profile from web config or ConfigManager."""
-    from ..sync_utils import get_current_profile
-
-    return get_current_profile()
-
-
-def _find_mount(profile, mount_name: str):
-    """Find a mount by name. Raises HTTPException 404 if not found."""
-    from ..sync_utils import find_mount
-
-    try:
-        return find_mount(profile, mount_name)
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+def _get_current_profile():  # noqa: ANN202
+    """Return the active SSH profile (router-level patch target)."""
+    return _submission_common.get_current_profile()
 
 
 def _workflow_dir(mount_name: str) -> Path:
-    """Resolve workflow directory for a given mount.
-
-    Returns ``<mount.local>/.srunx/workflows/``.
-    """
-    profile = _get_current_profile()
-    if profile is None:
-        raise HTTPException(status_code=503, detail="No SSH profile configured")
-    mount = _find_mount(profile, mount_name)
-    return Path(mount.local) / ".srunx" / "workflows"
+    return _submission_common.workflow_dir(mount_name, _get_current_profile)
 
 
 def _ensure_workflow_dir(mount_name: str) -> Path:
-    """Like ``_workflow_dir`` but creates the directory (and ``.srunx/.gitignore``) if needed."""
-    d = _workflow_dir(mount_name)
-    d.mkdir(parents=True, exist_ok=True)
-    gitignore = d.parent / ".gitignore"
-    if not gitignore.exists():
-        gitignore.write_text("*\n!workflows/\n!workflows/**\n!.gitignore\n")
-    return d
+    return _submission_common.ensure_workflow_dir(mount_name, _get_current_profile)
 
 
 def _find_yaml(name: str, mount_name: str) -> Path:
-    d = _workflow_dir(mount_name)
-    for ext in (".yaml", ".yml"):
-        p = d / f"{name}{ext}"
-        if p.exists():
-            return p
-    raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
+    return _submission_common.find_yaml(name, mount_name, _get_current_profile)
 
 
 def _reject_python_prefix_web(payload: Any, *, source: str) -> None:
-    """Reject ``python:``-prefixed strings in Web API payloads.
-
-    Centralizes the guard applied to both YAML args (pre-parsed by the
-    caller) and JSON ``args_override`` / ``sweep.matrix`` payloads.
-    Raises ``HTTPException(422)`` on the first violation.
-    """
-    violation = find_python_prefix(payload, source=source)
-    if violation is not None:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"{violation.source} at '{violation.path}' contains 'python:' "
-                "prefix which is not allowed via web for security reasons"
-            ),
-        )
+    _submission_common.reject_python_prefix_web(payload, source=source)
 
 
 def _reject_python_prefix_in_yaml_args(yaml_content: str) -> None:
-    """Parse YAML text and apply the ``python:`` guard to its ``args`` section.
-
-    Uses ``yaml.safe_load`` so legitimate uses of ``python:`` in commands
-    or comments are not blocked. Malformed YAML is left to downstream
-    validation to report.
-    """
-    try:
-        data = yaml.safe_load(yaml_content)
-    except Exception:
-        return
-
-    if not isinstance(data, dict):
-        return
-
-    args = data.get("args")
-    if not isinstance(args, dict):
-        return
-
-    _reject_python_prefix_web(args, source="args")
+    _submission_common.reject_python_prefix_in_yaml_args(yaml_content)
 
 
-def _serialize_workflow(
-    runner: WorkflowRunner,
-    raw_yaml_jobs: list[dict[str, Any]] | None = None,
-) -> dict[str, Any]:
-    wf = runner.workflow
-    # Build lookup for extra YAML fields not stored in Job model
-    raw_by_name: dict[str, dict[str, Any]] = {}
-    if raw_yaml_jobs:
-        for rj in raw_yaml_jobs:
-            raw_by_name[rj.get("name", "")] = rj
+def _storage() -> WorkflowStorageService:
+    """Build a per-call storage service bound to the router-level
+    ``_get_current_profile`` so test patches stay effective."""
+    return WorkflowStorageService(profile_resolver=_get_current_profile)
 
-    jobs: list[dict[str, Any]] = []
-    for job in wf.jobs:
-        d: dict[str, Any] = {
-            "name": job.name,
-            "job_id": job.job_id,
-            "status": job._status.value,
-            "depends_on": job.depends_on,
-            "exports": job.exports,
-        }
-        raw_job = raw_by_name.get(job.name, {})
-        if raw_job.get("template"):
-            d["template"] = raw_job["template"]
-        if hasattr(job, "command"):
-            cmd = job.command  # type: ignore[union-attr]
-            d["command"] = [cmd] if isinstance(cmd, str) else cmd
-            d["resources"] = {
-                "nodes": job.resources.nodes,  # type: ignore[union-attr]
-                "gpus_per_node": job.resources.gpus_per_node,  # type: ignore[union-attr]
-                "partition": job.resources.partition,  # type: ignore[union-attr]
-                "time_limit": job.resources.time_limit,  # type: ignore[union-attr]
-            }
-        elif hasattr(job, "script_path"):
-            d["script_path"] = job.script_path  # type: ignore[union-attr]
-            d["command"] = []
-            d["resources"] = {}
-        else:
-            d["command"] = []
-            d["resources"] = {}
-        jobs.append(d)
-    result: dict[str, Any] = {"name": wf.name, "jobs": jobs}
-    if runner.args:
-        result["args"] = runner.args
-    if runner.default_project:
-        result["default_project"] = runner.default_project
-    return result
+
+# Serialization shims (preserved for backward-compatible imports/tests) ──
+_serialize_workflow = WorkflowStorageService.serialize_workflow
+_workflow_to_yaml = WorkflowStorageService.workflow_to_yaml
+_validate_and_build_workflow = WorkflowStorageService.validate_and_build_workflow
 
 
 @router.get("")
 async def list_workflows(mount: str) -> list[dict[str, Any]]:
-    d = _workflow_dir(mount)
-    if not d.exists():
-        return []
-
-    results: list[dict[str, Any]] = []
-    for p in sorted(d.glob("*.y*ml")):
-        try:
-
-            def _load(_p=p):
-                import yaml as _yaml
-
-                runner = WorkflowRunner.from_yaml(_p)
-                raw = _yaml.safe_load(_p.read_text(encoding="utf-8"))
-                return runner, raw.get("jobs", [])
-
-            runner, raw_jobs = await anyio.to_thread.run_sync(_load)
-            results.append(_serialize_workflow(runner, raw_yaml_jobs=raw_jobs))
-        except Exception:
-            continue
-    return results
+    return await _storage().list_workflows(mount)
 
 
 def _parse_run_id(run_id: str) -> int:
@@ -559,39 +338,12 @@ async def validate_workflow(body: dict[str, str]) -> dict[str, Any]:
 
 @router.post("/upload")
 async def upload_workflow(body: dict[str, str]) -> dict[str, Any]:
-    yaml_content = body.get("yaml", "")
-    filename = body.get("filename", "")
-    mount_name = body.get("mount", "")
-
-    if not yaml_content or not filename or not mount_name:
-        raise HTTPException(
-            status_code=422, detail="'yaml', 'filename', and 'mount' are required"
-        )
-
-    _reject_python_prefix_in_yaml_args(yaml_content)
-
-    if len(yaml_content) > 1_000_000:
-        raise HTTPException(status_code=413, detail="YAML content exceeds 1MB limit")
-
-    safe_filename = Path(filename).name
-    name = Path(safe_filename).stem
-    if not _SAFE_NAME.match(name):
-        raise HTTPException(
-            status_code=422,
-            detail="Filename must be alphanumeric with hyphens/underscores only",
-        )
-
-    d = _ensure_workflow_dir(mount_name)
-    dest = d / safe_filename
-    dest.write_text(yaml_content)
-
-    try:
-        runner = await anyio.to_thread.run_sync(lambda: WorkflowRunner.from_yaml(dest))
-        await anyio.to_thread.run_sync(runner.workflow.validate)
-        return _serialize_workflow(runner)
-    except Exception as e:
-        dest.unlink(missing_ok=True)
-        raise HTTPException(status_code=422, detail=str(e)) from e
+    return await _storage().upload(
+        yaml_content=body.get("yaml", ""),
+        filename=body.get("filename", ""),
+        mount_name=body.get("mount", ""),
+        safe_name_re=_SAFE_NAME,
+    )
 
 
 @router.post("/create")
@@ -601,67 +353,7 @@ async def create_workflow(body: WorkflowCreateRequest) -> dict[str, Any]:
     Validates all jobs via Pydantic model construction, checks for
     dependency cycles, serializes to YAML, and persists to disk.
     """
-    name = body.name
-    mount_name = body.default_project
-    if not mount_name:
-        raise HTTPException(
-            status_code=422,
-            detail="A mount (default_project) is required to save a workflow",
-        )
-
-    # Reserved name guard
-    if name in _RESERVED_NAMES:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Workflow name '{name}' is reserved",
-        )
-
-    # Check for existing workflow with the same name
-    d = _ensure_workflow_dir(mount_name)
-    if not body.overwrite:
-        for ext in (".yaml", ".yml"):
-            if (d / f"{name}{ext}").exists():
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Workflow '{name}' already exists",
-                )
-
-    # Reject python: args from web for security (shared guard).
-    _reject_python_prefix_web(body.args, source="args")
-
-    # Build the raw dict list from the request for validation + serialization
-    jobs_raw: list[dict[str, Any]] = [
-        j.model_dump(exclude_none=True) for j in body.jobs
-    ]
-
-    data: dict[str, Any] = {"name": name, "jobs": jobs_raw}
-
-    # Validate by constructing domain models (synchronous — CPU-only, no I/O)
-    try:
-        _validate_and_build_workflow(data)
-    except WorkflowValidationError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    except Exception as exc:
-        from pydantic import ValidationError as _VE
-
-        if isinstance(exc, _VE):
-            errors = [
-                {"loc": list(e["loc"]), "msg": e["msg"], "type": e["type"]}
-                for e in exc.errors()
-            ]
-            raise HTTPException(status_code=422, detail=errors) from exc
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-
-    # Serialize and write to disk
-    yaml_content = _workflow_to_yaml(
-        name, jobs_raw, default_project=body.default_project, args=body.args or None
-    )
-    dest = d / f"{name}.yaml"
-    await anyio.to_thread.run_sync(lambda: dest.write_text(yaml_content))
-
-    # Re-load via WorkflowRunner to return the canonical serialized form
-    runner = await anyio.to_thread.run_sync(lambda: WorkflowRunner.from_yaml(dest))
-    return _serialize_workflow(runner)
+    return await _storage().create(body, reserved_names=_RESERVED_NAMES)
 
 
 _WORKFLOW_RUN_PRESETS = ("terminal", "running_and_terminal", "all")
@@ -1778,27 +1470,11 @@ async def delete_workflow(name: str, mount: str) -> dict[str, str]:
     """Delete a workflow YAML file."""
     if not _SAFE_NAME.match(name):
         raise HTTPException(status_code=422, detail="Invalid workflow name")
-    yaml_path = _find_yaml(name, mount)  # raises 404 if not found
-    await anyio.to_thread.run_sync(lambda: yaml_path.unlink())
-    return {"status": "deleted", "name": name}
+    return await _storage().delete(name, mount)
 
 
 @router.get("/{name}")
 async def get_workflow(name: str, mount: str) -> dict[str, Any]:
     if not _SAFE_NAME.match(name):
         raise HTTPException(status_code=422, detail="Invalid workflow name")
-
-    yaml_path = _find_yaml(name, mount)
-    try:
-
-        def _load():
-            import yaml as _yaml
-
-            runner = WorkflowRunner.from_yaml(yaml_path)
-            raw = _yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
-            return runner, raw.get("jobs", [])
-
-        runner, raw_jobs = await anyio.to_thread.run_sync(_load)
-        return _serialize_workflow(runner, raw_yaml_jobs=raw_jobs)
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=str(e)) from e
+    return await _storage().get(name, mount)

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -21,7 +21,6 @@ from typing import Any
 import anyio
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field, model_validator
 
 from srunx.db.connection import transaction
 from srunx.db.models import WorkflowRun as DBWorkflowRun
@@ -57,6 +56,23 @@ from srunx.sweep.orchestrator import SweepOrchestrator
 from srunx.sweep.state_service import WorkflowRunStateService
 
 from ..deps import get_adapter, get_db_conn
+from ..schemas.workflows import (
+    SweepSpecRequest,
+    WorkflowCreateRequest,
+    WorkflowJobInput,
+    WorkflowRunRequest,
+)
+
+# Re-exports for backward compatibility — external callers and tests that
+# ``from srunx.web.routers.workflows import WorkflowJobInput`` (etc.) keep
+# working. The canonical home is now ``srunx.web.schemas.workflows``.
+__all__ = [
+    "SweepSpecRequest",
+    "WorkflowCreateRequest",
+    "WorkflowJobInput",
+    "WorkflowRunRequest",
+    "router",
+]
 
 logger = get_logger(__name__)
 
@@ -68,45 +84,6 @@ router = APIRouter(prefix="/api/workflows", tags=["workflows"])
 
 _SAFE_NAME = re.compile(r"^[\w\-]+$")
 _RESERVED_NAMES = frozenset({"new"})
-
-
-# ── Request models ───────────────────────────────────
-
-
-class WorkflowJobInput(BaseModel):
-    name: str
-    command: list[str]
-    depends_on: list[str] = []
-    template: str | None = None
-    exports: dict[str, str] = Field(default_factory=dict)
-    resources: dict[str, Any] | None = None
-    environment: dict[str, Any] | None = None
-    work_dir: str | None = None
-    log_dir: str | None = None
-    retry: int | None = None
-    retry_delay: int | None = None
-    srun_args: str | None = None
-    launch_prefix: str | None = None
-
-    model_config = {"extra": "forbid"}
-
-    @model_validator(mode="before")
-    @classmethod
-    def reject_legacy_outputs(cls, data: Any) -> Any:
-        if isinstance(data, dict) and "outputs" in data:
-            raise ValueError(
-                "The 'outputs' field was renamed to 'exports' (see CHANGELOG). "
-                "Dependent jobs now reference values as '{{ deps.<job_name>.<key> }}'."
-            )
-        return data
-
-
-class WorkflowCreateRequest(BaseModel):
-    name: str = Field(..., pattern=r"^[\w\-]+$")
-    args: dict[str, Any] = Field(default_factory=dict)
-    jobs: list[WorkflowJobInput]
-    default_project: str | None = None
-    overwrite: bool = False
 
 
 # ── Shared helpers ───────────────────────────────────
@@ -685,42 +662,6 @@ async def create_workflow(body: WorkflowCreateRequest) -> dict[str, Any]:
     # Re-load via WorkflowRunner to return the canonical serialized form
     runner = await anyio.to_thread.run_sync(lambda: WorkflowRunner.from_yaml(dest))
     return _serialize_workflow(runner)
-
-
-class SweepSpecRequest(BaseModel):
-    """Sweep payload accepted by ``POST /api/workflows/{name}/run``.
-
-    Mirrors :class:`srunx.sweep.SweepSpec` but with a server-side default
-    for ``max_parallel`` (R7.9) so the client can omit it for small
-    sweeps.
-    """
-
-    model_config = {"extra": "forbid"}
-
-    matrix: dict[str, list[Any]] = Field(default_factory=dict)
-    fail_fast: bool = False
-    max_parallel: int = 4
-
-
-class WorkflowRunRequest(BaseModel):
-    from_job: str | None = None
-    to_job: str | None = None
-    single_job: str | None = None
-    dry_run: bool = False
-    # Notification subscription wiring. When ``notify`` is true and
-    # ``endpoint_id`` resolves to an enabled endpoint row, the run's
-    # auto-created ``kind='workflow_run'`` watch is paired with a
-    # subscription so the delivery poller fans status-transition
-    # events out to that endpoint. Matches the shape accepted by
-    # ``/api/jobs`` submit (R6 in design.md §Request models).
-    notify: bool = False
-    endpoint_id: int | None = Field(default=None, gt=0)
-    preset: str = "terminal"
-    # Sweep wiring (Phase G). ``args_override`` expands workflow-level
-    # ``args`` before Jinja rendering; ``sweep`` switches the request
-    # onto the :class:`SweepOrchestrator` path.
-    args_override: dict[str, Any] = Field(default_factory=dict)
-    sweep: SweepSpecRequest | None = None
 
 
 _WORKFLOW_RUN_PRESETS = ("terminal", "running_and_terminal", "all")

--- a/src/srunx/web/routers/workflows.py
+++ b/src/srunx/web/routers/workflows.py
@@ -22,8 +22,6 @@ import yaml
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from srunx.db.connection import transaction
-from srunx.db.models import WorkflowRun as DBWorkflowRun
-from srunx.db.models import WorkflowRunJob
 from srunx.db.repositories.base import now_iso
 from srunx.db.repositories.job_state_transitions import (
     JobStateTransitionRepository,
@@ -59,6 +57,19 @@ from ..schemas.workflows import (
     WorkflowRunRequest,
 )
 from ..services import _submission_common
+from ..services.workflow_run_cancellation import WorkflowRunCancellationService
+from ..services.workflow_run_query import (
+    WorkflowRunQueryService,
+)
+from ..services.workflow_run_query import (
+    build_run_response as _build_run_response,  # noqa: F401 — test patch surface
+)
+from ..services.workflow_run_query import (
+    parse_run_id as _parse_run_id,  # noqa: F401 — preserved for import parity
+)
+from ..services.workflow_run_query import (
+    serialize_run as _serialize_run,  # noqa: F401 — preserved for import parity
+)
 from ..services.workflow_storage import WorkflowStorageService
 from ..services.workflow_validation import WorkflowValidationService
 
@@ -134,86 +145,12 @@ async def list_workflows(mount: str) -> list[dict[str, Any]]:
     return await _storage().list_workflows(mount)
 
 
-def _parse_run_id(run_id: str) -> int:
-    """Parse a run_id string → int, raising 404 for non-integer ids.
-
-    The API accepts ``run_id`` as a string for historical compatibility
-    (the old UUID-keyed registry); internally we always store an int.
-    """
-    try:
-        return int(run_id)
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(
-            status_code=404, detail=f"Run '{run_id}' not found"
-        ) from exc
-
-
-def _serialize_run(
-    run: DBWorkflowRun,
-    memberships: list[WorkflowRunJob],
-    jobs_by_id: dict[int, str],
-) -> dict[str, Any]:
-    """Build the API response for a workflow run.
-
-    ``jobs_by_id`` maps SLURM job_id → observed status. Memberships with
-    no job_id (not yet submitted) are omitted from both ``job_ids`` and
-    ``job_statuses``.
-    """
-    job_ids: dict[str, str] = {}
-    job_statuses: dict[str, str] = {}
-    for wrj in memberships:
-        if wrj.job_id is None:
-            continue
-        job_ids[wrj.job_name] = str(wrj.job_id)
-        status = jobs_by_id.get(wrj.job_id)
-        if status is not None:
-            job_statuses[wrj.job_name] = status
-
-    return {
-        "id": str(run.id),
-        "workflow_name": run.workflow_name,
-        "started_at": run.started_at.isoformat() if run.started_at else None,
-        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
-        "status": run.status,
-        "job_ids": job_ids,
-        "job_statuses": job_statuses,
-        "error": run.error,
-        "sweep_run_id": run.sweep_run_id,
-    }
-
-
-def _build_run_response(conn: sqlite3.Connection, run: DBWorkflowRun) -> dict[str, Any]:
-    """Load memberships + child job statuses and serialize."""
-    if run.id is None:
-        return _serialize_run(run, [], {})
-    memberships = WorkflowRunJobRepository(conn).list_by_run(run.id)
-    job_repo = JobRepository(conn)
-    jobs_by_id: dict[int, str] = {}
-    for m in memberships:
-        # V5+: ``jobs_row_id`` is the authoritative FK to ``jobs.id``.
-        # Looking up via ``get_by_row_id`` avoids the pre-V5
-        # ``scheduler_key='local'`` default, which would drop SSH
-        # workflow children and miss their statuses in the API response.
-        if m.jobs_row_id is None or m.job_id is None:
-            continue
-        job = job_repo.get_by_row_id(m.jobs_row_id)
-        if job is not None:
-            jobs_by_id[m.job_id] = job.status
-    return _serialize_run(run, memberships, jobs_by_id)
-
-
 @router.get("/runs")
 async def list_runs(
     name: str | None = None,
     conn: sqlite3.Connection = Depends(get_db_conn),
 ) -> list[dict[str, Any]]:
-    def _load() -> list[dict[str, Any]]:
-        runs = WorkflowRunRepository(conn).list_all()
-        if name is not None:
-            runs = [r for r in runs if r.workflow_name == name]
-        return [_build_run_response(conn, r) for r in runs]
-
-    return await anyio.to_thread.run_sync(_load)
+    return await WorkflowRunQueryService().list_runs(conn, name)
 
 
 @router.get("/runs/{run_id}")
@@ -222,15 +159,7 @@ async def get_run(
     conn: sqlite3.Connection = Depends(get_db_conn),
 ) -> dict[str, Any]:
     """Get the status and details of a single workflow run."""
-    rid = _parse_run_id(run_id)
-
-    def _load() -> dict[str, Any]:
-        run = WorkflowRunRepository(conn).get(rid)
-        if run is None:
-            raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
-        return _build_run_response(conn, run)
-
-    return await anyio.to_thread.run_sync(_load)
+    return await WorkflowRunQueryService().get_run(conn, run_id)
 
 
 @router.post("/runs/{run_id}/cancel")
@@ -240,74 +169,11 @@ async def cancel_run(
     conn: sqlite3.Connection = Depends(get_db_conn),
 ) -> dict[str, Any]:
     """Cancel all jobs in a running workflow."""
-    rid = _parse_run_id(run_id)
-    run_repo = WorkflowRunRepository(conn)
-    wrj_repo = WorkflowRunJobRepository(conn)
-    watch_repo = WatchRepository(conn)
-
-    run = await anyio.to_thread.run_sync(lambda: run_repo.get(rid))
-    if run is None:
-        raise HTTPException(404, f"Run '{run_id}' not found")
-    if run.status in _WORKFLOW_TERMINAL_STATUSES:
-        raise HTTPException(422, f"Run is already {run.status}")
-
-    memberships = await anyio.to_thread.run_sync(lambda: wrj_repo.list_by_run(rid))
-    errors: list[str] = []
-    for m in memberships:
-        if m.job_id is None:
-            continue
-        try:
-            await anyio.to_thread.run_sync(
-                lambda jid=m.job_id: adapter.cancel_job(int(jid))  # type: ignore[misc]
-            )
-        except Exception as e:
-            errors.append(f"{m.job_name}: {e}")
-
-    # Route through WorkflowRunStateService so a
-    # ``workflow_run.status_changed`` event is emitted and subscribers
-    # receive a delivery. ``run.status`` was captured above and is
-    # guaranteed non-terminal by the 422 guard.
-    current_status = run.status
-
-    def _finalize() -> None:
-        with transaction(conn, "IMMEDIATE"):
-            transitioned = WorkflowRunStateService.update(
-                conn=conn,
-                workflow_run_id=rid,
-                from_status=current_status,
-                to_status="cancelled",
-                completed_at=now_iso(),
-            )
-            if not transitioned:
-                # Race with the poller: re-read the latest status and
-                # retry once. Skip if the row has reached a terminal
-                # state in the meantime.
-                latest = run_repo.get(rid)
-                if (
-                    latest is not None
-                    and latest.status not in _WORKFLOW_TERMINAL_STATUSES
-                ):
-                    WorkflowRunStateService.update(
-                        conn=conn,
-                        workflow_run_id=rid,
-                        from_status=latest.status,
-                        to_status="cancelled",
-                        completed_at=now_iso(),
-                    )
-            for w in watch_repo.list_by_target(
-                kind="workflow_run",
-                target_ref=f"workflow_run:{rid}",
-                only_open=True,
-            ):
-                if w.id is not None:
-                    watch_repo.close(w.id)
-
-    await anyio.to_thread.run_sync(_finalize)
-
-    result: dict[str, Any] = {"status": "cancelled", "run_id": str(rid)}
-    if errors:
-        result["warnings"] = errors
-    return result
+    return await WorkflowRunCancellationService(_WORKFLOW_TERMINAL_STATUSES).cancel(
+        run_id=run_id,
+        conn=conn,
+        adapter=adapter,
+    )
 
 
 @router.post("/validate")

--- a/src/srunx/web/schemas/__init__.py
+++ b/src/srunx/web/schemas/__init__.py
@@ -1,0 +1,19 @@
+"""Pydantic request/response schemas for the web API.
+
+Centralized here so service and router modules can share the same DTO
+definitions without router↔service import cycles.
+"""
+
+from .workflows import (
+    SweepSpecRequest,
+    WorkflowCreateRequest,
+    WorkflowJobInput,
+    WorkflowRunRequest,
+)
+
+__all__ = [
+    "SweepSpecRequest",
+    "WorkflowCreateRequest",
+    "WorkflowJobInput",
+    "WorkflowRunRequest",
+]

--- a/src/srunx/web/schemas/workflows.py
+++ b/src/srunx/web/schemas/workflows.py
@@ -1,0 +1,83 @@
+"""Pydantic DTOs for ``/api/workflows/*`` endpoints.
+
+Extracted from ``srunx.web.routers.workflows`` so the router and service
+modules can both import them without creating a circular import.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class WorkflowJobInput(BaseModel):
+    name: str
+    command: list[str]
+    depends_on: list[str] = []
+    template: str | None = None
+    exports: dict[str, str] = Field(default_factory=dict)
+    resources: dict[str, Any] | None = None
+    environment: dict[str, Any] | None = None
+    work_dir: str | None = None
+    log_dir: str | None = None
+    retry: int | None = None
+    retry_delay: int | None = None
+    srun_args: str | None = None
+    launch_prefix: str | None = None
+
+    model_config = {"extra": "forbid"}
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_outputs(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "outputs" in data:
+            raise ValueError(
+                "The 'outputs' field was renamed to 'exports' (see CHANGELOG). "
+                "Dependent jobs now reference values as '{{ deps.<job_name>.<key> }}'."
+            )
+        return data
+
+
+class WorkflowCreateRequest(BaseModel):
+    name: str = Field(..., pattern=r"^[\w\-]+$")
+    args: dict[str, Any] = Field(default_factory=dict)
+    jobs: list[WorkflowJobInput]
+    default_project: str | None = None
+    overwrite: bool = False
+
+
+class SweepSpecRequest(BaseModel):
+    """Sweep payload accepted by ``POST /api/workflows/{name}/run``.
+
+    Mirrors :class:`srunx.sweep.SweepSpec` but with a server-side default
+    for ``max_parallel`` (R7.9) so the client can omit it for small
+    sweeps.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    matrix: dict[str, list[Any]] = Field(default_factory=dict)
+    fail_fast: bool = False
+    max_parallel: int = 4
+
+
+class WorkflowRunRequest(BaseModel):
+    from_job: str | None = None
+    to_job: str | None = None
+    single_job: str | None = None
+    dry_run: bool = False
+    # Notification subscription wiring. When ``notify`` is true and
+    # ``endpoint_id`` resolves to an enabled endpoint row, the run's
+    # auto-created ``kind='workflow_run'`` watch is paired with a
+    # subscription so the delivery poller fans status-transition
+    # events out to that endpoint. Matches the shape accepted by
+    # ``/api/jobs`` submit (R6 in design.md §Request models).
+    notify: bool = False
+    endpoint_id: int | None = Field(default=None, gt=0)
+    preset: str = "terminal"
+    # Sweep wiring (Phase G). ``args_override`` expands workflow-level
+    # ``args`` before Jinja rendering; ``sweep`` switches the request
+    # onto the :class:`SweepOrchestrator` path.
+    args_override: dict[str, Any] = Field(default_factory=dict)
+    sweep: SweepSpecRequest | None = None

--- a/src/srunx/web/services/__init__.py
+++ b/src/srunx/web/services/__init__.py
@@ -1,0 +1,8 @@
+"""Service layer for ``/api/workflows/*`` endpoints.
+
+Framework-agnostic business logic — FastAPI ``Depends`` wiring and HTTP
+response shaping stay in the router module. Services accept plain
+arguments (DB connection, adapter, Pydantic schema instance) and expose
+async methods that internally wrap blocking calls with
+``anyio.to_thread.run_sync``.
+"""

--- a/src/srunx/web/services/_submission_common.py
+++ b/src/srunx/web/services/_submission_common.py
@@ -1,0 +1,331 @@
+"""Shared helpers across ``WorkflowStorageService``, ``WorkflowSubmissionService``,
+and ``SweepSubmissionService``.
+
+These were previously private top-level helpers in
+``srunx.web.routers.workflows``. They live here so both the service modules
+and the router can import them without creating a service↔router cycle.
+The router keeps module-level re-exports (``_get_current_profile`` etc.)
+so existing test patches on ``srunx.web.routers.workflows.<helper>``
+continue to work.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import anyio
+import yaml
+from fastapi import HTTPException
+
+from srunx.logging import get_logger
+from srunx.models import Workflow
+from srunx.rendering import SubmissionRenderContext
+from srunx.runner import WorkflowRunner
+from srunx.security import find_python_prefix
+
+logger = get_logger(__name__)
+
+
+class MountSyncFailedError(Exception):
+    """Raised by ``_hold_workflow_mounts_web`` when rsync/lock acquisition
+    fails before any sbatch runs.
+
+    Callers (``run_workflow`` / ``_dispatch_sweep``) convert this into
+    ``HTTPException(502)``. It's a distinct class from ``HTTPException``
+    so the non-sweep handler can tell "lock acquisition failed"
+    (no run row yet) apart from "sbatch body failed" (run row needs
+    to be marked failed).
+    """
+
+
+# ── Path resolution ────────────────────────────────────────────────
+
+
+def get_current_profile() -> Any:
+    """Wrapper around :func:`srunx.web.sync_utils.get_current_profile`.
+
+    Kept as a distinct helper so the router's ``_get_current_profile``
+    re-export stays a one-line delegate that ``unittest.mock.patch``
+    targets cleanly.
+    """
+    from ..sync_utils import get_current_profile as _resolve
+
+    return _resolve()
+
+
+def find_mount(profile: Any, mount_name: str) -> Any:
+    """Find a mount by name. Raises HTTPException 404 if not found."""
+    from ..sync_utils import find_mount as _find
+
+    try:
+        return _find(profile, mount_name)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+def workflow_dir(mount_name: str, profile_resolver: Any) -> Path:
+    """Resolve workflow directory for a given mount.
+
+    Returns ``<mount.local>/.srunx/workflows/``. ``profile_resolver`` is
+    a zero-arg callable returning the active ``ServerProfile`` (or
+    ``None``); the router passes its own ``_get_current_profile`` so test
+    patches keep working.
+    """
+    profile = profile_resolver()
+    if profile is None:
+        raise HTTPException(status_code=503, detail="No SSH profile configured")
+    mount = find_mount(profile, mount_name)
+    return Path(mount.local) / ".srunx" / "workflows"
+
+
+def ensure_workflow_dir(mount_name: str, profile_resolver: Any) -> Path:
+    """Like :func:`workflow_dir` but creates the directory (and
+    ``.srunx/.gitignore``) if needed."""
+    d = workflow_dir(mount_name, profile_resolver)
+    d.mkdir(parents=True, exist_ok=True)
+    gitignore = d.parent / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("*\n!workflows/\n!workflows/**\n!.gitignore\n")
+    return d
+
+
+def find_yaml(name: str, mount_name: str, profile_resolver: Any) -> Path:
+    d = workflow_dir(mount_name, profile_resolver)
+    for ext in (".yaml", ".yml"):
+        p = d / f"{name}{ext}"
+        if p.exists():
+            return p
+    raise HTTPException(status_code=404, detail=f"Workflow '{name}' not found")
+
+
+# ── python: prefix security guards ─────────────────────────────────
+
+
+def reject_python_prefix_web(payload: Any, *, source: str) -> None:
+    """Reject ``python:``-prefixed strings in Web API payloads.
+
+    Centralizes the guard applied to both YAML args (pre-parsed by the
+    caller) and JSON ``args_override`` / ``sweep.matrix`` payloads.
+    Raises ``HTTPException(422)`` on the first violation.
+    """
+    violation = find_python_prefix(payload, source=source)
+    if violation is not None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{violation.source} at '{violation.path}' contains 'python:' "
+                "prefix which is not allowed via web for security reasons"
+            ),
+        )
+
+
+def reject_python_prefix_in_yaml_args(yaml_content: str) -> None:
+    """Parse YAML text and apply the ``python:`` guard to its ``args`` section.
+
+    Uses ``yaml.safe_load`` so legitimate uses of ``python:`` in commands
+    or comments are not blocked. Malformed YAML is left to downstream
+    validation to report.
+    """
+    try:
+        data = yaml.safe_load(yaml_content)
+    except Exception:
+        return
+
+    if not isinstance(data, dict):
+        return
+
+    args = data.get("args")
+    if not isinstance(args, dict):
+        return
+
+    reject_python_prefix_web(args, source="args")
+
+
+# ── Mount + submission context ─────────────────────────────────────
+
+
+def build_submission_context(
+    mount_name: str | None,
+    profile: Any,
+) -> SubmissionRenderContext:
+    """Construct a :class:`SubmissionRenderContext` from the Web profile + mount.
+
+    - ``mount_name`` is the selected ``?mount=<name>`` query parameter.
+      When ``None``, no mount translation is performed.
+    - ``profile`` is the configured :class:`ServerProfile` (or ``None``
+      when no SSH profile is set up). Its ``mounts`` list is frozen into
+      a tuple so the context stays hashable / immutable.
+    - ``default_work_dir`` is the selected mount's remote path (so jobs
+      whose ``work_dir`` is empty inherit the mount root).
+    """
+    mounts: tuple[Any, ...] = tuple(profile.mounts) if profile is not None else ()
+    default_work_dir: str | None = None
+    if mount_name is not None and profile is not None:
+        for m in profile.mounts:
+            if m.name == mount_name:
+                default_work_dir = m.remote
+                break
+    return SubmissionRenderContext(
+        mount_name=mount_name,
+        mounts=mounts,
+        default_work_dir=default_work_dir,
+    )
+
+
+def enforce_shell_script_roots(
+    workflow: Workflow,
+    mount: str,
+    profile: Any,
+    *,
+    profile_resolver: Any,
+) -> None:
+    """Guard that every :class:`ShellJob`'s script_path stays under allowed roots.
+
+    The canonical render helper reads :class:`ShellJob` scripts
+    verbatim (``render_shell_job_script`` uses ``script_path`` as the
+    template); we still need the directory-traversal check that the
+    old ``_render_scripts`` performed before the file was opened. Called
+    before render so bogus paths surface as 403 with no partial render
+    side effects.
+    """
+    from srunx.security import find_shell_script_violation
+
+    allowed_roots = [workflow_dir(mount, profile_resolver).resolve()]
+    if profile:
+        allowed_roots.extend(Path(m.local).resolve() for m in profile.mounts)
+    violation = find_shell_script_violation(workflow, allowed_roots)
+    if violation is not None:
+        raise HTTPException(
+            403,
+            f"Script path '{violation.script_path}' is outside allowed directories",
+        )
+
+
+# ── Mount session (lock + rsync) ───────────────────────────────────
+
+
+@contextlib.asynccontextmanager
+async def hold_workflow_mounts_web(
+    workflow: Workflow,
+    runner: WorkflowRunner,
+    *,
+    sync_required: bool = True,
+) -> AsyncIterator[Any]:
+    """Hold the per-mount sync lock across the whole workflow submission.
+
+    Workflow Phase 2 (#135) — web parity with the CLI's
+    :func:`srunx.cli.workflow._hold_workflow_mounts`. Each unique
+    mount touched by the workflow's :class:`ShellJob` ``script_path``
+    values is rsynced **once** under
+    :func:`~srunx.sync.service.mount_sync_session`, and the
+    per-(profile, mount) lock is held for the entire ``async with``
+    block so a concurrent ``srunx flow run`` / ``/api/workflows/run``
+    can't rsync different bytes between our sync and our submission.
+
+    Sort order matches the profile's ``mounts`` list so two web
+    requests touching overlapping mount sets always acquire locks
+    in the same global order — eliminates lock-inversion deadlock,
+    same fix as Codex follow-up #2 on PR #141.
+
+    Yields the resolved :class:`ServerProfile` so the caller can use
+    it for path translation / submission-context construction. Yields
+    ``None`` when no SSH profile is configured (legacy local path).
+
+    Lock acquisition + rsync errors surface as
+    :class:`MountSyncFailedError`. Exceptions raised from the body
+    (sbatch failures, render errors) propagate **unchanged** so the
+    caller can route them through the existing per-phase ``_fail``
+    bookkeeping. Mirrors the CLI exception-scoping rationale (Codex
+    blocker #1 on PR #141).
+
+    ``sync_required=False`` skips the rsync but still acquires the
+    lock — preserves the race-free submission invariant for callers
+    that opted out of the transfer.
+    """
+    from srunx.config import get_config
+    from srunx.runtime.submission_plan import collect_touched_mounts
+    from srunx.ssh.core.config import ConfigManager
+    from srunx.sync.lock import SyncLockTimeoutError
+    from srunx.sync.service import SyncAbortedError, mount_sync_session
+
+    from ..config import get_web_config
+    from ..sync_utils import get_current_profile
+
+    def _resolve_profile_with_name() -> tuple[Any, str | None]:
+        # Mirrors ``sync_utils.get_current_profile`` but returns the
+        # name too — :func:`acquire_sync_lock` keys the lock file on
+        # ``(profile_name, mount_name)`` so we need both halves.
+        web_cfg = get_web_config()
+        cm = ConfigManager()
+        name = web_cfg.ssh_profile or cm.get_current_profile_name()
+        if not name:
+            return None, None
+        return cm.get_profile(name), name
+
+    profile, profile_name = await anyio.to_thread.run_sync(_resolve_profile_with_name)
+    if profile is None:
+        # Fall back to the patched-in ``get_current_profile`` so tests
+        # that mock the helper directly (without seeding the
+        # ``ConfigManager`` registry) still see a profile here.
+        profile = await anyio.to_thread.run_sync(get_current_profile)
+        if profile is None:
+            yield None
+            return
+        profile_name = profile_name or runner.default_project or ""
+
+    mounts = collect_touched_mounts(workflow, profile)
+    if not mounts:
+        yield profile
+        return
+
+    mount_order = {m.name: i for i, m in enumerate(profile.mounts)}
+    mounts.sort(key=lambda m: mount_order.get(m.name, len(mount_order)))
+
+    config = get_config()
+    # Lock-file key — falls back to the workflow's default_project so
+    # we never hand an empty string to acquire_sync_lock.
+    effective_profile_name = profile_name or runner.default_project or "default"
+
+    def _enter_all_mounts() -> contextlib.ExitStack:
+        # ExitStack lifetime spans the ``async with`` body; constructed
+        # off-thread because mount_sync_session is a synchronous CM
+        # (file lock + subprocess rsync). The stack is closed back in
+        # ``_close_stack`` after the body exits.
+        stack = contextlib.ExitStack()
+        try:
+            for mount in mounts:
+                outcome = stack.enter_context(
+                    mount_sync_session(
+                        profile_name=effective_profile_name,
+                        profile=profile,
+                        mount=mount,
+                        config=config.sync,
+                        sync_required=sync_required,
+                    )
+                )
+                if outcome.performed:
+                    logger.info("Synced mount '%s'", mount.name)
+        except BaseException:
+            stack.close()
+            raise
+        return stack
+
+    try:
+        stack = await anyio.to_thread.run_sync(_enter_all_mounts)
+    except SyncAbortedError as exc:
+        raise MountSyncFailedError(str(exc)) from exc
+    except SyncLockTimeoutError as exc:
+        raise MountSyncFailedError(str(exc)) from exc
+    except RuntimeError as exc:
+        raise MountSyncFailedError(str(exc)) from exc
+
+    try:
+        # Body exceptions MUST propagate as-is (sbatch failures vs sync
+        # failures must stay distinguishable to the caller's per-phase
+        # _fail bookkeeping). Codex blocker #1 on PR #141.
+        yield profile
+    finally:
+        await anyio.to_thread.run_sync(stack.close)

--- a/src/srunx/web/services/sweep_submission.py
+++ b/src/srunx/web/services/sweep_submission.py
@@ -1,0 +1,256 @@
+"""Sweep workflow dispatch.
+
+Drives the ``POST /api/workflows/{name}/run`` sweep branch — materializes
+all matrix cells synchronously, then spawns the orchestrator as a
+background task so the HTTP 202 returns immediately. The execution loop
+lives in :func:`run_sweep_background`.
+
+``SweepSpec`` and ``SweepOrchestrator`` are imported at the router-module
+level (not here) because tests patch them via
+``srunx.web.routers.workflows.SweepSpec`` / ``.SweepOrchestrator``;
+:meth:`SweepSubmissionService.dispatch` accepts them as constructor
+arguments so those patches flow through.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import anyio
+import yaml
+from fastapi import HTTPException, Request
+
+from srunx.exceptions import SweepExecutionError, WorkflowValidationError
+from srunx.logging import get_logger
+from srunx.runner import WorkflowRunner
+from srunx.slurm.ssh import SlurmSSHAdapter
+from srunx.slurm.ssh_executor import SlurmSSHExecutorPool
+
+from ..schemas.workflows import WorkflowRunRequest
+from ._submission_common import (
+    build_submission_context,
+    enforce_shell_script_roots,
+    hold_workflow_mounts_web,
+)
+
+logger = get_logger(__name__)
+
+
+async def run_sweep_background(
+    orchestrator: Any,
+    sweep_run_id: int,
+    pool: SlurmSSHExecutorPool | None = None,
+) -> None:
+    """Background task body: drive already-materialized cells to completion.
+
+    Exceptions are logged and swallowed — the sweep's status columns in
+    the DB are authoritative, and the aggregator will converge the sweep
+    to a terminal state even if this task crashes mid-flight.
+
+    When a ``pool`` is supplied, every pooled SSH adapter is torn down
+    after the orchestrator returns (success or crash) so a completed
+    sweep never leaks SSH sessions against the cluster.
+    """
+    try:
+        await orchestrator.arun_from_materialized(sweep_run_id)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Background sweep task for sweep_run_id=%s raised",
+            sweep_run_id,
+            exc_info=True,
+        )
+    finally:
+        if pool is not None:
+            try:
+                await anyio.to_thread.run_sync(pool.close)
+            except Exception:  # noqa: BLE001 — pool cleanup is best-effort
+                logger.warning(
+                    "Failed to close SSH executor pool for sweep_run_id=%s",
+                    sweep_run_id,
+                    exc_info=True,
+                )
+
+
+class SweepSubmissionService:
+    """Materialize + dispatch a sweep request.
+
+    :param sweep_spec_cls: The :class:`~srunx.sweep.SweepSpec` class as
+        named in the router module. Passed in so tests patching
+        ``srunx.web.routers.workflows.SweepSpec`` affect materialization.
+    :param orchestrator_cls: The :class:`~srunx.sweep.orchestrator.SweepOrchestrator`
+        class. Same patchability rationale.
+    :param profile_resolver: Zero-arg callable returning the active
+        :class:`ServerProfile` (or ``None``).
+    """
+
+    def __init__(
+        self,
+        *,
+        sweep_spec_cls: Any,
+        orchestrator_cls: Any,
+        profile_resolver: Callable[[], Any],
+        workflow_runner_cls: Any = WorkflowRunner,
+        executor_pool_cls: Any = SlurmSSHExecutorPool,
+    ) -> None:
+        self._sweep_spec_cls = sweep_spec_cls
+        self._orchestrator_cls = orchestrator_cls
+        self._profile_resolver = profile_resolver
+        self._runner_cls = workflow_runner_cls
+        self._executor_pool_cls = executor_pool_cls
+
+    async def dispatch(
+        self,
+        *,
+        yaml_path: Path,
+        name: str,
+        body: WorkflowRunRequest,
+        request: Request,
+        adapter: SlurmSSHAdapter,
+        mount: str | None = None,
+    ) -> dict[str, Any]:
+        """Materialize synchronously + spawn orchestrator as a background task.
+
+        Returns 202 as soon as the cells exist in the DB so HTTP
+        clients don't block on the full sweep.
+        """
+        assert body.sweep is not None  # narrowed by caller
+
+        # Read raw YAML once so the orchestrator can see base ``args``
+        # and the workflow name.
+        def _load_raw() -> dict[str, Any]:
+            raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+            return raw if isinstance(raw, dict) else {}
+
+        workflow_data = await anyio.to_thread.run_sync(_load_raw)
+
+        try:
+            sweep_spec = self._sweep_spec_cls(
+                matrix=body.sweep.matrix,
+                fail_fast=body.sweep.fail_fast,
+                max_parallel=body.sweep.max_parallel,
+            )
+        except Exception as exc:  # noqa: BLE001 — Pydantic / value errors
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        # C3 (security): apply the same ShellJob script-root guard the
+        # non-sweep path runs, before any DB materialize side effect.
+        profile = await anyio.to_thread.run_sync(self._profile_resolver)
+        base_runner: WorkflowRunner | None = None
+        if mount is not None:
+            runner_cls = self._runner_cls
+            try:
+                base_runner = await anyio.to_thread.run_sync(
+                    lambda: runner_cls.from_yaml(
+                        yaml_path,
+                        args_override=body.args_override or None,
+                    )
+                )
+            except WorkflowValidationError as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            except Exception as exc:  # noqa: BLE001 — YAML / Jinja errors
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            assert base_runner is not None
+            runner_for_guard = base_runner
+            await anyio.to_thread.run_sync(
+                lambda: enforce_shell_script_roots(
+                    runner_for_guard.workflow,
+                    mount,
+                    profile,
+                    profile_resolver=self._profile_resolver,
+                )
+            )
+
+            # Workflow Phase 2 (#135 web parity): rsync each touched
+            # mount **once** at dispatch time, even when the sweep
+            # expands into many cells targeting the same mount.
+            async with hold_workflow_mounts_web(
+                runner_for_guard.workflow, runner_for_guard, sync_required=True
+            ):
+                pass
+
+        endpoint_id: int | None = None
+        if body.notify and body.endpoint_id is not None:
+            endpoint_id = body.endpoint_id
+        elif body.notify and body.endpoint_id is None:
+            logger.warning("sweep run: notify=true with no endpoint_id; skipping")
+
+        # Build a per-sweep SSH executor pool so each cell's runner
+        # submits through the configured cluster adapter instead of
+        # the local :class:`Slurm` client. ``self._executor_pool_cls``
+        # lets tests patch
+        # ``srunx.web.routers.workflows.SlurmSSHExecutorPool`` and have
+        # that replacement reach this constructor call.
+        pool_size = max(1, min(sweep_spec.max_parallel, 8))
+        pool = self._executor_pool_cls(
+            adapter.connection_spec,
+            callbacks=[],
+            size=pool_size,
+        )
+
+        submission_context = build_submission_context(mount, profile)
+
+        orchestrator = self._orchestrator_cls(
+            workflow_yaml_path=yaml_path,
+            workflow_data={"name": name, **workflow_data},
+            args_override=body.args_override or None,
+            sweep_spec=sweep_spec,
+            submission_source="web",
+            endpoint_id=endpoint_id,
+            preset=body.preset,
+            executor_factory=pool.lease,
+            submission_context=submission_context,
+        )
+
+        try:
+            sweep_run_id = await anyio.to_thread.run_sync(orchestrator.materialize)
+        except WorkflowValidationError as exc:
+            pool.close()
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except SweepExecutionError as exc:
+            pool.close()
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+        except BaseException:
+            pool.close()
+            raise
+
+        # Spawn the execution loop on the app's lifespan task group so
+        # the HTTP request can return 202 immediately.
+        task_group = getattr(request.app.state, "task_group", None)
+        if task_group is not None:
+            task_group.start_soon(
+                run_sweep_background, orchestrator, sweep_run_id, pool
+            )
+        else:
+            # Fallback for test harnesses that don't run lifespan.
+            import asyncio
+
+            pending = getattr(request.app.state, "background_tasks", None)
+            if pending is None:
+                pending = set()
+                request.app.state.background_tasks = pending
+            task = asyncio.create_task(
+                run_sweep_background(orchestrator, sweep_run_id, pool)
+            )
+            pending.add(task)
+            task.add_done_callback(pending.discard)
+
+        # Read the freshly-materialized row so counters + status
+        # reflect the DB state, not the orchestrator's pre-run view.
+        from srunx.db.connection import open_connection as _open
+        from srunx.db.repositories.sweep_runs import SweepRunRepository
+
+        def _load_sweep() -> Any:
+            db_conn = _open()
+            try:
+                return SweepRunRepository(db_conn).get(sweep_run_id)
+            finally:
+                db_conn.close()
+
+        sweep_row = await anyio.to_thread.run_sync(_load_sweep)
+        return {
+            "sweep_run_id": sweep_run_id,
+            "status": sweep_row.status if sweep_row is not None else "pending",
+            "cell_count": sweep_row.cell_count if sweep_row is not None else 0,
+        }

--- a/src/srunx/web/services/workflow_run_cancellation.py
+++ b/src/srunx/web/services/workflow_run_cancellation.py
@@ -1,0 +1,105 @@
+"""Workflow run cancellation.
+
+Wraps ``POST /api/workflows/runs/{run_id}/cancel`` — best-effort
+``scancel`` fan-out across all job memberships, then a single atomic
+terminal transition via :class:`WorkflowRunStateService`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import anyio
+from fastapi import HTTPException
+
+from srunx.db.connection import transaction
+from srunx.db.repositories.base import now_iso
+from srunx.db.repositories.watches import WatchRepository
+from srunx.db.repositories.workflow_run_jobs import WorkflowRunJobRepository
+from srunx.db.repositories.workflow_runs import WorkflowRunRepository
+from srunx.slurm.ssh import SlurmSSHAdapter
+from srunx.sweep.state_service import WorkflowRunStateService
+
+from .workflow_run_query import parse_run_id
+
+
+class WorkflowRunCancellationService:
+    """Cancel a running workflow (scancel its live children + mark the run)."""
+
+    def __init__(self, terminal_statuses: frozenset[str]) -> None:
+        self._terminal = terminal_statuses
+
+    async def cancel(
+        self,
+        *,
+        run_id: str,
+        conn: sqlite3.Connection,
+        adapter: SlurmSSHAdapter,
+    ) -> dict[str, Any]:
+        rid = parse_run_id(run_id)
+        run_repo = WorkflowRunRepository(conn)
+        wrj_repo = WorkflowRunJobRepository(conn)
+        watch_repo = WatchRepository(conn)
+
+        run = await anyio.to_thread.run_sync(lambda: run_repo.get(rid))
+        if run is None:
+            raise HTTPException(404, f"Run '{run_id}' not found")
+        if run.status in self._terminal:
+            raise HTTPException(422, f"Run is already {run.status}")
+
+        memberships = await anyio.to_thread.run_sync(lambda: wrj_repo.list_by_run(rid))
+        errors: list[str] = []
+        for m in memberships:
+            if m.job_id is None:
+                continue
+            try:
+                await anyio.to_thread.run_sync(
+                    lambda jid=m.job_id: adapter.cancel_job(int(jid))  # type: ignore[misc]
+                )
+            except Exception as e:
+                errors.append(f"{m.job_name}: {e}")
+
+        # Route through WorkflowRunStateService so a
+        # ``workflow_run.status_changed`` event is emitted and subscribers
+        # receive a delivery. ``run.status`` was captured above and is
+        # guaranteed non-terminal by the 422 guard.
+        current_status = run.status
+        terminal = self._terminal
+
+        def _finalize() -> None:
+            with transaction(conn, "IMMEDIATE"):
+                transitioned = WorkflowRunStateService.update(
+                    conn=conn,
+                    workflow_run_id=rid,
+                    from_status=current_status,
+                    to_status="cancelled",
+                    completed_at=now_iso(),
+                )
+                if not transitioned:
+                    # Race with the poller: re-read the latest status and
+                    # retry once. Skip if the row has reached a terminal
+                    # state in the meantime.
+                    latest = run_repo.get(rid)
+                    if latest is not None and latest.status not in terminal:
+                        WorkflowRunStateService.update(
+                            conn=conn,
+                            workflow_run_id=rid,
+                            from_status=latest.status,
+                            to_status="cancelled",
+                            completed_at=now_iso(),
+                        )
+                for w in watch_repo.list_by_target(
+                    kind="workflow_run",
+                    target_ref=f"workflow_run:{rid}",
+                    only_open=True,
+                ):
+                    if w.id is not None:
+                        watch_repo.close(w.id)
+
+        await anyio.to_thread.run_sync(_finalize)
+
+        result: dict[str, Any] = {"status": "cancelled", "run_id": str(rid)}
+        if errors:
+            result["warnings"] = errors
+        return result

--- a/src/srunx/web/services/workflow_run_query.py
+++ b/src/srunx/web/services/workflow_run_query.py
@@ -1,0 +1,124 @@
+"""Read-only ``workflow_runs`` queries.
+
+Wraps ``GET /api/workflows/runs`` and ``GET /api/workflows/runs/{run_id}``,
+plus the shared ``_build_run_response`` helper that hydrates a
+``WorkflowRun`` row with its child job statuses. The router re-exports
+``_build_run_response`` so ``tests/transport/test_review_fixes.py``'s
+direct import (``from srunx.web.routers.workflows import _build_run_response``)
+keeps working.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import anyio
+from fastapi import HTTPException
+
+from srunx.db.models import WorkflowRun as DBWorkflowRun
+from srunx.db.models import WorkflowRunJob
+from srunx.db.repositories.jobs import JobRepository
+from srunx.db.repositories.workflow_run_jobs import WorkflowRunJobRepository
+from srunx.db.repositories.workflow_runs import WorkflowRunRepository
+
+
+def parse_run_id(run_id: str) -> int:
+    """Parse a run_id string → int, raising 404 for non-integer ids.
+
+    The API accepts ``run_id`` as a string for historical compatibility
+    (the old UUID-keyed registry); internally we always store an int.
+    """
+    try:
+        return int(run_id)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=404, detail=f"Run '{run_id}' not found"
+        ) from exc
+
+
+def serialize_run(
+    run: DBWorkflowRun,
+    memberships: list[WorkflowRunJob],
+    jobs_by_id: dict[int, str],
+) -> dict[str, Any]:
+    """Build the API response for a workflow run.
+
+    ``jobs_by_id`` maps SLURM job_id → observed status. Memberships with
+    no job_id (not yet submitted) are omitted from both ``job_ids`` and
+    ``job_statuses``.
+    """
+    job_ids: dict[str, str] = {}
+    job_statuses: dict[str, str] = {}
+    for wrj in memberships:
+        if wrj.job_id is None:
+            continue
+        job_ids[wrj.job_name] = str(wrj.job_id)
+        status = jobs_by_id.get(wrj.job_id)
+        if status is not None:
+            job_statuses[wrj.job_name] = status
+
+    return {
+        "id": str(run.id),
+        "workflow_name": run.workflow_name,
+        "started_at": run.started_at.isoformat() if run.started_at else None,
+        "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+        "status": run.status,
+        "job_ids": job_ids,
+        "job_statuses": job_statuses,
+        "error": run.error,
+        "sweep_run_id": run.sweep_run_id,
+    }
+
+
+def build_run_response(conn: sqlite3.Connection, run: DBWorkflowRun) -> dict[str, Any]:
+    """Load memberships + child job statuses and serialize."""
+    if run.id is None:
+        return serialize_run(run, [], {})
+    memberships = WorkflowRunJobRepository(conn).list_by_run(run.id)
+    job_repo = JobRepository(conn)
+    jobs_by_id: dict[int, str] = {}
+    for m in memberships:
+        # V5+: ``jobs_row_id`` is the authoritative FK to ``jobs.id``.
+        # Looking up via ``get_by_row_id`` avoids the pre-V5
+        # ``scheduler_key='local'`` default, which would drop SSH
+        # workflow children and miss their statuses in the API response.
+        if m.jobs_row_id is None or m.job_id is None:
+            continue
+        job = job_repo.get_by_row_id(m.jobs_row_id)
+        if job is not None:
+            jobs_by_id[m.job_id] = job.status
+    return serialize_run(run, memberships, jobs_by_id)
+
+
+class WorkflowRunQueryService:
+    """Read-only workflow_runs queries."""
+
+    async def list_runs(
+        self,
+        conn: sqlite3.Connection,
+        name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        def _load() -> list[dict[str, Any]]:
+            runs = WorkflowRunRepository(conn).list_all()
+            if name is not None:
+                runs = [r for r in runs if r.workflow_name == name]
+            return [build_run_response(conn, r) for r in runs]
+
+        return await anyio.to_thread.run_sync(_load)
+
+    async def get_run(
+        self,
+        conn: sqlite3.Connection,
+        run_id: str,
+    ) -> dict[str, Any]:
+        """Get the status and details of a single workflow run."""
+        rid = parse_run_id(run_id)
+
+        def _load() -> dict[str, Any]:
+            run = WorkflowRunRepository(conn).get(rid)
+            if run is None:
+                raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+            return build_run_response(conn, run)
+
+        return await anyio.to_thread.run_sync(_load)

--- a/src/srunx/web/services/workflow_storage.py
+++ b/src/srunx/web/services/workflow_storage.py
@@ -1,0 +1,371 @@
+"""Workflow file CRUD + serialization.
+
+Owns the ``<mount.local>/.srunx/workflows/`` directory convention and all
+YAML ↔ dict translation. :class:`WorkflowStorageService` takes a
+zero-arg ``profile_resolver`` callable so the router can pass its own
+module-level ``_get_current_profile`` — tests that patch
+``srunx.web.routers.workflows._get_current_profile`` then resolve the
+patched callable at every method call.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import anyio
+import yaml
+from fastapi import HTTPException
+
+from srunx.exceptions import WorkflowValidationError
+from srunx.models import Job, JobEnvironment, JobResource, ShellJob, Workflow
+from srunx.runner import WorkflowRunner
+
+from ._submission_common import (
+    ensure_workflow_dir,
+    find_yaml,
+    reject_python_prefix_in_yaml_args,
+    reject_python_prefix_web,
+    workflow_dir,
+)
+
+
+class WorkflowStorageService:
+    """Filesystem-backed workflow store.
+
+    :param profile_resolver: Zero-arg callable returning the active
+        :class:`ServerProfile` (or ``None``). The router passes its own
+        module-level ``_get_current_profile`` so ``unittest.mock.patch``
+        targets on that attribute stay effective.
+    """
+
+    def __init__(self, profile_resolver: Callable[[], Any]) -> None:
+        self._profile_resolver = profile_resolver
+
+    # ── Path helpers (thin delegates so service consumers don't need
+    # to thread the resolver through every call site) ──────────────
+
+    def workflow_dir(self, mount_name: str) -> Path:
+        return workflow_dir(mount_name, self._profile_resolver)
+
+    def ensure_workflow_dir(self, mount_name: str) -> Path:
+        return ensure_workflow_dir(mount_name, self._profile_resolver)
+
+    def find_yaml(self, name: str, mount_name: str) -> Path:
+        return find_yaml(name, mount_name, self._profile_resolver)
+
+    # ── Serialization ───────────────────────────────────────────────
+
+    @staticmethod
+    def serialize_workflow(
+        runner: WorkflowRunner,
+        raw_yaml_jobs: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        wf = runner.workflow
+        # Build lookup for extra YAML fields not stored in Job model
+        raw_by_name: dict[str, dict[str, Any]] = {}
+        if raw_yaml_jobs:
+            for rj in raw_yaml_jobs:
+                raw_by_name[rj.get("name", "")] = rj
+
+        jobs: list[dict[str, Any]] = []
+        for job in wf.jobs:
+            d: dict[str, Any] = {
+                "name": job.name,
+                "job_id": job.job_id,
+                "status": job._status.value,
+                "depends_on": job.depends_on,
+                "exports": job.exports,
+            }
+            raw_job = raw_by_name.get(job.name, {})
+            if raw_job.get("template"):
+                d["template"] = raw_job["template"]
+            if hasattr(job, "command"):
+                cmd = job.command  # type: ignore[union-attr]
+                d["command"] = [cmd] if isinstance(cmd, str) else cmd
+                d["resources"] = {
+                    "nodes": job.resources.nodes,  # type: ignore[union-attr]
+                    "gpus_per_node": job.resources.gpus_per_node,  # type: ignore[union-attr]
+                    "partition": job.resources.partition,  # type: ignore[union-attr]
+                    "time_limit": job.resources.time_limit,  # type: ignore[union-attr]
+                }
+            elif hasattr(job, "script_path"):
+                d["script_path"] = job.script_path  # type: ignore[union-attr]
+                d["command"] = []
+                d["resources"] = {}
+            else:
+                d["command"] = []
+                d["resources"] = {}
+            jobs.append(d)
+        result: dict[str, Any] = {"name": wf.name, "jobs": jobs}
+        if runner.args:
+            result["args"] = runner.args
+        if runner.default_project:
+            result["default_project"] = runner.default_project
+        return result
+
+    @staticmethod
+    def workflow_to_yaml(
+        name: str,
+        jobs_data: list[dict[str, Any]],
+        default_project: str | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> str:
+        """Serialize a workflow to YAML compatible with
+        ``WorkflowRunner.from_yaml``.
+
+        Only includes non-default / non-None resource and environment
+        fields so the resulting file stays clean.
+        """
+        serialized_jobs: list[dict[str, Any]] = []
+        for jd in jobs_data:
+            entry: dict[str, Any] = {
+                "name": jd["name"],
+                "command": jd["command"],
+            }
+
+            depends = jd.get("depends_on", [])
+            if depends:
+                entry["depends_on"] = depends
+
+            exports = jd.get("exports", {})
+            if exports:
+                entry["exports"] = exports
+
+            # Resources — only include non-None values
+            raw_res = jd.get("resources") or {}
+            resources = {k: v for k, v in raw_res.items() if v is not None}
+            if resources:
+                entry["resources"] = resources
+
+            # Environment — only include non-None values
+            raw_env = jd.get("environment") or {}
+            environment = {k: v for k, v in raw_env.items() if v is not None}
+            if environment:
+                entry["environment"] = environment
+
+            # Job-level optional fields
+            if jd.get("template"):
+                entry["template"] = jd["template"]
+            if jd.get("work_dir"):
+                entry["work_dir"] = jd["work_dir"]
+            if jd.get("log_dir"):
+                entry["log_dir"] = jd["log_dir"]
+            if jd.get("retry") is not None:
+                entry["retry"] = jd["retry"]
+            if jd.get("retry_delay") is not None:
+                entry["retry_delay"] = jd["retry_delay"]
+            if jd.get("srun_args"):
+                entry["srun_args"] = jd["srun_args"]
+            if jd.get("launch_prefix"):
+                entry["launch_prefix"] = jd["launch_prefix"]
+
+            serialized_jobs.append(entry)
+
+        doc: dict[str, Any] = {"name": name}
+        if default_project:
+            doc["default_project"] = default_project
+        if args:
+            doc["args"] = args
+        doc["jobs"] = serialized_jobs
+        return yaml.dump(doc, default_flow_style=False, sort_keys=False)
+
+    @staticmethod
+    def validate_and_build_workflow(data: dict[str, Any]) -> Workflow:
+        """Construct and validate a Workflow from a plain dict.
+
+        Builds Job instances with JobResource / JobEnvironment, then
+        runs cycle-detection via ``Workflow.validate()``.  Raises on any
+        Pydantic or workflow-level validation failure.
+        """
+        name: str = data["name"]
+        jobs_data: list[dict[str, Any]] = data.get("jobs", [])
+
+        jobs: list[Job | ShellJob] = []
+        for jd in jobs_data:
+            resource = JobResource.model_validate(jd.get("resources") or {})
+            environment = JobEnvironment.model_validate(jd.get("environment") or {})
+            job_kwargs: dict[str, Any] = {
+                "name": jd["name"],
+                "command": jd["command"],
+                "depends_on": jd.get("depends_on", []),
+                "exports": jd.get("exports", {}),
+                "resources": resource,
+                "environment": environment,
+            }
+            # Always pass work_dir and log_dir explicitly to prevent Job's
+            # default_factory from calling os.getcwd() (wrong for the web
+            # server) or defaulting to "logs" (meaningless on a remote
+            # SLURM host). Empty strings are falsy and skipped by
+            # workflow_to_yaml and the SLURM template (#SBATCH --chdir is
+            # only emitted when truthy).
+            job_kwargs["work_dir"] = jd.get("work_dir") or ""
+            job_kwargs["log_dir"] = jd.get("log_dir") or ""
+            if jd.get("retry") is not None:
+                job_kwargs["retry"] = jd["retry"]
+            if jd.get("retry_delay") is not None:
+                job_kwargs["retry_delay"] = jd["retry_delay"]
+            job = Job(**job_kwargs)
+            jobs.append(job)
+
+        workflow = Workflow(name=name, jobs=jobs)
+        workflow.validate()
+        return workflow
+
+    # ── Router-facing async operations ──────────────────────────────
+
+    async def list_workflows(self, mount: str) -> list[dict[str, Any]]:
+        d = self.workflow_dir(mount)
+        if not d.exists():
+            return []
+
+        results: list[dict[str, Any]] = []
+        for p in sorted(d.glob("*.y*ml")):
+            try:
+
+                def _load(_p: Path = p) -> tuple[WorkflowRunner, list[dict[str, Any]]]:
+                    import yaml as _yaml
+
+                    runner = WorkflowRunner.from_yaml(_p)
+                    raw = _yaml.safe_load(_p.read_text(encoding="utf-8"))
+                    return runner, raw.get("jobs", [])
+
+                runner, raw_jobs = await anyio.to_thread.run_sync(_load)
+                results.append(self.serialize_workflow(runner, raw_yaml_jobs=raw_jobs))
+            except Exception:
+                continue
+        return results
+
+    async def get(self, name: str, mount: str) -> dict[str, Any]:
+        yaml_path = self.find_yaml(name, mount)
+        try:
+
+            def _load() -> tuple[WorkflowRunner, list[dict[str, Any]]]:
+                import yaml as _yaml
+
+                runner = WorkflowRunner.from_yaml(yaml_path)
+                raw = _yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+                return runner, raw.get("jobs", [])
+
+            runner, raw_jobs = await anyio.to_thread.run_sync(_load)
+            return self.serialize_workflow(runner, raw_yaml_jobs=raw_jobs)
+        except Exception as e:
+            raise HTTPException(status_code=502, detail=str(e)) from e
+
+    async def delete(self, name: str, mount: str) -> dict[str, str]:
+        yaml_path = self.find_yaml(name, mount)  # raises 404 if not found
+        await anyio.to_thread.run_sync(lambda: yaml_path.unlink())
+        return {"status": "deleted", "name": name}
+
+    async def upload(
+        self,
+        yaml_content: str,
+        filename: str,
+        mount_name: str,
+        *,
+        safe_name_re: Any,
+    ) -> dict[str, Any]:
+        if not yaml_content or not filename or not mount_name:
+            raise HTTPException(
+                status_code=422, detail="'yaml', 'filename', and 'mount' are required"
+            )
+
+        reject_python_prefix_in_yaml_args(yaml_content)
+
+        if len(yaml_content) > 1_000_000:
+            raise HTTPException(
+                status_code=413, detail="YAML content exceeds 1MB limit"
+            )
+
+        safe_filename = Path(filename).name
+        name = Path(safe_filename).stem
+        if not safe_name_re.match(name):
+            raise HTTPException(
+                status_code=422,
+                detail="Filename must be alphanumeric with hyphens/underscores only",
+            )
+
+        d = self.ensure_workflow_dir(mount_name)
+        dest = d / safe_filename
+        dest.write_text(yaml_content)
+
+        try:
+            runner = await anyio.to_thread.run_sync(
+                lambda: WorkflowRunner.from_yaml(dest)
+            )
+            await anyio.to_thread.run_sync(runner.workflow.validate)
+            return self.serialize_workflow(runner)
+        except Exception as e:
+            dest.unlink(missing_ok=True)
+            raise HTTPException(status_code=422, detail=str(e)) from e
+
+    async def create(
+        self,
+        body: Any,  # WorkflowCreateRequest (loosely typed to avoid import cycle)
+        *,
+        reserved_names: frozenset[str],
+    ) -> dict[str, Any]:
+        """Create a new workflow from a structured JSON payload.
+
+        Validates all jobs via Pydantic model construction, checks for
+        dependency cycles, serializes to YAML, and persists to disk.
+        """
+        name = body.name
+        mount_name = body.default_project
+        if not mount_name:
+            raise HTTPException(
+                status_code=422,
+                detail="A mount (default_project) is required to save a workflow",
+            )
+
+        if name in reserved_names:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Workflow name '{name}' is reserved",
+            )
+
+        d = self.ensure_workflow_dir(mount_name)
+        if not body.overwrite:
+            for ext in (".yaml", ".yml"):
+                if (d / f"{name}{ext}").exists():
+                    raise HTTPException(
+                        status_code=409,
+                        detail=f"Workflow '{name}' already exists",
+                    )
+
+        # Reject python: args from web for security (shared guard).
+        reject_python_prefix_web(body.args, source="args")
+
+        jobs_raw: list[dict[str, Any]] = [
+            j.model_dump(exclude_none=True) for j in body.jobs
+        ]
+
+        data: dict[str, Any] = {"name": name, "jobs": jobs_raw}
+
+        try:
+            self.validate_and_build_workflow(data)
+        except WorkflowValidationError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        except Exception as exc:
+            from pydantic import ValidationError as _VE
+
+            if isinstance(exc, _VE):
+                errors = [
+                    {"loc": list(e["loc"]), "msg": e["msg"], "type": e["type"]}
+                    for e in exc.errors()
+                ]
+                raise HTTPException(status_code=422, detail=errors) from exc
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        yaml_content = self.workflow_to_yaml(
+            name,
+            jobs_raw,
+            default_project=body.default_project,
+            args=body.args or None,
+        )
+        dest = d / f"{name}.yaml"
+        await anyio.to_thread.run_sync(lambda: dest.write_text(yaml_content))
+
+        runner = await anyio.to_thread.run_sync(lambda: WorkflowRunner.from_yaml(dest))
+        return self.serialize_workflow(runner)

--- a/src/srunx/web/services/workflow_submission.py
+++ b/src/srunx/web/services/workflow_submission.py
@@ -1,0 +1,725 @@
+"""Non-sweep workflow submission.
+
+Drives the ``POST /api/workflows/{name}/run`` happy path when no
+``sweep`` spec is present:
+
+1. Resolve the profile + render the workflow via the canonical
+   :func:`~srunx.rendering.render_workflow_for_submission` helper.
+2. Hold the per-mount sync lock across the entire BFS submit via
+   :func:`_submission_common.hold_workflow_mounts_web`.
+3. BFS-submit each job in topological order, writing
+   ``jobs`` / ``job_state_transitions`` / ``workflow_run_jobs`` rows
+   atomically.
+4. Open a ``kind='workflow_run'`` watch (plus subscription when
+   ``notify=true``) so ``ActiveWatchPoller`` can drive aggregate
+   transitions.
+
+The class takes a ``profile_resolver`` callable so the router can
+forward its own module-level ``_get_current_profile`` — patching that
+attribute in tests continues to short-circuit the resolution.
+"""
+
+from __future__ import annotations
+
+import functools
+import sqlite3
+from collections import deque
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import anyio
+from fastapi import HTTPException, Request
+
+from srunx.db.connection import transaction
+from srunx.db.repositories.base import now_iso
+from srunx.db.repositories.job_state_transitions import (
+    JobStateTransitionRepository,
+)
+from srunx.db.repositories.jobs import JobRepository
+from srunx.db.repositories.watches import WatchRepository
+from srunx.db.repositories.workflow_run_jobs import WorkflowRunJobRepository
+from srunx.db.repositories.workflow_runs import WorkflowRunRepository
+from srunx.logging import get_logger
+from srunx.models import Job, ShellJob, Workflow
+from srunx.rendering import (
+    RenderedWorkflow,
+    SubmissionRenderContext,
+    render_workflow_for_submission,
+)
+from srunx.runner import WorkflowRunner
+from srunx.slurm.ssh import SlurmSSHAdapter
+from srunx.sweep.state_service import WorkflowRunStateService
+
+from ..schemas.workflows import WorkflowRunRequest
+from ._submission_common import (
+    MountSyncFailedError,
+    build_submission_context,
+    enforce_shell_script_roots,
+    hold_workflow_mounts_web,
+    reject_python_prefix_web,
+)
+
+logger = get_logger(__name__)
+
+
+def filter_workflow_jobs(
+    workflow: Workflow,
+    from_job: str | None,
+    to_job: str | None,
+    single_job: str | None,
+) -> list[Job | ShellJob]:
+    """Filter workflow jobs based on execution control parameters."""
+    all_jobs = {job.name: job for job in workflow.jobs}
+
+    if single_job:
+        if single_job not in all_jobs:
+            raise HTTPException(422, f"Job '{single_job}' not found in workflow")
+        job = all_jobs[single_job]
+        # Create a copy-like job with no dependencies for standalone execution
+        return [job]
+
+    names = [job.name for job in workflow.jobs]
+
+    start_idx = 0
+    end_idx = len(names)
+
+    if from_job:
+        if from_job not in all_jobs:
+            raise HTTPException(422, f"Job '{from_job}' not found in workflow")
+        start_idx = names.index(from_job)
+
+    if to_job:
+        if to_job not in all_jobs:
+            raise HTTPException(422, f"Job '{to_job}' not found in workflow")
+        end_idx = names.index(to_job) + 1
+
+    if from_job and to_job and start_idx >= end_idx:
+        raise HTTPException(
+            422,
+            f"from_job '{from_job}' must appear before to_job '{to_job}' in the workflow",
+        )
+
+    selected_names = set(names[start_idx:end_idx])
+    return [job for job in workflow.jobs if job.name in selected_names]
+
+
+def render_workflow(
+    yaml_path: Path,
+    *,
+    submission_context: SubmissionRenderContext,
+    args_override: dict[str, Any] | None = None,
+    single_job: str | None = None,
+) -> RenderedWorkflow:
+    """Thin wrapper around :func:`render_workflow_for_submission`."""
+    return render_workflow_for_submission(
+        yaml_path,
+        args_override=args_override,
+        context=submission_context,
+        single_job=single_job,
+    )
+
+
+def resolve_in_place_target(
+    job: Job | ShellJob,
+    rendered_text: str,
+    profile: Any,
+) -> tuple[str, str] | None:
+    """Decide whether *job* qualifies for the in-place sbatch path.
+
+    Workflow Phase 2 (#135): only :class:`ShellJob` instances whose
+    ``script_path`` resolves under one of the SSH profile's mount
+    ``local`` roots, and whose Jinja-rendered bytes still equal the
+    on-disk source bytes, can run the user's file verbatim on the
+    cluster. Anything else (``Job`` with ``command``, ShellJob outside
+    every mount, or rendered output that diverged from source) must
+    fall back to the legacy temp-upload path so the rendered artifact
+    actually reaches the cluster.
+
+    Returns ``(remote_path, submit_cwd)`` when the in-place path is
+    safe, otherwise ``None``. ``submit_cwd`` is the script's parent
+    directory on the remote so relative paths inside the user's
+    ``#SBATCH`` directives resolve as they would on a head-node
+    ``sbatch ./script.sh``. Same ``parent_remote or remote_script``
+    fallback the single-job /api/jobs path uses.
+
+    Path security: the workflow's ``_enforce_shell_script_roots``
+    guard already rejected scripts outside every allowed root before
+    render, so reaching here means the path is safe to translate.
+    The mount lookup is a longest-prefix match via
+    :func:`resolve_mount_for_path` so nested mounts pick the deepest
+    owner.
+    """
+    from srunx.runtime.submission_plan import (
+        render_text_matches_source,
+        resolve_mount_for_path,
+        translate_local_to_remote,
+    )
+
+    if profile is None or not isinstance(job, ShellJob):
+        return None
+
+    script_attr = getattr(job, "script_path", None)
+    if not script_attr:
+        return None
+
+    try:
+        source_path = Path(script_attr)
+    except (TypeError, ValueError):
+        return None
+
+    mount = resolve_mount_for_path(source_path, profile)
+    if mount is None:
+        return None
+
+    if not render_text_matches_source(rendered_text, source_path):
+        return None
+
+    remote_path = translate_local_to_remote(source_path, mount)
+    parent_remote, _, _ = remote_path.rpartition("/")
+    submit_cwd = parent_remote or remote_path
+    return remote_path, submit_cwd
+
+
+async def submit_jobs_bfs(
+    workflow: Workflow,
+    scripts: dict[str, str],
+    run_opts: WorkflowRunRequest,
+    adapter: SlurmSSHAdapter,
+    *,
+    conn: sqlite3.Connection,
+    run_id: int,
+    profile: Any = None,
+    unrendered_jobs_by_name: dict[str, Job | ShellJob] | None = None,
+) -> dict[str, str]:
+    """Submit jobs in topological order via BFS, returning {name: slurm_id}.
+
+    Each successful submit is persisted atomically:
+
+    1. ``jobs`` row via :meth:`JobRepository.record_submission` (with
+       ``submission_source='workflow'`` + ``workflow_run_id``).
+    2. Seed ``job_state_transitions`` with ``PENDING`` so the active
+       watch poller's first observation produces a real transition.
+    3. Link to the workflow via :meth:`WorkflowRunJobRepository.create`.
+
+    On sbatch failure we record a membership row with ``job_id=None``
+    so the response can still reflect the attempted job set, then
+    raise.
+    """
+    job_repo = JobRepository(conn)
+    wrj_repo = WorkflowRunJobRepository(conn)
+    transition_repo = JobStateTransitionRepository(conn)
+
+    filtered_names = {job.name for job in workflow.jobs}
+    job_map: dict[str, Job | ShellJob] = {job.name: job for job in workflow.jobs}
+    dependents: dict[str, list[str]] = {job.name: [] for job in workflow.jobs}
+    in_degree: dict[str, int] = {
+        job.name: len(
+            [d for d in job.parsed_dependencies if d.job_name in filtered_names]
+        )
+        for job in workflow.jobs
+    }
+
+    for job in workflow.jobs:
+        for dep in job.parsed_dependencies:
+            if dep.job_name in filtered_names:
+                dependents[dep.job_name].append(job.name)
+
+    queue: deque[str] = deque(
+        job.name for job in workflow.jobs if in_degree[job.name] == 0
+    )
+    submitted: dict[str, str] = {}
+
+    while queue:
+        current_name = queue.popleft()
+        current_job = job_map[current_name]
+
+        dep_parts: list[str] = []
+        if not run_opts.single_job:
+            for dep in current_job.parsed_dependencies:
+                if dep.job_name in submitted:
+                    parent_id = submitted[dep.job_name]
+                    dep_parts.append(f"{dep.dep_type}:{parent_id}")
+        dependency = ",".join(dep_parts) if dep_parts else None
+
+        depends_on = [
+            d.job_name
+            for d in current_job.parsed_dependencies
+            if d.job_name in filtered_names
+        ]
+
+        # The rendered ``current_job`` may have its ``script_path``
+        # already translated to remote form by
+        # ``_normalize_paths_for_mount``, which makes the in-place
+        # mount lookup miss. Use the unrendered job (with its original
+        # local path) when the caller threaded one through. See #150
+        # root cause.
+        in_place_job = (
+            unrendered_jobs_by_name.get(current_name, current_job)
+            if unrendered_jobs_by_name is not None
+            else current_job
+        )
+        in_place = resolve_in_place_target(in_place_job, scripts[current_name], profile)
+
+        try:
+            if in_place is not None:
+                remote_path, submit_cwd = in_place
+
+                def _in_place_submit(
+                    rp: str = remote_path,
+                    cwd: str = submit_cwd,
+                    n: str = current_name,
+                    d: str | None = dependency,
+                ) -> int:
+                    submitted_obj = adapter.submit_remote_sbatch(
+                        rp,
+                        submit_cwd=cwd,
+                        job_name=n,
+                        dependency=d,
+                    )
+                    if submitted_obj is None or submitted_obj.job_id is None:
+                        raise RuntimeError("remote sbatch returned no job_id")
+                    return int(submitted_obj.job_id)
+
+                slurm_id = await anyio.to_thread.run_sync(_in_place_submit)
+            else:
+                result = await anyio.to_thread.run_sync(
+                    lambda s=scripts[current_name],  # type: ignore[misc]
+                    n=current_name,
+                    d=dependency: adapter.submit_job(s, job_name=n, dependency=d)
+                )
+                slurm_id = int(result["job_id"])
+            submitted[current_name] = str(slurm_id)
+        except Exception as exc:
+            # R3: record a membership row with ``job_id=None`` so the
+            # GET /runs/{id} response still shows the failed node.
+            # Best-effort — a write failure must not mask the original
+            # sbatch exception.
+            try:
+
+                def _record_failed(
+                    jname: str = current_name,
+                    deps: list[str] = depends_on,
+                ) -> None:
+                    wrj_repo.create(
+                        workflow_run_id=run_id,
+                        job_name=jname,
+                        depends_on=deps or None,
+                        job_id=None,
+                    )
+
+                await anyio.to_thread.run_sync(_record_failed)
+            except Exception:
+                logger.debug(
+                    "Failed to record membership for the failed job",
+                    exc_info=True,
+                )
+            raise HTTPException(
+                status_code=502,
+                detail=f"sbatch failed for '{current_name}': {exc}",
+            ) from exc
+
+        # R1: persist the three related rows atomically. On autocommit
+        # connections (isolation_level=None) each ``execute`` would
+        # otherwise commit on its own — a mid-sequence failure would
+        # leave e.g. the jobs row inserted with no transition or
+        # membership to match it, breaking poller dedup downstream.
+        wf_scheduler_key = adapter.scheduler_key
+        if wf_scheduler_key.startswith("ssh:"):
+            wf_transport_type = "ssh"
+            wf_profile_name: str | None = wf_scheduler_key[len("ssh:") :]
+        else:
+            wf_transport_type = "local"
+            wf_profile_name = None
+
+        def _persist(
+            jid: int = slurm_id,
+            jname: str = current_name,
+            job_obj: Job | ShellJob = current_job,
+            deps: list[str] = depends_on,
+            tt: str = wf_transport_type,
+            pn: str | None = wf_profile_name,
+            sk: str = wf_scheduler_key,
+        ) -> None:
+            resources = getattr(job_obj, "resources", None)
+            environment = getattr(job_obj, "environment", None)
+            command_val = getattr(job_obj, "command", None)
+            with transaction(conn, "IMMEDIATE"):
+                job_repo.record_submission(
+                    job_id=jid,
+                    name=jname,
+                    status="PENDING",
+                    submission_source="workflow",
+                    transport_type=tt,  # type: ignore[arg-type]
+                    profile_name=pn,
+                    scheduler_key=sk,
+                    workflow_run_id=run_id,
+                    command=command_val if isinstance(command_val, list) else None,
+                    nodes=getattr(resources, "nodes", None) if resources else None,
+                    gpus_per_node=(
+                        getattr(resources, "gpus_per_node", None) if resources else None
+                    ),
+                    memory_per_node=(
+                        getattr(resources, "memory_per_node", None)
+                        if resources
+                        else None
+                    ),
+                    time_limit=(
+                        getattr(resources, "time_limit", None) if resources else None
+                    ),
+                    partition=(
+                        getattr(resources, "partition", None) if resources else None
+                    ),
+                    nodelist=(
+                        getattr(resources, "nodelist", None) if resources else None
+                    ),
+                    conda=(
+                        getattr(environment, "conda", None) if environment else None
+                    ),
+                    venv=(getattr(environment, "venv", None) if environment else None),
+                    env_vars=(
+                        getattr(environment, "env_vars", None) if environment else None
+                    ),
+                )
+                transition_repo.insert(
+                    job_id=jid,
+                    from_status=None,
+                    to_status="PENDING",
+                    source="webhook",
+                    scheduler_key=sk,
+                )
+                wrj_repo.create(
+                    workflow_run_id=run_id,
+                    job_name=jname,
+                    depends_on=deps or None,
+                    job_id=jid,
+                    scheduler_key=sk,
+                )
+
+        await anyio.to_thread.run_sync(_persist)
+
+        for dep_name in dependents[current_name]:
+            in_degree[dep_name] -= 1
+            if in_degree[dep_name] == 0:
+                queue.append(dep_name)
+
+    return submitted
+
+
+class WorkflowSubmissionService:
+    """Submit a non-sweep workflow end-to-end.
+
+    :param profile_resolver: Zero-arg callable → ``ServerProfile | None``.
+        Router passes its ``_get_current_profile`` so test patches stay
+        effective.
+    :param workflow_runner_cls: :class:`WorkflowRunner` class. Router
+        passes its module-level import so
+        ``patch('srunx.web.routers.workflows.WorkflowRunner', ...)``
+        reaches the ``from_yaml`` call.
+    """
+
+    def __init__(
+        self,
+        *,
+        profile_resolver: Callable[[], Any],
+        terminal_statuses: frozenset[str],
+        allowed_presets: tuple[str, ...],
+        workflow_runner_cls: Any = WorkflowRunner,
+    ) -> None:
+        self._profile_resolver = profile_resolver
+        self._terminal = terminal_statuses
+        self._allowed_presets = allowed_presets
+        self._runner_cls = workflow_runner_cls
+
+    async def run(
+        self,
+        *,
+        name: str,
+        mount: str,
+        yaml_path: Path,
+        run_opts: WorkflowRunRequest,
+        request: Request,
+        adapter: SlurmSSHAdapter,
+        conn: sqlite3.Connection,
+    ) -> dict[str, Any]:
+        """Handle the non-sweep branch of ``POST /{name}/run``.
+
+        Caller has already resolved the YAML path (via
+        :meth:`WorkflowStorageService.find_yaml`), validated the name
+        regex, and confirmed ``run_opts.sweep is None``.
+        """
+        # Validate preset up-front — before mounting, rendering, and
+        # sbatching. Deferring this check until post-submit means a
+        # bogus preset returns 422 with jobs already queued.
+        if run_opts.notify and run_opts.preset not in self._allowed_presets:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Invalid preset '{run_opts.preset}'. "
+                    f"Allowed: {self._allowed_presets}"
+                ),
+            )
+
+        # R7: sanitize structured sweep / args_override payloads.
+        if run_opts.args_override:
+            reject_python_prefix_web(run_opts.args_override, source="args_override")
+
+        # Load and optionally filter workflow. ``self._runner_cls`` is
+        # the router module's ``WorkflowRunner`` attribute so test
+        # patches on that attribute replace the ``from_yaml`` target.
+        runner_cls = self._runner_cls
+        runner = await anyio.to_thread.run_sync(
+            lambda: runner_cls.from_yaml(
+                yaml_path,
+                args_override=run_opts.args_override or None,
+            )
+        )
+        workflow = runner.workflow
+        if run_opts.from_job or run_opts.to_job or run_opts.single_job:
+            filtered_jobs = filter_workflow_jobs(
+                workflow,
+                run_opts.from_job,
+                run_opts.to_job,
+                run_opts.single_job,
+            )
+            workflow = Workflow(name=workflow.name, jobs=filtered_jobs)
+
+        run_repo = WorkflowRunRepository(conn)
+        watch_repo = WatchRepository(conn)
+
+        # Create run record (skip for dry runs)
+        run_id: int | None = None
+        if not run_opts.dry_run:
+            run_id = await anyio.to_thread.run_sync(
+                lambda: run_repo.create(
+                    workflow_name=name,
+                    yaml_path=str(yaml_path),
+                    args=runner.args or None,
+                    triggered_by="web",
+                )
+            )
+
+        terminal = self._terminal
+
+        def _fail(reason: str) -> None:
+            if run_id is None:
+                return
+            # Route through WorkflowRunStateService so a status_changed
+            # event is emitted (subscribers of the auto-created
+            # workflow_run watch then receive a Slack-etc. delivery).
+            # Read the current status fresh — the poller may have
+            # already advanced the row before the failure fires.
+            with transaction(conn, "IMMEDIATE"):
+                latest = run_repo.get(run_id)
+                if latest is None or latest.status in terminal:
+                    return
+                WorkflowRunStateService.update(
+                    conn=conn,
+                    workflow_run_id=run_id,
+                    from_status=latest.status,
+                    to_status="failed",
+                    error=reason,
+                    completed_at=now_iso(),
+                )
+
+        # Resolve the SSH profile up-front so render + the shell-script
+        # guard see the same mount registry the lock-and-submit path
+        # will use.
+        profile = await anyio.to_thread.run_sync(self._profile_resolver)
+
+        # Phase 2: Render scripts via the canonical helper. Mount
+        # translation and template resolution live in
+        # :mod:`srunx.rendering` so Web non-sweep, Web sweep, and MCP
+        # share identical semantics.
+        submission_context = build_submission_context(mount, profile)
+        shell_check_workflow = (
+            Workflow(
+                name=runner.workflow.name,
+                jobs=[j for j in runner.workflow.jobs if j.name == run_opts.single_job],
+            )
+            if run_opts.single_job
+            else runner.workflow
+        )
+        try:
+            await anyio.to_thread.run_sync(
+                lambda: enforce_shell_script_roots(
+                    shell_check_workflow,
+                    mount,
+                    profile,
+                    profile_resolver=self._profile_resolver,
+                )
+            )
+            rendered = await anyio.to_thread.run_sync(
+                lambda: render_workflow(
+                    yaml_path,
+                    submission_context=submission_context,
+                    args_override=run_opts.args_override or None,
+                    single_job=run_opts.single_job,
+                )
+            )
+        except HTTPException:
+            # 403 shell-script-root violation: propagate without _fail
+            # side effects (no jobs queued, no cluster state to roll
+            # back).
+            raise
+        except Exception as exc:
+            reason = f"Script rendering failed: {exc}"
+            await anyio.to_thread.run_sync(functools.partial(_fail, reason))
+            raise HTTPException(status_code=500, detail=reason) from exc
+
+        # When ``from_job`` / ``to_job`` are set the canonical helper
+        # doesn't prune; apply the existing filter over the rendered
+        # result. The ``single_job`` case is already handled inside the
+        # helper.
+        if run_opts.from_job or run_opts.to_job:
+            filtered_names = {
+                j.name
+                for j in filter_workflow_jobs(
+                    rendered.workflow,
+                    run_opts.from_job,
+                    run_opts.to_job,
+                    None,
+                )
+            }
+            rendered_jobs = tuple(
+                rj for rj in rendered.jobs if rj.job.name in filtered_names
+            )
+        else:
+            rendered_jobs = rendered.jobs
+
+        submission_workflow = Workflow(
+            name=rendered.workflow.name,
+            jobs=[rj.job for rj in rendered_jobs],
+        )
+        scripts: dict[str, str] = {rj.job.name: rj.script_text for rj in rendered_jobs}
+
+        # Phase 3: Dry run early return
+        if run_opts.dry_run:
+            job_names_in_wf = {job.name for job in submission_workflow.jobs}
+            return {
+                "dry_run": True,
+                "jobs": [
+                    {
+                        "name": job.name,
+                        "script": scripts.get(job.name, ""),
+                        "depends_on": [
+                            d.job_name
+                            for d in job.parsed_dependencies
+                            if d.job_name in job_names_in_wf
+                        ],
+                        "resources": job.resources.model_dump()
+                        if isinstance(job, Job)
+                        else {},
+                    }
+                    for job in submission_workflow.jobs
+                ],
+                "execution_order": [job.name for job in submission_workflow.jobs],
+            }
+
+        # Phase 4: Submit + persist + link + seed transition.
+        assert run_id is not None
+        try:
+            # Pass the UNRENDERED workflow to the lock-acquisition
+            # helper so ``collect_touched_mounts`` sees the original
+            # local script_paths (mount.local form) rather than the
+            # post-render remote form.
+            async with hold_workflow_mounts_web(
+                runner.workflow, runner, sync_required=True
+            ) as locked_profile:
+                unrendered_by_name: dict[str, Job | ShellJob] = {
+                    j.name: j for j in runner.workflow.jobs
+                }
+                try:
+                    await submit_jobs_bfs(
+                        submission_workflow,
+                        scripts,
+                        run_opts,
+                        adapter,
+                        conn=conn,
+                        run_id=run_id,
+                        profile=locked_profile,
+                        unrendered_jobs_by_name=unrendered_by_name,
+                    )
+                except HTTPException as exc:
+                    reason = (
+                        f"Submission failed: {exc.detail}"
+                        if isinstance(exc.detail, str)
+                        else "Submission failed"
+                    )
+
+                    # R2: cancel any jobs that were already accepted by
+                    # sbatch before the failure.
+                    def _load_orphan_ids() -> list[int]:
+                        memberships = WorkflowRunJobRepository(conn).list_by_run(run_id)
+                        return [m.job_id for m in memberships if m.job_id is not None]
+
+                    orphan_ids = await anyio.to_thread.run_sync(_load_orphan_ids)
+                    for jid in orphan_ids:
+                        try:
+                            await anyio.to_thread.run_sync(
+                                lambda x=jid: adapter.cancel_job(int(x))  # type: ignore[misc]
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Failed to cancel orphan SLURM job %s during "
+                                "workflow-run rollback",
+                                jid,
+                                exc_info=True,
+                            )
+
+                    await anyio.to_thread.run_sync(functools.partial(_fail, reason))
+                    raise
+        except MountSyncFailedError as exc:
+            # Lock-acquisition failures land here (raised from
+            # ``hold_workflow_mounts_web`` before the body runs). Mark
+            # the run as failed with the sync-failure reason.
+            reason = f"Mount sync failed: {exc}"
+            await anyio.to_thread.run_sync(functools.partial(_fail, reason))
+            raise HTTPException(status_code=502, detail=reason) from exc
+
+        # Phase 5: open the workflow_run watch so the poller can drive
+        # status transitions going forward.
+        def _open_watch() -> int | None:
+            new_watch_id = watch_repo.create(
+                kind="workflow_run",
+                target_ref=f"workflow_run:{run_id}",
+            )
+            if run_opts.notify and run_opts.endpoint_id is not None:
+                from srunx.db.repositories.endpoints import EndpointRepository
+                from srunx.db.repositories.subscriptions import (
+                    SubscriptionRepository,
+                )
+
+                endpoint = EndpointRepository(conn).get(run_opts.endpoint_id)
+                if endpoint is None or endpoint.disabled_at is not None:
+                    # Non-fatal: the watch still exists, the run is
+                    # open, the user just won't get external
+                    # notifications.
+                    logger.warning(
+                        "workflow_run %s: requested endpoint_id=%s not usable "
+                        "(missing or disabled); skipping subscription",
+                        run_id,
+                        run_opts.endpoint_id,
+                    )
+                    return new_watch_id
+                SubscriptionRepository(conn).create(
+                    watch_id=new_watch_id,
+                    endpoint_id=run_opts.endpoint_id,
+                    preset=run_opts.preset,
+                )
+            return new_watch_id
+
+        await anyio.to_thread.run_sync(_open_watch)
+
+        def _load_final() -> dict[str, Any]:
+            # Local import to avoid a service↔service cycle (query
+            # service imports models; submission service imports
+            # repositories directly).
+            from .workflow_run_query import build_run_response
+
+            final_run = run_repo.get(run_id)  # type: ignore[arg-type]
+            if final_run is None:
+                return {"id": str(run_id), "status": "pending"}
+            return build_run_response(conn, final_run)
+
+        return await anyio.to_thread.run_sync(_load_final)

--- a/src/srunx/web/services/workflow_validation.py
+++ b/src/srunx/web/services/workflow_validation.py
@@ -1,0 +1,47 @@
+"""Workflow YAML validation.
+
+Wraps the ``/api/workflows/validate`` endpoint body — parses YAML, runs
+the ``python:``-prefix guard on the ``args`` block, then drives it
+through :meth:`WorkflowRunner.from_yaml` + :meth:`Workflow.validate` to
+surface cycle-detection and other domain errors.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import anyio
+
+from srunx.exceptions import WorkflowValidationError
+from srunx.runner import WorkflowRunner
+
+from ._submission_common import reject_python_prefix_in_yaml_args
+
+
+class WorkflowValidationService:
+    """Validate a YAML workflow payload end-to-end."""
+
+    async def validate_yaml(self, yaml_content: str) -> dict[str, Any]:
+        if not yaml_content:
+            return {"valid": False, "errors": ["Empty YAML content"]}
+
+        reject_python_prefix_in_yaml_args(yaml_content)
+
+        with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+            f.write(yaml_content)
+            tmp_path = f.name
+
+        try:
+            runner = await anyio.to_thread.run_sync(
+                lambda: WorkflowRunner.from_yaml(tmp_path)
+            )
+            await anyio.to_thread.run_sync(runner.workflow.validate)
+            return {"valid": True}
+        except WorkflowValidationError as e:
+            return {"valid": False, "errors": [str(e)]}
+        except Exception as e:
+            return {"valid": False, "errors": [str(e)]}
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
Extract business logic from `src/srunx/web/routers/workflows.py` (1863 LOC) into focused services under `src/srunx/web/services/`. Router shrinks **82%** (1863 → 322 LOC); each handler is now a single delegate call.

## Layout

```
src/srunx/web/
├── routers/
│   └── workflows.py              # 322 LOC — routes + Depends + thin shims
├── schemas/
│   └── workflows.py              # 83 LOC  — Pydantic DTOs
└── services/
    ├── _submission_common.py     # 331 LOC — profile/mount/path helpers
    ├── workflow_storage.py       # 371 LOC — list/upload/create/get/delete
    ├── workflow_validation.py    # 47 LOC  — YAML validation + python:-prefix guards
    ├── workflow_run_query.py     # 124 LOC — list_runs, get_run, build_run_response
    ├── workflow_run_cancellation.py  # 105 LOC — cancel_run
    ├── workflow_submission.py    # 725 LOC — non-sweep /run
    └── sweep_submission.py       # 256 LOC — _dispatch_sweep + background task
```

## Commits
1. `88e925b` — extract Pydantic schemas to `web/schemas/workflows.py`
2. `34b9a90` — extract `WorkflowStorageService` + `_submission_common` helpers
3. `67cacaa` — extract `WorkflowValidationService`
4. `636c24a` — extract `WorkflowRunQueryService` + `WorkflowRunCancellationService`
5. `d127c53` — extract `WorkflowSubmissionService` + `SweepSubmissionService`

The planned 6th "thin router" commit was absorbed — each extraction removed its helpers, ending at 322 LOC.

## Critical invariants preserved

- **`Depends(...)` stays in the router** — services accept `conn`, `adapter`, `request` as plain args; framework-agnostic and testable without `TestClient`.
- **Test patchability preserved via constructor injection** — all 5 test-patched attributes (`_get_current_profile`, `SweepSpec`, `SweepOrchestrator`, `WorkflowRunner`, `SlurmSSHExecutorPool`) are live module-level attributes; services receive them via constructor args so `unittest.mock.patch` replacements reach the call sites. `_build_run_response`, `_dispatch_sweep`, `_run_sweep_background`, `_parse_run_id`, `_serialize_run`, `_serialize_workflow` all stay importable from `srunx.web.routers.workflows` as thin re-exports.
- **Lazy imports moved verbatim** — no hoisting. Preserved for `srunx.config`, `srunx.runtime.submission_plan`, `srunx.ssh.core.config`, `srunx.sync.*`, `srunx.security.find_shell_script_violation`, `EndpointRepository/SubscriptionRepository`, `SweepRunRepository`, `asyncio` fallback.
- **Async/sync boundary** — services expose async methods wrapping blocking ops with `anyio.to_thread.run_sync`; router stays async end-to-end.
- **Transaction scoping** — `with transaction(conn, "IMMEDIATE")` stays in exactly 3 non-nested sites (cancellation `_finalize`, submission `_fail`, submission `_persist`).
- **Typed `MountSyncFailedError`** replaces the previous `HTTPException(502)` string-match on `"Mount sync failed:"` detail; router catches explicitly and routes to `_fail` without string-sniffing.
- **Background tasks** — services accept `request` and consult `request.app.state.task_group` / `app.state.background_tasks` exactly as before.
- **python:-prefix security guards** called at all previous sites (create, upload, validate, run args_override, run sweep matrix).

## Scope departures
- **`workflow_submission.py` at 725 LOC** (>600 advisory). `WorkflowSubmissionService.run` (~350 LOC) + `submit_jobs_bfs` (~240 LOC) are one tightly-coupled orchestration pass (render → lock → BFS submit → per-step persist → watch/subscription). Splitting would fragment the TX envelope and error-handling state across modules. Kept as one cohesive unit.
- **5 commits instead of planned 6.** The "final thin-out" commit was absorbed — each extraction also removed the helper it moved.

## Test plan
- [x] `tests/web/` — 276 passed
- [x] `tests/transport/test_review_fixes.py` — 32 passed (direct `_build_run_response` import preserved)
- [x] `tests/sweep/test_sweep_ssh_integration.py` — 14 passed (direct `wf_mod._dispatch_sweep` / `_run_sweep_background` / `SlurmSSHExecutorPool` patches preserved)
- [x] Full suite: 1881 passed / 2 skipped (unchanged from baseline)
- [x] `tests/architecture/test_import_layers.py` — 2 passed
- [x] `mypy src/srunx/web/` — clean (29 files)
- [x] `ruff check src/srunx/web/` + `ruff format --check` — clean

3 pre-existing `main` failures (local `~/.config/srunx/config.json` bleed-through) are not regressions.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)