### PR TITLE
refactor(cli): rework status surface — banner, sinfo/gpus split, history, sacct, squeue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ srunx-specific commands that don't map to a SLURM binary:
 - `uv run srunx sacct -a -S now-1day` - All users over the last day (like native `sacct -a -S now-1day`)
 - `uv run srunx sacct -j <job_id>` / `-u <user>` / `-s FAILED,TIMEOUT` / `-p <partition>` - Standard sacct filters
 - `uv run srunx sacct --show-steps` - Include `.batch` / `.extern` sub-step rows
-- `uv run srunx tail <job_id> --follow` - Stream job logs (use `--profile` for SSH)
+- `uv run srunx tail <job_id> --follow` - Stream job logs. Works over SSH via periodic `tail_log_incremental` polls; tune with `--interval <seconds>` (default 2s). Ctrl+C exits
 
 `sbatch` accepts the standard SLURM short flags (`-J` / `-N` / `-n` / `-c` /
 `-t` / `-p` / `-w` / `-D`) and `--gres=gpu:N`. srunx-specific extensions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ srunx-specific commands that don't map to a SLURM binary:
 - `uv run srunx sacct -a -S now-1day` - All users over the last day (like native `sacct -a -S now-1day`)
 - `uv run srunx sacct -j <job_id>` / `-u <user>` / `-s FAILED,TIMEOUT` / `-p <partition>` - Standard sacct filters
 - `uv run srunx sacct --show-steps` - Include `.batch` / `.extern` sub-step rows
+- `uv run srunx tail <job_id>` - Show the last 10 lines of the job log (matches native `tail`; use `-n N` for a different cap, `--all` to dump the whole file)
 - `uv run srunx tail <job_id> --follow` - Stream job logs. Works over SSH via periodic `tail_log_incremental` polls; tune with `--interval <seconds>` (default 2s). Ctrl+C exits
 
 `sbatch` accepts the standard SLURM short flags (`-J` / `-N` / `-n` / `-c` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,34 +12,45 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### CLI Usage
 
 #### Job Management (SLURM-aligned commands)
-Command names mirror SLURM's CLI (`sbatch` / `squeue` / `scancel` / `sinfo` /
-`sacct` / `sreport`) so a SLURM user can map their muscle memory directly.
-`tail` and `watch` are srunx-specific wrappers that have no direct SLURM
-counterpart.
+Command names mirror SLURM's CLI where it makes sense (`sbatch` / `squeue` /
+`scancel` / `sinfo`) so a SLURM user can map their muscle memory directly.
+srunx-specific commands that don't map to a SLURM binary:
+
+- `history` — srunx's own submission history (SQLite-backed). Named
+  `history` rather than `sacct` because it shares no backend with real
+  `sacct`; only jobs submitted via srunx are listed.
+- `gpus` — GPU aggregate summary across partitions.
+- `tail` / `watch` — log tailing and cluster watching.
 
 - `uv run srunx sbatch <script>` - Submit a sbatch script (positional, like real sbatch)
 - `uv run srunx sbatch --wrap "cmd ..."` - Wrap a command into a SLURM job (mutually exclusive with the positional script)
 - `uv run srunx sbatch --profile <name> ...` - Submit over SSH to a configured profile
-- `uv run srunx squeue` - List user's jobs in the queue
+- `uv run srunx squeue` - List active jobs (all users by default — matches native `squeue`). Default columns: Job ID, User, Name, Status, GPUs, Elapsed, NodeList
 - `uv run srunx squeue -j <job_id>` - Filter to a specific job (replaces the old `srunx status` for active jobs)
-- `uv run srunx squeue --show-gpus` - Include GPU allocation column
-- `uv run srunx squeue --format json` - Emit JSON instead of a table
+- `uv run srunx squeue -u <user>` - Filter to a single user
+- `uv run srunx squeue --show-partition --show-cpus --show-limit --show-nodes` - Opt-in columns (each flag adds one)
+- `uv run srunx squeue -a` - Shortcut for all opt-in columns at once
+- `uv run srunx squeue --format json` - JSON always includes every field regardless of show flags
 - `uv run srunx scancel <job_id>` - Cancel a job
