### PR TITLE
fix(web): unhide collapsed sidebar labels + fix E2E selectors

### DIFF
--- a/src/srunx/web/frontend/e2e/demo-record.spec.ts
+++ b/src/srunx/web/frontend/e2e/demo-record.spec.ts
@@ -291,8 +291,8 @@ test("record sbatch submission demo", async ({ page }) => {
   await moveCursor(page, VIEWPORT.width - 60, VIEWPORT.height - 60, 0);
   await page.waitForTimeout(500);
 
-  // 1. Click Explorer in sidebar
-  const explorerToggle = 'button:has-text("Explorer")';
+  // 1. Click Explorer in sidebar (NavLink → anchor)
+  const explorerToggle = 'aside a:has-text("Explorer")';
   await focusOn(page, explorerToggle);
   await moveToElement(page, explorerToggle, 800);
   await page.waitForTimeout(250);

--- a/src/srunx/web/frontend/e2e/navigation.spec.ts
+++ b/src/srunx/web/frontend/e2e/navigation.spec.ts
@@ -47,15 +47,15 @@ test.describe("Navigation & Layout", () => {
     /* The sidebar should show "srunx" brand text */
     await expect(page.getByText("srunx")).toBeVisible();
 
-    /* Click collapse button (chevron) */
-    const collapseBtn = page.locator("aside button").last();
-    await collapseBtn.click();
+    /* Click collapse button (aria-label matches both collapse/expand states) */
+    const toggleBtn = page.locator('aside button[aria-label$="sidebar"]');
+    await toggleBtn.click();
 
     /* Brand text should be hidden after collapse */
     await expect(page.getByText("srunx")).toBeHidden();
 
-    /* Click expand button */
-    await collapseBtn.click();
+    /* Click expand button (re-query — the element re-renders on toggle) */
+    await page.locator('aside button[aria-label$="sidebar"]').click();
 
     /* Brand text should reappear */
     await expect(page.getByText("srunx")).toBeVisible();

--- a/src/srunx/web/frontend/src/components/Sidebar.tsx
+++ b/src/srunx/web/frontend/src/components/Sidebar.tsx
@@ -196,23 +196,30 @@ export function Sidebar() {
             display: "block",
           }}
         />
-        <motion.span
-          animate={{ opacity: collapsed ? 0 : 1 }}
-          transition={{ duration: 0.12 }}
-          style={{
-            fontFamily: "var(--font-display)",
-            fontWeight: 700,
-            fontSize: "1.15rem",
-            letterSpacing: "0.06em",
-            color: "var(--text-primary)",
-            whiteSpace: "nowrap",
-            pointerEvents: collapsed ? "none" : "auto",
-            flex: 1,
-            overflow: "hidden",
-          }}
-        >
-          srunx
-        </motion.span>
+        <AnimatePresence initial={false}>
+          {!collapsed && (
+            <motion.span
+              key="brand"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              style={{
+                fontFamily: "var(--font-display)",
+                fontWeight: 700,
+                fontSize: "1.15rem",
+                letterSpacing: "0.06em",
+                color: "var(--text-primary)",
+                whiteSpace: "nowrap",
+                flex: 1,
+                overflow: "hidden",
+                minWidth: 0,
+              }}
+            >
+              srunx
+            </motion.span>
+          )}
+        </AnimatePresence>
         {/* Toggle button — visible in expanded state, top-right corner */}
         {!collapsed && (
           <button
@@ -380,20 +387,27 @@ export function Sidebar() {
                   : "var(--text-muted)",
               }}
             />
-            <motion.span
-              animate={{ opacity: collapsed ? 0 : 1 }}
-              transition={{ duration: 0.12 }}
-              style={{
-                flex: 1,
-                textAlign: "left",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                pointerEvents: collapsed ? "none" : "auto",
-              }}
-            >
-              {connectedProfile ?? "No connection"}
-            </motion.span>
+            <AnimatePresence initial={false}>
+              {!collapsed && (
+                <motion.span
+                  key="profile-label"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.12 }}
+                  style={{
+                    flex: 1,
+                    textAlign: "left",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    minWidth: 0,
+                  }}
+                >
+                  {connectedProfile ?? "No connection"}
+                </motion.span>
+              )}
+            </AnimatePresence>
             {!collapsed && (
               <ChevronUpIcon
                 size={12}
@@ -489,17 +503,24 @@ function SidebarNavLink({
             />
           )}
           <span style={{ flexShrink: 0, display: "flex" }}>{icon}</span>
-          <motion.span
-            animate={{ opacity: collapsed ? 0 : 1 }}
-            transition={{ duration: 0.12 }}
-            style={{
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              pointerEvents: collapsed ? "none" : "auto",
-            }}
-          >
-            {label}
-          </motion.span>
+          <AnimatePresence initial={false}>
+            {!collapsed && (
+              <motion.span
+                key="label"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.12 }}
+                style={{
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  minWidth: 0,
+                }}
+              >
+                {label}
+              </motion.span>
+            )}
+          </AnimatePresence>
         </>
       )}
     </NavLink>


### PR DESCRIPTION
## Summary

#190 broke two E2E tests that were already on `main`. This PR fixes them.

- **Sidebar labels stayed detectable when collapsed.** The previous rewrite faded labels with `opacity: 0`, which Playwright's `toBeHidden()` still treats as visible. Switch to `AnimatePresence` so the brand text, nav labels, and profile label unmount from the DOM on collapse. Visual behavior is unchanged.
- **`navigation.spec.ts` selector drift.** `aside button:last()` used to be the collapse toggle; in the new sidebar it's the profile switcher, so the test clicked the wrong button. Switched to `aria-label$="sidebar"`, which matches both "Collapse sidebar" and "Expand sidebar" states.
- **`demo-record.spec.ts` selector drift.** Explorer is now a `NavLink` (`<a>`) rather than a `<button>`; updated the selector accordingly.

## Test plan

- [x] `navigation.spec.ts` — all 3 tests pass locally (`npx playwright test navigation.spec.ts`)
- [x] `demo-record.spec.ts` — passes locally (`npx playwright test demo-record.spec.ts`)
- [x] `tsc -b` clean; `vite build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)