-- `uv run srunx sinfo` - Display current GPU/node resource availability
+- `uv run srunx sinfo` - Partition / state / nodelist listing (same columns as native SLURM `sinfo`)
 - `uv run srunx sinfo --profile <name>` - Query a remote cluster via SSH adapter (#139)
-- `uv run srunx sinfo --partition gpu --format json` - Partition resources as JSON
-- `uv run srunx sacct` - DB-backed job execution history (uses srunx.db, not real sacct)
-- `uv run srunx sacct -j <job_id>` - Filter history to a specific job (replaces `srunx status` for finished jobs)
-- `uv run srunx sacct --profile <name>` - Scope history to a single cluster's jobs (`scheduler_key` filter)
-- `uv run srunx sreport` - Aggregated execution report from srunx.db
-- `uv run srunx sreport --profile <name>` - Aggregate only jobs that ran on the given cluster
+- `uv run srunx sinfo --partition gpu --format json` - Partition rows as JSON
+- `uv run srunx gpus` - GPU aggregate summary (what the old `srunx sinfo` showed)
+- `uv run srunx gpus --profile <name> --partition gpu` - GPU summary scoped to one partition on a remote cluster
+- `uv run srunx history` - DB-backed submission history (srunx's own SQLite). Only jobs submitted via srunx are listed
+- `uv run srunx history -j <job_id>` - Filter history to a specific job (replaces `srunx status` for finished jobs)
+- `uv run srunx history --profile <name>` - Scope history to a single cluster's jobs (`scheduler_key` filter)
+- `uv run srunx sacct` - Real SLURM `sacct` wrapper (cluster accounting DB — includes manual sbatch jobs, needs slurmdbd). Default columns: Job ID, User, Name, Partition, State, ExitCode, Elapsed
+- `uv run srunx sacct -a -S now-1day` - All users over the last day (like native `sacct -a -S now-1day`)
+- `uv run srunx sacct -j <job_id>` / `-u <user>` / `-s FAILED,TIMEOUT` / `-p <partition>` - Standard sacct filters
+- `uv run srunx sacct --show-steps` - Include `.batch` / `.extern` sub-step rows
 - `uv run srunx tail <job_id> --follow` - Stream job logs (use `--profile` for SSH)
 
 `sbatch` accepts the standard SLURM short flags (`-J` / `-N` / `-n` / `-c` /
 `-t` / `-p` / `-w` / `-D`) and `--gres=gpu:N`. srunx-specific extensions
 (`--profile` / `--conda` / `--venv` / `--container` / `--template` / etc.)
-layer on top. `status` was intentionally dropped — use `squeue -j <id>` or
-`sacct -j <id>` depending on whether the job is active or historical.
+layer on top. `status` was intentionally dropped — use `squeue -j <id>` for
+active jobs or `history -j <id>` for finished jobs.
 
 ##### Auto-sync + in-place execution
 
@@ -165,6 +176,9 @@ uv run srunx watch jobs --all --continuous --interval 30
 uv run srunx watch cluster --schedule 1h --notify $SLACK_WEBHOOK
 
 # Check current resource availability
+uv run srunx gpus --partition gpu
+
+# Inspect partition / state / nodelist (native-sinfo parity)
 uv run srunx sinfo --partition gpu
 ```
 
@@ -241,7 +255,7 @@ src/srunx/
 │   ├── main.py        # Thin Typer root (app, flow_app, sub-app registration)
 │   ├── watch.py       # watch app (jobs / resources / cluster)
 │   ├── workflow.py    # flow run executor (_execute_workflow)
-│   ├── commands/      # Per-command-group modules: jobs (sbatch/squeue/scancel/sinfo/tail), reports (sacct/sreport), config, templates, ui
+│   ├── commands/      # Per-command-group modules: jobs (sbatch/squeue/scancel/sinfo/gpus/tail), reports (history), config, templates, ui
 │   └── _helpers/      # debug_callback, sbatch_helpers, notification_setup, transport_options
 │
 ├── mcp/               # MCP server for AI agent integration (FastMCP tool surface)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ srunx-specific commands that don't map to a SLURM binary:
 - `uv run srunx squeue -u <user>` - Filter to a single user
 - `uv run srunx squeue --show-partition --show-cpus --show-limit --show-nodes` - Opt-in columns (each flag adds one)
 - `uv run srunx squeue -a` - Shortcut for all opt-in columns at once
+- `uv run srunx squeue -i <seconds>` - Live refresh: re-query and redraw in place every N seconds (like native `squeue -i`). Ctrl+C exits
 - `uv run srunx squeue --format json` - JSON always includes every field regardless of show flags
 - `uv run srunx scancel <job_id>` - Cancel a job
 - `uv run srunx sinfo` - Partition / state / nodelist listing (same columns as native SLURM `sinfo`)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Stop juggling `sbatch` scripts, `squeue` loops, and SSH sessions.
 - **Submit & manage** SLURM jobs from CLI, browser, or Python
 - **Orchestrate** multi-step workflows with YAML and dependency graphs
 - **Monitor** GPU availability and job states with Slack notifications
-- **SSH remote** — submit jobs, sync files, and browse remote clusters from your laptop
+- **Local or remote, one CLI** — target a local SLURM or any SSH'd cluster with `--profile <name>`; no shell-in, no separate "remote" commands — the same verbs you already know
 - **Container-native** — Pyxis, Apptainer, and Singularity support built in
 
 ## Installation
@@ -67,6 +67,19 @@ Or describe the whole pipeline once and let srunx drive it:
 srunx flow run workflow.yaml
 ```
 
+### Same commands, remote cluster
+
+Every command above accepts `--profile <name>` and dispatches transparently over SSH — same syntax, same output, same feel as local:
+
+```bash
+srunx sbatch --profile dgx --name training --gpus-per-node 2 --conda ml_env -- python train.py
+srunx squeue --profile dgx
+srunx tail   --profile dgx 847291 --follow
+srunx flow run pipeline.yaml --profile dgx
+```
+
+srunx rsyncs your code under a per-mount lock, runs `sbatch` in place on the remote, and streams logs back. Your shell never leaves the laptop.
+
 ## Why srunx?
 
 Instead of stitching together `sbatch`, `squeue`, SSH, and a pipeline runner, srunx offers one coherent surface that covers the day-to-day SLURM loop.
@@ -88,24 +101,47 @@ If you need full-featured scientific workflow tooling, Snakemake / Nextflow are 
 
 ## CLI
 
-| Command | Description |
-|---------|-------------|
-| `srunx sbatch <script>` / `srunx sbatch --wrap "<cmd>"` | Submit a SLURM job |
-| `srunx squeue` | List jobs in queue (use `-j <id>` for a single job's state) |
-| `srunx scancel <id>` | Cancel a job |
-| `srunx tail <id>` | View / stream job logs |
-| `srunx sinfo` | Partition / state / nodelist listing (native-sinfo parity) |
-| `srunx gpus` | GPU aggregate summary |
-| `srunx watch jobs\|resources\|cluster` | Watch for state changes / resource availability |
-| `srunx flow` | Run / validate YAML workflows |
-| `srunx flow run --arg KEY=VALUE` | Override workflow `args` from the CLI |
-| `srunx flow run --sweep KEY=V1,V2 --max-parallel N` | Ad-hoc matrix parameter sweep |
-| `srunx ssh` | Remote SLURM operations over SSH |
-| `srunx history` | srunx's own submission history (SQLite-backed) |
-| `srunx sacct` | Real SLURM `sacct` wrapper (cluster accounting DB) |
-| `srunx config` | Manage configuration |
-| `srunx template` | Manage job templates |
-| `srunx ui` | Launch the web dashboard |
+**Every command below runs locally _or_ against a remote cluster over SSH.** Add `--profile <name>` (or set `$SRUNX_SSH_PROFILE`) and `sbatch` / `squeue` / `sinfo` / `sacct` / `history` / `gpus` / `tail` / `watch` / `flow run` transparently dispatch through the SSH adapter — no shell-in first, no separate "remote" subcommand. `srunx ssh` is just for managing those profiles (add / list / sync / test); it does not run jobs itself.
+
+`Type` column: **SLURM** = mirrors the native SLURM CLI (muscle memory maps directly); **srunx** = srunx-original command with no direct SLURM counterpart.
+
+### Job submission & control (SLURM parity)
+
+| Command | Type | Description |
+|---------|------|-------------|
+| `srunx sbatch <script>` / `srunx sbatch --wrap "<cmd>"` | SLURM | Submit a SLURM job |
+| `srunx scancel <id>` | SLURM | Cancel a job |
+
+### Status & accounting
+
+| Command | Type | Description |
+|---------|------|-------------|
+| `srunx squeue` | SLURM | List active jobs (use `-j <id>` for a single job's state) |
+| `srunx sinfo` | SLURM | Partition / state / nodelist listing (native-sinfo parity) |
+| `srunx sacct` | SLURM | Real SLURM `sacct` wrapper (cluster accounting DB) |
+| `srunx history` | srunx | srunx's own submission history (SQLite-backed) |
+| `srunx gpus` | srunx | GPU aggregate summary across partitions |
+| `srunx tail <id>` | srunx | View / stream job logs |
+| `srunx watch jobs\|resources\|cluster` | srunx | Watch for state changes / resource availability |
+
+### Workflows & sweeps
+
+| Command | Type | Description |
+|---------|------|-------------|
+| `srunx flow` | srunx | Run / validate YAML workflows |
+| `srunx flow run --arg KEY=VALUE` | srunx | Override workflow `args` from the CLI |
+| `srunx flow run --sweep KEY=V1,V2 --max-parallel N` | srunx | Ad-hoc matrix parameter sweep |
+
+### Environment & tooling
+
+| Command | Type | Description |
+|---------|------|-------------|
+| `srunx ssh` | srunx | Manage SSH profiles (add / list / sync / test) — remote execution itself is `--profile` on the commands above |
+| `srunx config` | srunx | Manage configuration |
+| `srunx template` | srunx | Manage job templates |
+| `srunx ui` | srunx | Launch the web dashboard |
+
+More CLI examples: [User Guide](https://ksterx.github.io/srunx/how-to/user_guide/) · Python-side counterparts: [API Reference](https://ksterx.github.io/srunx/reference/api/)
 
 ## Web Dashboard
 
@@ -139,6 +175,8 @@ GPU and node availability per partition.
 Browse remote files via SSH mounts. Shell scripts can be submitted as sbatch jobs directly from the file tree.
 
 <img src="https://raw.githubusercontent.com/ksterx/srunx/main/docs/assets/images/ui-explorer-sbatch.gif" width="800" alt="Explorer sbatch submission">
+
+Full walkthrough: [Web UI tutorial](https://ksterx.github.io/srunx/tutorials/webui/) · [Web UI how-to](https://ksterx.github.io/srunx/how-to/webui/) · [Explorer how-to](https://ksterx.github.io/srunx/how-to/explorer/)
 
 ## Workflow Orchestration
 
@@ -223,6 +261,8 @@ srunx flow run --sweep lr=0.001,0.01 --max-parallel 2 --dry-run train.yaml
 
 Sweeps are a first-class concept across **CLI, Web UI, and MCP**. Web-triggered sweeps route cells through a bounded `SlurmSSHExecutorPool` against the configured SSH profile, while CLI and MCP runs use the local SLURM client by default. The Web UI surfaces per-cell progress with ETA, filter / sort, and per-cell cancellation.
 
+Full workflow surface (validation, retries, partial execution, sweep recipes): [Workflows how-to](https://ksterx.github.io/srunx/how-to/workflows/)
+
 ## Monitoring
 
 ```bash
@@ -237,26 +277,30 @@ srunx sbatch --wrap "python train.py" --gpus-per-node 4
 srunx watch cluster --schedule 1h --notify $SLACK_WEBHOOK
 ```
 
+Full monitoring options (continuous watch, thresholds, scheduled reports): [Monitoring how-to](https://ksterx.github.io/srunx/how-to/monitoring/)
+
 ## Remote SSH
 
-Keep your local editor workflow while running on the cluster:
+Keep your local editor workflow while the jobs actually run on the cluster. Configure a profile **once**, and every srunx command accepts `--profile <name>` with the same syntax as local:
 
 ```bash
-# Submit to remote cluster (auto-syncs the script's mount first, then runs in-place)
-srunx sbatch train.sh --profile dgx-server
-
-# Manage connection profiles
-srunx ssh profile add myserver --ssh-host dgx1
-
-# Map local directories to remote and sync with rsync
-srunx ssh profile mount add myserver workspace \
+# One-time setup
+srunx ssh profile add dgx --ssh-host dgx1
+srunx ssh profile mount add dgx ml-exp \
   --local ~/projects/ml-exp --remote /home/user/ml-exp
-srunx ssh sync
+
+# Same verbs you already use — now against the remote cluster
+srunx sbatch train.sh --profile dgx                   # auto-rsyncs the mount + sbatch runs in-place on the remote path
+srunx squeue --profile dgx                            # live queue on the remote cluster
+srunx tail 847291 --profile dgx --follow              # stream remote logs
+srunx flow run pipeline.yaml --profile dgx            # full DAG: sync once, hold the per-mount lock, submit
 ```
 
-- SSH config hosts, saved profiles, and proxy jump support
+- SSH config hosts, saved profiles, and ProxyJump support
 - Environment variable passthrough (`--env KEY=VALUE`, `--env-local WANDB_API_KEY`)
-- File sync via rsync — auto-detects profile from current directory
+- File sync via rsync with per-mount locking — auto-detects profile from current directory
+
+Mount model, sync semantics, and in-place execution rules: [SSH sync how-to](https://ksterx.github.io/srunx/how-to/sync/)
 
 ## Slack Notifications
 
@@ -294,6 +338,8 @@ run_workflow(
 ```
 
 Passing `mount=<name>` routes the run through the matching SSH profile mount, translating `work_dir` / `log_dir` into remote paths — so the agent can launch mount-aware submissions against a remote cluster without leaving the chat.
+
+Setup + tool-by-tool usage: [MCP Setup tutorial](https://ksterx.github.io/srunx/tutorials/mcp-setup/) · [MCP Usage how-to](https://ksterx.github.io/srunx/how-to/mcp-usage/) · [MCP Tools reference](https://ksterx.github.io/srunx/reference/mcp-tools/)
 
 ## Python API
 
@@ -339,7 +385,12 @@ runner.run()                                    # blocks until the DAG finishes
 
 ## Documentation
 
-Full documentation at **[ksterx.github.io/srunx](https://ksterx.github.io/srunx/)**.
+Full docs (Diátaxis-structured) at **[ksterx.github.io/srunx](https://ksterx.github.io/srunx/)**:
+
+- **Tutorials** (learn by doing) — [Installation](https://ksterx.github.io/srunx/tutorials/installation/) · [Quickstart](https://ksterx.github.io/srunx/tutorials/quickstart/) · [Web UI](https://ksterx.github.io/srunx/tutorials/webui/) · [MCP setup](https://ksterx.github.io/srunx/tutorials/mcp-setup/)
+- **How-to guides** (solve specific tasks) — [User guide](https://ksterx.github.io/srunx/how-to/user_guide/) · [Workflows & sweeps](https://ksterx.github.io/srunx/how-to/workflows/) · [Monitoring](https://ksterx.github.io/srunx/how-to/monitoring/) · [SSH sync](https://ksterx.github.io/srunx/how-to/sync/) · [Web UI](https://ksterx.github.io/srunx/how-to/webui/) · [Explorer](https://ksterx.github.io/srunx/how-to/explorer/) · [MCP usage](https://ksterx.github.io/srunx/how-to/mcp-usage/) · [Settings](https://ksterx.github.io/srunx/how-to/settings/) · [Smoke-test notifications](https://ksterx.github.io/srunx/how-to/smoke-test-notifications/)
+- **Reference** (look up exact API) — [Python API](https://ksterx.github.io/srunx/reference/api/) · [Web API](https://ksterx.github.io/srunx/reference/webui-api/) · [MCP tools](https://ksterx.github.io/srunx/reference/mcp-tools/)
+- **Explanation** (how it works under the hood) — [Architecture](https://ksterx.github.io/srunx/explanation/architecture/) · [MCP architecture](https://ksterx.github.io/srunx/explanation/mcp-architecture/)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -94,14 +94,15 @@ If you need full-featured scientific workflow tooling, Snakemake / Nextflow are 
 | `srunx squeue` | List jobs in queue (use `-j <id>` for a single job's state) |
 | `srunx scancel <id>` | Cancel a job |
 | `srunx tail <id>` | View / stream job logs |
-| `srunx sinfo` | Display GPU availability |
+| `srunx sinfo` | Partition / state / nodelist listing (native-sinfo parity) |
+| `srunx gpus` | GPU aggregate summary |
 | `srunx watch jobs\|resources\|cluster` | Watch for state changes / resource availability |
 | `srunx flow` | Run / validate YAML workflows |
 | `srunx flow run --arg KEY=VALUE` | Override workflow `args` from the CLI |
 | `srunx flow run --sweep KEY=V1,V2 --max-parallel N` | Ad-hoc matrix parameter sweep |
 | `srunx ssh` | Remote SLURM operations over SSH |
-| `srunx sacct` | Show job execution history |
-| `srunx sreport` | Generate job execution report |
+| `srunx history` | srunx's own submission history (SQLite-backed) |
+| `srunx sacct` | Real SLURM `sacct` wrapper (cluster accounting DB) |
 | `srunx config` | Manage configuration |
 | `srunx template` | Manage job templates |
 | `srunx ui` | Launch the web dashboard |

--- a/docs/how-to/monitoring.md
+++ b/docs/how-to/monitoring.md
@@ -92,7 +92,7 @@ srunx watch resources --min-gpus 4 --timeout 7200
 ```
 
 !!! note
-    To display current resources without waiting, use `srunx sinfo` instead (see [User Guide](../how-to/user_guide.md)).
+    To display current GPU availability without waiting, use `srunx gpus` (aggregate summary across partitions). For partition / state / nodelist listing that mirrors native SLURM, use `srunx sinfo`.
 
 ### Continuous Resource Monitoring
 

--- a/docs/how-to/user_guide.md
+++ b/docs/how-to/user_guide.md
@@ -159,10 +159,38 @@ Filter to a single user (default is all users):
 srunx squeue --user alice
 ```
 
-List in JSON format:
+Live in-place refresh (like native `squeue -i`; Ctrl+C to exit):
+
+``` bash
+srunx squeue -i 5
+```
+
+Show additional columns (each `--show-*` flag adds one; `-a` enables all):
+
+``` bash
+srunx squeue --show-partition --show-cpus --show-limit --show-nodes
+srunx squeue -a
+```
+
+List in JSON format (always includes every field, regardless of `--show-*`):
 
 ``` bash
 srunx squeue --format json
+```
+
+Inspect cluster resources:
+
+``` bash
+srunx gpus                 # GPU aggregate summary across partitions
+srunx sinfo                # partition / state / nodelist (native-sinfo parity)
+```
+
+Cluster-side accounting history (real SLURM `sacct`, requires `slurmdbd`):
+
+``` bash
+srunx sacct -a -S now-1day                      # all users, last 24h
+srunx sacct -j 12345 --show-steps               # include .batch / .extern sub-steps
+srunx sacct -s FAILED,TIMEOUT -p gpu            # filter by state / partition
 ```
 
 ### Job Control

--- a/docs/how-to/user_guide.md
+++ b/docs/how-to/user_guide.md
@@ -144,7 +144,7 @@ srunx squeue -j 12345
 For finished jobs (srunx state DB):
 
 ``` bash
-srunx sacct -j 12345
+srunx history -j 12345
 ```
 
 List all jobs:
@@ -153,10 +153,10 @@ List all jobs:
 srunx squeue
 ```
 
-List with GPU allocation info:
+Filter to a single user (default is all users):
 
 ``` bash
-srunx squeue --show-gpus
+srunx squeue --user alice
 ```
 
 List in JSON format:

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -33,7 +33,7 @@ srunx squeue -j <job_id>
 Check historical status (finished jobs too, via the srunx state DB):
 
 ``` bash
-srunx sacct -j <job_id>
+srunx history -j <job_id>
 ```
 
 List your jobs:

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -36,7 +36,7 @@ Check historical status (finished jobs too, via the srunx state DB):
 srunx history -j <job_id>
 ```
 
-List your jobs:
+List active jobs (all users by default, like native `squeue`):
 
 ``` bash
 srunx squeue

--- a/src/srunx/cli/_helpers/state_colors.py
+++ b/src/srunx/cli/_helpers/state_colors.py
@@ -1,0 +1,53 @@
+"""Shared SLURM state → Rich colour mapping.
+
+Both ``srunx squeue`` and ``srunx sacct`` colourise the Status / State
+column. The two commands used to keep independent copies of the map
+with a "kept in sync" comment — which is exactly the drift-prone
+anti-pattern this module removes. Any future state colour change
+happens here and propagates to every renderer automatically.
+
+Colour semantics — the grouping is the contract, not the individual
+hues. A reviewer should be able to change ``cyan`` → ``blue`` for the
+"in-progress" group without breaking anything:
+
+* ``cyan``      — in-progress (RUNNING / COMPLETING / CONFIGURING)
+* ``green``     — success
+* ``yellow``    — waiting
+* ``magenta``   — unusual live state (suspended / stopped)
+* ``bright_black`` (gray) — user stopped / neutral terminal
+* ``red``       — job-level failure
+* ``bright_red``— infrastructure failure
+"""
+
+from __future__ import annotations
+
+SLURM_STATE_COLORS: dict[str, str] = {
+    "RUNNING": "cyan",
+    "COMPLETING": "cyan",
+    "CONFIGURING": "cyan",
+    "COMPLETED": "green",
+    "PENDING": "yellow",
+    "SUSPENDED": "magenta",
+    "STOPPED": "magenta",
+    "CANCELLED": "bright_black",
+    "REVOKED": "bright_black",
+    "UNKNOWN": "bright_black",
+    "FAILED": "red",
+    "TIMEOUT": "red",
+    "PREEMPTED": "red",
+    "DEADLINE": "red",
+    "BOOT_FAIL": "bright_red",
+    "NODE_FAIL": "bright_red",
+    "OUT_OF_MEMORY": "bright_red",
+}
+
+
+def colorize_state(state: str, *, default: str = "white") -> str:
+    """Return ``state`` wrapped in Rich markup for its semantic colour.
+
+    Unknown states fall back to ``default`` (plain white). Keeps the
+    ``[color]X[/color]`` wrapping pattern in one place so the two
+    table renderers can't drift on formatting either.
+    """
+    color = SLURM_STATE_COLORS.get(state, default)
+    return f"[{color}]{state}[/{color}]"

--- a/src/srunx/cli/commands/config.py
+++ b/src/srunx/cli/commands/config.py
@@ -21,7 +21,7 @@ def config_show() -> None:
     config = get_config()
 
     console = Console()
-    table = Table(title="srunx Configuration")
+    table = Table()
     table.add_column("Section", style="cyan")
     table.add_column("Key", style="magenta")
     table.add_column("Value", style="green")

--- a/src/srunx/cli/commands/jobs.py
+++ b/src/srunx/cli/commands/jobs.py
@@ -2,6 +2,8 @@
 
 import os
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -561,6 +563,17 @@ def squeue(
             ),
         ),
     ] = None,
+    iterate: Annotated[
+        float | None,
+        typer.Option(
+            "-i",
+            "--iterate",
+            help=(
+                "Re-query the queue every N seconds and redraw in place "
+                "(matches native ``squeue -i``). Exit with Ctrl+C."
+            ),
+        ),
+    ] = None,
     show_partition: Annotated[
         bool,
         typer.Option("--show-partition", help="Add the Partition column."),
@@ -604,6 +617,12 @@ def squeue(
     emits every field regardless of these flags — scripts can pick
     what they need.
 
+    ``-i N`` / ``--iterate N`` re-queries the queue every ``N``
+    seconds and redraws the table in place (like native
+    ``squeue -i``). Incompatible with ``--format json`` (live mode is
+    human-facing only). Ctrl+C exits and leaves the final frame on
+    screen.
+
     For finished jobs, see ``srunx history``.
 
     Examples:
@@ -611,106 +630,66 @@ def squeue(
         srunx squeue -j 12345
         srunx squeue --user alice
         srunx squeue -a
-        srunx squeue --show-partition --show-cpus
+        srunx squeue -i 5                # refresh every 5 seconds
         srunx squeue --format json
     """
     import json
 
+    if iterate is not None:
+        if iterate <= 0:
+            typer.secho(
+                "--iterate must be a positive number of seconds.",
+                err=True,
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=2)
+        if format == "json":
+            typer.secho(
+                "--iterate is incompatible with --format json.",
+                err=True,
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(code=2)
+
+    # Column-visibility flags — the four SLURM fields flagged as
+    # "useful but not always needed" are hidden by default; ``--show-X``
+    # (or ``-a``) surfaces them.
+    visibility = _SqueueColumnVisibility(
+        partition=show_partition or show_all,
+        cpus=show_cpus or show_all,
+        limit=show_limit or show_all,
+        nodes=show_nodes or show_all,
+    )
+
     try:
         with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
-            if rt.transport_type == "local":
-                client = _slurm_local.Slurm()
-                jobs = client.queue(user=user)
-            else:
-                jobs = rt.job_ops.queue(user=user)
 
-        # Filter to user-specified job IDs after the queue() call so
-        # the dispatch path stays simple; SLURM's own ``squeue -j`` does
-        # the same in-memory filtering at the client side.
-        if job_filter:
-            wanted = {int(j) for j in job_filter}
-            jobs = [j for j in jobs if j.job_id in wanted]
+            def fetch() -> list[Any]:
+                if rt.transport_type == "local":
+                    client = _slurm_local.Slurm()
+                    jobs = client.queue(user=user)
+                else:
+                    jobs = rt.job_ops.queue(user=user)
+                if job_filter:
+                    wanted = {int(j) for j in job_filter}
+                    jobs = [j for j in jobs if j.job_id in wanted]
+                return jobs
 
-        # JSON format always emits every field (scripts pick what
-        # they consume — column-hiding would just force callers to
-        # reconstruct the full shape from multiple calls).
-        if format == "json":
-            job_data = [
-                {
-                    "job_id": job.job_id,
-                    "user": getattr(job, "user", None),
-                    "name": job.name,
-                    "partition": getattr(job, "partition", None),
-                    "status": (
-                        job.status.name if hasattr(job, "status") else "UNKNOWN"
-                    ),
-                    "nodes": getattr(job, "nodes", None),
-                    "cpus": getattr(job, "cpus", None),
-                    "gpus": getattr(job, "gpus", None),
-                    "nodelist": getattr(job, "nodelist", None),
-                    "elapsed_time": getattr(job, "elapsed_time", None),
-                    "time_limit": getattr(job, "time_limit", None),
-                }
-                for job in jobs
-            ]
-            Console().print(json.dumps(job_data, indent=2))
-            return
+            if iterate is not None:
+                _run_squeue_live(fetch, visibility=visibility, interval=iterate)
+                return
 
-        # Empty-queue sentinel only for human-facing table format.
-        if not jobs:
-            Console().print("No jobs in queue")
-            return
+            jobs = fetch()
 
-        # Column visibility. The four SLURM fields the user flagged as
-        # "information density, not always needed" are hidden by
-        # default; flags (or ``-a``) surface them. Keeping GPUs /
-        # NodeList / User in the default set because those are what
-        # disambiguate jobs in a multi-user queue — the original
-        # complaint that triggered this redesign.
-        show_partition_col = show_partition or show_all
-        show_cpus_col = show_cpus or show_all
-        show_limit_col = show_limit or show_all
-        show_nodes_col = show_nodes or show_all
+            if format == "json":
+                Console().print(json.dumps(_squeue_json(jobs), indent=2))
+                return
 
-        table = Table()
-        table.add_column("Job ID", style="cyan")
-        table.add_column("User")
-        table.add_column("Name", style="magenta", overflow="fold")
-        if show_partition_col:
-            table.add_column("Partition")
-        table.add_column("Status")
-        if show_nodes_col:
-            table.add_column("Nodes", justify="right")
-        if show_cpus_col:
-            table.add_column("CPUs", justify="right")
-        table.add_column("GPUs", justify="right", style="yellow")
-        table.add_column("Elapsed", justify="right")
-        if show_limit_col:
-            table.add_column("Limit", justify="right")
-        table.add_column("NodeList", overflow="fold")
+            if not jobs:
+                Console().print("No jobs in queue")
+                return
 
-        for job in jobs:
-            status_name = job.status.name if hasattr(job, "status") else "UNKNOWN"
-            row: list[str] = [
-                str(job.job_id) if job.job_id else "N/A",
-                getattr(job, "user", None) or "N/A",
-                job.name,
-            ]
-            if show_partition_col:
-                row.append(getattr(job, "partition", None) or "N/A")
-            row.append(colorize_state(status_name))
-            if show_nodes_col:
-                row.append(str(getattr(job, "nodes", None) or "N/A"))
-            if show_cpus_col:
-                row.append(str(getattr(job, "cpus", None) or 0))
-            row.append(str(getattr(job, "gpus", None) or 0))
-            row.append(getattr(job, "elapsed_time", None) or "N/A")
-            if show_limit_col:
-                row.append(getattr(job, "time_limit", None) or "N/A")
-            row.append(getattr(job, "nodelist", None) or "N/A")
-            table.add_row(*row)
-
-        Console().print(table)
+            Console().print(_render_squeue_table(jobs, visibility))
 
     except TransportError as exc:
         typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
@@ -718,6 +697,137 @@ def squeue(
     except Exception as e:
         typer.secho(f"Error retrieving job queue: {e}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=1) from e
+
+
+@dataclass(frozen=True)
+class _SqueueColumnVisibility:
+    """Which opt-in columns the squeue table should render."""
+
+    partition: bool
+    cpus: bool
+    limit: bool
+    nodes: bool
+
+
+def _render_squeue_table(jobs: list[Any], v: _SqueueColumnVisibility) -> Table:
+    """Build the Rich ``Table`` for one squeue snapshot.
+
+    Split out of :func:`squeue` so the live-refresh path and the
+    one-shot path render through the exact same code — no drift
+    possible between "first frame" and "refreshed frame" layouts.
+    """
+    table = Table()
+    table.add_column("Job ID", style="cyan")
+    table.add_column("User")
+    table.add_column("Name", style="magenta", overflow="fold")
+    if v.partition:
+        table.add_column("Partition")
+    table.add_column("Status")
+    if v.nodes:
+        table.add_column("Nodes", justify="right")
+    if v.cpus:
+        table.add_column("CPUs", justify="right")
+    table.add_column("GPUs", justify="right", style="yellow")
+    table.add_column("Elapsed", justify="right")
+    if v.limit:
+        table.add_column("Limit", justify="right")
+    table.add_column("NodeList", overflow="fold")
+
+    for job in jobs:
+        status_name = job.status.name if hasattr(job, "status") else "UNKNOWN"
+        row: list[str] = [
+            str(job.job_id) if job.job_id else "N/A",
+            getattr(job, "user", None) or "N/A",
+            job.name,
+        ]
+        if v.partition:
+            row.append(getattr(job, "partition", None) or "N/A")
+        row.append(colorize_state(status_name))
+        if v.nodes:
+            row.append(str(getattr(job, "nodes", None) or "N/A"))
+        if v.cpus:
+            row.append(str(getattr(job, "cpus", None) or 0))
+        row.append(str(getattr(job, "gpus", None) or 0))
+        row.append(getattr(job, "elapsed_time", None) or "N/A")
+        if v.limit:
+            row.append(getattr(job, "time_limit", None) or "N/A")
+        row.append(getattr(job, "nodelist", None) or "N/A")
+        table.add_row(*row)
+
+    return table
+
+
+def _squeue_json(jobs: list[Any]) -> list[dict[str, Any]]:
+    """Serialise a squeue result set to JSON-ready dicts.
+
+    Fields match what the Pydantic BaseJob surfaces via
+    ``local.Slurm.queue`` / ``SlurmSSHAdapter.queue`` after the S1
+    refactor — kept separate from the Table builder so ``--format
+    json`` isn't affected by column-visibility flags.
+    """
+    return [
+        {
+            "job_id": job.job_id,
+            "user": getattr(job, "user", None),
+            "name": job.name,
+            "partition": getattr(job, "partition", None),
+            "status": (job.status.name if hasattr(job, "status") else "UNKNOWN"),
+            "nodes": getattr(job, "nodes", None),
+            "cpus": getattr(job, "cpus", None),
+            "gpus": getattr(job, "gpus", None),
+            "nodelist": getattr(job, "nodelist", None),
+            "elapsed_time": getattr(job, "elapsed_time", None),
+            "time_limit": getattr(job, "time_limit", None),
+        }
+        for job in jobs
+    ]
+
+
+def _run_squeue_live(
+    fetch: "Callable[[], list[Any]]",
+    *,
+    visibility: _SqueueColumnVisibility,
+    interval: float,
+) -> None:
+    """Drive the live-refresh loop for ``srunx squeue -i``.
+
+    Uses :class:`rich.live.Live` in overlay mode so the transport
+    banner (emitted once before we enter) stays visible above the
+    refreshing region, and so Ctrl+C leaves the last frame on screen
+    instead of wiping it (which alt-screen mode would do).
+
+    The transport context is owned by the caller — we only redraw.
+    A transient ``queue()`` failure (SLURM flapping, SSH hiccup) is
+    rendered as a dim notice in place of the table for that tick
+    rather than bubbling out; otherwise one sinfo timeout would kill
+    an hours-long watch.
+    """
+    import time as _time
+
+    from rich.live import Live
+    from rich.text import Text
+
+    def _snapshot() -> Any:
+        try:
+            jobs = fetch()
+        except Exception as exc:  # noqa: BLE001 — best-effort refresh
+            return Text(f"(refresh failed: {exc})", style="bright_black italic")
+        if not jobs:
+            return Text("No jobs in queue", style="dim")
+        return _render_squeue_table(jobs, visibility)
+
+    # ``transient=False`` keeps the final frame on screen after Ctrl+C
+    # so the user can scroll back over what they just saw.
+    # ``refresh_per_second=4`` is Rich's default and is fine even for
+    # our slow data-refresh cadence — Live only re-renders when we
+    # call ``live.update()``.
+    with Live(_snapshot(), console=Console(), transient=False) as live:
+        try:
+            while True:
+                _time.sleep(interval)
+                live.update(_snapshot())
+        except KeyboardInterrupt:
+            return
 
 
 def scancel(

--- a/src/srunx/cli/commands/jobs.py
+++ b/src/srunx/cli/commands/jobs.py
@@ -865,7 +865,12 @@ def scancel(
         raise typer.Exit(code=1) from e
 
 
-_STATE_COLORS = {
+# Node state colours for ``srunx sinfo`` — disjoint from the job-state
+# colour map in :mod:`srunx.cli._helpers.state_colors`. SLURM uses
+# lowercase node states (idle/mixed/allocated/...) that have different
+# semantics from the uppercase job states (RUNNING/COMPLETED/...), so
+# the two maps intentionally live apart.
+_NODE_STATE_COLORS = {
     "idle": "green",
     "mixed": "yellow",
     "mix": "yellow",
@@ -970,7 +975,7 @@ def _render_sinfo_table(rows: list[Any]) -> None:
     for row in rows:
         partition_display = f"{row.partition}*" if row.is_default else row.partition
         avail_color = "green" if row.avail == "up" else "red"
-        state_color = _STATE_COLORS.get(row.state.lower(), "white")
+        state_color = _NODE_STATE_COLORS.get(row.state.lower(), "white")
         table.add_row(
             partition_display,
             f"[{avail_color}]{row.avail}[/{avail_color}]",

--- a/src/srunx/cli/commands/jobs.py
+++ b/src/srunx/cli/commands/jobs.py
@@ -830,6 +830,93 @@ def _run_squeue_live(
             return
 
 
+def _run_tail_follow_ssh(
+    job_ops: Any,
+    *,
+    job_id: int,
+    last: int | None,
+    interval: float,
+) -> None:
+    """Stream incremental log output from an SSH-hosted SLURM job.
+
+    Mirrors the structural pattern of :func:`_run_squeue_live` — ``fetch``
+    runs inside a ``try`` that renders transient failures (log file not
+    yet created, SSH hiccup) without killing the loop, and
+    :class:`KeyboardInterrupt` exits cleanly. Follows ``tail -f``
+    convention of polling forever; the user is expected to stop via
+    Ctrl+C.
+
+    Log writes go straight to ``sys.stdout`` / ``sys.stderr`` (not
+    through Rich) because this is an append-oriented stream, not a
+    rewritten snapshot — using :class:`~rich.live.Live` would wipe and
+    redraw every tick and destroy the scrollback the user is there to
+    read.
+
+    ``last`` applies to the **initial** chunk only; subsequent ticks
+    print every new byte. Matches how ``tail -fn N`` works at the OS
+    level.
+    """
+    import time as _time
+
+    offset_out = 0
+    offset_err = 0
+
+    # First poll: pull everything since 0, apply --last N to whatever
+    # text we got. Subsequent offsets come from the chunk itself so
+    # we never re-read what we already printed.
+    try:
+        chunk = job_ops.tail_log_incremental(job_id, offset_out, offset_err)
+    except Exception as exc:  # noqa: BLE001 — first poll can race the log file's creation
+        typer.secho(
+            f"(log not yet available: {exc})",
+            err=True,
+            fg=typer.colors.BRIGHT_BLACK,
+        )
+    else:
+        stdout_text = chunk.stdout or ""
+        stderr_text = chunk.stderr or ""
+        if last is not None:
+            if stdout_text:
+                stdout_text = "\n".join(stdout_text.splitlines()[-last:])
+                if chunk.stdout and chunk.stdout.endswith("\n"):
+                    stdout_text += "\n"
+            if stderr_text and stderr_text != chunk.stdout:
+                stderr_text = "\n".join(stderr_text.splitlines()[-last:])
+                if chunk.stderr and chunk.stderr.endswith("\n"):
+                    stderr_text += "\n"
+        if stdout_text:
+            sys.stdout.write(stdout_text)
+            sys.stdout.flush()
+        if stderr_text and stderr_text != (chunk.stdout or ""):
+            sys.stderr.write(stderr_text)
+            sys.stderr.flush()
+        offset_out = chunk.stdout_offset
+        offset_err = chunk.stderr_offset
+
+    try:
+        while True:
+            _time.sleep(interval)
+            try:
+                chunk = job_ops.tail_log_incremental(job_id, offset_out, offset_err)
+            except Exception as exc:  # noqa: BLE001 — keep the tail alive through transient errors
+                typer.secho(
+                    f"(poll failed, retrying: {exc})",
+                    err=True,
+                    fg=typer.colors.BRIGHT_BLACK,
+                )
+                continue
+            if chunk.stdout:
+                sys.stdout.write(chunk.stdout)
+                sys.stdout.flush()
+            if chunk.stderr:
+                sys.stderr.write(chunk.stderr)
+                sys.stderr.flush()
+            offset_out = chunk.stdout_offset
+            offset_err = chunk.stderr_offset
+    except KeyboardInterrupt:
+        return
+
+
 def scancel(
     job_id: Annotated[int, typer.Argument(help="Job ID to cancel")],
     profile: ProfileOpt = None,
@@ -1082,6 +1169,17 @@ def tail(
         bool,
         typer.Option("--follow", "-f", help="Stream logs in real-time (like tail -f)"),
     ] = False,
+    interval: Annotated[
+        float,
+        typer.Option(
+            "--interval",
+            help=(
+                "Seconds between polls when --follow is set over SSH "
+                "(local follow inherits Slurm.tail_log's existing cadence). "
+                "Default 2s."
+            ),
+        ),
+    ] = 2.0,
     last: Annotated[
         int | None, typer.Option("--last", "-n", help="Show only the last N lines")
     ] = None,
@@ -1094,6 +1192,14 @@ def tail(
     quiet: QuietOpt = False,
 ) -> None:
     """Display job logs with optional real-time streaming."""
+    if follow and interval <= 0:
+        typer.secho(
+            "--interval must be a positive number of seconds.",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=2)
+
     try:
         with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
             if rt.transport_type == "local":
@@ -1107,25 +1213,21 @@ def tail(
                     follow=follow,
                     last_n=last,
                 )
+            elif follow:
+                _run_tail_follow_ssh(
+                    rt.job_ops, job_id=job_id, last=last, interval=interval
+                )
             else:
-                # SSH path: use the pure Protocol tail_log_incremental
-                # once for non-follow retrieval. --follow over SSH is a
-                # Phase 5b+ concern (loop belongs in the CLI layer, but
-                # the SSH adapter does not yet stream logs).
+                # One-shot SSH read: pull the full log, honour --last N
+                # client-side (the adapter streams by offset, not by
+                # line — slicing here is the cheapest way to keep --last
+                # working without a second protocol method).
                 chunk = rt.job_ops.tail_log_incremental(job_id, 0, 0)
-                # ``--last N`` is applied client-side on the SSH path:
-                # the adapter returns the full log content and we slice
-                # here so the flag isn't silently dropped (SF6). The
-                # local path above already honours ``last_n`` via
-                # ``Slurm.tail_log``.
                 stdout_text = chunk.stdout or ""
                 stderr_text = chunk.stderr or ""
                 if last is not None:
                     if stdout_text:
                         stdout_text = "\n".join(stdout_text.splitlines()[-last:])
-                        # Preserve the trailing newline if the original
-                        # chunk ended with one so terminal output stays
-                        # unambiguous.
                         if chunk.stdout and chunk.stdout.endswith("\n"):
                             stdout_text += "\n"
                     if stderr_text and stderr_text != chunk.stdout:
@@ -1136,12 +1238,6 @@ def tail(
                     sys.stdout.write(stdout_text)
                 if stderr_text and stderr_text != (chunk.stdout or ""):
                     sys.stderr.write(stderr_text)
-                if follow:
-                    typer.secho(
-                        "--follow is not yet supported for SSH transports.",
-                        err=True,
-                        fg=typer.colors.YELLOW,
-                    )
 
     except JobNotFoundError:
         typer.secho(

--- a/src/srunx/cli/commands/jobs.py
+++ b/src/srunx/cli/commands/jobs.py
@@ -861,11 +861,15 @@ def _run_tail_follow_ssh(
     offset_out = 0
     offset_err = 0
 
-    # First poll: pull everything since 0, apply --last N to whatever
-    # text we got. Subsequent offsets come from the chunk itself so
-    # we never re-read what we already printed.
+    # First poll uses ``last_n=last`` so the remote runs ``tail -n N``
+    # and only the tail ships over SSH — we never bring a multi-GB log
+    # across the wire just to show its last 50 lines. The chunk
+    # returns an offset at current EOF; subsequent ticks resume from
+    # there.
     try:
-        chunk = job_ops.tail_log_incremental(job_id, offset_out, offset_err)
+        chunk = job_ops.tail_log_incremental(
+            job_id, offset_out, offset_err, last_n=last
+        )
     except Exception as exc:  # noqa: BLE001 — first poll can race the log file's creation
         typer.secho(
             f"(log not yet available: {exc})",
@@ -873,22 +877,11 @@ def _run_tail_follow_ssh(
             fg=typer.colors.BRIGHT_BLACK,
         )
     else:
-        stdout_text = chunk.stdout or ""
-        stderr_text = chunk.stderr or ""
-        if last is not None:
-            if stdout_text:
-                stdout_text = "\n".join(stdout_text.splitlines()[-last:])
-                if chunk.stdout and chunk.stdout.endswith("\n"):
-                    stdout_text += "\n"
-            if stderr_text and stderr_text != chunk.stdout:
-                stderr_text = "\n".join(stderr_text.splitlines()[-last:])
-                if chunk.stderr and chunk.stderr.endswith("\n"):
-                    stderr_text += "\n"
-        if stdout_text:
-            sys.stdout.write(stdout_text)
+        if chunk.stdout:
+            sys.stdout.write(chunk.stdout)
             sys.stdout.flush()
-        if stderr_text and stderr_text != (chunk.stdout or ""):
-            sys.stderr.write(stderr_text)
+        if chunk.stderr and chunk.stderr != chunk.stdout:
+            sys.stderr.write(chunk.stderr)
             sys.stderr.flush()
         offset_out = chunk.stdout_offset
         offset_err = chunk.stderr_offset
@@ -1218,26 +1211,15 @@ def tail(
                     rt.job_ops, job_id=job_id, last=last, interval=interval
                 )
             else:
-                # One-shot SSH read: pull the full log, honour --last N
-                # client-side (the adapter streams by offset, not by
-                # line — slicing here is the cheapest way to keep --last
-                # working without a second protocol method).
-                chunk = rt.job_ops.tail_log_incremental(job_id, 0, 0)
-                stdout_text = chunk.stdout or ""
-                stderr_text = chunk.stderr or ""
-                if last is not None:
-                    if stdout_text:
-                        stdout_text = "\n".join(stdout_text.splitlines()[-last:])
-                        if chunk.stdout and chunk.stdout.endswith("\n"):
-                            stdout_text += "\n"
-                    if stderr_text and stderr_text != chunk.stdout:
-                        stderr_text = "\n".join(stderr_text.splitlines()[-last:])
-                        if chunk.stderr and chunk.stderr.endswith("\n"):
-                            stderr_text += "\n"
-                if stdout_text:
-                    sys.stdout.write(stdout_text)
-                if stderr_text and stderr_text != (chunk.stdout or ""):
-                    sys.stderr.write(stderr_text)
+                # One-shot SSH read. ``--last N`` flows through as
+                # ``last_n`` so the remote runs ``tail -n N`` and only
+                # the tail bytes traverse the SSH link, even for a
+                # multi-GB log.
+                chunk = rt.job_ops.tail_log_incremental(job_id, 0, 0, last_n=last)
+                if chunk.stdout:
+                    sys.stdout.write(chunk.stdout)
+                if chunk.stderr and chunk.stderr != chunk.stdout:
+                    sys.stderr.write(chunk.stderr)
 
     except JobNotFoundError:
         typer.secho(

--- a/src/srunx/cli/commands/jobs.py
+++ b/src/srunx/cli/commands/jobs.py
@@ -1174,8 +1174,27 @@ def tail(
         ),
     ] = 2.0,
     last: Annotated[
-        int | None, typer.Option("--last", "-n", help="Show only the last N lines")
-    ] = None,
+        int,
+        typer.Option(
+            "--last",
+            "-n",
+            help=(
+                "Show only the last N lines (default 10, matches native "
+                "``tail``). Use ``--all`` to dump the entire log."
+            ),
+        ),
+    ] = 10,
+    show_all: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help=(
+                "Dump the entire log instead of the last ``--last`` lines. "
+                "Skips the ``tail -n`` optimization and ``cat``s the whole "
+                "file — a multi-GB log will transfer across SSH as-is."
+            ),
+        ),
+    ] = False,
     job_name: Annotated[
         str | None,
         typer.Option("--name", help="Job name for better log file detection"),
@@ -1184,7 +1203,14 @@ def tail(
     local: LocalOpt = False,
     quiet: QuietOpt = False,
 ) -> None:
-    """Display job logs with optional real-time streaming."""
+    """Display job logs with optional real-time streaming.
+
+    Defaults to the last 10 lines of the log (native ``tail``
+    convention). Pass ``-n N`` for a different cap, or ``--all`` to
+    dump everything. With ``--follow`` / ``-f``, the default also
+    applies to the initial frame — subsequent ticks stream only the
+    delta regardless.
+    """
     if follow and interval <= 0:
         typer.secho(
             "--interval must be a positive number of seconds.",
@@ -1192,6 +1218,17 @@ def tail(
             fg=typer.colors.RED,
         )
         raise typer.Exit(code=2)
+    if last <= 0 and not show_all:
+        typer.secho(
+            "--last must be a positive integer (or use --all to dump everything).",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=2)
+
+    # ``--all`` wins over ``--last``: passing ``last_n=None`` to the
+    # adapter triggers the legacy ``cat`` full-read path.
+    effective_last: int | None = None if show_all else last
 
     try:
         with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
@@ -1204,18 +1241,23 @@ def tail(
                     job_id=job_id,
                     job_name=job_name,
                     follow=follow,
-                    last_n=last,
+                    last_n=effective_last,
                 )
             elif follow:
                 _run_tail_follow_ssh(
-                    rt.job_ops, job_id=job_id, last=last, interval=interval
+                    rt.job_ops,
+                    job_id=job_id,
+                    last=effective_last,
+                    interval=interval,
                 )
             else:
-                # One-shot SSH read. ``--last N`` flows through as
-                # ``last_n`` so the remote runs ``tail -n N`` and only
-                # the tail bytes traverse the SSH link, even for a
-                # multi-GB log.
-                chunk = rt.job_ops.tail_log_incremental(job_id, 0, 0, last_n=last)
+                # One-shot SSH read. ``last_n`` flows through so the
+                # remote runs ``tail -n N`` — only the tail bytes cross
+                # the SSH link. ``--all`` passes ``last_n=None`` which
+                # falls back to ``cat`` for a full dump.
+                chunk = rt.job_ops.tail_log_incremental(
+                    job_id, 0, 0, last_n=effective_last
+                )
                 if chunk.stdout:
                     sys.stdout.write(chunk.stdout)
                 if chunk.stderr and chunk.stderr != chunk.stdout:

--- a/src/srunx/cli/commands/jobs.py
+++ b/src/srunx/cli/commands/jobs.py
@@ -1,4 +1,4 @@
-"""Job-oriented CLI commands: sbatch, squeue, scancel, sinfo, tail."""
+"""Job-oriented CLI commands: sbatch, squeue, scancel, sinfo, gpus, tail."""
 
 import os
 import sys
@@ -23,6 +23,7 @@ from srunx.cli._helpers.sbatch_helpers import (
     _print_in_place_sync_preview,
     _submit_via_transport,
 )
+from srunx.cli._helpers.state_colors import colorize_state
 from srunx.cli._helpers.transport_options import LocalOpt, ProfileOpt, QuietOpt
 from srunx.common.config import get_config
 from srunx.common.exceptions import JobNotFoundError, TransportError
@@ -549,9 +550,40 @@ def squeue(
             ),
         ),
     ] = None,
-    show_gpus: Annotated[
+    user: Annotated[
+        str | None,
+        typer.Option(
+            "-u",
+            "--user",
+            help=(
+                "Filter to a single username (like ``squeue --user <name>``). "
+                "Default is all users."
+            ),
+        ),
+    ] = None,
+    show_partition: Annotated[
         bool,
-        typer.Option("--show-gpus", "-g", help="Show GPU allocation for each job"),
+        typer.Option("--show-partition", help="Add the Partition column."),
+    ] = False,
+    show_cpus: Annotated[
+        bool,
+        typer.Option("--show-cpus", help="Add the CPUs column."),
+    ] = False,
+    show_limit: Annotated[
+        bool,
+        typer.Option("--show-limit", help="Add the time-limit column."),
+    ] = False,
+    show_nodes: Annotated[
+        bool,
+        typer.Option("--show-nodes", help="Add the Nodes count column."),
+    ] = False,
+    show_all: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help="Shortcut for --show-partition --show-cpus --show-limit --show-nodes.",
+        ),
     ] = False,
     format: Annotated[
         str,
@@ -561,14 +593,26 @@ def squeue(
     local: LocalOpt = False,
     quiet: QuietOpt = False,
 ) -> None:
-    """List user's jobs in the queue.
+    """List active jobs on the cluster.
+
+    Shows all users' jobs by default (matching native ``squeue``).
+
+    Default columns: Job ID, User, Name, Status, GPUs, Elapsed,
+    NodeList. Use ``--show-partition`` / ``--show-cpus`` /
+    ``--show-limit`` / ``--show-nodes`` (or ``-a`` / ``--all``) to
+    surface the remaining SLURM fields. ``--format json`` always
+    emits every field regardless of these flags — scripts can pick
+    what they need.
+
+    For finished jobs, see ``srunx history``.
 
     Examples:
         srunx squeue
         srunx squeue -j 12345
-        srunx squeue --show-gpus
+        srunx squeue --user alice
+        srunx squeue -a
+        srunx squeue --show-partition --show-cpus
         srunx squeue --format json
-        srunx squeue --show-gpus --format json
     """
     import json
 
@@ -576,9 +620,9 @@ def squeue(
         with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
             if rt.transport_type == "local":
                 client = _slurm_local.Slurm()
-                jobs = client.queue()
+                jobs = client.queue(user=user)
             else:
-                jobs = rt.job_ops.queue()
+                jobs = rt.job_ops.queue(user=user)
 
         # Filter to user-specified job IDs after the queue() call so
         # the dispatch path stays simple; SLURM's own ``squeue -j`` does
@@ -587,79 +631,86 @@ def squeue(
             wanted = {int(j) for j in job_filter}
             jobs = [j for j in jobs if j.job_id in wanted]
 
-        # JSON format output (emit before the "empty queue" banner so
-        # --format json stdout stays pure JSON — AC-7.1 / AC-7.2).
+        # JSON format always emits every field (scripts pick what
+        # they consume — column-hiding would just force callers to
+        # reconstruct the full shape from multiple calls).
         if format == "json":
-            job_data = []
-            for job in jobs:
-                data = {
+            job_data = [
+                {
                     "job_id": job.job_id,
+                    "user": getattr(job, "user", None),
                     "name": job.name,
-                    "status": job.status.name if hasattr(job, "status") else "UNKNOWN",
-                    "nodes": getattr(getattr(job, "resources", None), "nodes", None),
-                    "time_limit": getattr(
-                        getattr(job, "resources", None), "time_limit", None
+                    "partition": getattr(job, "partition", None),
+                    "status": (
+                        job.status.name if hasattr(job, "status") else "UNKNOWN"
                     ),
+                    "nodes": getattr(job, "nodes", None),
+                    "cpus": getattr(job, "cpus", None),
+                    "gpus": getattr(job, "gpus", None),
+                    "nodelist": getattr(job, "nodelist", None),
+                    "elapsed_time": getattr(job, "elapsed_time", None),
+                    "time_limit": getattr(job, "time_limit", None),
                 }
-                if show_gpus:
-                    resources = getattr(job, "resources", None)
-                    if resources:
-                        total_gpus = resources.nodes * resources.gpus_per_node
-                        data["gpus"] = total_gpus
-                    else:
-                        data["gpus"] = 0
-                job_data.append(data)
-
-            console = Console()
-            console.print(json.dumps(job_data, indent=2))
+                for job in jobs
+            ]
+            Console().print(json.dumps(job_data, indent=2))
             return
 
         # Empty-queue sentinel only for human-facing table format.
-        # Moved past the json branch to fix the pre-existing bug where
-        # ``srunx squeue --format json`` on an empty queue emitted the
-        # human-readable line instead of ``[]`` (AC-7.1 prerequisite).
         if not jobs:
-            console = Console()
-            console.print("No jobs in queue")
+            Console().print("No jobs in queue")
             return
 
-        # Table format output.
-        #
-        # Columns read from ``BaseJob`` top-level fields populated by
-        # both the local and SSH ``queue()`` implementations (squeue
-        # ``%.6D`` / ``%.10M`` / ``%.9l``). Pre-Phase-2 code reached for
-        # ``job.resources.nodes`` etc. but ``BaseJob`` has no
-        # ``resources`` attribute, so every row came back as ``N/A`` —
-        # regardless of transport. Two distinct time columns are shown
-        # because users care about both "how long has this been running"
-        # (Elapsed) and "when will SLURM kill it" (Limit).
-        table = Table(title="Job Queue")
+        # Column visibility. The four SLURM fields the user flagged as
+        # "information density, not always needed" are hidden by
+        # default; flags (or ``-a``) surface them. Keeping GPUs /
+        # NodeList / User in the default set because those are what
+        # disambiguate jobs in a multi-user queue — the original
+        # complaint that triggered this redesign.
+        show_partition_col = show_partition or show_all
+        show_cpus_col = show_cpus or show_all
+        show_limit_col = show_limit or show_all
+        show_nodes_col = show_nodes or show_all
+
+        table = Table()
         table.add_column("Job ID", style="cyan")
-        table.add_column("Name", style="magenta")
-        table.add_column("Status", style="green")
-        table.add_column("Nodes", justify="right")
-        if show_gpus:
-            table.add_column("GPUs", justify="right", style="yellow")
+        table.add_column("User")
+        table.add_column("Name", style="magenta", overflow="fold")
+        if show_partition_col:
+            table.add_column("Partition")
+        table.add_column("Status")
+        if show_nodes_col:
+            table.add_column("Nodes", justify="right")
+        if show_cpus_col:
+            table.add_column("CPUs", justify="right")
+        table.add_column("GPUs", justify="right", style="yellow")
         table.add_column("Elapsed", justify="right")
-        table.add_column("Limit", justify="right")
+        if show_limit_col:
+            table.add_column("Limit", justify="right")
+        table.add_column("NodeList", overflow="fold")
 
         for job in jobs:
-            row = [
+            status_name = job.status.name if hasattr(job, "status") else "UNKNOWN"
+            row: list[str] = [
                 str(job.job_id) if job.job_id else "N/A",
+                getattr(job, "user", None) or "N/A",
                 job.name,
-                job.status.name if hasattr(job, "status") else "UNKNOWN",
-                str(getattr(job, "nodes", None) or "N/A"),
             ]
-
-            if show_gpus:
-                row.append(str(getattr(job, "gpus", 0) or 0))
-
+            if show_partition_col:
+                row.append(getattr(job, "partition", None) or "N/A")
+            row.append(colorize_state(status_name))
+            if show_nodes_col:
+                row.append(str(getattr(job, "nodes", None) or "N/A"))
+            if show_cpus_col:
+                row.append(str(getattr(job, "cpus", None) or 0))
+            row.append(str(getattr(job, "gpus", None) or 0))
             row.append(getattr(job, "elapsed_time", None) or "N/A")
-            row.append(getattr(job, "time_limit", None) or "N/A")
+            if show_limit_col:
+                row.append(getattr(job, "time_limit", None) or "N/A")
+            row.append(getattr(job, "nodelist", None) or "N/A")
             table.add_row(*row)
 
-        console = Console()
-        console.print(table)
+        Console().print(table)
 
     except TransportError as exc:
         typer.secho(f"Transport error: {exc}", err=True, fg=typer.colors.RED)
@@ -704,6 +755,26 @@ def scancel(
         raise typer.Exit(code=1) from e
 
 
+_STATE_COLORS = {
+    "idle": "green",
+    "mixed": "yellow",
+    "mix": "yellow",
+    "allocated": "red",
+    "alloc": "red",
+    "completing": "cyan",
+    "drained": "magenta",
+    "drain": "magenta",
+    "draining": "magenta",
+    "down": "bright_red",
+    "fail": "bright_red",
+    "failing": "bright_red",
+    "maint": "bright_black",
+    "reserved": "blue",
+    "future": "bright_black",
+    "unknown": "bright_black",
+}
+
+
 def sinfo(
     partition: Annotated[
         str | None,
@@ -717,19 +788,120 @@ def sinfo(
     local: LocalOpt = False,
     quiet: QuietOpt = False,
 ) -> None:
-    """Display current GPU resource availability.
+    """Display partition / node state — same information as native ``sinfo``.
+
+    Columns mirror the default ``sinfo`` layout: ``PARTITION`` (with
+    ``*`` on the default partition), ``AVAIL`` (up/down), ``TIMELIMIT``,
+    ``NODES``, ``STATE``, ``NODELIST``. For the GPU-aggregate summary
+    that used to live here, see ``srunx gpus``.
 
     With ``--profile <name>`` (or ``$SRUNX_SSH_PROFILE`` / current
     profile) the query runs against the remote cluster via the SSH
-    adapter. Local mode keeps the legacy ``sinfo`` / ``squeue``
-    subprocess path so a head-node user sees no behaviour change.
+    adapter. Local mode shells out to the head-node ``sinfo`` binary.
 
     Examples:
         srunx sinfo
         srunx sinfo --partition gpu
         srunx sinfo --format json
-        srunx sinfo --partition gpu --format json
         srunx sinfo --profile dgx-server --partition gpu
+    """
+    import json
+    from typing import cast
+
+    from srunx.slurm.partitions import (
+        PartitionRow,
+        fetch_sinfo_rows_local,
+        fetch_sinfo_rows_ssh,
+    )
+    from srunx.transport import resolve_transport
+
+    try:
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            rows: list[PartitionRow]
+            if rt.transport_type == "ssh":
+                # Cast Protocol → concrete ``SlurmSSHAdapter`` so we
+                # can reuse the adapter-scoped ``_run_slurm_cmd`` path
+                # (login-shell env, SLURM PATH, I/O lock). The
+                # Protocol deliberately doesn't expose SSH primitives.
+                from srunx.slurm.ssh import SlurmSSHAdapter
+
+                adapter = cast(SlurmSSHAdapter, rt.job_ops)
+                rows = fetch_sinfo_rows_ssh(adapter, partition)
+            else:
+                rows = fetch_sinfo_rows_local(partition)
+
+        if format == "json":
+            Console().print(json.dumps([row.to_dict() for row in rows], indent=2))
+            return
+
+        _render_sinfo_table(rows)
+
+    except Exception as e:
+        logger.error(f"Error querying partition info: {e}")
+        Console().print(f"[red]Error: {e}[/red]")
+        sys.exit(1)
+
+
+def _render_sinfo_table(rows: list[Any]) -> None:
+    """Render :class:`PartitionRow` list as a Rich table.
+
+    The shape matches native ``sinfo`` (same columns, same order) so a
+    SLURM user sees familiar output. Styling uses colour on ``STATE``
+    to make node health scan-able; no column is dropped or re-ordered.
+    """
+    table = Table()
+    table.add_column("PARTITION", style="cyan")
+    table.add_column("AVAIL")
+    table.add_column("TIMELIMIT")
+    table.add_column("NODES", justify="right")
+    table.add_column("STATE")
+    table.add_column("NODELIST", overflow="fold")
+
+    for row in rows:
+        partition_display = f"{row.partition}*" if row.is_default else row.partition
+        avail_color = "green" if row.avail == "up" else "red"
+        state_color = _STATE_COLORS.get(row.state.lower(), "white")
+        table.add_row(
+            partition_display,
+            f"[{avail_color}]{row.avail}[/{avail_color}]",
+            row.timelimit,
+            str(row.nodes),
+            f"[{state_color}]{row.state}[/{state_color}]",
+            row.nodelist,
+        )
+
+    Console().print(table)
+
+
+def gpus(
+    partition: Annotated[
+        str | None,
+        typer.Option("--partition", "-p", help="SLURM partition to query"),
+    ] = None,
+    format: Annotated[
+        str,
+        typer.Option("--format", "-f", help="Output format: table or json"),
+    ] = "table",
+    profile: ProfileOpt = None,
+    local: LocalOpt = False,
+    quiet: QuietOpt = False,
+) -> None:
+    """Display current GPU resource availability (aggregate snapshot).
+
+    Produces the GPU-focused summary that used to live under
+    ``srunx sinfo``. For the native-``sinfo`` partition / state /
+    nodelist listing, see ``srunx sinfo``.
+
+    With ``--profile <name>`` (or ``$SRUNX_SSH_PROFILE`` / current
+    profile) the query runs against the remote cluster via the SSH
+    adapter. Local mode keeps the subprocess ``sinfo`` / ``squeue``
+    path.
+
+    Examples:
+        srunx gpus
+        srunx gpus --partition gpu
+        srunx gpus --format json
+        srunx gpus --profile dgx-server --partition gpu
     """
     import json
     from typing import cast
@@ -743,22 +915,8 @@ def sinfo(
 
     try:
         with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
-            # SSH path delegates to the existing
-            # ``SSHAdapterResourceSource`` so cluster-wide vs
-            # per-partition dedup, error propagation, and dict→snapshot
-            # coercion all match what the resource snapshotter / Web
-            # ``/api/resources`` already use. Local stays on the
-            # subprocess fallback (source=None) — head-node behaviour
-            # is byte-for-byte identical to pre-#139.
             source: ResourceSource | None = None
             if rt.transport_type == "ssh":
-                # ``rt.job_ops`` is the live ``SlurmSSHAdapter`` for
-                # this profile (see ``_build_ssh_handle``). Cast away
-                # the Protocol → concrete narrowing — the Protocol
-                # doesn't expose ``get_resources`` /
-                # ``get_cluster_snapshot`` because those are SSH-only,
-                # and bouncing through a fresh Protocol adds no value
-                # over the existing ``SSHAdapterResourceSource``.
                 from srunx.slurm.ssh import SlurmSSHAdapter
 
                 adapter = cast(SlurmSSHAdapter, rt.job_ops)
@@ -778,13 +936,10 @@ def sinfo(
                 "nodes_idle": snapshot.nodes_idle,
                 "nodes_down": snapshot.nodes_down,
             }
-            console = Console()
-            console.print(json.dumps(data, indent=2))
+            Console().print(json.dumps(data, indent=2))
             return
 
-        partition_name = snapshot.partition or "all partitions"
-        table = Table(title=f"GPU Resources - {partition_name}")
-
+        table = Table()
         table.add_column("Metric", style="cyan")
         table.add_column("Value", justify="right", style="green")
 
@@ -798,13 +953,11 @@ def sinfo(
         table.add_row("Idle Nodes", str(snapshot.nodes_idle))
         table.add_row("Down Nodes", str(snapshot.nodes_down))
 
-        console = Console()
-        console.print(table)
+        Console().print(table)
 
     except Exception as e:
-        logger.error(f"Error querying resources: {e}")
-        console = Console()
-        console.print(f"[red]Error: {e}[/red]")
+        logger.error(f"Error querying GPU resources: {e}")
+        Console().print(f"[red]Error: {e}[/red]")
         sys.exit(1)
 
 

--- a/src/srunx/cli/commands/reports.py
+++ b/src/srunx/cli/commands/reports.py
@@ -1,4 +1,17 @@
-"""DB-backed history / reporting commands: sacct, sreport."""
+"""Job-history commands.
+
+Two related-but-distinct surfaces live here:
+
+* :func:`history` — srunx's own SQLite history. Only shows jobs
+  submitted via srunx itself. Works even on clusters where SLURM
+  accounting is disabled.
+* :func:`sacct` — real-SLURM ``sacct`` wrapper. Queries the cluster
+  accounting DB and thus sees every job SLURM has seen (including
+  manual ``sbatch`` runs). Falls flat if the cluster has no
+  ``slurmdbd``.
+
+``sreport`` was dropped earlier; see commit history.
+"""
 
 import sys
 from typing import Annotated
@@ -7,13 +20,14 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from srunx.cli._helpers.state_colors import colorize_state
 from srunx.cli._helpers.transport_options import LocalOpt, ProfileOpt, QuietOpt
 from srunx.common.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-def sacct(
+def history(
     job_filter: Annotated[
         list[int] | None,
         typer.Option(
@@ -21,8 +35,7 @@ def sacct(
             "--jobs",
             help=(
                 "Filter to one or more specific job IDs. Replaces the old "
-                "``srunx status <id>`` command for finished jobs — equivalent "
-                "to ``sacct -j ID``."
+                "``srunx status <id>`` command for finished jobs."
             ),
         ),
     ] = None,
@@ -33,7 +46,12 @@ def sacct(
     local: LocalOpt = False,
     quiet: QuietOpt = False,
 ) -> None:
-    """Show job execution history.
+    """Show srunx's own submission history.
+
+    Lists jobs that srunx itself submitted (from the local SQLite at
+    ``$XDG_CONFIG_HOME/srunx/srunx.db``). Jobs submitted outside srunx
+    — e.g. from a manual ``sbatch`` on the cluster — are **not**
+    listed. Use the cluster's own ``sacct`` for that.
 
     With ``--profile <name>`` (or ``$SRUNX_SSH_PROFILE`` / current
     profile), results are filtered to jobs that ran against that
@@ -48,7 +66,7 @@ def sacct(
             resolve_transport_source,
         )
 
-        # sacct is a pure DB query — no SSH connection needed even
+        # history is a pure DB query — no SSH connection needed even
         # for SSH profiles. ``peek_scheduler_key`` gives us the WHERE
         # filter without paying the round-trip cost of opening an
         # SSH adapter just to read the local SQLite history.
@@ -69,7 +87,7 @@ def sacct(
             return
 
         console = Console()
-        table = Table(title=f"Job History (Last {len(jobs)} jobs)")
+        table = Table()
         table.add_column("Job ID", style="cyan")
         table.add_column("Name", style="magenta")
         table.add_column("Status", style="green")
@@ -113,105 +131,198 @@ def sacct(
         sys.exit(1)
 
 
-def sreport(
-    from_date: Annotated[
-        str | None, typer.Option("--from", help="Start date (YYYY-MM-DD)")
+def sacct(
+    job_filter: Annotated[
+        list[int] | None,
+        typer.Option(
+            "-j",
+            "--jobs",
+            help="Filter to one or more specific job IDs (sacct -j).",
+        ),
     ] = None,
-    to_date: Annotated[
-        str | None, typer.Option("--to", help="End date (YYYY-MM-DD)")
+    user: Annotated[
+        str | None,
+        typer.Option(
+            "-u",
+            "--user",
+            help=(
+                "Filter to a single username. Omit (and omit -a) to use "
+                "sacct's implicit current-user default."
+            ),
+        ),
     ] = None,
-    workflow: Annotated[
-        str | None, typer.Option("--workflow", help="Workflow name")
+    all_users: Annotated[
+        bool,
+        typer.Option(
+            "-a",
+            "--allusers",
+            help="Show every user's jobs (overrides -u).",
+        ),
+    ] = False,
+    start_time: Annotated[
+        str | None,
+        typer.Option(
+            "-S",
+            "--starttime",
+            help="sacct --starttime (e.g. '2026-04-20', 'now-1day').",
+        ),
     ] = None,
+    end_time: Annotated[
+        str | None,
+        typer.Option("-E", "--endtime", help="sacct --endtime."),
+    ] = None,
+    state: Annotated[
+        str | None,
+        typer.Option(
+            "-s",
+            "--state",
+            help="Comma-separated states (e.g. 'FAILED,TIMEOUT').",
+        ),
+    ] = None,
+    partition: Annotated[
+        str | None,
+        typer.Option("-p", "--partition", help="Filter to a single partition."),
+    ] = None,
+    show_steps: Annotated[
+        bool,
+        typer.Option(
+            "--show-steps",
+            help=(
+                "Include job-step rows (.batch / .extern / .N). Hidden by "
+                "default because the parent row already summarises them."
+            ),
+        ),
+    ] = False,
+    show_account: Annotated[
+        bool,
+        typer.Option("--show-account", help="Add the Account column."),
+    ] = False,
+    show_start_end: Annotated[
+        bool,
+        typer.Option(
+            "--show-times",
+            help="Add the Submit / Start / End time columns.",
+        ),
+    ] = False,
+    format: Annotated[
+        str,
+        typer.Option("--format", "-f", help="Output format: table or json."),
+    ] = "table",
     profile: ProfileOpt = None,
     local: LocalOpt = False,
     quiet: QuietOpt = False,
 ) -> None:
-    """Generate job execution report.
+    """Query SLURM accounting via the real ``sacct`` binary.
 
-    With ``--profile <name>`` (or ``$SRUNX_SSH_PROFILE`` / current
-    profile), aggregates are scoped to jobs that ran on that
-    cluster. Without a transport selector, every transport is
-    aggregated together — matching legacy behaviour.
+    Unlike :func:`history` (which reads srunx's own SQLite), this
+    shells out to ``sacct`` on the cluster, so it sees **every** job
+    SLURM has accounted for — including manual ``sbatch`` runs done
+    outside srunx. Requires a cluster with ``slurmdbd`` accounting
+    enabled; otherwise the output will be empty.
+
+    Default columns: Job ID, User, Name, Partition, State, ExitCode,
+    Elapsed. Use ``--show-account`` / ``--show-times`` to add more.
+    ``--format json`` always emits every field.
+
+    Examples:
+        srunx sacct
+        srunx sacct -j 12345
+        srunx sacct -u alice -s FAILED
+        srunx sacct -a -S now-1day
+        srunx sacct --show-steps
+        srunx sacct --profile dgx -j 9876 --format json
     """
+    import json
+    from typing import cast
+
+    from srunx.slurm.accounting import (
+        SacctRow,
+        fetch_sacct_rows_local,
+        fetch_sacct_rows_ssh,
+        filter_out_steps,
+    )
+    from srunx.transport import resolve_transport
+
     try:
-        from srunx.observability.storage.cli_helpers import (
-            compute_job_stats,
-            compute_workflow_stats,
-        )
-        from srunx.transport import (
-            emit_transport_banner,
-            peek_scheduler_key,
-            resolve_transport_source,
-        )
+        job_ids = [int(j) for j in job_filter] if job_filter else None
+        with resolve_transport(profile=profile, local=local, quiet=quiet) as rt:
+            rows: list[SacctRow]
+            if rt.transport_type == "ssh":
+                from srunx.slurm.ssh import SlurmSSHAdapter
 
-        # sreport is a pure DB query — see ``sacct`` for the rationale
-        # behind the ``peek_scheduler_key`` shortcut.
-        source = resolve_transport_source(profile=profile, local=local)
-        scheduler_key = peek_scheduler_key(profile=profile, local=local)
-        emit_transport_banner(label=scheduler_key, source=source, quiet=quiet)
+                adapter = cast(SlurmSSHAdapter, rt.job_ops)
+                rows = fetch_sacct_rows_ssh(
+                    adapter,
+                    job_ids=job_ids,
+                    user=user,
+                    all_users=all_users,
+                    start_time=start_time,
+                    end_time=end_time,
+                    state=state,
+                    partition=partition,
+                )
+            else:
+                rows = fetch_sacct_rows_local(
+                    job_ids=job_ids,
+                    user=user,
+                    all_users=all_users,
+                    start_time=start_time,
+                    end_time=end_time,
+                    state=state,
+                    partition=partition,
+                )
 
-        if workflow:
-            stats = compute_workflow_stats(workflow, scheduler_key=scheduler_key)
+        if not show_steps:
+            rows = filter_out_steps(rows)
 
-            console = Console()
-            console.print(f"\n[bold cyan]Workflow Report: {workflow}[/bold cyan]")
-            console.print(f"Total Jobs: {stats['total_jobs']}")
-            if stats["avg_duration_seconds"]:
-                mins = int(stats["avg_duration_seconds"] / 60)
-                console.print(f"Average Duration: {mins} minutes")
-            console.print(f"First Submitted: {stats['first_submitted']}")
-            console.print(f"Last Submitted: {stats['last_submitted']}\n")
+        if format == "json":
+            Console().print(json.dumps([row.to_dict() for row in rows], indent=2))
+            return
 
-        else:
-            stats = compute_job_stats(
-                from_date=from_date,
-                to_date=to_date,
-                scheduler_key=scheduler_key,
-            )
+        if not rows:
+            Console().print("[yellow]No accounting records[/yellow]")
+            return
 
-            console = Console()
-            console.print("\n[bold cyan]Job Execution Report[/bold cyan]")
+        table = Table()
+        table.add_column("Job ID", style="cyan")
+        table.add_column("User")
+        table.add_column("Name", style="magenta", overflow="fold")
+        table.add_column("Partition")
+        if show_account:
+            table.add_column("Account")
+        table.add_column("State")
+        table.add_column("ExitCode", justify="right")
+        table.add_column("Elapsed", justify="right")
+        if show_start_end:
+            table.add_column("Submit")
+            table.add_column("Start")
+            table.add_column("End")
 
-            if from_date or to_date:
-                date_range = []
-                if from_date:
-                    date_range.append(f"From: {from_date}")
-                if to_date:
-                    date_range.append(f"To: {to_date}")
-                console.print(f"[yellow]{' | '.join(date_range)}[/yellow]\n")
+        for row in rows:
+            cells: list[str] = [
+                row.job_id,
+                row.user or "-",
+                row.job_name,
+                row.partition or "-",
+            ]
+            if show_account:
+                cells.append(row.account or "-")
+            cells += [
+                colorize_state(row.state or "UNKNOWN"),
+                row.exit_code or "-",
+                row.elapsed or "-",
+            ]
+            if show_start_end:
+                cells += [
+                    row.submit or "-",
+                    row.start or "-",
+                    row.end or "-",
+                ]
+            table.add_row(*cells)
 
-            # Summary table
-            summary_table = Table(title="Summary")
-            summary_table.add_column("Metric", style="cyan")
-            summary_table.add_column("Value", style="green", justify="right")
-
-            summary_table.add_row("Total Jobs", str(stats["total_jobs"]))
-
-            if stats["avg_duration_seconds"]:
-                mins = int(stats["avg_duration_seconds"] / 60)
-                summary_table.add_row("Average Duration", f"{mins} minutes")
-
-            summary_table.add_row(
-                "Total GPU Hours", f"{stats['total_gpu_hours']:.1f} hours"
-            )
-
-            console.print(summary_table)
-
-            # Status breakdown
-            if stats["jobs_by_status"]:
-                console.print()
-                status_table = Table(title="Jobs by Status")
-                status_table.add_column("Status", style="cyan")
-                status_table.add_column("Count", style="green", justify="right")
-
-                for status, count in stats["jobs_by_status"].items():
-                    status_table.add_row(status, str(count))
-
-                console.print(status_table)
-
-            console.print()
+        Console().print(table)
 
     except Exception as e:
-        logger.error(f"Error generating report: {e}")
+        logger.error(f"Error running sacct: {e}")
+        Console().print(f"[red]Error: {e}[/red]")
         sys.exit(1)

--- a/src/srunx/cli/commands/templates.py
+++ b/src/srunx/cli/commands/templates.py
@@ -23,7 +23,7 @@ def template_list() -> None:
     templates = list_templates()
 
     console = Console()
-    table = Table(title="Available Job Templates")
+    table = Table()
     table.add_column("Name", style="cyan")
     table.add_column("Description", style="magenta")
     table.add_column("Use Case", style="green")

--- a/src/srunx/cli/main.py
+++ b/src/srunx/cli/main.py
@@ -12,8 +12,8 @@ import typer
 
 from srunx.cli._helpers.transport_options import LocalOpt, ProfileOpt, QuietOpt
 from srunx.cli.commands.config import config_app
-from srunx.cli.commands.jobs import sbatch, scancel, sinfo, squeue, tail
-from srunx.cli.commands.reports import sacct, sreport
+from srunx.cli.commands.jobs import gpus, sbatch, scancel, sinfo, squeue, tail
+from srunx.cli.commands.reports import history, sacct
 from srunx.cli.commands.templates import template_app
 from srunx.cli.commands.ui import ui
 from srunx.cli.watch import watch_app
@@ -48,9 +48,10 @@ app.command("sbatch")(sbatch)
 app.command("squeue")(squeue)
 app.command("scancel")(scancel)
 app.command("sinfo")(sinfo)
+app.command("gpus")(gpus)
 app.command("tail")(tail)
+app.command("history")(history)
 app.command("sacct")(sacct)
-app.command("sreport")(sreport)
 
 
 @flow_app.command("run")

--- a/src/srunx/cli/watch.py
+++ b/src/srunx/cli/watch.py
@@ -37,7 +37,11 @@ def watch_jobs(
     ] = None,
     all_jobs: Annotated[
         bool,
-        typer.Option("--all", "-a", help="Watch all user jobs"),
+        typer.Option(
+            "--all",
+            "-a",
+            help="Watch every active job in the cluster queue (all users).",
+        ),
     ] = False,
     schedule: Annotated[
         str | None,
@@ -128,12 +132,15 @@ def watch_jobs(
         # SSH via resolve_transport rather than silently falling back to
         # a local Slurm singleton.
         if all_jobs:
-            all_user_jobs = rt.job_ops.queue()
-            job_ids = [job.job_id for job in all_user_jobs if job.job_id is not None]
+            # ``queue()`` with no ``user=`` follows native ``squeue``
+            # semantics (all users). ``--all`` here means "every active
+            # job on the cluster", not just the calling user's jobs.
+            queue_jobs = rt.job_ops.queue()
+            job_ids = [job.job_id for job in queue_jobs if job.job_id is not None]
             if not job_ids:
-                console.print("[yellow]No jobs found for current user[/yellow]")
+                console.print("[yellow]No active jobs in queue[/yellow]")
                 sys.exit(0)
-            console.print(f"📋 Watching {len(job_ids)} jobs for current user")
+            console.print(f"📋 Watching {len(job_ids)} active jobs (all users)")
 
         # Setup callbacks.
         #

--- a/src/srunx/observability/storage/cli_helpers.py
+++ b/src/srunx/observability/storage/cli_helpers.py
@@ -224,12 +224,12 @@ def list_recent_jobs(
 
     Thin wrapper around :meth:`JobRepository.list_recent_as_dict`.
     When ``job_ids`` is supplied, the SQL filter pushes the IDs down
-    and bypasses the ``LIMIT`` so the CLI's ``srunx sacct -j <id>``
+    and bypasses the ``LIMIT`` so the CLI's ``srunx history -j <id>``
     finds rows that fell outside the most recent ``limit`` page.
 
     ``scheduler_key`` (``"local"`` / ``"ssh:<profile>"``) scopes to
     a single transport — passed through to the SQL ``WHERE`` so
-    ``srunx sacct --profile X`` only sees that cluster's jobs.
+    ``srunx history --profile X`` only sees that cluster's jobs.
     """
     from srunx.observability.storage.connection import initialized_connection
     from srunx.observability.storage.repositories.jobs import JobRepository
@@ -238,78 +238,3 @@ def list_recent_jobs(
         return JobRepository(conn).list_recent_as_dict(
             limit=limit, job_ids=job_ids, scheduler_key=scheduler_key
         )
-
-
-def compute_job_stats(
-    from_date: str | None = None,
-    to_date: str | None = None,
-    *,
-    scheduler_key: str | None = None,
-) -> dict[str, Any]:
-    """Return aggregate job stats in the legacy ``get_job_stats`` shape.
-
-    Thin wrapper around :meth:`JobRepository.compute_stats` that owns
-    the connection; used by the CLI ``report`` command.
-
-    ``scheduler_key`` filters to a single transport for SSH parity
-    on ``srunx sreport --profile X``.
-    """
-    from srunx.observability.storage.connection import initialized_connection
-    from srunx.observability.storage.repositories.jobs import JobRepository
-
-    with initialized_connection() as conn:
-        return JobRepository(conn).compute_stats(
-            from_date=from_date, to_date=to_date, scheduler_key=scheduler_key
-        )
-
-
-def compute_workflow_stats(
-    workflow_name: str,
-    *,
-    scheduler_key: str | None = None,
-) -> dict[str, Any]:
-    """Return workflow-scoped stats in the legacy ``get_workflow_stats`` shape.
-
-    Joins ``jobs`` with ``workflow_runs`` on ``workflow_name`` and
-    aggregates. Fields: ``workflow_name``, ``total_jobs``,
-    ``avg_duration_seconds``, ``first_submitted``, ``last_submitted``.
-    Used by the CLI ``report --workflow`` command.
-
-    ``scheduler_key`` scopes the join to jobs that ran on a given
-    transport so ``--profile X`` reports only that cluster's runs
-    of the workflow.
-    """
-    from srunx.observability.storage.connection import initialized_connection
-
-    scheduler_clause = ""
-    params: tuple[Any, ...] = (workflow_name,)
-    if scheduler_key is not None:
-        scheduler_clause = " AND j.scheduler_key = ?"
-        params = (workflow_name, scheduler_key)
-
-    with initialized_connection() as conn:
-        row = conn.execute(
-            f"""
-            SELECT
-                COUNT(*)                          AS total_jobs,
-                AVG(j.duration_secs)              AS avg_duration_seconds,
-                MIN(j.submitted_at)               AS first_submitted,
-                MAX(j.submitted_at)               AS last_submitted
-            FROM jobs j
-            JOIN workflow_runs wr ON wr.id = j.workflow_run_id
-            WHERE wr.workflow_name = ?{scheduler_clause}
-            """,
-            params,
-        ).fetchone()
-
-    return {
-        "workflow_name": workflow_name,
-        "total_jobs": int(row["total_jobs"] or 0),
-        "avg_duration_seconds": (
-            float(row["avg_duration_seconds"])
-            if row["avg_duration_seconds"] is not None
-            else None
-        ),
-        "first_submitted": row["first_submitted"],
-        "last_submitted": row["last_submitted"],
-    }

--- a/src/srunx/observability/storage/repositories/jobs.py
+++ b/src/srunx/observability/storage/repositories/jobs.py
@@ -424,19 +424,19 @@ class JobRepository(BaseRepository):
     ) -> list[dict[str, Any]]:
         """Return the ``limit`` most recent jobs in the legacy dict shape.
 
-        Used by the ``/api/history`` router + ``srunx sacct`` CLI to
+        Used by the ``/api/history`` router + ``srunx history`` CLI to
         keep the response/display formats stable across the cutover
         from the removed ``srunx.history`` module (P2-4 #A).
 
         ``job_ids`` filters to a specific subset of jobs and bypasses
-        the ``LIMIT`` so ``srunx sacct -j <id>`` finds the job even
+        the ``LIMIT`` so ``srunx history -j <id>`` finds the job even
         when it falls outside the most recent ``limit`` rows. Codex
         follow-up #2 on PR #134 — without this push-down the CLI
         would silently report "no history found" for any job older
         than the page size.
 
         ``scheduler_key`` (e.g. ``"local"`` / ``"ssh:dgx"``) scopes
-        the query to a single transport so ``srunx sacct --profile X``
+        the query to a single transport so ``srunx history --profile X``
         only sees jobs that ran against that cluster. ``None`` keeps
         the legacy "all transports" behaviour for the Web UI history.
         """
@@ -530,8 +530,8 @@ class JobRepository(BaseRepository):
         matching the legacy behaviour.
 
         ``scheduler_key`` (e.g. ``"local"`` / ``"ssh:dgx"``) scopes the
-        aggregate to a single transport so ``srunx sreport --profile X``
-        reflects only that cluster.
+        aggregate to a single transport so the Web ``/api/history``
+        summary reflects only that cluster.
         """
         conditions: list[str] = []
         params: list[Any] = []

--- a/src/srunx/slurm/accounting.py
+++ b/src/srunx/slurm/accounting.py
@@ -191,11 +191,14 @@ def build_sacct_filter_args(
     from srunx.slurm.ssh import _validate_identifier
 
     args: list[str] = []
+    # ``-a`` and ``-u`` are independent flags in native ``sacct`` — passing
+    # both is valid and means "scan all users but filter to <user>" (``-a``
+    # only overrides the implicit self-filter default). Emit both when the
+    # caller provides both so srunx matches real sacct's semantics instead
+    # of silently dropping the narrower filter.
     if all_users:
-        # ``-a`` / ``--allusers`` overrides the implicit "current user"
-        # default that sacct applies when no user filter is given.
         args.append("--allusers")
-    elif user:
+    if user:
         _validate_identifier(user, "user")
         args += ["--user", user]
     if job_ids:

--- a/src/srunx/slurm/accounting.py
+++ b/src/srunx/slurm/accounting.py
@@ -1,0 +1,316 @@
+"""Native SLURM ``sacct`` wrapper for the ``srunx sacct`` CLI.
+
+This module is the complement to :mod:`srunx.slurm.partitions`: it
+wraps the real SLURM ``sacct`` binary so ``srunx sacct`` can answer
+"what happened on this cluster" queries. ``srunx history`` remains the
+view into srunx's own SQLite (submissions this client made) — these
+two are deliberately separate axes (cluster-wide accounting vs.
+srunx's own record).
+
+The parser and fetchers mirror the structure of
+:mod:`srunx.slurm.partitions`: a transport-agnostic parser plus
+subprocess / SSH fetchers that share the same row shape.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from srunx.slurm.ssh import SlurmSSHAdapter
+
+
+# The column set is deliberately wider than the default ``sacct``
+# output so the JSON emitter has every field a power user might want
+# without a second call. ``AllocTRES`` is included so a downstream
+# caller can extract GPU counts the same way ``_list_active_jobs``
+# does from ``%b`` (gpu:N inside the TRES string).
+_SACCT_COLUMNS: tuple[str, ...] = (
+    "JobID",
+    "JobName",
+    "User",
+    "Partition",
+    "Account",
+    "State",
+    "ExitCode",
+    "Elapsed",
+    "Submit",
+    "Start",
+    "End",
+    "AllocCPUS",
+    "AllocTRES",
+)
+_SACCT_FORMAT = ",".join(_SACCT_COLUMNS)
+
+# ``--parsable2`` = pipe-delimited, no trailing pipe. Combined with
+# ``--noheader`` the parser sees one row per line with exactly
+# ``len(_SACCT_COLUMNS)`` fields. Safer than whitespace splitting
+# because JobName and AllocTRES can contain spaces or commas.
+_SACCT_BASE_FLAGS: tuple[str, ...] = (
+    "--parsable2",
+    "--noheader",
+    f"--format={_SACCT_FORMAT}",
+)
+
+
+@dataclass(frozen=True)
+class SacctRow:
+    """One line from ``sacct --parsable2``.
+
+    ``job_id`` stays a string because SLURM uses ``.batch`` / ``.N``
+    suffixes for job steps (e.g. ``"12345.batch"``) — stripping those
+    would collapse distinct accounting rows. :attr:`is_step` is the
+    convenience predicate the CLI uses to hide steps by default.
+    """
+
+    job_id: str
+    job_name: str
+    user: str | None
+    partition: str | None
+    account: str | None
+    state: str
+    exit_code: str
+    elapsed: str | None
+    submit: str | None
+    start: str | None
+    end: str | None
+    alloc_cpus: int | None
+    alloc_tres: str | None
+
+    @property
+    def is_step(self) -> bool:
+        """True for sub-step rows (``12345.batch`` / ``12345.0`` / ...).
+
+        Useful for the CLI's default "hide sub-steps" behaviour — real
+        ``sacct`` shows them, but the median srunx user wants the
+        parent job summary.
+        """
+        return "." in self.job_id
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "job_id": self.job_id,
+            "job_name": self.job_name,
+            "user": self.user,
+            "partition": self.partition,
+            "account": self.account,
+            "state": self.state,
+            "exit_code": self.exit_code,
+            "elapsed": self.elapsed,
+            "submit": self.submit,
+            "start": self.start,
+            "end": self.end,
+            "alloc_cpus": self.alloc_cpus,
+            "alloc_tres": self.alloc_tres,
+            "is_step": self.is_step,
+        }
+
+
+def parse_sacct_rows(stdout: str) -> list[SacctRow]:
+    """Parse the output of ``sacct --parsable2 --noheader --format=...``.
+
+    Malformed lines (wrong field count) are skipped rather than
+    raising — a single bad row shouldn't sink the whole listing, and
+    ``sacct`` can emit partial data under slurmdbd hiccups.
+    ``state`` is normalised to the first word so ``CANCELLED by 1000``
+    becomes ``CANCELLED`` (the parent status).
+    """
+    rows: list[SacctRow] = []
+    for raw in stdout.splitlines():
+        line = raw.rstrip("\n")
+        if not line.strip():
+            continue
+        parts = line.split("|")
+        if len(parts) != len(_SACCT_COLUMNS):
+            continue
+        (
+            job_id,
+            job_name,
+            user,
+            partition,
+            account,
+            state,
+            exit_code,
+            elapsed,
+            submit,
+            start,
+            end,
+            alloc_cpus,
+            alloc_tres,
+        ) = (p.strip() for p in parts)
+        cpus: int | None
+        try:
+            cpus = int(alloc_cpus) if alloc_cpus else None
+        except ValueError:
+            cpus = None
+        # ``CANCELLED by 1000`` → keep just ``CANCELLED`` so the
+        # downstream colour map / filter logic sees the canonical
+        # state name. Full reason stays one split away if ever needed.
+        state_norm = state.split()[0] if state else ""
+        rows.append(
+            SacctRow(
+                job_id=job_id,
+                job_name=job_name,
+                user=user or None,
+                partition=partition or None,
+                account=account or None,
+                state=state_norm,
+                exit_code=exit_code,
+                elapsed=elapsed or None,
+                submit=submit or None,
+                start=start or None,
+                end=end or None,
+                alloc_cpus=cpus,
+                alloc_tres=alloc_tres or None,
+            )
+        )
+    return rows
+
+
+def build_sacct_filter_args(
+    *,
+    job_ids: Sequence[int] | None = None,
+    user: str | None = None,
+    all_users: bool = False,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    state: str | None = None,
+    partition: str | None = None,
+) -> list[str]:
+    """Translate CLI filter options into ``sacct`` flag strings.
+
+    Shared by the local and SSH fetchers so the two transports can't
+    drift on which filters they forward. Omits validation that only
+    SLURM itself can judge (e.g. state name spelling) — if the flag
+    is bogus, ``sacct`` exits non-zero and the CLI surfaces the
+    error as-is.
+    """
+    from srunx.slurm.ssh import _validate_identifier
+
+    args: list[str] = []
+    if all_users:
+        # ``-a`` / ``--allusers`` overrides the implicit "current user"
+        # default that sacct applies when no user filter is given.
+        args.append("--allusers")
+    elif user:
+        _validate_identifier(user, "user")
+        args += ["--user", user]
+    if job_ids:
+        # sacct accepts a comma-separated list on ``--jobs``. Cast
+        # through str(int) to keep the command shell-safe without
+        # having to invoke a shell at all (subprocess runs the argv
+        # directly).
+        args += ["--jobs", ",".join(str(int(j)) for j in job_ids)]
+    if start_time:
+        args += ["--starttime", start_time]
+    if end_time:
+        args += ["--endtime", end_time]
+    if state:
+        args += ["--state", state]
+    if partition:
+        _validate_identifier(partition, "partition")
+        args += ["--partition", partition]
+    return args
+
+
+def fetch_sacct_rows_local(
+    *,
+    job_ids: Sequence[int] | None = None,
+    user: str | None = None,
+    all_users: bool = False,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    state: str | None = None,
+    partition: str | None = None,
+    timeout: float = 60.0,
+) -> list[SacctRow]:
+    """Run local ``sacct`` with the requested filters and parse the output.
+
+    Raises the underlying :class:`subprocess.CalledProcessError` /
+    :class:`FileNotFoundError` / :class:`subprocess.TimeoutExpired`
+    so the CLI layer can render a transport-appropriate error
+    message consistent with :mod:`srunx.slurm.partitions`.
+    """
+    cmd = ["sacct", *_SACCT_BASE_FLAGS]
+    cmd += build_sacct_filter_args(
+        job_ids=job_ids,
+        user=user,
+        all_users=all_users,
+        start_time=start_time,
+        end_time=end_time,
+        state=state,
+        partition=partition,
+    )
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    )
+    return parse_sacct_rows(result.stdout)
+
+
+def fetch_sacct_rows_ssh(
+    adapter: SlurmSSHAdapter,
+    *,
+    job_ids: Sequence[int] | None = None,
+    user: str | None = None,
+    all_users: bool = False,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    state: str | None = None,
+    partition: str | None = None,
+) -> list[SacctRow]:
+    """Run ``sacct`` on the remote cluster via the SSH adapter.
+
+    Uses the same ``_run_slurm_cmd`` path as
+    :mod:`srunx.slurm.partitions` so login-shell env + SLURM PATH
+    resolution + the adapter's I/O lock all apply uniformly.
+    """
+    from srunx.slurm.ssh import _run_slurm_cmd
+
+    parts: list[str] = ["sacct", *_SACCT_BASE_FLAGS]
+    parts += build_sacct_filter_args(
+        job_ids=job_ids,
+        user=user,
+        all_users=all_users,
+        start_time=start_time,
+        end_time=end_time,
+        state=state,
+        partition=partition,
+    )
+    # Shell-quote nothing because every element has already been
+    # validated (_validate_identifier) or is a simple literal; the
+    # identifiers can't contain whitespace or metacharacters.
+    cmd = " ".join(_shell_quote(p) for p in parts)
+    stdout = _run_slurm_cmd(adapter, cmd)
+    return parse_sacct_rows(stdout)
+
+
+def _shell_quote(arg: str) -> str:
+    """Minimal shell quoting for ``_run_slurm_cmd`` argv → string.
+
+    ``_run_slurm_cmd`` takes a single command string (runs through
+    ``bash -lc`` on the remote). Fields like ``--format=JobID,...``
+    need no quoting but date strings like ``2026-04-01 00:00:00``
+    do. Single-quote everything that contains whitespace or a
+    shell meta-character — identifiers are already ASCII-safe by
+    construction (validated upstream).
+    """
+    if arg and all(c.isalnum() or c in "-_=:/," for c in arg):
+        return arg
+    escaped = arg.replace("'", "'\\''")
+    return f"'{escaped}'"
+
+
+def filter_out_steps(rows: Iterable[SacctRow]) -> list[SacctRow]:
+    """Return only the parent job rows (drop ``.batch`` / ``.N`` steps).
+
+    Small helper used by the CLI default view; kept here so the
+    tests can exercise it directly without spinning up the CLI.
+    """
+    return [row for row in rows if not row.is_step]

--- a/src/srunx/slurm/local.py
+++ b/src/srunx/slurm/local.py
@@ -244,6 +244,7 @@ class LocalClient:
         job_id: int,
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        last_n: int | None = None,
     ) -> LogChunk:
         """Return new log content since the given byte offsets.
 
@@ -253,16 +254,22 @@ class LocalClient:
         yet exist (e.g. the job is still PENDING), returns an empty chunk
         with the offsets unchanged — callers should treat a missing file
         as "no new data" rather than a hard error.
+
+        ``last_n`` is honoured on the initial read (both offsets 0):
+        we still read the full file from disk (it's local, no network
+        cost), then slice to the last N lines and set the offset to
+        file size. This keeps the Protocol symmetric with the SSH
+        implementation's optimization.
         """
         from srunx.slurm.protocols import LogChunk
 
         stdout_path, stderr_path = self._find_log_paths(job_id)
         stdout_content, new_stdout_offset = self._read_file_from_offset(
-            stdout_path, stdout_offset
+            stdout_path, stdout_offset, last_n=last_n
         )
         if stderr_path is not None and stderr_path != stdout_path:
             stderr_content, new_stderr_offset = self._read_file_from_offset(
-                stderr_path, stderr_offset
+                stderr_path, stderr_offset, last_n=last_n
             )
         else:
             stderr_content, new_stderr_offset = "", stderr_offset
@@ -300,13 +307,22 @@ class LocalClient:
         return stdout_path, stderr_path
 
     @staticmethod
-    def _read_file_from_offset(path: str | None, offset: int) -> tuple[str, int]:
-        """Read from *offset* to EOF. Missing file → ``("", offset)``."""
+    def _read_file_from_offset(
+        path: str | None, offset: int, *, last_n: int | None = None
+    ) -> tuple[str, int]:
+        """Read log content from *offset* (or last N lines on initial read).
+
+        Missing file → ``("", offset)``. When ``offset == 0`` and
+        ``last_n`` is set, returns only the last N lines with the new
+        offset at end-of-file — matches the SSH implementation's
+        semantic so callers see consistent behaviour across transports.
+        """
         if not path:
             return "", offset
         try:
             with open(path, "rb") as f:
-                f.seek(offset)
+                if offset:
+                    f.seek(offset)
                 data = f.read()
         except FileNotFoundError:
             return "", offset
@@ -317,6 +333,12 @@ class LocalClient:
             text = data.decode("utf-8")
         except UnicodeDecodeError:
             text = data.decode("utf-8", errors="replace")
+
+        if offset == 0 and last_n is not None and last_n > 0:
+            # Slice to last N lines; new offset stays at file size so
+            # the follow loop picks up future writes from EOF.
+            lines = text.splitlines(keepends=True)
+            text = "".join(lines[-last_n:]) if lines else ""
         return text, offset + len(data)
 
     def submit_remote_sbatch(

--- a/src/srunx/slurm/local.py
+++ b/src/srunx/slurm/local.py
@@ -365,19 +365,24 @@ class LocalClient:
             raise
 
     def queue(self, user: str | None = None) -> list[BaseJob]:
-        """List jobs for a user.
+        """List active jobs.
 
-        Args:
-            user: Username (defaults to current user).
+        ``user=None`` shows all users' jobs (matches native ``squeue``).
+        Pass a username to filter.
 
-        Returns:
-            List of Job objects.
+        Returns: list of :class:`BaseJob` populated with the same
+        field set as the SSH adapter's :meth:`~srunx.slurm.ssh.SlurmSSHAdapter.queue`
+        so CLI callers see a consistent shape regardless of transport.
         """
-        # Format: JobID Partition Name User State Time TimeLimit Nodes Nodelist TRES
+        # Pipe-delimited format — nodelist/reason (%R) can contain
+        # whitespace + parens, so space-splitting is fragile.
+        # Fields: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b
+        # (job_id, partition, name, user, state, elapsed, limit, nodes,
+        # total_cpus, nodelist_or_reason, TRES_PER_NODE)
         cmd = [
             "squeue",
             "--format",
-            "%.18i %.9P %.30j %.12u %.8T %.10M %.9l %.6D %R %b",
+            "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b",
             "--noheader",
         ]
         if user:
@@ -390,48 +395,65 @@ class LocalClient:
             if not line.strip():
                 continue
 
-            parts = line.split(maxsplit=9)  # Split into at most 10 parts
-            if len(parts) >= 5:
-                job_id = int(parts[0])
-                partition = parts[1] if len(parts) > 1 else None
-                job_name = parts[2]
-                user_name = parts[3] if len(parts) > 3 else None
-                status_str = parts[4]
-                elapsed_time = parts[5] if len(parts) > 5 else None
-                time_limit = parts[6] if len(parts) > 6 else None
-                nodes_str = parts[7] if len(parts) > 7 else "1"
-                tres = parts[9] if len(parts) > 9 else ""
+            parts = line.split("|")
+            if len(parts) < 11:
+                continue
 
-                try:
-                    status = JobStatus(status_str)
-                except ValueError:
-                    status = JobStatus.PENDING  # Default for unknown status
+            try:
+                job_id = int(parts[0].strip())
+            except ValueError:
+                continue
 
-                # Parse number of nodes
-                try:
-                    nodes = int(nodes_str)
-                except (ValueError, AttributeError):
-                    nodes = 1
+            partition = parts[1].strip() or None
+            job_name = parts[2].strip()
+            user_name = parts[3].strip() or None
+            status_str = parts[4].strip()
+            elapsed_time = parts[5].strip() or None
+            time_limit = parts[6].strip() or None
+            nodes_str = parts[7].strip()
+            cpus_str = parts[8].strip()
+            nodelist = parts[9].strip() or None
+            tres = parts[10].strip()
 
-                # Parse GPU count from TRES (e.g., "gpu:8" or "billing=8,cpu=8,gres/gpu=8,mem=100G,node=1")
-                gpus = 0
-                if tres and "gpu" in tres.lower():
-                    gpu_match = GPU_TRES_RE.search(tres)
-                    if gpu_match:
-                        gpus = int(gpu_match.group(1))
+            try:
+                status = JobStatus(status_str)
+            except ValueError:
+                status = JobStatus.PENDING  # Default for unknown status
 
-                job = BaseJob(
-                    name=job_name,
-                    job_id=job_id,
-                    user=user_name,
-                    partition=partition,
-                    elapsed_time=elapsed_time,
-                    time_limit=time_limit,
-                    nodes=nodes,
-                    gpus=gpus,
-                )
-                job.status = status
-                jobs.append(job)
+            try:
+                nodes = int(nodes_str)
+            except (ValueError, AttributeError):
+                nodes = 1
+
+            try:
+                cpus = int(cpus_str) if cpus_str else 0
+            except ValueError:
+                cpus = 0
+
+            # Parse GPU count from TRES (e.g., "gpu:8" or
+            # "billing=8,cpu=8,gres/gpu=8,mem=100G,node=1"). Total
+            # across all nodes so the column matches what a SLURM user
+            # reading ``sinfo`` / ``scontrol show job`` expects.
+            gpus_per_node = 0
+            if tres and "gpu" in tres.lower():
+                gpu_match = GPU_TRES_RE.search(tres)
+                if gpu_match:
+                    gpus_per_node = int(gpu_match.group(1))
+
+            job = BaseJob(
+                name=job_name,
+                job_id=job_id,
+                user=user_name,
+                partition=partition,
+                elapsed_time=elapsed_time,
+                time_limit=time_limit,
+                nodes=nodes,
+                cpus=cpus,
+                gpus=gpus_per_node * nodes,
+                nodelist=nodelist,
+            )
+            job.status = status
+            jobs.append(job)
 
         return jobs
 

--- a/src/srunx/slurm/partitions.py
+++ b/src/srunx/slurm/partitions.py
@@ -1,0 +1,139 @@
+"""Partition-level ``sinfo`` info for the ``srunx sinfo`` CLI.
+
+Native SLURM ``sinfo`` answers "what partitions exist, which nodes
+are in each state, which nodelist each row covers". srunx previously
+aggregated those rows into a GPU-only summary (now moved to
+``srunx gpus``). This module provides the raw row model so the CLI
+can render the same information a SLURM user expects.
+
+Data flow mirrors :mod:`srunx.slurm.ssh._run_slurm_cmd` vs
+:mod:`subprocess.run` dispatch: the parser is transport-agnostic, and
+the two fetchers wrap whichever command runner fits the transport.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from srunx.slurm.ssh import SlurmSSHAdapter
+
+
+# ``|`` delimiter: sinfo field values never contain it, and it avoids
+# the ambiguity that whitespace-splitting would introduce for NODELIST
+# values like ``node[01-03,05]`` or any partition name SLURM allows.
+_SINFO_FORMAT = "%P|%a|%l|%D|%T|%N"
+_SINFO_ARGS = ["-o", _SINFO_FORMAT, "--noheader"]
+
+
+@dataclass(frozen=True)
+class PartitionRow:
+    """One row of ``sinfo`` output.
+
+    ``partition`` is the bare partition name (trailing ``*`` default
+    marker is lifted into :attr:`is_default`). ``state`` is the long
+    form (e.g. ``idle`` / ``mixed`` / ``allocated`` / ``drained``) as
+    returned by ``sinfo -o %T``.
+    """
+
+    partition: str
+    is_default: bool
+    avail: str
+    timelimit: str
+    nodes: int
+    state: str
+    nodelist: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "partition": self.partition,
+            "is_default": self.is_default,
+            "avail": self.avail,
+            "timelimit": self.timelimit,
+            "nodes": self.nodes,
+            "state": self.state,
+            "nodelist": self.nodelist,
+        }
+
+
+def parse_sinfo_partition_rows(stdout: str) -> list[PartitionRow]:
+    """Parse ``sinfo -o '%P|%a|%l|%D|%T|%N' --noheader`` output.
+
+    Malformed lines (wrong field count, non-integer node count) are
+    skipped rather than raising — ``sinfo`` can emit partial output
+    for partitions in odd states, and one bad row shouldn't sink the
+    whole listing.
+    """
+    rows: list[PartitionRow] = []
+    for raw in stdout.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        parts = line.split("|")
+        if len(parts) != 6:
+            continue
+        partition_field, avail, timelimit, nodes_str, state, nodelist = parts
+        try:
+            nodes = int(nodes_str)
+        except ValueError:
+            continue
+        is_default = partition_field.endswith("*")
+        partition = partition_field.rstrip("*")
+        rows.append(
+            PartitionRow(
+                partition=partition,
+                is_default=is_default,
+                avail=avail,
+                timelimit=timelimit,
+                nodes=nodes,
+                state=state,
+                nodelist=nodelist,
+            )
+        )
+    return rows
+
+
+def fetch_sinfo_rows_local(
+    partition: str | None = None, *, timeout: float = 30.0
+) -> list[PartitionRow]:
+    """Run local ``sinfo`` and return parsed partition rows.
+
+    Raises the underlying :class:`subprocess.CalledProcessError` /
+    :class:`FileNotFoundError` / :class:`subprocess.TimeoutExpired`
+    so the CLI layer can render a transport-appropriate error message
+    (consistent with the rest of ``srunx.cli.commands.jobs``).
+    """
+    cmd = ["sinfo", *_SINFO_ARGS]
+    if partition:
+        cmd += ["-p", partition]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    )
+    return parse_sinfo_partition_rows(result.stdout)
+
+
+def fetch_sinfo_rows_ssh(
+    adapter: SlurmSSHAdapter, partition: str | None = None
+) -> list[PartitionRow]:
+    """Run ``sinfo`` on the remote cluster via the SSH adapter.
+
+    Delegates to the same ``_run_slurm_cmd`` path the rest of
+    :mod:`srunx.slurm.ssh` uses so login-shell env, SLURM PATH
+    resolution, and the adapter's I/O lock all apply uniformly.
+    """
+    # Import locally so the CLI doesn't pay the paramiko import cost
+    # on the local subprocess path.
+    from srunx.slurm.ssh import _run_slurm_cmd, _validate_identifier
+
+    cmd = f"sinfo -o '{_SINFO_FORMAT}' --noheader"
+    if partition:
+        _validate_identifier(partition, "partition")
+        cmd += f" -p {partition}"
+    stdout = _run_slurm_cmd(adapter, cmd)
+    return parse_sinfo_partition_rows(stdout)

--- a/src/srunx/slurm/protocols.py
+++ b/src/srunx/slurm/protocols.py
@@ -129,10 +129,11 @@ class JobOperations(Protocol):
         ...
 
     def queue(self, user: str | None = None) -> list[BaseJob]:
-        """List jobs for *user* (defaults to the transport's current user).
+        """List active jobs.
 
-        Local: ``$USER``. SSH: the profile's username. Empty list if
-        none, never raises.
+        ``user=None`` means "all users", matching native SLURM
+        ``squeue`` semantics. Pass a username to filter. Empty list
+        if there are no active jobs; never raises.
         """
         ...
 

--- a/src/srunx/slurm/protocols.py
+++ b/src/srunx/slurm/protocols.py
@@ -142,11 +142,22 @@ class JobOperations(Protocol):
         job_id: int,
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        last_n: int | None = None,
     ) -> LogChunk:
         """Return new log content since *stdout_offset* / *stderr_offset*.
 
         For ``follow`` behaviour, callers poll this method with the
         returned offsets. The Protocol itself never blocks.
+
+        ``last_n`` is an optimization hint for the *initial* read: when
+        both offsets are 0 and ``last_n`` is given, implementations
+        should return only the last N lines of the log and set the
+        returned offsets to the current file size, so subsequent calls
+        poll from the tail. When offsets are non-zero, ``last_n`` is
+        ignored (explicit offsets win — they mean "I've already read up
+        to this point"). The SSH implementation uses this to avoid
+        downloading a multi-GB log on startup when the user only asked
+        for the last N lines.
         """
         ...
 

--- a/src/srunx/slurm/ssh.py
+++ b/src/srunx/slurm/ssh.py
@@ -477,7 +477,13 @@ class SlurmSSHAdapter:
 
         for line in output.strip().splitlines():
             parts = line.split("|")
-            if len(parts) < 11:
+            # Strict equality check — SLURM allows ``|`` inside user-chosen
+            # fields like job name (``#SBATCH --job-name=foo|bar``). Such
+            # rows split into 12+ fields; ``< 11`` would pass and the
+            # subsequent indexing would silently misalign every column
+            # downstream of the embedded pipe. Better to drop the row
+            # than render corrupted data in an admin's queue listing.
+            if len(parts) != 11:
                 continue
 
             try:

--- a/src/srunx/slurm/ssh.py
+++ b/src/srunx/slurm/ssh.py
@@ -436,10 +436,36 @@ class SlurmSSHAdapter:
 
     # ── Job Operations ────────────────────────────
 
-    def list_jobs(self, user: str | None = None) -> list[dict[str, Any]]:
-        """List SLURM jobs via squeue + recent completed/failed jobs via sacct."""
-        # --- Active jobs from squeue ---
-        fmt = "%.18i %.9P %.30j %.12u %.8T %.10M %.9l %.6D %R %b"
+    def _list_active_jobs(
+        self, user: str | None = None
+    ) -> tuple[list[dict[str, Any]], set[int]]:
+        """Return active (PENDING / RUNNING / ...) jobs from ``squeue`` only.
+
+        Split out from :meth:`list_jobs` so :meth:`queue` (the CLI
+        ``srunx squeue`` path) can call this without triggering the
+        ``sacct -S now-6hours`` merge that would otherwise inject
+        terminal-state rows from the past 6 hours — that asymmetry
+        with the local ``Slurm.queue()`` broke user expectations
+        (native ``squeue`` never shows finished jobs).
+
+        ``user=None`` shows all users' jobs (matches native ``squeue``
+        and local :meth:`~srunx.slurm.local.Slurm.queue`). Pass a
+        username to filter.
+
+        Format fields (all surfaced by :meth:`queue`):
+        ``%i`` job_id | ``%P`` partition | ``%j`` name | ``%u`` user |
+        ``%T`` state (long) | ``%M`` elapsed | ``%l`` time_limit |
+        ``%D`` nodes | ``%C`` total CPUs | ``%R`` nodelist-or-reason |
+        ``%b`` TRES_PER_NODE (for GPU extraction).
+
+        Returns ``(entries, seen_ids)`` so the merging caller can
+        dedup sacct rows against active IDs without re-scanning.
+        """
+        # ``|`` delimiter: nodelist reasons can contain whitespace and
+        # parens (e.g. "(Resources, Priority)"), so splitting on
+        # whitespace with maxsplit is fragile. Pipe is the safe
+        # separator — SLURM fields never contain it.
+        fmt = "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b"
         cmd = f'squeue --format "{fmt}" --noheader'
         if user:
             _validate_identifier(user, "user")
@@ -450,45 +476,72 @@ class SlurmSSHAdapter:
         seen_ids: set[int] = set()
 
         for line in output.strip().splitlines():
-            parts = line.split()
-            if len(parts) < 9:
+            parts = line.split("|")
+            if len(parts) < 11:
                 continue
 
-            job_id_str = parts[0].strip()
             try:
-                job_id = int(job_id_str)
+                job_id = int(parts[0].strip())
             except ValueError:
                 continue
 
-            # parts[7] = %D (node count), parts[9] = %b (TRES per node)
-            num_nodes = int(parts[7]) if parts[7].strip().isdigit() else 1
+            partition = parts[1].strip()
+            name = parts[2].strip()
+            owner = parts[3].strip() or None
+            state = parts[4].strip()
+            elapsed = parts[5].strip()
+            time_limit = parts[6].strip()
+            nodes_str = parts[7].strip()
+            cpus_str = parts[8].strip()
+            nodelist = parts[9].strip()
+            tres = parts[10].strip()
+
+            num_nodes = int(nodes_str) if nodes_str.isdigit() else 1
+            try:
+                cpus_total = int(cpus_str) if cpus_str else 0
+            except ValueError:
+                cpus_total = 0
             gpus_per_node = 0
-            if len(parts) >= 10:
-                gpu_match = GPU_TRES_RE.search(parts[9])
-                if gpu_match:
-                    gpus_per_node = int(gpu_match.group(1))
+            gpu_match = GPU_TRES_RE.search(tres)
+            if gpu_match:
+                gpus_per_node = int(gpu_match.group(1))
 
             seen_ids.add(job_id)
             jobs.append(
                 {
-                    "name": parts[2].strip(),
+                    "name": name,
                     "job_id": job_id,
-                    "status": parts[4].strip(),
+                    "status": state,
                     "depends_on": [],
                     "command": [],
                     "resources": {
                         "nodes": num_nodes,
                         "gpus_per_node": gpus_per_node,
-                        "partition": parts[1].strip(),
-                        "time_limit": parts[6].strip(),
+                        "partition": partition,
+                        "time_limit": time_limit,
                     },
-                    "partition": parts[1].strip(),
+                    "partition": partition,
+                    "user": owner,
                     "nodes": num_nodes,
+                    "cpus": cpus_total,
                     "gpus": gpus_per_node * num_nodes,
-                    "elapsed_time": parts[5].strip(),
-                    "time_limit": parts[6].strip(),
+                    "nodelist": nodelist,
+                    "elapsed_time": elapsed,
+                    "time_limit": time_limit,
                 }
             )
+
+        return jobs, seen_ids
+
+    def list_jobs(self, user: str | None = None) -> list[dict[str, Any]]:
+        """List SLURM jobs via squeue + recent completed/failed jobs via sacct.
+
+        Used by the Web UI and MCP ``list_jobs`` tool. The CLI
+        ``srunx squeue`` path goes through :meth:`queue` instead,
+        which uses :meth:`_list_active_jobs` directly so it matches
+        native ``squeue`` semantics (active jobs only).
+        """
+        jobs, seen_ids = self._list_active_jobs(user)
 
         # --- Recently finished jobs from sacct (last 6 hours) ---
         # NOTE: --state filter is omitted because some SLURM versions
@@ -774,7 +827,7 @@ class SlurmSSHAdapter:
 
         Records the submission to the state DB and fires the
         ``on_job_submitted`` callbacks just like :meth:`submit`, so
-        Notification watches and ``srunx sacct`` see the job. Codex
+        Notification watches and ``srunx history`` see the job. Codex
         blocker #2 on PR #134 — the previous implementation skipped
         both, leaving in-place submissions invisible to the rest of
         the system.
@@ -816,7 +869,7 @@ class SlurmSSHAdapter:
         if isinstance(callbacks_job, ShellJob):
             callbacks_job.script_path = remote_path
 
-        # Record to DB so `srunx sacct` / poller pick it up. Mirrors
+        # Record to DB so `srunx history` / poller pick it up. Mirrors
         # :meth:`submit` step 3.
         if self._profile_name is not None:
             self._record_job_submission(
@@ -1116,19 +1169,23 @@ class SlurmSSHAdapter:
         return job
 
     def queue(self, user: str | None = None) -> list[BaseJob]:
-        """List jobs for *user* (defaults to the profile's username).
+        """List *active* jobs (all users by default).
 
-        Adapts :meth:`list_jobs` (which yields dicts) into Pydantic
-        :class:`BaseJob` objects so the return type matches
-        :class:`~srunx.slurm.protocols.JobOperations.queue`.
-        ``user=None`` uses the profile's configured username, matching
-        the Protocol's "transport's current user" contract.
+        Adapts :meth:`_list_active_jobs` (squeue only, no sacct merge)
+        into Pydantic :class:`BaseJob` objects so the return type
+        matches :class:`~srunx.slurm.protocols.JobOperations.queue` and
+        the CLI ``srunx squeue`` output matches native SLURM
+        ``squeue`` semantics (active jobs only — finished jobs are the
+        domain of ``srunx history``).
+
+        ``user=None`` shows **all users' jobs**, matching native
+        ``squeue`` and the local :meth:`~srunx.slurm.local.Slurm.queue`.
+        Pass a username explicitly (e.g. from ``-u`` / ``--user``) to
+        filter to that user.
         """
         from srunx.domain import BaseJob, JobStatus
 
-        effective_user = user if user is not None else self._username or None
-
-        raw_entries = self.list_jobs(user=effective_user)
+        raw_entries, _ = self._list_active_jobs(user=user)
         out: list[BaseJob] = []
         for entry in raw_entries:
             status_str = str(entry.get("status", "UNKNOWN"))
@@ -1144,11 +1201,13 @@ class SlurmSSHAdapter:
                 name=str(entry.get("name", "job")),
                 job_id=job_id_val,
                 partition=entry.get("partition"),
+                user=entry.get("user"),
                 nodes=entry.get("nodes"),
+                cpus=entry.get("cpus"),
                 gpus=entry.get("gpus"),
+                nodelist=entry.get("nodelist") or None,
                 elapsed_time=entry.get("elapsed_time"),
                 time_limit=entry.get("time_limit"),
-                user=effective_user,
             )
             job.status = status_enum
             out.append(job)

--- a/src/srunx/slurm/ssh.py
+++ b/src/srunx/slurm/ssh.py
@@ -910,10 +910,17 @@ class SlurmSSHAdapter:
         job_name: str | None = None,
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        last_n: int | None = None,
     ) -> tuple[str, str, int, int]:
         """Get job stdout/stderr log contents from remote.
 
         Returns ``(stdout, stderr, new_stdout_offset, new_stderr_offset)``.
+
+        ``last_n`` is the initial-read optimization: when both offsets
+        are 0 and ``last_n`` is set, only the last N lines are
+        transferred (via ``tail -n N`` on the remote) and the returned
+        offsets point at end-of-file. This avoids shipping a multi-GB
+        log across SSH when the user only wants the tail.
 
         Ensures the SSH connection is live before reading — callers that
         reach this method via a fresh :class:`SlurmSSHAdapter` (e.g. CLI
@@ -929,6 +936,7 @@ class SlurmSSHAdapter:
                 job_name=job_name,
                 stdout_offset=stdout_offset,
                 stderr_offset=stderr_offset,
+                last_n=last_n,
             )
 
     def get_job_status(self, job_id: int) -> str:
@@ -1224,6 +1232,7 @@ class SlurmSSHAdapter:
         job_id: int,
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        last_n: int | None = None,
     ) -> LogChunk:
         """Return new log content since the given byte offsets.
 
@@ -1231,6 +1240,10 @@ class SlurmSSHAdapter:
         ``(stdout, stderr, new_stdout_offset, new_stderr_offset)``. Pure
         function: no stdout writes, no blocking. Callers that want
         ``tail -f`` semantics poll this method in a loop.
+
+        ``last_n`` honours the Protocol hint — applied by the underlying
+        ``RemoteLogReader`` when both offsets are 0 so a ``tail -f -n N``
+        kicks off with only the tail of a large log on the wire.
         """
 
         import paramiko
@@ -1247,6 +1260,7 @@ class SlurmSSHAdapter:
                 int(job_id),
                 stdout_offset=stdout_offset,
                 stderr_offset=stderr_offset,
+                last_n=last_n,
             )
         except paramiko.AuthenticationException as exc:
             raise TransportAuthError(f"SSH authentication failed: {exc}") from exc

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -797,6 +797,7 @@ class SSHSlurmClient:
         job_name: str | None = None,
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        last_n: int | None = None,
     ) -> tuple[str, str, int, int]:
         try:
             safe_job_id = self._sanitize_job_id(job_id)
@@ -813,12 +814,12 @@ class SSHSlurmClient:
 
             if stdout_path:
                 output_content, new_stdout_offset = self._read_file_from_offset(
-                    stdout_path, stdout_offset
+                    stdout_path, stdout_offset, last_n=last_n
                 )
 
             if stderr_path and stderr_path != stdout_path:
                 error_content, new_stderr_offset = self._read_file_from_offset(
-                    stderr_path, stderr_offset
+                    stderr_path, stderr_offset, last_n=last_n
                 )
 
             if output_content or error_content:
@@ -836,11 +837,36 @@ class SSHSlurmClient:
             self.logger.error(f"Failed to get job output for {job_id}: {e}")
             return "", "", stdout_offset, stderr_offset
 
-    def _read_file_from_offset(self, path: str, offset: int) -> tuple[str, int]:
+    def _read_file_from_offset(
+        self, path: str, offset: int, *, last_n: int | None = None
+    ) -> tuple[str, int]:
+        """Read remote log content starting at *offset* (or last N lines).
+
+        Three distinct paths based on the args:
+
+        * ``offset > 0``  → ``tail -c +<offset+1> <path>`` — pure byte
+          delta since the previous poll. Steady-state for ``tail -f``.
+        * ``offset == 0`` AND ``last_n`` set → ``tail -n <last_n> <path>``
+          — transfer **only the tail** of the file; returned offset is
+          the current file size so subsequent polls continue from EOF.
+          This is the optimization for ``srunx tail --last N`` / the
+          initial frame of ``tail -fn N`` that avoids shipping a multi-GB
+          log over SSH.
+        * ``offset == 0`` AND ``last_n`` is None → ``cat <path>`` — full
+          initial read (unchanged legacy behaviour).
+        """
         quoted = shlex.quote(path)
         if offset > 0:
             out, _, rc = self.execute_command(
                 f"tail -c +{offset + 1} {quoted} 2>/dev/null"
+            )
+        elif last_n is not None and last_n > 0:
+            # ``tail -n N`` streams only the last N lines over SSH even
+            # for multi-GB logs — the remote does the work, we receive
+            # kilobytes. Offsets reset to file size so the follow loop
+            # continues from true EOF.
+            out, _, rc = self.execute_command(
+                f"tail -n {int(last_n)} {quoted} 2>/dev/null"
             )
         else:
             out, _, rc = self.execute_command(f"cat {quoted} 2>/dev/null")

--- a/src/srunx/ssh/core/log_reader.py
+++ b/src/srunx/ssh/core/log_reader.py
@@ -44,6 +44,7 @@ class RemoteLogReader:
         job_name: str | None = None,
         stdout_offset: int = 0,
         stderr_offset: int = 0,
+        last_n: int | None = None,
     ) -> tuple[str, str, int, int]:
         """Get job output from SLURM log files.
 
@@ -53,6 +54,11 @@ class RemoteLogReader:
 
         When *stdout_offset* / *stderr_offset* are non-zero, only the bytes
         **after** that position are returned (tail-like incremental reads).
+
+        ``last_n`` is honoured only on the initial read (both offsets 0):
+        the remote runs ``tail -n <last_n>`` so a multi-GB log only ships
+        its tail over SSH. Ignored when offsets are non-zero (the follow
+        loop is already tailing incrementally).
 
         Returns:
             ``(stdout, stderr, new_stdout_offset, new_stderr_offset)``
@@ -73,12 +79,12 @@ class RemoteLogReader:
 
             if stdout_path:
                 output_content, new_stdout_offset = self._read_file_from_offset(
-                    stdout_path, stdout_offset
+                    stdout_path, stdout_offset, last_n=last_n
                 )
 
             if stderr_path and stderr_path != stdout_path:
                 error_content, new_stderr_offset = self._read_file_from_offset(
-                    stderr_path, stderr_offset
+                    stderr_path, stderr_offset, last_n=last_n
                 )
 
             if output_content or error_content:
@@ -289,12 +295,27 @@ class RemoteLogReader:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _read_file_from_offset(self, path: str, offset: int) -> tuple[str, int]:
-        """Read a remote file from a byte offset. Returns (content, new_offset)."""
+    def _read_file_from_offset(
+        self, path: str, offset: int, *, last_n: int | None = None
+    ) -> tuple[str, int]:
+        """Read remote log content.
+
+        * ``offset > 0``: byte-delta via ``tail -c +N`` (steady-state
+          follow poll).
+        * ``offset == 0`` + ``last_n`` set: ``tail -n N`` — ship only
+          the tail of a large log across SSH. New offset = file size,
+          so subsequent polls resume from EOF.
+        * ``offset == 0`` + ``last_n`` None: full ``cat`` (legacy path,
+          e.g. the Web UI's "show everything" one-shot).
+        """
         quoted = shlex.quote(path)
         if offset > 0:
             out, _, rc = self._conn.execute_command(
                 f"tail -c +{offset + 1} {quoted} 2>/dev/null"
+            )
+        elif last_n is not None and last_n > 0:
+            out, _, rc = self._conn.execute_command(
+                f"tail -n {int(last_n)} {quoted} 2>/dev/null"
             )
         else:
             out, _, rc = self._conn.execute_command(f"cat {quoted} 2>/dev/null")

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -186,22 +186,74 @@ def emit_transport_banner(
     # emission is not on any hot path.
     #
     # Rich markup: a colored dot flags transport kind (cyan for SSH,
-    # yellow for local), the scheduler_key is bold so it reads at a
-    # glance, and the source string trails in dim italic to show where
-    # the decision came from without stealing focus from the label.
+    # yellow for local), the connection target is the headline, the
+    # profile name + decision source trail in dim so "where am I
+    # running" reads at a glance without stealing focus.
     is_ssh = label.startswith("ssh:")
     dot_color = "cyan" if is_ssh else "yellow"
     source_display = {
-        "--profile": "--profile",
-        "--local": "--local",
-        "env": "$SRUNX_SSH_PROFILE",
-        "current-profile": "current profile",
-    }.get(source, source)
-    Console(file=sys.stderr).print(
-        f"[{dot_color}]●[/{dot_color}] "
-        f"[bold]{label}[/bold]  "
-        f"[dim italic]· via {source_display}[/dim italic]"
+        "--profile": "via --profile",
+        "--local": "via --local",
+        "env": "via $SRUNX_SSH_PROFILE",
+        "current-profile": "via current profile",
+    }.get(source, f"via {source}")
+    if is_ssh:
+        body = _format_ssh_banner_body(
+            profile_name=label.removeprefix("ssh:"),
+            source_display=source_display,
+        )
+    else:
+        body = f"[bold]Local SLURM[/bold]  [dim italic]({source_display})[/dim italic]"
+    Console(file=sys.stderr).print(f"[{dot_color}]●[/{dot_color}]  {body}")
+
+
+def _format_ssh_banner_body(*, profile_name: str, source_display: str) -> str:
+    """Build the SSH half of the transport banner.
+
+    Shows ``user@host`` (plus ``:port`` when non-default and
+    ``via <proxy>`` when ``proxy_jump`` is set) as the headline so the
+    banner answers "which machine am I reaching" without forcing the
+    user to remember what ``<profile_name>`` maps to. Profile name and
+    decision source are kept as parenthetical metadata.
+
+    Falls back to ``SSH profile: <name>`` when the profile lookup
+    fails (config file missing, profile removed, import error) — the
+    banner must never raise, even from a degraded state.
+    """
+    profile = _lookup_profile_silently(profile_name)
+    if profile is None:
+        return (
+            f"[bold]SSH profile: {profile_name}[/bold]  "
+            f"[dim italic]({source_display})[/dim italic]"
+        )
+    target = f"{profile.username}@{profile.hostname}"
+    if profile.port != 22:
+        target += f":{profile.port}"
+    if profile.proxy_jump:
+        target += f" via {profile.proxy_jump}"
+    return (
+        f"[bold]Connected to[/bold] [cyan]{target}[/cyan]  "
+        f"[dim italic](profile: {profile_name} · {source_display})[/dim italic]"
     )
+
+
+def _lookup_profile_silently(name: str) -> ServerProfile | None:
+    """Return the :class:`ServerProfile` for *name*, or None on any failure.
+
+    Used by the banner emitter, which must never raise — a missing
+    config file or a profile that was deleted between resolution and
+    banner emission should degrade to the fallback label, not crash
+    the CLI.
+    """
+    try:
+        from srunx.ssh.core.config import ConfigManager
+    except ImportError:
+        return None
+    try:
+        return ConfigManager().get_profile(name)
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.debug("Could not load SSH profile %r for banner: %s", name, exc)
+        return None
 
 
 def _current_profile_name() -> str | None:

--- a/tests/db/test_cli_helpers.py
+++ b/tests/db/test_cli_helpers.py
@@ -1,10 +1,8 @@
 """Tests for ``srunx.observability.storage.cli_helpers`` — the CLI-side state-DB bridge.
 
-Focused on the workflow-identity round-trip introduced to fix the
-``srunx report --workflow`` regression: CLI-launched workflows must
-create a ``workflow_runs`` row and link submitted jobs back via
-``workflow_run_id`` so ``compute_workflow_stats`` (which JOINs on
-``workflow_run_id``) actually picks them up.
+Focused on the ``scheduler_key`` push-down that ``srunx history``
+relies on: CLI history queries must scope to the resolved transport
+so cross-cluster jobs don't bleed into each other's listings.
 """
 
 from __future__ import annotations
@@ -13,8 +11,6 @@ import pytest
 
 from srunx.domain import Job, JobEnvironment, JobResource
 from srunx.observability.storage.cli_helpers import (
-    compute_job_stats,
-    compute_workflow_stats,
     create_cli_workflow_run,
     list_recent_jobs,
     record_submission_from_job,
@@ -43,13 +39,13 @@ def _record_ssh_job(
 
 
 class TestSchedulerKeyFilter:
-    """SSH-parity for ``sacct`` / ``sreport``: scheduler_key push-down.
+    """SSH-parity for ``srunx history``: scheduler_key push-down.
 
     The CLI passes ``scheduler_key="ssh:<profile>"`` (or ``"local"``)
     into the helpers; the SQL ``WHERE`` filter must scope rows to that
     transport so cross-cluster jobs don't bleed into each other's
-    history / aggregates. ``scheduler_key=None`` keeps the legacy
-    behaviour (every transport).
+    history. ``scheduler_key=None`` keeps the legacy behaviour (every
+    transport).
     """
 
     def test_list_recent_jobs_filters_by_scheduler_key(self, _isolated_db):
@@ -74,7 +70,7 @@ class TestSchedulerKeyFilter:
     def test_list_recent_jobs_id_filter_respects_scheduler_key(self, _isolated_db):
         """``-j <id>`` push-down still scopes to the requested transport.
 
-        Without the AND-clause, ``srunx sacct -j 100 --profile dgx``
+        Without the AND-clause, ``srunx history -j 100 --profile dgx``
         would happily return a local job that happens to share the
         SLURM ``job_id`` (different clusters reuse the int counter).
         """
@@ -88,48 +84,6 @@ class TestSchedulerKeyFilter:
 
         only_ssh = list_recent_jobs(job_ids=[100], scheduler_key="ssh:dgx")
         assert {j["job_name"] for j in only_ssh} == {"dgx_100"}
-
-    def test_compute_job_stats_filters_by_scheduler_key(self, _isolated_db):
-        record_submission_from_job(_make_job("local_a", 1))
-        record_submission_from_job(_make_job("local_b", 2))
-        _record_ssh_job(_make_job("ssh_a", 3), profile="dgx")
-
-        assert compute_job_stats(scheduler_key="local")["total_jobs"] == 2
-        assert compute_job_stats(scheduler_key="ssh:dgx")["total_jobs"] == 1
-        assert compute_job_stats()["total_jobs"] == 3  # legacy: all
-
-    def test_compute_workflow_stats_filters_by_scheduler_key(self, _isolated_db):
-        """Same workflow can run on multiple clusters — stats scope per key."""
-        run_id = create_cli_workflow_run(workflow_name="multi_cluster")
-        assert run_id is not None
-
-        # Workflow run rows aren't transport-tagged; the per-job
-        # ``scheduler_key`` is what scopes the JOIN.
-        record_submission_from_job(
-            _make_job("local_step", 50),
-            workflow_name="multi_cluster",
-            workflow_run_id=run_id,
-        )
-        _record_ssh_job(
-            _make_job("dgx_step", 51),
-            profile="dgx",
-            workflow_run_id=run_id,
-        )
-        _record_ssh_job(
-            _make_job("dgx_step_2", 52),
-            profile="dgx",
-            workflow_run_id=run_id,
-        )
-
-        local_stats = compute_workflow_stats("multi_cluster", scheduler_key="local")
-        assert local_stats["total_jobs"] == 1
-
-        dgx_stats = compute_workflow_stats("multi_cluster", scheduler_key="ssh:dgx")
-        assert dgx_stats["total_jobs"] == 2
-
-        # Legacy (no scope): both clusters' rows aggregate together.
-        all_stats = compute_workflow_stats("multi_cluster")
-        assert all_stats["total_jobs"] == 3
 
 
 @pytest.fixture
@@ -174,46 +128,3 @@ class TestCreateCliWorkflowRun:
 
         monkeypatch.setattr(connection_mod, "init_db", boom)
         assert create_cli_workflow_run(workflow_name="pipeline") is None
-
-
-class TestWorkflowStatsRoundTrip:
-    """End-to-end: create run → record jobs linked to it → stats non-empty.
-
-    Guards the regression that ``compute_workflow_stats`` silently
-    returned zero counts for CLI-launched workflows (the JOIN missed
-    every row because jobs weren't linked).
-    """
-
-    def test_cli_workflow_jobs_show_up_in_report(self, _isolated_db):
-        run_id = create_cli_workflow_run(workflow_name="ml_pipeline")
-        assert run_id is not None
-
-        # Simulate two CLI-launched workflow jobs.
-        record_submission_from_job(
-            _make_job("preprocess", 100, gpus=2),
-            workflow_name="ml_pipeline",
-            workflow_run_id=run_id,
-        )
-        record_submission_from_job(
-            _make_job("train", 101, gpus=4),
-            workflow_name="ml_pipeline",
-            workflow_run_id=run_id,
-        )
-
-        stats = compute_workflow_stats("ml_pipeline")
-        assert stats["workflow_name"] == "ml_pipeline"
-        assert stats["total_jobs"] == 2
-
-    def test_missing_workflow_run_id_falls_out_of_report(self, _isolated_db):
-        """The bug this PR fixes — without linking, stats return zero."""
-        create_cli_workflow_run(workflow_name="unlinked_flow")
-        # Deliberately NOT passing workflow_run_id — matches the old
-        # CLI behaviour before P3-7.1 #93.
-        record_submission_from_job(
-            _make_job("orphan_job", 200),
-            workflow_name="unlinked_flow",
-            workflow_run_id=None,
-        )
-
-        stats = compute_workflow_stats("unlinked_flow")
-        assert stats["total_jobs"] == 0  # JOIN misses the row

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,7 +58,7 @@ class TestTyperCLI:
         assert "squeue" in result.stdout
         assert "scancel" in result.stdout
         assert "sinfo" in result.stdout
-        assert "sacct" in result.stdout
+        assert "history" in result.stdout
         assert "tail" in result.stdout
         assert "watch" in result.stdout
         assert "flow" in result.stdout
@@ -85,7 +85,7 @@ class TestTyperCLI:
         """Test squeue command help."""
         result = self.runner.invoke(app, ["squeue", "--help"])
         assert result.exit_code == 0
-        assert "List user's jobs in the queue" in result.stdout
+        assert "List active jobs" in result.stdout
 
     def test_scancel_help(self):
         """Test scancel command help."""
@@ -384,7 +384,6 @@ class TestTyperCLI:
         result = self.runner.invoke(app, ["config", "show"])
 
         assert result.exit_code == 0
-        assert "srunx Configuration" in result.stdout
         mock_get_config.assert_called_once()
 
     @patch("srunx.cli.commands.config.get_config_paths")

--- a/tests/test_cli_gpus.py
+++ b/tests/test_cli_gpus.py
@@ -1,0 +1,442 @@
+"""Tests for the ``srunx gpus`` command (GPU aggregate snapshot).
+
+The partition/state/nodelist listing now lives under ``srunx sinfo``
+(see ``test_cli_sinfo.py``). This file covers the GPU-summary surface
+that moved out of ``sinfo`` and into ``gpus``.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+from srunx.observability.monitoring.types import ResourceSnapshot
+
+
+@pytest.fixture
+def runner():
+    """Create CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_snapshot():
+    """Create mock resource snapshot."""
+    return ResourceSnapshot(
+        partition="gpu",
+        total_gpus=16,
+        gpus_in_use=10,
+        gpus_available=6,
+        jobs_running=3,
+        nodes_total=4,
+        nodes_idle=1,
+        nodes_down=0,
+    )
+
+
+@pytest.fixture
+def mock_snapshot_all_partitions():
+    """Create mock resource snapshot for all partitions."""
+    return ResourceSnapshot(
+        partition=None,
+        total_gpus=32,
+        gpus_in_use=20,
+        gpus_available=12,
+        jobs_running=5,
+        nodes_total=8,
+        nodes_idle=2,
+        nodes_down=1,
+    )
+
+
+class TestGpusCommand:
+    """Test suite for the ``srunx gpus`` GPU-aggregate output."""
+
+    def test_resources_table_format_default(self, runner, mock_snapshot_all_partitions):
+        """Test resources command with default table format."""
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = (
+                mock_snapshot_all_partitions
+            )
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus"])
+
+            assert result.exit_code == 0
+            assert "Total GPUs" in result.stdout
+            assert "32" in result.stdout  # total_gpus
+            assert "20" in result.stdout  # gpus_in_use
+            assert "12" in result.stdout  # gpus_available
+            assert "Running Jobs" in result.stdout
+            assert "5" in result.stdout  # jobs_running
+            assert "Total Nodes" in result.stdout
+            assert "8" in result.stdout  # nodes_total
+            assert "Idle Nodes" in result.stdout
+            assert "2" in result.stdout  # nodes_idle
+            assert "Down Nodes" in result.stdout
+            assert "1" in result.stdout  # nodes_down
+
+    def test_resources_table_format_with_partition(self, runner, mock_snapshot):
+        """Test resources command with specific partition."""
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = mock_snapshot
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "--partition", "gpu"])
+
+            assert result.exit_code == 0
+            assert "16" in result.stdout  # total_gpus
+            assert "10" in result.stdout  # gpus_in_use
+            assert "6" in result.stdout  # gpus_available
+            assert "3" in result.stdout  # jobs_running
+            assert "4" in result.stdout  # nodes_total
+            assert "1" in result.stdout  # nodes_idle
+            assert "0" in result.stdout  # nodes_down
+
+            # Verify ResourceMonitor was created with correct partition
+            mock_monitor_class.assert_called_once_with(
+                min_gpus=0, partition="gpu", source=None
+            )
+
+    def test_resources_json_format_default(self, runner, mock_snapshot_all_partitions):
+        """Test resources command with JSON format."""
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = (
+                mock_snapshot_all_partitions
+            )
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "--format", "json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+
+            assert data["partition"] is None
+            assert data["gpus_total"] == 32
+            assert data["gpus_in_use"] == 20
+            assert data["gpus_available"] == 12
+            assert data["jobs_running"] == 5
+            assert data["nodes_total"] == 8
+            assert data["nodes_idle"] == 2
+            assert data["nodes_down"] == 1
+
+    def test_resources_json_format_with_partition(self, runner, mock_snapshot):
+        """Test resources command with JSON format and partition."""
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = mock_snapshot
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "-p", "gpu", "-f", "json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+
+            assert data["partition"] == "gpu"
+            assert data["gpus_total"] == 16
+            assert data["gpus_in_use"] == 10
+            assert data["gpus_available"] == 6
+            assert data["jobs_running"] == 3
+            assert data["nodes_total"] == 4
+            assert data["nodes_idle"] == 1
+            assert data["nodes_down"] == 0
+
+            # Verify ResourceMonitor was created with correct partition
+            mock_monitor_class.assert_called_once_with(
+                min_gpus=0, partition="gpu", source=None
+            )
+
+    def test_resources_zero_gpus_available(self, runner):
+        """Test resources command when no GPUs available."""
+        snapshot = ResourceSnapshot(
+            partition="gpu",
+            total_gpus=16,
+            gpus_in_use=16,
+            gpus_available=0,
+            jobs_running=8,
+            nodes_total=4,
+            nodes_idle=0,
+            nodes_down=0,
+        )
+
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = snapshot
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "--format", "json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert data["gpus_available"] == 0
+            assert data["gpus_total"] == data["gpus_in_use"]
+
+    def test_resources_with_down_nodes(self, runner):
+        """Test resources command with some nodes down."""
+        snapshot = ResourceSnapshot(
+            partition="gpu",
+            total_gpus=8,  # Only from available nodes
+            gpus_in_use=4,
+            gpus_available=4,
+            jobs_running=2,
+            nodes_total=4,
+            nodes_idle=1,
+            nodes_down=2,  # 2 nodes down
+        )
+
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = snapshot
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "--format", "json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert data["nodes_total"] == 4
+            assert data["nodes_down"] == 2
+            # Total GPUs should only count available nodes
+            assert data["gpus_total"] == 8
+
+    def test_resources_error_handling(self, runner):
+        """Test resources command error handling."""
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.side_effect = Exception(
+                "SLURM connection error"
+            )
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus"])
+
+            assert result.exit_code == 1
+            assert "Error" in result.stdout
+
+    def test_resources_partition_not_found(self, runner):
+        """Test resources command with non-existent partition."""
+        # ResourceMonitor will return zeros for non-existent partition
+        snapshot = ResourceSnapshot(
+            partition="nonexistent",
+            total_gpus=0,
+            gpus_in_use=0,
+            gpus_available=0,
+            jobs_running=0,
+            nodes_total=0,
+            nodes_idle=0,
+            nodes_down=0,
+        )
+
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = snapshot
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "-p", "nonexistent", "-f", "json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            # Should return zeros for non-existent partition
+            assert data["gpus_total"] == 0
+            assert data["nodes_total"] == 0
+
+    def test_resources_short_flags(self, runner, mock_snapshot):
+        """Test resources command with short flag variants."""
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = mock_snapshot
+            mock_monitor_class.return_value = mock_monitor
+
+            # Test -p and -f short flags
+            result = runner.invoke(app, ["gpus", "-p", "gpu", "-f", "json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            assert data["partition"] == "gpu"
+
+            # Verify ResourceMonitor was created correctly
+            mock_monitor_class.assert_called_once_with(
+                min_gpus=0, partition="gpu", source=None
+            )
+
+    def test_resources_high_utilization(self, runner):
+        """Test resources command with high GPU utilization."""
+        snapshot = ResourceSnapshot(
+            partition="gpu",
+            total_gpus=100,
+            gpus_in_use=95,
+            gpus_available=5,
+            jobs_running=20,
+            nodes_total=25,
+            nodes_idle=1,
+            nodes_down=0,
+        )
+
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = snapshot
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "--format", "json"])
+
+            assert result.exit_code == 0
+            data = json.loads(result.stdout)
+            # 95% utilization
+            assert data["gpus_in_use"] / data["gpus_total"] == 0.95
+            assert data["gpus_available"] == 5
+
+
+class TestGpusSshParity:
+    """#139: ``--profile`` routes ``gpus`` through the SSH adapter.
+
+    SSH path uses :class:`SSHAdapterResourceSource` (the same backend
+    the resource snapshotter / Web ``/api/resources`` already use), so
+    these tests mock the SSH transport handle and assert the cluster
+    snapshot path runs against the adapter — never the local
+    ``subprocess.run('sinfo')`` fallback.
+    """
+
+    def test_profile_routes_through_ssh_adapter_cluster_snapshot(self, runner):
+        from srunx.transport.registry import TransportHandle
+
+        fake_adapter = MagicMock()
+        fake_adapter.get_cluster_snapshot.return_value = {
+            "partition": None,
+            "total_gpus": 64,
+            "gpus_in_use": 16,
+            "gpus_available": 48,
+            "jobs_running": 4,
+            "nodes_total": 8,
+            "nodes_idle": 4,
+            "nodes_down": 0,
+        }
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=fake_adapter,
+            queue_client=fake_adapter,
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ):
+            result = runner.invoke(
+                app, ["gpus", "--profile", "dgx", "--format", "json"]
+            )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        data = json.loads(result.stdout)
+        assert data["gpus_total"] == 64
+        assert data["gpus_available"] == 48
+        # The whole point of #139 — local sinfo must NOT have run.
+        fake_adapter.get_cluster_snapshot.assert_called_once()
+        fake_adapter.get_resources.assert_not_called()
+
+    def test_profile_with_partition_uses_per_partition_query(self, runner):
+        from srunx.transport.registry import TransportHandle
+
+        fake_adapter = MagicMock()
+        fake_adapter.get_resources.return_value = [
+            {
+                "partition": "gpu",
+                "total_gpus": 32,
+                "gpus_in_use": 8,
+                "gpus_available": 24,
+                "jobs_running": 2,
+                "nodes_total": 4,
+                "nodes_idle": 2,
+                "nodes_down": 0,
+            }
+        ]
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=fake_adapter,
+            queue_client=fake_adapter,
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(fake_handle, None),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "gpus",
+                    "--profile",
+                    "dgx",
+                    "--partition",
+                    "gpu",
+                    "--format",
+                    "json",
+                ],
+            )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        data = json.loads(result.stdout)
+        assert data["partition"] == "gpu"
+        assert data["gpus_total"] == 32
+        # Per-partition path: get_resources('gpu') called, NOT
+        # get_cluster_snapshot.
+        fake_adapter.get_resources.assert_called_once_with("gpu")
+        fake_adapter.get_cluster_snapshot.assert_not_called()
+
+    def test_local_path_unchanged_when_no_profile(
+        self, runner, mock_snapshot_all_partitions
+    ):
+        """Regression guard: local default still uses ResourceMonitor subprocess.
+
+        Without ``--profile``/``$SRUNX_SSH_PROFILE`` the SSH branch
+        must NOT activate — the existing
+        :class:`TestResourcesCommand` tests already cover the table
+        path, this one explicitly asserts ``source=None`` so the
+        subprocess fallback stays the default.
+        """
+        with patch(
+            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
+        ) as mock_monitor_class:
+            mock_monitor = MagicMock()
+            mock_monitor.get_partition_resources.return_value = (
+                mock_snapshot_all_partitions
+            )
+            mock_monitor_class.return_value = mock_monitor
+
+            result = runner.invoke(app, ["gpus", "--local", "--format", "json"])
+
+        assert result.exit_code == 0
+        # ``source=None`` means the local subprocess path runs — see
+        # the docstring on ``ResourceMonitor.get_partition_resources``.
+        mock_monitor_class.assert_called_once_with(
+            min_gpus=0, partition=None, source=None
+        )

--- a/tests/test_cli_sacct.py
+++ b/tests/test_cli_sacct.py
@@ -259,9 +259,11 @@ class TestSacctLocalCLI:
             partition="defq",
         )
 
-    def test_allusers_flag_overrides_user(
+    def test_allusers_and_user_both_forwarded(
         self, runner: CliRunner, sample_rows: list[SacctRow]
     ) -> None:
+        """Both flags flow through to the fetcher so sacct can combine
+        them (``-a`` scans everyone, ``-u`` narrows to one user)."""
         with patch(
             "srunx.slurm.accounting.fetch_sacct_rows_local",
             return_value=sample_rows,
@@ -271,8 +273,7 @@ class TestSacctLocalCLI:
         assert result.exit_code == 0
         kwargs = fetch.call_args.kwargs
         assert kwargs["all_users"] is True
-        # The data-layer respects the `-a` precedence — the CLI just
-        # forwards both. Verified in the unit test below.
+        assert kwargs["user"] == "alice"
 
 
 class TestSacctSshRouting:
@@ -324,12 +325,19 @@ class TestBuildFilterArgs:
     to which ``sacct`` argument.
     """
 
-    def test_allusers_beats_user(self) -> None:
+    def test_allusers_and_user_coexist(self) -> None:
+        """Native sacct accepts ``-a -u <name>`` (scan-all-then-filter).
+
+        Earlier srunx dropped ``-u`` when ``-a`` was set; this guards
+        the regression-fix that now forwards both flags to match real
+        sacct semantics.
+        """
         from srunx.slurm.accounting import build_sacct_filter_args
 
         args = build_sacct_filter_args(user="alice", all_users=True)
         assert "--allusers" in args
-        assert "--user" not in args
+        assert "--user" in args
+        assert "alice" in args
 
     def test_user_forwarded_when_no_allusers(self) -> None:
         from srunx.slurm.accounting import build_sacct_filter_args

--- a/tests/test_cli_sacct.py
+++ b/tests/test_cli_sacct.py
@@ -1,0 +1,346 @@
+"""Tests for ``srunx sacct`` (native SLURM sacct wrapper).
+
+Distinct from ``srunx history`` (which reads srunx's own SQLite):
+``sacct`` shells out to the cluster accounting DB via the real
+``sacct`` binary. Tests here exercise the parser, the step-filtering
+default, and the local / SSH transport dispatch — never the real
+subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+from srunx.slurm.accounting import (
+    SacctRow,
+    filter_out_steps,
+    parse_sacct_rows,
+)
+
+# 13-column sample: JobID|JobName|User|Partition|Account|State|ExitCode|
+# Elapsed|Submit|Start|End|AllocCPUS|AllocTRES
+_SAMPLE_STDOUT = (
+    "2780|train|alice|defq|sci|RUNNING|0:0|00:05:00|"
+    "2026-04-24T12:00:00|2026-04-24T12:00:05|Unknown|2|cpu=2,gres/gpu=1\n"
+    "2780.batch|batch||||RUNNING|0:0|00:05:00||||2|cpu=2\n"
+    "19849|g4-cpt-v17|bob|defq||FAILED by 1000|1:0|01:00:00|"
+    "2026-04-23T10:00:00|2026-04-23T10:00:05|2026-04-23T11:00:05|16|"
+    "cpu=16,gres/gpu=8\n"
+    "19849.batch|batch||||FAILED|1:0|01:00:00||||16|cpu=16\n"
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def sample_rows() -> list[SacctRow]:
+    return parse_sacct_rows(_SAMPLE_STDOUT)
+
+
+class TestSacctParsing:
+    def test_field_extraction(self) -> None:
+        rows = parse_sacct_rows(_SAMPLE_STDOUT)
+        assert len(rows) == 4
+
+        parent, step, failed, failed_step = rows
+        assert parent.job_id == "2780"
+        assert parent.is_step is False
+        assert parent.user == "alice"
+        assert parent.partition == "defq"
+        assert parent.account == "sci"
+        assert parent.state == "RUNNING"
+        assert parent.alloc_cpus == 2
+        assert parent.alloc_tres == "cpu=2,gres/gpu=1"
+
+        assert step.job_id == "2780.batch"
+        assert step.is_step is True
+        assert step.user is None  # sub-steps have empty user
+        assert step.alloc_cpus == 2
+
+        assert failed.job_id == "19849"
+        # "FAILED by 1000" must collapse to the canonical state name.
+        assert failed.state == "FAILED"
+        assert failed.user == "bob"
+        assert failed.exit_code == "1:0"
+
+        assert failed_step.is_step is True
+
+    def test_filter_out_steps_returns_parents_only(
+        self, sample_rows: list[SacctRow]
+    ) -> None:
+        parents = filter_out_steps(sample_rows)
+        assert [r.job_id for r in parents] == ["2780", "19849"]
+
+    def test_malformed_rows_skipped(self) -> None:
+        # Too few fields → dropped; correctly shaped survives.
+        stdout = (
+            "not|enough|fields\n"
+            "2780|train|alice|defq|sci|RUNNING|0:0|00:05:00||||2|cpu=2\n"
+        )
+        rows = parse_sacct_rows(stdout)
+        assert [r.job_id for r in rows] == ["2780"]
+
+
+class TestSacctLocalCLI:
+    def test_default_hides_steps(
+        self, runner: CliRunner, sample_rows: list[SacctRow]
+    ) -> None:
+        """Parent rows only by default — .batch steps should be hidden."""
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=sample_rows,
+        ):
+            result = runner.invoke(app, ["sacct", "--local"], env={"COLUMNS": "200"})
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        assert "2780" in result.stdout
+        assert "19849" in result.stdout
+        # Sub-step rows must not leak through the default view.
+        assert "2780.batch" not in result.stdout
+        assert "19849.batch" not in result.stdout
+
+    def test_show_steps_includes_sub_steps(
+        self, runner: CliRunner, sample_rows: list[SacctRow]
+    ) -> None:
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=sample_rows,
+        ):
+            result = runner.invoke(
+                app,
+                ["sacct", "--local", "--show-steps"],
+                env={"COLUMNS": "200"},
+            )
+
+        assert result.exit_code == 0
+        assert "2780.batch" in result.stdout
+        assert "19849.batch" in result.stdout
+
+    def test_default_columns(
+        self, runner: CliRunner, sample_rows: list[SacctRow]
+    ) -> None:
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=sample_rows,
+        ):
+            result = runner.invoke(app, ["sacct", "--local"], env={"COLUMNS": "200"})
+
+        assert result.exit_code == 0
+        for shown in (
+            "Job ID",
+            "User",
+            "Name",
+            "Partition",
+            "State",
+            "ExitCode",
+            "Elapsed",
+        ):
+            assert shown in result.stdout, f"default column missing: {shown}"
+        # Opt-in columns stay hidden.
+        assert "Account" not in result.stdout
+        assert "Submit" not in result.stdout
+        assert "Start" not in result.stdout
+        assert "End" not in result.stdout
+
+    def test_show_account_and_times(
+        self, runner: CliRunner, sample_rows: list[SacctRow]
+    ) -> None:
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=sample_rows,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "sacct",
+                    "--local",
+                    "--show-account",
+                    "--show-times",
+                ],
+                env={"COLUMNS": "240"},
+            )
+
+        assert result.exit_code == 0
+        assert "Account" in result.stdout
+        assert "Submit" in result.stdout
+        assert "Start" in result.stdout
+        assert "End" in result.stdout
+
+    def test_json_schema(self, runner: CliRunner, sample_rows: list[SacctRow]) -> None:
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=sample_rows,
+        ):
+            result = runner.invoke(app, ["sacct", "--local", "--format", "json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        # Default (no --show-steps): parent rows only.
+        assert len(data) == 2
+        first = data[0]
+        for key in (
+            "job_id",
+            "job_name",
+            "user",
+            "partition",
+            "account",
+            "state",
+            "exit_code",
+            "elapsed",
+            "submit",
+            "start",
+            "end",
+            "alloc_cpus",
+            "alloc_tres",
+            "is_step",
+        ):
+            assert key in first, f"JSON field missing: {key}"
+
+    def test_empty_shows_sentinel(self, runner: CliRunner) -> None:
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=[],
+        ):
+            result = runner.invoke(app, ["sacct", "--local"])
+        assert result.exit_code == 0
+        assert "No accounting records" in result.stdout
+
+    def test_filters_forwarded_to_fetcher(
+        self, runner: CliRunner, sample_rows: list[SacctRow]
+    ) -> None:
+        """Every CLI filter option must reach the subprocess fetcher.
+
+        Otherwise SLURM would happily run an unfiltered query and the
+        CLI would post-process client-side — defeating the point of
+        letting slurmdbd narrow results.
+        """
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=sample_rows,
+        ) as fetch:
+            result = runner.invoke(
+                app,
+                [
+                    "sacct",
+                    "--local",
+                    "-j",
+                    "2780",
+                    "-j",
+                    "19849",
+                    "-u",
+                    "alice",
+                    "-S",
+                    "now-1day",
+                    "-E",
+                    "now",
+                    "-s",
+                    "FAILED,TIMEOUT",
+                    "-p",
+                    "defq",
+                ],
+            )
+
+        assert result.exit_code == 0
+        fetch.assert_called_once_with(
+            job_ids=[2780, 19849],
+            user="alice",
+            all_users=False,
+            start_time="now-1day",
+            end_time="now",
+            state="FAILED,TIMEOUT",
+            partition="defq",
+        )
+
+    def test_allusers_flag_overrides_user(
+        self, runner: CliRunner, sample_rows: list[SacctRow]
+    ) -> None:
+        with patch(
+            "srunx.slurm.accounting.fetch_sacct_rows_local",
+            return_value=sample_rows,
+        ) as fetch:
+            result = runner.invoke(app, ["sacct", "--local", "-a", "-u", "alice"])
+
+        assert result.exit_code == 0
+        kwargs = fetch.call_args.kwargs
+        assert kwargs["all_users"] is True
+        # The data-layer respects the `-a` precedence — the CLI just
+        # forwards both. Verified in the unit test below.
+
+
+class TestSacctSshRouting:
+    """``--profile`` must route through the SSH adapter, not local subprocess."""
+
+    def test_profile_calls_ssh_fetcher(
+        self, runner: CliRunner, sample_rows: list[SacctRow]
+    ) -> None:
+        from srunx.transport.registry import TransportHandle
+
+        fake_adapter = MagicMock()
+        fake_handle = TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=fake_adapter,
+            queue_client=fake_adapter,
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+        with (
+            patch(
+                "srunx.transport.registry._build_ssh_handle",
+                return_value=(fake_handle, None),
+            ),
+            patch(
+                "srunx.slurm.accounting.fetch_sacct_rows_ssh",
+                return_value=sample_rows,
+            ) as ssh_fetch,
+            patch("srunx.slurm.accounting.fetch_sacct_rows_local") as local_fetch,
+        ):
+            result = runner.invoke(
+                app,
+                ["sacct", "--profile", "dgx", "--format", "json"],
+            )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        ssh_fetch.assert_called_once()
+        # First positional arg is the adapter — guard so a refactor
+        # can't silently pass something else.
+        assert ssh_fetch.call_args.args[0] is fake_adapter
+        local_fetch.assert_not_called()
+
+
+class TestBuildFilterArgs:
+    """Direct unit coverage of the shared filter-arg builder.
+
+    Guarantees the two fetchers can't diverge on which CLI flag maps
+    to which ``sacct`` argument.
+    """
+
+    def test_allusers_beats_user(self) -> None:
+        from srunx.slurm.accounting import build_sacct_filter_args
+
+        args = build_sacct_filter_args(user="alice", all_users=True)
+        assert "--allusers" in args
+        assert "--user" not in args
+
+    def test_user_forwarded_when_no_allusers(self) -> None:
+        from srunx.slurm.accounting import build_sacct_filter_args
+
+        args = build_sacct_filter_args(user="alice")
+        assert "--user" in args
+        assert "alice" in args
+
+    def test_job_ids_comma_joined(self) -> None:
+        from srunx.slurm.accounting import build_sacct_filter_args
+
+        args = build_sacct_filter_args(job_ids=[1, 2, 3])
+        assert "--jobs" in args
+        assert "1,2,3" in args

--- a/tests/test_cli_sinfo.py
+++ b/tests/test_cli_sinfo.py
@@ -1,4 +1,13 @@
-"""Tests for resources command CLI."""
+"""Tests for ``srunx sinfo`` (partition / state / nodelist listing).
+
+The GPU-aggregate snapshot previously rendered by ``srunx sinfo``
+moved to ``srunx gpus`` — see ``test_cli_gpus.py``. This file
+exercises the new ``sinfo`` behaviour, which mirrors native SLURM
+``sinfo`` output columns (PARTITION / AVAIL / TIMELIMIT / NODES /
+STATE / NODELIST).
+"""
+
+from __future__ import annotations
 
 import json
 from unittest.mock import MagicMock, patch
@@ -7,331 +16,146 @@ import pytest
 from typer.testing import CliRunner
 
 from srunx.cli.main import app
-from srunx.observability.monitoring.types import ResourceSnapshot
+from srunx.slurm.partitions import (
+    PartitionRow,
+    parse_sinfo_partition_rows,
+)
+
+_SAMPLE_STDOUT = (
+    "defq*|up|infinite|2|mixed|indus,sagittarius\n"
+    "defq*|up|infinite|2|allocated|lynx,orion\n"
+    "gpu|up|1-00:00:00|1|idle|node01\n"
+)
 
 
 @pytest.fixture
-def runner():
-    """Create CLI test runner."""
+def runner() -> CliRunner:
     return CliRunner()
 
 
 @pytest.fixture
-def mock_snapshot():
-    """Create mock resource snapshot."""
-    return ResourceSnapshot(
-        partition="gpu",
-        total_gpus=16,
-        gpus_in_use=10,
-        gpus_available=6,
-        jobs_running=3,
-        nodes_total=4,
-        nodes_idle=1,
-        nodes_down=0,
-    )
+def sample_rows() -> list[PartitionRow]:
+    return parse_sinfo_partition_rows(_SAMPLE_STDOUT)
 
 
-@pytest.fixture
-def mock_snapshot_all_partitions():
-    """Create mock resource snapshot for all partitions."""
-    return ResourceSnapshot(
-        partition=None,
-        total_gpus=32,
-        gpus_in_use=20,
-        gpus_available=12,
-        jobs_running=5,
-        nodes_total=8,
-        nodes_idle=2,
-        nodes_down=1,
-    )
+class TestSinfoParsing:
+    def test_parses_default_marker_and_fields(self) -> None:
+        rows = parse_sinfo_partition_rows(_SAMPLE_STDOUT)
+        assert len(rows) == 3
+        r0, r1, r2 = rows
+        assert r0.partition == "defq"
+        assert r0.is_default is True
+        assert r0.avail == "up"
+        assert r0.timelimit == "infinite"
+        assert r0.nodes == 2
+        assert r0.state == "mixed"
+        assert r0.nodelist == "indus,sagittarius"
 
+        assert r1.partition == "defq"
+        assert r1.state == "allocated"
+        assert r1.nodelist == "lynx,orion"
 
-class TestResourcesCommand:
-    """Test suite for resources command."""
+        assert r2.partition == "gpu"
+        assert r2.is_default is False
+        assert r2.timelimit == "1-00:00:00"
+        assert r2.nodelist == "node01"
 
-    def test_resources_table_format_default(self, runner, mock_snapshot_all_partitions):
-        """Test resources command with default table format."""
-        with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = (
-                mock_snapshot_all_partitions
-            )
-            mock_monitor_class.return_value = mock_monitor
-
-            result = runner.invoke(app, ["sinfo"])
-
-            assert result.exit_code == 0
-            assert "GPU Resources" in result.stdout
-            assert "all" in result.stdout  # "all partitions" in title
-            assert "Total GPUs" in result.stdout
-            assert "32" in result.stdout  # total_gpus
-            assert "20" in result.stdout  # gpus_in_use
-            assert "12" in result.stdout  # gpus_available
-            assert "Running Jobs" in result.stdout
-            assert "5" in result.stdout  # jobs_running
-            assert "Total Nodes" in result.stdout
-            assert "8" in result.stdout  # nodes_total
-            assert "Idle Nodes" in result.stdout
-            assert "2" in result.stdout  # nodes_idle
-            assert "Down Nodes" in result.stdout
-            assert "1" in result.stdout  # nodes_down
-
-    def test_resources_table_format_with_partition(self, runner, mock_snapshot):
-        """Test resources command with specific partition."""
-        with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = mock_snapshot
-            mock_monitor_class.return_value = mock_monitor
-
-            result = runner.invoke(app, ["sinfo", "--partition", "gpu"])
-
-            assert result.exit_code == 0
-            assert "GPU Resources - gpu" in result.stdout
-            assert "16" in result.stdout  # total_gpus
-            assert "10" in result.stdout  # gpus_in_use
-            assert "6" in result.stdout  # gpus_available
-            assert "3" in result.stdout  # jobs_running
-            assert "4" in result.stdout  # nodes_total
-            assert "1" in result.stdout  # nodes_idle
-            assert "0" in result.stdout  # nodes_down
-
-            # Verify ResourceMonitor was created with correct partition
-            mock_monitor_class.assert_called_once_with(
-                min_gpus=0, partition="gpu", source=None
-            )
-
-    def test_resources_json_format_default(self, runner, mock_snapshot_all_partitions):
-        """Test resources command with JSON format."""
-        with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = (
-                mock_snapshot_all_partitions
-            )
-            mock_monitor_class.return_value = mock_monitor
-
-            result = runner.invoke(app, ["sinfo", "--format", "json"])
-
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-
-            assert data["partition"] is None
-            assert data["gpus_total"] == 32
-            assert data["gpus_in_use"] == 20
-            assert data["gpus_available"] == 12
-            assert data["jobs_running"] == 5
-            assert data["nodes_total"] == 8
-            assert data["nodes_idle"] == 2
-            assert data["nodes_down"] == 1
-
-    def test_resources_json_format_with_partition(self, runner, mock_snapshot):
-        """Test resources command with JSON format and partition."""
-        with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = mock_snapshot
-            mock_monitor_class.return_value = mock_monitor
-
-            result = runner.invoke(app, ["sinfo", "-p", "gpu", "-f", "json"])
-
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-
-            assert data["partition"] == "gpu"
-            assert data["gpus_total"] == 16
-            assert data["gpus_in_use"] == 10
-            assert data["gpus_available"] == 6
-            assert data["jobs_running"] == 3
-            assert data["nodes_total"] == 4
-            assert data["nodes_idle"] == 1
-            assert data["nodes_down"] == 0
-
-            # Verify ResourceMonitor was created with correct partition
-            mock_monitor_class.assert_called_once_with(
-                min_gpus=0, partition="gpu", source=None
-            )
-
-    def test_resources_zero_gpus_available(self, runner):
-        """Test resources command when no GPUs available."""
-        snapshot = ResourceSnapshot(
-            partition="gpu",
-            total_gpus=16,
-            gpus_in_use=16,
-            gpus_available=0,
-            jobs_running=8,
-            nodes_total=4,
-            nodes_idle=0,
-            nodes_down=0,
+    def test_skips_malformed_lines(self) -> None:
+        stdout = (
+            "defq*|up|infinite|2|mixed|indus\n"
+            "bogus line without delimiters\n"
+            "gpu|up|1:00:00|notanumber|idle|node01\n"
+            "\n"
+            "ok|up|infinite|1|idle|n1\n"
         )
+        rows = parse_sinfo_partition_rows(stdout)
+        assert [r.partition for r in rows] == ["defq", "ok"]
 
+
+class TestSinfoLocalPath:
+    def test_renders_partition_rows(
+        self, runner: CliRunner, sample_rows: list[PartitionRow]
+    ) -> None:
         with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = snapshot
-            mock_monitor_class.return_value = mock_monitor
+            "srunx.slurm.partitions.fetch_sinfo_rows_local",
+            return_value=sample_rows,
+        ):
+            result = runner.invoke(app, ["sinfo", "--local"])
 
-            result = runner.invoke(app, ["sinfo", "--format", "json"])
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        # Native-sinfo columns must all be present in the rendered table.
+        for column in (
+            "PARTITION",
+            "AVAIL",
+            "TIMELIMIT",
+            "NODES",
+            "STATE",
+            "NODELIST",
+        ):
+            assert column in result.stdout
+        # Row values: default marker, nodelist, state all surface.
+        assert "defq*" in result.stdout
+        assert "infinite" in result.stdout
+        assert "mixed" in result.stdout
+        assert "allocated" in result.stdout
+        assert "lynx,orion" in result.stdout
+        assert "gpu" in result.stdout
+        assert "node01" in result.stdout
 
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-            assert data["gpus_available"] == 0
-            assert data["gpus_total"] == data["gpus_in_use"]
-
-    def test_resources_with_down_nodes(self, runner):
-        """Test resources command with some nodes down."""
-        snapshot = ResourceSnapshot(
-            partition="gpu",
-            total_gpus=8,  # Only from available nodes
-            gpus_in_use=4,
-            gpus_available=4,
-            jobs_running=2,
-            nodes_total=4,
-            nodes_idle=1,
-            nodes_down=2,  # 2 nodes down
-        )
-
+    def test_json_format_emits_row_list(
+        self, runner: CliRunner, sample_rows: list[PartitionRow]
+    ) -> None:
         with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = snapshot
-            mock_monitor_class.return_value = mock_monitor
+            "srunx.slurm.partitions.fetch_sinfo_rows_local",
+            return_value=sample_rows,
+        ):
+            result = runner.invoke(app, ["sinfo", "--local", "--format", "json"])
 
-            result = runner.invoke(app, ["sinfo", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert isinstance(data, list)
+        assert len(data) == 3
+        first = data[0]
+        # Same keys as PartitionRow.to_dict
+        assert first["partition"] == "defq"
+        assert first["is_default"] is True
+        assert first["avail"] == "up"
+        assert first["state"] == "mixed"
+        assert first["nodelist"] == "indus,sagittarius"
+        # Nodes must be an int, not a string
+        assert isinstance(first["nodes"], int)
 
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-            assert data["nodes_total"] == 4
-            assert data["nodes_down"] == 2
-            # Total GPUs should only count available nodes
-            assert data["gpus_total"] == 8
-
-    def test_resources_error_handling(self, runner):
-        """Test resources command error handling."""
+    def test_partition_filter_forwarded_to_fetcher(
+        self, runner: CliRunner, sample_rows: list[PartitionRow]
+    ) -> None:
         with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.side_effect = Exception(
-                "SLURM connection error"
-            )
-            mock_monitor_class.return_value = mock_monitor
+            "srunx.slurm.partitions.fetch_sinfo_rows_local",
+            return_value=sample_rows,
+        ) as fetch:
+            result = runner.invoke(app, ["sinfo", "--local", "--partition", "gpu"])
 
-            result = runner.invoke(app, ["sinfo"])
+        assert result.exit_code == 0
+        fetch.assert_called_once_with("gpu")
 
-            assert result.exit_code == 1
-            assert "Error" in result.stdout
-
-    def test_resources_partition_not_found(self, runner):
-        """Test resources command with non-existent partition."""
-        # ResourceMonitor will return zeros for non-existent partition
-        snapshot = ResourceSnapshot(
-            partition="nonexistent",
-            total_gpus=0,
-            gpus_in_use=0,
-            gpus_available=0,
-            jobs_running=0,
-            nodes_total=0,
-            nodes_idle=0,
-            nodes_down=0,
-        )
-
+    def test_error_exits_nonzero(self, runner: CliRunner) -> None:
         with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = snapshot
-            mock_monitor_class.return_value = mock_monitor
-
-            result = runner.invoke(app, ["sinfo", "-p", "nonexistent", "-f", "json"])
-
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-            # Should return zeros for non-existent partition
-            assert data["gpus_total"] == 0
-            assert data["nodes_total"] == 0
-
-    def test_resources_short_flags(self, runner, mock_snapshot):
-        """Test resources command with short flag variants."""
-        with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = mock_snapshot
-            mock_monitor_class.return_value = mock_monitor
-
-            # Test -p and -f short flags
-            result = runner.invoke(app, ["sinfo", "-p", "gpu", "-f", "json"])
-
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-            assert data["partition"] == "gpu"
-
-            # Verify ResourceMonitor was created correctly
-            mock_monitor_class.assert_called_once_with(
-                min_gpus=0, partition="gpu", source=None
-            )
-
-    def test_resources_high_utilization(self, runner):
-        """Test resources command with high GPU utilization."""
-        snapshot = ResourceSnapshot(
-            partition="gpu",
-            total_gpus=100,
-            gpus_in_use=95,
-            gpus_available=5,
-            jobs_running=20,
-            nodes_total=25,
-            nodes_idle=1,
-            nodes_down=0,
-        )
-
-        with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = snapshot
-            mock_monitor_class.return_value = mock_monitor
-
-            result = runner.invoke(app, ["sinfo", "--format", "json"])
-
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-            # 95% utilization
-            assert data["gpus_in_use"] / data["gpus_total"] == 0.95
-            assert data["gpus_available"] == 5
+            "srunx.slurm.partitions.fetch_sinfo_rows_local",
+            side_effect=RuntimeError("sinfo not on PATH"),
+        ):
+            result = runner.invoke(app, ["sinfo", "--local"])
+        assert result.exit_code == 1
+        assert "Error" in result.stdout
 
 
-class TestSinfoSshParity:
-    """#139: ``--profile`` routes ``sinfo`` through the SSH adapter.
+class TestSinfoSshPath:
+    """``--profile`` must route through the SSH adapter, not local sinfo."""
 
-    SSH path uses :class:`SSHAdapterResourceSource` (the same backend
-    the resource snapshotter / Web ``/api/resources`` already use), so
-    these tests mock the SSH transport handle and assert the cluster
-    snapshot path runs against the adapter — never the local
-    ``subprocess.run('sinfo')`` fallback.
-    """
-
-    def test_profile_routes_through_ssh_adapter_cluster_snapshot(self, runner):
+    def test_profile_calls_ssh_fetcher(
+        self, runner: CliRunner, sample_rows: list[PartitionRow]
+    ) -> None:
         from srunx.transport.registry import TransportHandle
 
         fake_adapter = MagicMock()
-        fake_adapter.get_cluster_snapshot.return_value = {
-            "partition": None,
-            "total_gpus": 64,
-            "gpus_in_use": 16,
-            "gpus_available": 48,
-            "jobs_running": 4,
-            "nodes_total": 8,
-            "nodes_idle": 4,
-            "nodes_down": 0,
-        }
         fake_handle = TransportHandle(
             scheduler_key="ssh:dgx",
             profile_name="dgx",
@@ -342,38 +166,40 @@ class TestSinfoSshParity:
             submission_context=None,
         )
 
-        with patch(
-            "srunx.transport.registry._build_ssh_handle",
-            return_value=(fake_handle, None),
+        with (
+            patch(
+                "srunx.transport.registry._build_ssh_handle",
+                return_value=(fake_handle, None),
+            ),
+            patch(
+                "srunx.slurm.partitions.fetch_sinfo_rows_ssh",
+                return_value=sample_rows,
+            ) as ssh_fetch,
+            patch("srunx.slurm.partitions.fetch_sinfo_rows_local") as local_fetch,
         ):
             result = runner.invoke(
-                app, ["sinfo", "--profile", "dgx", "--format", "json"]
+                app,
+                ["sinfo", "--profile", "dgx", "--format", "json"],
             )
 
         assert result.exit_code == 0, result.stdout + (result.stderr or "")
-        data = json.loads(result.stdout)
-        assert data["gpus_total"] == 64
-        assert data["gpus_available"] == 48
-        # The whole point of #139 — local sinfo must NOT have run.
-        fake_adapter.get_cluster_snapshot.assert_called_once()
-        fake_adapter.get_resources.assert_not_called()
+        # SSH branch must run; local subprocess must not.
+        ssh_fetch.assert_called_once()
+        called_adapter, called_partition = ssh_fetch.call_args.args
+        assert called_adapter is fake_adapter
+        assert called_partition is None
+        local_fetch.assert_not_called()
 
-    def test_profile_with_partition_uses_per_partition_query(self, runner):
+        data = json.loads(result.stdout)
+        assert len(data) == 3
+        assert {r["partition"] for r in data} == {"defq", "gpu"}
+
+    def test_profile_with_partition_flag_forwards_filter(
+        self, runner: CliRunner, sample_rows: list[PartitionRow]
+    ) -> None:
         from srunx.transport.registry import TransportHandle
 
         fake_adapter = MagicMock()
-        fake_adapter.get_resources.return_value = [
-            {
-                "partition": "gpu",
-                "total_gpus": 32,
-                "gpus_in_use": 8,
-                "gpus_available": 24,
-                "jobs_running": 2,
-                "nodes_total": 4,
-                "nodes_idle": 2,
-                "nodes_down": 0,
-            }
-        ]
         fake_handle = TransportHandle(
             scheduler_key="ssh:dgx",
             profile_name="dgx",
@@ -384,9 +210,15 @@ class TestSinfoSshParity:
             submission_context=None,
         )
 
-        with patch(
-            "srunx.transport.registry._build_ssh_handle",
-            return_value=(fake_handle, None),
+        with (
+            patch(
+                "srunx.transport.registry._build_ssh_handle",
+                return_value=(fake_handle, None),
+            ),
+            patch(
+                "srunx.slurm.partitions.fetch_sinfo_rows_ssh",
+                return_value=[sample_rows[2]],
+            ) as ssh_fetch,
         ):
             result = runner.invoke(
                 app,
@@ -401,40 +233,5 @@ class TestSinfoSshParity:
                 ],
             )
 
-        assert result.exit_code == 0, result.stdout + (result.stderr or "")
-        data = json.loads(result.stdout)
-        assert data["partition"] == "gpu"
-        assert data["gpus_total"] == 32
-        # Per-partition path: get_resources('gpu') called, NOT
-        # get_cluster_snapshot.
-        fake_adapter.get_resources.assert_called_once_with("gpu")
-        fake_adapter.get_cluster_snapshot.assert_not_called()
-
-    def test_local_path_unchanged_when_no_profile(
-        self, runner, mock_snapshot_all_partitions
-    ):
-        """Regression guard: local default still uses ResourceMonitor subprocess.
-
-        Without ``--profile``/``$SRUNX_SSH_PROFILE`` the SSH branch
-        must NOT activate — the existing
-        :class:`TestResourcesCommand` tests already cover the table
-        path, this one explicitly asserts ``source=None`` so the
-        subprocess fallback stays the default.
-        """
-        with patch(
-            "srunx.observability.monitoring.resource_monitor.ResourceMonitor"
-        ) as mock_monitor_class:
-            mock_monitor = MagicMock()
-            mock_monitor.get_partition_resources.return_value = (
-                mock_snapshot_all_partitions
-            )
-            mock_monitor_class.return_value = mock_monitor
-
-            result = runner.invoke(app, ["sinfo", "--local", "--format", "json"])
-
         assert result.exit_code == 0
-        # ``source=None`` means the local subprocess path runs — see
-        # the docstring on ``ResourceMonitor.get_partition_resources``.
-        mock_monitor_class.assert_called_once_with(
-            min_gpus=0, partition=None, source=None
-        )
+        ssh_fetch.assert_called_once_with(fake_adapter, "gpu")

--- a/tests/test_cli_squeue.py
+++ b/tests/test_cli_squeue.py
@@ -1,4 +1,13 @@
-"""Tests for list command CLI."""
+"""Tests for ``srunx squeue`` (active-jobs listing).
+
+The command now mirrors native ``squeue`` semantics: all users' jobs by
+default, User/Partition/CPUs/GPUs/NodeList columns, ``-u/--user`` to
+filter. The previous ``--show-gpus`` flag is gone — GPUs are always
+shown because the user explicitly asked for a combined CPU + GPU +
+NODELIST view.
+"""
+
+from __future__ import annotations
 
 import json
 from unittest.mock import MagicMock, patch
@@ -7,199 +16,257 @@ import pytest
 from typer.testing import CliRunner
 
 from srunx.cli.main import app
-from srunx.domain import Job, JobResource, JobStatus
+from srunx.domain import BaseJob, JobStatus
 
 
 @pytest.fixture
-def runner():
-    """Create CLI test runner."""
+def runner() -> CliRunner:
     return CliRunner()
 
 
+def _make_job(
+    *,
+    job_id: int,
+    name: str,
+    user: str,
+    partition: str,
+    status: JobStatus,
+    nodes: int,
+    cpus: int,
+    gpus: int,
+    nodelist: str,
+    elapsed: str = "0:05",
+    time_limit: str = "UNLIMITED",
+) -> BaseJob:
+    job = BaseJob(
+        name=name,
+        job_id=job_id,
+        user=user,
+        partition=partition,
+        nodes=nodes,
+        cpus=cpus,
+        gpus=gpus,
+        nodelist=nodelist,
+        elapsed_time=elapsed,
+        time_limit=time_limit,
+    )
+    job.status = status
+    return job
+
+
 @pytest.fixture
-def mock_jobs():
-    """Create mock job list for testing."""
-    jobs = []
-
-    # Job 1: With GPUs
-    job1 = Job(
-        name="gpu_job",
-        job_id=12345,
-        command=["python", "train.py"],
-        nodes=2,
-        gpus=8,
-        time_limit="4:00:00",
-    )
-    job1._status = JobStatus.RUNNING
-    job1.resources = JobResource(nodes=2, gpus_per_node=4, time_limit="4:00:00")
-    jobs.append(job1)
-
-    # Job 2: No GPUs
-    job2 = Job(
-        name="cpu_job",
-        job_id=12346,
-        command=["python", "process.py"],
-        nodes=1,
-        gpus=0,
-        time_limit="1:00:00",
-    )
-    job2._status = JobStatus.PENDING
-    job2.resources = JobResource(nodes=1, gpus_per_node=0, time_limit="1:00:00")
-    jobs.append(job2)
-
-    # Job 3: Multiple GPUs per node
-    job3 = Job(
-        name="multi_gpu",
-        job_id=12347,
-        command=["python", "parallel.py"],
-        nodes=4,
-        gpus=8,
-        time_limit="2:00:00",
-    )
-    job3._status = JobStatus.COMPLETED
-    job3.resources = JobResource(nodes=4, gpus_per_node=2, time_limit="2:00:00")
-    jobs.append(job3)
-
-    return jobs
+def mock_jobs() -> list[BaseJob]:
+    return [
+        _make_job(
+            job_id=12345,
+            name="gpu_job",
+            user="alice",
+            partition="gpu",
+            status=JobStatus.RUNNING,
+            nodes=2,
+            cpus=32,
+            gpus=8,
+            nodelist="dgx-node[1-2]",
+        ),
+        _make_job(
+            job_id=12346,
+            name="cpu_job",
+            user="bob",
+            partition="defq",
+            status=JobStatus.PENDING,
+            nodes=1,
+            cpus=4,
+            gpus=0,
+            nodelist="(Priority)",
+        ),
+        _make_job(
+            job_id=12347,
+            name="multi_gpu",
+            user="ksterx",
+            partition="gpu",
+            status=JobStatus.RUNNING,
+            nodes=4,
+            cpus=128,
+            gpus=16,
+            nodelist="dgx-node[3-6]",
+        ),
+    ]
 
 
-class TestListCommand:
-    """Test suite for list command."""
-
-    def test_list_table_format_default(self, runner, mock_jobs):
-        """Test list command with default table format."""
+class TestSqueueTable:
+    def test_default_columns(self, runner: CliRunner, mock_jobs) -> None:
+        """Default view: Job ID / User / Name / Status / GPUs / Elapsed /
+        NodeList. Partition / CPUs / Limit / Nodes are opt-in."""
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.return_value = mock_jobs
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            # Rich auto-shrinks column headers when the (captured) terminal
+            # is narrower than the table needs — set COLUMNS so header text
+            # doesn't truncate to single characters.
+            result = runner.invoke(app, ["squeue", "--local"], env={"COLUMNS": "200"})
 
-            result = runner.invoke(app, ["squeue"])
+        assert result.exit_code == 0
+        for shown in (
+            "Job ID",
+            "User",
+            "Name",
+            "Status",
+            "GPUs",
+            "Elapsed",
+            "NodeList",
+        ):
+            assert shown in result.stdout, f"default column missing: {shown}"
+        # Opt-in columns must not appear by default.
+        for hidden in ("Partition", "CPUs", "Limit", "Nodes"):
+            assert hidden not in result.stdout, f"opt-in column leaked: {hidden}"
+        # Default-set values still surface.
+        assert "alice" in result.stdout
+        assert "dgx-node[1-2]" in result.stdout
+        assert "RUNNING" in result.stdout
 
-            assert result.exit_code == 0
-            assert "Job Queue" in result.stdout
-            assert "12345" in result.stdout
-            assert "gpu_job" in result.stdout
-            assert "RUNNING" in result.stdout
-            assert "12346" in result.stdout
-            assert "cpu_job" in result.stdout
-            assert "PENDING" in result.stdout
-            # Should NOT show GPUs column by default
-            assert "GPUs" not in result.stdout
-
-    def test_list_table_format_with_gpus(self, runner, mock_jobs):
-        """Test list command with --show-gpus flag."""
+    def test_show_all_flag_reveals_every_column(
+        self, runner: CliRunner, mock_jobs
+    ) -> None:
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.return_value = mock_jobs
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(
+                app, ["squeue", "--local", "-a"], env={"COLUMNS": "200"}
+            )
 
-            result = runner.invoke(app, ["squeue", "--show-gpus"])
+        assert result.exit_code == 0
+        for header in (
+            "Job ID",
+            "User",
+            "Name",
+            "Partition",
+            "Status",
+            "Nodes",
+            "CPUs",
+            "GPUs",
+            "Elapsed",
+            "Limit",
+            "NodeList",
+        ):
+            assert header in result.stdout, f"column missing under -a: {header}"
 
-            assert result.exit_code == 0
-            assert "Job Queue" in result.stdout
-            assert "GPUs" in result.stdout
-            # GPU counts: job1 = 2*4=8, job2 = 1*0=0, job3 = 4*2=8
-            assert "8" in result.stdout  # job1 and job3 GPUs
-            assert "0" in result.stdout  # job2 GPUs
-
-    def test_list_json_format_without_gpus(self, runner, mock_jobs):
-        """Test list command with JSON format."""
+    def test_individual_show_flags(self, runner: CliRunner, mock_jobs) -> None:
+        """Each --show-X flag adds exactly one of the opt-in columns."""
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.return_value = mock_jobs
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(
+                app,
+                ["squeue", "--local", "--show-partition", "--show-cpus"],
+                env={"COLUMNS": "200"},
+            )
 
-            result = runner.invoke(app, ["squeue", "--format", "json"])
+        assert result.exit_code == 0
+        assert "Partition" in result.stdout
+        assert "CPUs" in result.stdout
+        # The two NOT requested remain hidden.
+        assert "Limit" not in result.stdout
+        assert "Nodes" not in result.stdout
 
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-
-            assert len(data) == 3
-            assert data[0]["job_id"] == 12345
-            assert data[0]["name"] == "gpu_job"
-            assert data[0]["status"] == "RUNNING"
-            assert data[0]["nodes"] == 2
-            assert data[0]["time_limit"] == "4:00:00"
-            # Should NOT have gpus field without --show-gpus
-            assert "gpus" not in data[0]
-
-    def test_list_json_format_with_gpus(self, runner, mock_jobs):
-        """Test list command with JSON format and --show-gpus."""
+    def test_empty_queue(self, runner: CliRunner) -> None:
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.return_value = mock_jobs
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.return_value = []
+            mock_slurm.return_value = client
+            result = runner.invoke(app, ["squeue", "--local"])
+        assert result.exit_code == 0
+        assert "No jobs in queue" in result.stdout
 
-            result = runner.invoke(app, ["squeue", "--show-gpus", "--format", "json"])
-
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-
-            assert len(data) == 3
-            # Job 1: 2 nodes * 4 GPUs/node = 8
-            assert data[0]["gpus"] == 8
-            # Job 2: 1 node * 0 GPUs/node = 0
-            assert data[1]["gpus"] == 0
-            # Job 3: 4 nodes * 2 GPUs/node = 8
-            assert data[2]["gpus"] == 8
-
-    def test_list_empty_queue(self, runner):
-        """Test list command with empty job queue."""
+    def test_error_exit_code(self, runner: CliRunner) -> None:
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.return_value = []
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.side_effect = RuntimeError("SLURM connection error")
+            mock_slurm.return_value = client
+            result = runner.invoke(app, ["squeue", "--local"])
+        assert result.exit_code == 1
 
-            result = runner.invoke(app, ["squeue"])
 
-            assert result.exit_code == 0
-            assert "No jobs in queue" in result.stdout
-
-    def test_list_gpu_calculation(self, runner):
-        """Test GPU calculation: nodes * gpus_per_node."""
-        jobs = []
-        job = Job(name="test", job_id=99999, command=["test"])
-        job._status = JobStatus.RUNNING
-        # 5 nodes * 3 GPUs/node = 15 total GPUs
-        job.resources = JobResource(nodes=5, gpus_per_node=3)
-        jobs.append(job)
-
+class TestSqueueJson:
+    def test_json_schema_includes_new_fields(
+        self, runner: CliRunner, mock_jobs
+    ) -> None:
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.return_value = jobs
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(app, ["squeue", "--local", "--format", "json"])
 
-            result = runner.invoke(app, ["squeue", "--show-gpus", "--format", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 3
+        first = data[0]
+        # Every field a srunx user should see for a job — surfaced in
+        # the JSON too so scripts don't have to round-trip through the
+        # table renderer.
+        assert first["job_id"] == 12345
+        assert first["user"] == "alice"
+        assert first["name"] == "gpu_job"
+        assert first["partition"] == "gpu"
+        assert first["status"] == "RUNNING"
+        assert first["nodes"] == 2
+        assert first["cpus"] == 32
+        assert first["gpus"] == 8
+        assert first["nodelist"] == "dgx-node[1-2]"
 
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-            assert data[0]["gpus"] == 15
-
-    def test_list_job_without_resources(self, runner):
-        """Test list command with job that has no resources."""
-        job = Job(name="no_resources", job_id=88888, command=["test"])
-        job._status = JobStatus.RUNNING
-        # No resources set
-
+    def test_empty_queue_emits_empty_list(self, runner: CliRunner) -> None:
+        """Pre-existing regression — ``--format json`` on empty queue
+        must emit ``[]`` (valid JSON), not the human string."""
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.return_value = [job]
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.return_value = []
+            mock_slurm.return_value = client
+            result = runner.invoke(app, ["squeue", "--local", "--format", "json"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == []
 
-            result = runner.invoke(app, ["squeue", "--show-gpus", "--format", "json"])
 
-            assert result.exit_code == 0
-            data = json.loads(result.stdout)
-            # Should handle missing resources gracefully
-            assert data[0]["gpus"] == 0
-
-    def test_list_error_handling(self, runner):
-        """Test list command error handling."""
+class TestSqueueUserFilter:
+    def test_user_flag_forwarded_to_client(self, runner: CliRunner, mock_jobs) -> None:
+        """``--user`` must reach the ``queue()`` call so SLURM filters
+        server-side — client-side filtering would miss jobs that
+        squeue's own ``--user`` flag would include in edge cases."""
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
-            mock_client = MagicMock()
-            mock_client.queue.side_effect = Exception("SLURM connection error")
-            mock_slurm.return_value = mock_client
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(
+                app, ["squeue", "--local", "--user", "alice", "--format", "json"]
+            )
 
-            result = runner.invoke(app, ["squeue"])
+        assert result.exit_code == 0
+        client.queue.assert_called_once_with(user="alice")
 
-            assert result.exit_code == 1
+    def test_default_shows_all_users(self, runner: CliRunner, mock_jobs) -> None:
+        """Without ``--user``, pass ``user=None`` — matches native
+        ``squeue`` (all users) and local ``Slurm.queue`` semantics."""
+        with patch("srunx.slurm.local.Slurm") as mock_slurm:
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(app, ["squeue", "--local", "--format", "json"])
+
+        assert result.exit_code == 0
+        client.queue.assert_called_once_with(user=None)
+
+
+class TestSqueueJobIdFilter:
+    def test_job_id_filter_narrows_result(self, runner: CliRunner, mock_jobs) -> None:
+        with patch("srunx.slurm.local.Slurm") as mock_slurm:
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(
+                app, ["squeue", "--local", "-j", "12346", "--format", "json"]
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert len(data) == 1
+        assert data[0]["job_id"] == 12346

--- a/tests/test_cli_squeue.py
+++ b/tests/test_cli_squeue.py
@@ -270,3 +270,77 @@ class TestSqueueJobIdFilter:
         data = json.loads(result.stdout)
         assert len(data) == 1
         assert data[0]["job_id"] == 12346
+
+
+class TestSqueueIterate:
+    """``-i`` / ``--iterate`` live-refresh mode.
+
+    The real loop sleeps between ticks, so tests patch the
+    ``_run_squeue_live`` helper or short-circuit it via the
+    ``time.sleep`` hook — whichever proves the contract (fetch is
+    called per tick, KeyboardInterrupt exits cleanly, invalid inputs
+    fail early).
+    """
+
+    def test_rejects_non_positive_interval(self, runner: CliRunner, mock_jobs) -> None:
+        with patch("srunx.slurm.local.Slurm") as mock_slurm:
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(app, ["squeue", "--local", "-i", "0"])
+        assert result.exit_code != 0
+        combined = result.stdout + (result.stderr or "")
+        assert "positive" in combined.lower()
+
+    def test_rejects_json_combined_with_iterate(
+        self, runner: CliRunner, mock_jobs
+    ) -> None:
+        """Live view is human-facing; streaming JSON would need a
+        different contract (line-delimited JSON etc.) — reject until
+        someone actually asks for it."""
+        with patch("srunx.slurm.local.Slurm") as mock_slurm:
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(
+                app, ["squeue", "--local", "-i", "5", "--format", "json"]
+            )
+        assert result.exit_code != 0
+        combined = result.stdout + (result.stderr or "")
+        assert "incompatible" in combined.lower() or "json" in combined.lower()
+
+    def test_live_loop_repolls_until_interrupt(
+        self, runner: CliRunner, mock_jobs
+    ) -> None:
+        """Each ``time.sleep`` wake-up should fetch a fresh snapshot.
+
+        We inject ``KeyboardInterrupt`` on the third sleep so the loop
+        terminates deterministically after N ticks. ``client.queue``
+        is expected to have been called: 1x for the initial frame
+        + 2x during the loop before the interrupt = 3 total.
+        """
+        sleep_calls = {"n": 0}
+
+        def fake_sleep(_seconds: float) -> None:
+            sleep_calls["n"] += 1
+            if sleep_calls["n"] >= 3:
+                raise KeyboardInterrupt
+
+        with (
+            patch("srunx.slurm.local.Slurm") as mock_slurm,
+            patch("time.sleep", fake_sleep),
+        ):
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(
+                app,
+                ["squeue", "--local", "-i", "0.01"],
+                env={"COLUMNS": "200"},
+            )
+
+        # KeyboardInterrupt during the loop must exit 0 (user-initiated
+        # stop), not bubble as an error.
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        # Initial frame + two live ticks before interrupt = 3 fetches.
+        assert client.queue.call_count == 3

--- a/tests/test_cli_tail.py
+++ b/tests/test_cli_tail.py
@@ -70,7 +70,13 @@ class TestTailFollowSsh:
         ]
         call_args: list[tuple[int, int]] = []
 
-        def fake_tail(job_id: int, out_off: int, err_off: int) -> LogChunk:
+        def fake_tail(
+            job_id: int,
+            out_off: int,
+            err_off: int,
+            *,
+            last_n: int | None = None,
+        ) -> LogChunk:
             call_args.append((out_off, err_off))
             return (
                 chunks.pop(0)
@@ -106,6 +112,83 @@ class TestTailFollowSsh:
         assert call_args[:3] == [(0, 0), (6, 0), (13, 5)]
         assert "first" in result.stdout
         assert "second" in result.stdout
+
+    def test_last_flag_forwarded_as_last_n_on_initial_call(
+        self, runner: CliRunner
+    ) -> None:
+        """``--last N`` must reach the adapter as ``last_n=N`` on the
+        *initial* poll so the remote runs ``tail -n N`` and only the
+        tail ships over SSH. Subsequent ticks must NOT pass ``last_n``
+        (the follow loop is already incrementing offsets).
+        """
+        seen_last_n: list[int | None] = []
+
+        def fake_tail(
+            job_id: int,
+            out_off: int,
+            err_off: int,
+            *,
+            last_n: int | None = None,
+        ) -> LogChunk:
+            seen_last_n.append(last_n)
+            return _chunk("tail\n", "", out_off=5, err_off=0)
+
+        job_ops = MagicMock()
+        job_ops.tail_log_incremental.side_effect = fake_tail
+
+        tick = {"n": 0}
+
+        def fake_sleep(_seconds: float) -> None:
+            tick["n"] += 1
+            if tick["n"] >= 2:
+                raise KeyboardInterrupt
+
+        with (
+            patch(
+                "srunx.transport.registry._build_ssh_handle",
+                return_value=(self._fake_handle(job_ops), None),
+            ),
+            patch("time.sleep", fake_sleep),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "tail",
+                    "12345",
+                    "--follow",
+                    "--interval",
+                    "0.01",
+                    "--profile",
+                    "dgx",
+                    "--last",
+                    "50",
+                ],
+            )
+
+        assert result.exit_code == 0
+        # Initial call gets last_n=50; every subsequent call gets None
+        # so the adapter falls back to pure-offset delta reads.
+        assert seen_last_n[0] == 50
+        assert all(x is None for x in seen_last_n[1:])
+
+    def test_non_follow_one_shot_forwards_last_n(self, runner: CliRunner) -> None:
+        """``srunx tail 123 --last 10 --profile X`` (no --follow) must
+        push ``last_n=10`` into the single SSH call so the remote
+        ships only the tail."""
+        job_ops = MagicMock()
+        job_ops.tail_log_incremental.return_value = _chunk(
+            "only tail lines\n", "", out_off=100, err_off=0
+        )
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(self._fake_handle(job_ops), None),
+        ):
+            result = runner.invoke(
+                app,
+                ["tail", "12345", "--profile", "dgx", "--last", "10"],
+            )
+        assert result.exit_code == 0
+        job_ops.tail_log_incremental.assert_called_once_with(12345, 0, 0, last_n=10)
 
     def test_transient_poll_failure_does_not_kill_loop(self, runner: CliRunner) -> None:
         """An exception from ``tail_log_incremental`` mid-loop must

--- a/tests/test_cli_tail.py
+++ b/tests/test_cli_tail.py
@@ -172,8 +172,8 @@ class TestTailFollowSsh:
         assert all(x is None for x in seen_last_n[1:])
 
     def test_non_follow_one_shot_forwards_last_n(self, runner: CliRunner) -> None:
-        """``srunx tail 123 --last 10 --profile X`` (no --follow) must
-        push ``last_n=10`` into the single SSH call so the remote
+        """``srunx tail 123 --last 50 --profile X`` (no --follow) must
+        push ``last_n=50`` into the single SSH call so the remote
         ships only the tail."""
         job_ops = MagicMock()
         job_ops.tail_log_incremental.return_value = _chunk(
@@ -185,10 +185,46 @@ class TestTailFollowSsh:
         ):
             result = runner.invoke(
                 app,
-                ["tail", "12345", "--profile", "dgx", "--last", "10"],
+                ["tail", "12345", "--profile", "dgx", "--last", "50"],
             )
         assert result.exit_code == 0
+        job_ops.tail_log_incremental.assert_called_once_with(12345, 0, 0, last_n=50)
+
+    def test_default_last_is_ten_not_full_log(self, runner: CliRunner) -> None:
+        """``srunx tail <id> --profile X`` with no ``--last`` and no
+        ``--all`` must default to 10 lines — matches native ``tail``
+        and prevents an accidental multi-GB SSH download.
+        """
+        job_ops = MagicMock()
+        job_ops.tail_log_incremental.return_value = _chunk("", "", out_off=0, err_off=0)
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(self._fake_handle(job_ops), None),
+        ):
+            result = runner.invoke(app, ["tail", "12345", "--profile", "dgx"])
+        assert result.exit_code == 0
         job_ops.tail_log_incremental.assert_called_once_with(12345, 0, 0, last_n=10)
+
+    def test_all_flag_dumps_full_log(self, runner: CliRunner) -> None:
+        """``--all`` overrides ``--last`` and passes ``last_n=None`` to
+        the adapter, which falls through to the legacy ``cat`` path."""
+        job_ops = MagicMock()
+        job_ops.tail_log_incremental.return_value = _chunk(
+            "everything\n", "", out_off=11, err_off=0
+        )
+        with patch(
+            "srunx.transport.registry._build_ssh_handle",
+            return_value=(self._fake_handle(job_ops), None),
+        ):
+            result = runner.invoke(app, ["tail", "12345", "--profile", "dgx", "--all"])
+        assert result.exit_code == 0
+        job_ops.tail_log_incremental.assert_called_once_with(12345, 0, 0, last_n=None)
+
+    def test_zero_last_rejected_unless_all(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["tail", "12345", "--last", "0"])
+        assert result.exit_code != 0
+        combined = result.stdout + (result.stderr or "")
+        assert "positive" in combined.lower() or "--all" in combined
 
     def test_transient_poll_failure_does_not_kill_loop(self, runner: CliRunner) -> None:
         """An exception from ``tail_log_incremental`` mid-loop must

--- a/tests/test_cli_tail.py
+++ b/tests/test_cli_tail.py
@@ -1,0 +1,151 @@
+"""Tests for ``srunx tail`` — both one-shot and ``--follow`` over SSH.
+
+Local ``--follow`` still delegates to the existing ``Slurm.tail_log``
+subprocess path (covered by ``tests/test_logs.py``); this file focuses
+on the SSH polling loop introduced alongside ``squeue -i``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+from srunx.slurm.protocols import LogChunk
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _chunk(stdout: str, stderr: str, *, out_off: int, err_off: int) -> LogChunk:
+    return LogChunk(
+        stdout=stdout,
+        stderr=stderr,
+        stdout_offset=out_off,
+        stderr_offset=err_off,
+    )
+
+
+class TestTailFollowValidation:
+    def test_rejects_non_positive_interval(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["tail", "12345", "--follow", "--interval", "0"])
+        assert result.exit_code != 0
+        combined = result.stdout + (result.stderr or "")
+        assert "positive" in combined.lower()
+
+
+class TestTailFollowSsh:
+    """``--follow`` over SSH must poll ``tail_log_incremental`` with the
+    offset returned by the previous chunk and keep streaming until
+    Ctrl+C — same structural pattern as ``squeue -i``.
+    """
+
+    def _fake_handle(self, job_ops: MagicMock):
+        from srunx.transport.registry import TransportHandle
+
+        return TransportHandle(
+            scheduler_key="ssh:dgx",
+            profile_name="dgx",
+            transport_type="ssh",
+            job_ops=job_ops,
+            queue_client=job_ops,
+            executor_factory=MagicMock(),
+            submission_context=None,
+        )
+
+    def test_poll_loop_advances_offsets_and_prints_new_chunks(
+        self, runner: CliRunner
+    ) -> None:
+        """Each tick's offset must flow into the next ``tail_log_incremental``
+        call so we never re-read already-printed bytes.
+        """
+        chunks = [
+            _chunk("first\n", "", out_off=6, err_off=0),
+            _chunk("second\n", "warn\n", out_off=13, err_off=5),
+            _chunk("", "", out_off=13, err_off=5),
+        ]
+        call_args: list[tuple[int, int]] = []
+
+        def fake_tail(job_id: int, out_off: int, err_off: int) -> LogChunk:
+            call_args.append((out_off, err_off))
+            return (
+                chunks.pop(0)
+                if chunks
+                else _chunk("", "", out_off=out_off, err_off=err_off)
+            )
+
+        job_ops = MagicMock()
+        job_ops.tail_log_incremental.side_effect = fake_tail
+
+        sleep_calls = {"n": 0}
+
+        def fake_sleep(_seconds: float) -> None:
+            sleep_calls["n"] += 1
+            # Let the loop run through all three canned chunks then abort.
+            if sleep_calls["n"] >= 3:
+                raise KeyboardInterrupt
+
+        with (
+            patch(
+                "srunx.transport.registry._build_ssh_handle",
+                return_value=(self._fake_handle(job_ops), None),
+            ),
+            patch("time.sleep", fake_sleep),
+        ):
+            result = runner.invoke(
+                app,
+                ["tail", "12345", "--follow", "--interval", "0.01", "--profile", "dgx"],
+            )
+
+        assert result.exit_code == 0, result.stdout + (result.stderr or "")
+        # First call at offset (0, 0); then (6, 0) from chunk 1; then (13, 5) from chunk 2.
+        assert call_args[:3] == [(0, 0), (6, 0), (13, 5)]
+        assert "first" in result.stdout
+        assert "second" in result.stdout
+
+    def test_transient_poll_failure_does_not_kill_loop(self, runner: CliRunner) -> None:
+        """An exception from ``tail_log_incremental`` mid-loop must
+        surface as a dim notice and the next tick must still run.
+        Matches the error-tolerance contract of ``_run_squeue_live``.
+        """
+        first = _chunk("hello\n", "", out_off=6, err_off=0)
+        recovered = _chunk("world\n", "", out_off=12, err_off=0)
+        side_effects: list = [first, RuntimeError("ssh hiccup"), recovered]
+
+        def fake_tail(*_a, **_kw) -> LogChunk:
+            item = side_effects.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        job_ops = MagicMock()
+        job_ops.tail_log_incremental.side_effect = fake_tail
+
+        tick = {"n": 0}
+
+        def fake_sleep(_seconds: float) -> None:
+            tick["n"] += 1
+            # Stop after we've seen the post-error recovery chunk.
+            if tick["n"] >= 3:
+                raise KeyboardInterrupt
+
+        with (
+            patch(
+                "srunx.transport.registry._build_ssh_handle",
+                return_value=(self._fake_handle(job_ops), None),
+            ),
+            patch("time.sleep", fake_sleep),
+        ):
+            result = runner.invoke(
+                app,
+                ["tail", "12345", "--follow", "--interval", "0.01", "--profile", "dgx"],
+            )
+
+        assert result.exit_code == 0
+        # Both pre-error and post-error chunks reach stdout.
+        assert "hello" in result.stdout
+        assert "world" in result.stdout

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,10 +254,15 @@ class TestSlurm:
 
     @patch("subprocess.run")
     def test_queue_with_jobs(self, mock_run):
-        """Test queue with jobs."""
+        """Test queue with jobs.
+
+        Format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b — new pipe-delimited
+        shape gained when squeue started surfacing user/CPUs/NodeList
+        alongside the original columns.
+        """
         mock_run.return_value.stdout = (
-            "12345 gpu test_job1 user RUNNING 5:00 1:00:00 1 node1\n"
-            "12346 cpu test_job2 user PENDING 0:00 30:00 1 (Priority)\n"
+            "12345|gpu|test_job1|user|RUNNING|5:00|1:00:00|1|8|node1|gpu:4\n"
+            "12346|cpu|test_job2|user|PENDING|0:00|30:00|1|4|(Priority)|(null)\n"
         )
 
         client = Slurm()
@@ -268,9 +273,13 @@ class TestSlurm:
         assert jobs[0].name == "test_job1"
         # Use private _status field instead of status property to avoid refresh
         assert jobs[0]._status == JobStatus.RUNNING
+        assert jobs[0].cpus == 8
+        assert jobs[0].gpus == 4  # gpu:4 per node * 1 node
+        assert jobs[0].nodelist == "node1"
         assert jobs[1].job_id == 12346
         assert jobs[1].name == "test_job2"
         assert jobs[1]._status == JobStatus.PENDING
+        assert jobs[1].nodelist == "(Priority)"
 
     @patch("subprocess.run")
     def test_queue_with_user(self, mock_run):

--- a/tests/test_transport_protocols_phase2.py
+++ b/tests/test_transport_protocols_phase2.py
@@ -132,7 +132,14 @@ class TestSlurmSSHAdapterProtocolCompliance:
                 adapter.status(99999)
 
     def test_ssh_adapter_queue_returns_list_base_job(self) -> None:
-        """``queue`` adapts list_jobs dicts into Pydantic BaseJob instances."""
+        """``queue`` adapts active-squeue dicts into Pydantic BaseJob instances.
+
+        Post-S1: ``queue`` routes through :meth:`_list_active_jobs`
+        (squeue only) rather than :meth:`list_jobs` (squeue + sacct
+        merge), so ``srunx squeue`` matches native SLURM ``squeue``
+        semantics. This test patches the active-only helper to prove
+        the sacct merge never runs on the CLI path.
+        """
         from srunx.domain import BaseJob, JobStatus
         from srunx.slurm.ssh import SlurmSSHAdapter
 
@@ -147,7 +154,14 @@ class TestSlurmSSHAdapterProtocolCompliance:
                 "elapsed_time": "0:10",
             }
         ]
-        with patch.object(SlurmSSHAdapter, "list_jobs", return_value=fake_rows):
+        with (
+            patch.object(
+                SlurmSSHAdapter,
+                "_list_active_jobs",
+                return_value=(fake_rows, {101}),
+            ),
+            patch.object(SlurmSSHAdapter, "list_jobs") as list_jobs_mock,
+        ):
             adapter = SlurmSSHAdapter.__new__(SlurmSSHAdapter)
             adapter._username = "alice"  # queue() reads profile's username on None
             out = adapter.queue(user="alice")
@@ -156,6 +170,8 @@ class TestSlurmSSHAdapterProtocolCompliance:
         assert isinstance(out[0], BaseJob)
         assert out[0].job_id == 101
         assert out[0]._status == JobStatus.RUNNING
+        # Regression guard — queue must NOT pull the sacct merge path.
+        list_jobs_mock.assert_not_called()
 
     def test_ssh_adapter_tail_log_incremental_returns_log_chunk(self) -> None:
         """``tail_log_incremental`` returns a Pydantic LogChunk."""

--- a/tests/web/test_ssh_adapter_parsing.py
+++ b/tests/web/test_ssh_adapter_parsing.py
@@ -108,11 +108,13 @@ class TestUnavailableStates:
 class TestListJobsParsing:
     """Test the list_jobs parsing logic by mocking _run_slurm_cmd."""
 
+    # Pipe-delimited format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b
+    # (job_id|partition|name|user|state|elapsed|time_limit|nodes|cpus|nodelist_or_reason|TRES_PER_NODE)
     SAMPLE_SQUEUE = """\
-             18431     defq     qwen3-tts   ksterx  RUNNING 1-00:03:20  UNLIMITED        1 dgx-node1 gpu:8
-             18477     defq          cosy   ksterx  RUNNING   12:30:45  UNLIMITED        1 dgx-node2 gpu:NVIDIA-A100:8
-             18490     defq    gemma3-cpt   ksterx  RUNNING    5:15:00  UNLIMITED        2 dgx-node[3-4] gpu:4
-             18500     defq       pending   ksterx  PENDING       0:00  UNLIMITED        1 (Priority) (null)
+18431|defq|qwen3-tts|ksterx|RUNNING|1-00:03:20|UNLIMITED|1|16|dgx-node1|gpu:8
+18477|defq|cosy|ksterx|RUNNING|12:30:45|UNLIMITED|1|32|dgx-node2|gpu:NVIDIA-A100:8
+18490|defq|gemma3-cpt|alice|RUNNING|5:15:00|UNLIMITED|2|64|dgx-node[3-4]|gpu:4
+18500|defq|pending|bob|PENDING|0:00|UNLIMITED|1|8|(Priority)|(null)
 """
 
     def test_parse_running_jobs(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -214,6 +216,45 @@ class TestListJobsParsing:
         assert jobs[0]["resources"]["gpus_per_node"] == 8
         assert jobs[0]["nodes"] == 1
         assert jobs[0]["gpus"] == 8  # 8 * 1
+
+    def test_parse_user(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "srunx.slurm.ssh._run_slurm_cmd",
+            lambda _a, _c: self.SAMPLE_SQUEUE,
+        )
+        adapter = object.__new__(SlurmSSHAdapter)
+        jobs = adapter.list_jobs()
+
+        assert jobs[0]["user"] == "ksterx"
+        assert jobs[2]["user"] == "alice"
+        assert jobs[3]["user"] == "bob"
+
+    def test_parse_cpus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """%C field surfaces as the total allocated CPU count."""
+        monkeypatch.setattr(
+            "srunx.slurm.ssh._run_slurm_cmd",
+            lambda _a, _c: self.SAMPLE_SQUEUE,
+        )
+        adapter = object.__new__(SlurmSSHAdapter)
+        jobs = adapter.list_jobs()
+
+        assert jobs[0]["cpus"] == 16
+        assert jobs[2]["cpus"] == 64
+
+    def test_parse_nodelist_running_vs_pending(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """%R is the nodelist for running jobs and the reason for pending ones."""
+        monkeypatch.setattr(
+            "srunx.slurm.ssh._run_slurm_cmd",
+            lambda _a, _c: self.SAMPLE_SQUEUE,
+        )
+        adapter = object.__new__(SlurmSSHAdapter)
+        jobs = adapter.list_jobs()
+
+        assert jobs[0]["nodelist"] == "dgx-node1"
+        assert jobs[2]["nodelist"] == "dgx-node[3-4]"
+        assert jobs[3]["nodelist"] == "(Priority)"
 
     def test_empty_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(

--- a/tests/web/test_ssh_adapter_parsing.py
+++ b/tests/web/test_ssh_adapter_parsing.py
@@ -277,6 +277,29 @@ class TestListJobsParsing:
             assert "status" in job
             assert "depends_on" in job
 
+    def test_row_with_embedded_pipe_in_job_name_is_dropped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SLURM lets users pick job names containing ``|`` (e.g.
+        ``#SBATCH --job-name=foo|bar``). Such a row splits into 12
+        fields; a lenient ``< 11`` check would pass and then every
+        column downstream of the name would silently shift. Guards
+        that we drop those rows instead of rendering misaligned data.
+        """
+        bogus = (
+            "18431|defq|qwen3-tts|ksterx|RUNNING|1-00:03:20|"
+            "UNLIMITED|1|8|dgx-node1|gpu:8\n"
+            "18432|defq|mal|icious|name|alice|RUNNING|"
+            "0:05|1:00:00|1|8|dgx-node2|gpu:8\n"  # 13 fields (bad)
+        )
+        monkeypatch.setattr(
+            "srunx.slurm.ssh._run_slurm_cmd",
+            lambda _a, _c: bogus,
+        )
+        adapter = object.__new__(SlurmSSHAdapter)
+        jobs = adapter.list_jobs()
+        assert [j["job_id"] for j in jobs] == [18431]
+
 
 # ── sacct Output Parsing ──────────────────────────
 


### PR DESCRIPTION
## Summary

Reworks the `srunx` status-query surface (`squeue` / `sinfo` / `history` / `sacct`) so each command answers one clear question, with a shared state-colour map and SLURM-CLI-faithful semantics.

### Transport banner — richer
`●  Connected to researcher@dgx.example.com  (profile: pyxis · via current profile)` — hostname is the headline (answering *where* the user is running), profile name + decision source trail as metadata. Graceful fallback when profile lookup fails.

### `srunx sinfo` / `srunx gpus` — split by concern
- `srunx sinfo` now mirrors native SLURM `sinfo` (PARTITION / AVAIL / TIMELIMIT / NODES / STATE / NODELIST).
- GPU aggregate snapshot extracted to new `srunx gpus` command.

### `srunx sreport` deleted, `srunx sacct` → `srunx history`
- `sreport` was a thin wrapper over srunx.db that `history` already covers per-job.
- Old `srunx sacct` (misleadingly named — reads srunx's own SQLite) renamed to `srunx history`.

### New `srunx sacct` — real SLURM `sacct` wrapper
- New `srunx/slurm/accounting.py` runs native `sacct --parsable2` via local subprocess or SSH adapter.
- Native flags: `-j` / `-u` / `-a` / `-S` / `-E` / `-s` / `-p`, plus `--show-steps`, `--show-account`, `--show-times`.

### `srunx squeue` — symmetric + richer
- Removed the SSH-only `sacct -S now-6hours` merge that made `squeue` asymmetric between transports and polluted the "active queue" view with recently-finished jobs. Web UI / MCP `list_jobs` keeps the merged behaviour.
- `user=None` now means "all users" (matches native `squeue` + local `Slurm.queue`); explicit `-u/--user` added.
- Format switched to `|`-delimited `%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b` so nodelist reasons with whitespace parse cleanly.
- Default columns: Job ID, User, Name, Status, GPUs, Elapsed, NodeList. `--show-partition` / `--show-cpus` / `--show-limit` / `--show-nodes` (or `-a` / `--all`) surface the rest.

### Shared state-colour map
- `src/srunx/cli/_helpers/state_colors.py`: single `SLURM_STATE_COLORS` dict + `colorize_state()` helper, replacing the per-command copies that were only "kept in sync" by comments.
- Colours are grouped semantically (cyan = in-progress, green = success, yellow = waiting, gray = neutral / user-stopped, red / bright_red = failure); no two semantically different states share a hue.

### UI polish
- Table titles removed from all CLI tables (squeue, sacct, history, sinfo, gpus, config show, template list).

## Test plan
- [x] mypy + ruff clean (160 source files, 0 issues)
- [x] New tests pass: 15 for sacct, 10 for squeue, 11 for sinfo partition rows
- [x] All transport / cli / test_cli_* suites green (~260+ tests)
- [x] Full suite: 2010 pass (3 pre-existing `log_dir` failures + 1 flaky concurrent-migration test are unrelated)
- [ ] Verified color output in real terminal (ANSI codes confirmed for RUNNING=cyan, COMPLETED=green, CANCELLED=gray, FAILED=red)
- [ ] Manual smoke on a live SSH profile (delegated to reviewer — requires cluster access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)