### PR TITLE
feat(ssh): add --pull (remote→local) direction to `ssh sync`

### DIFF
--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -177,6 +177,13 @@ def sync_mount(
     dry_run: Annotated[
         bool, typer.Option("--dry-run", "-n", help="Preview without syncing")
     ] = False,
+    pull: Annotated[
+        bool,
+        typer.Option(
+            "--pull",
+            help="Reverse direction: sync remote → local (default is local → remote)",
+        ),
+    ] = False,
     config: Annotated[
         str | None,
         typer.Option(
@@ -184,15 +191,21 @@ def sync_mount(
         ),
     ] = None,
 ):
-    """Sync a mount's local directory to the remote via rsync.
+    """Sync a mount between local and remote via rsync.
+
+    By default syncs local → remote (push). Pass ``--pull`` to reverse the
+    direction and sync remote → local — useful for pulling back results or
+    checkpoints a job wrote on the cluster.
 
     With no arguments, auto-detects the profile and mount from the current
     working directory. Works even when inside a subdirectory of the mount.
 
     Examples:
-      srunx ssh sync                          # auto-detect from cwd
-      srunx ssh sync pyxis ml-project         # explicit profile and mount
+      srunx ssh sync                          # push, auto-detect from cwd
+      srunx ssh sync pyxis ml-project         # push, explicit profile and mount
       srunx ssh sync pyxis ml-project --dry-run
+      srunx ssh sync --pull                   # pull remote → local
+      srunx ssh sync pyxis ml-project --pull --dry-run
     """
     from srunx.ssh.core.config import MountConfig
     from srunx.sync.rsync import RsyncClient
@@ -259,9 +272,11 @@ def sync_mount(
 
         # Sync
         action = "Previewing" if dry_run else "Syncing"
+        direction = "remote → local (pull)" if pull else "local → remote (push)"
         console.print(f"[bold]{action}[/bold] mount [cyan]{mount.name}[/cyan]")
         console.print(f"  Local:  {mount.local}")
         console.print(f"  Remote: {mount.remote}")
+        console.print(f"  Direction: {direction}")
         console.print(f"  Profile: {profile_name}")
         if dry_run:
             console.print("  [yellow]Dry run — no files will be transferred[/yellow]")
@@ -295,7 +310,20 @@ def sync_mount(
                 exclude_patterns=all_excludes or None,
             )
 
-        result = rsync.push(mount.local, mount.remote, dry_run=dry_run)
+        # itemize=dry_run so the preview lists every file rsync *would*
+        # touch; a real sync stays quiet (itemize defaults off).
+        if pull:
+            # Trailing slash on the remote source so rsync copies the
+            # mount's *contents* into the local dir (mirroring push),
+            # not the directory itself one level deeper.
+            remote_src = mount.remote.rstrip("/") + "/"
+            result = rsync.pull(
+                remote_src, mount.local, dry_run=dry_run, itemize=dry_run
+            )
+        else:
+            result = rsync.push(
+                mount.local, mount.remote, dry_run=dry_run, itemize=dry_run
+            )
 
         if result.returncode == 0:
             if dry_run:

--- a/tests/ssh/cli/test_commands.py
+++ b/tests/ssh/cli/test_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,15 @@ from typer.testing import CliRunner
 
 from srunx.ssh.cli.commands import ssh_app
 from srunx.ssh.core.config import ConfigManager, MountConfig, ServerProfile
+
+# Rich/Typer styles help text with SGR escapes, which can split ``--pull``
+# into ``-`` + escape + ``-pull`` depending on terminal width/colour. Strip
+# them before asserting so the test doesn't depend on the rendering env.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 @pytest.fixture
@@ -134,4 +144,4 @@ class TestSyncHelp:
     def test_help_lists_pull_flag(self, runner: CliRunner):
         result = runner.invoke(ssh_app, ["sync", "--help"])
         assert result.exit_code == 0
-        assert "--pull" in result.output
+        assert "--pull" in _strip_ansi(result.output)

--- a/tests/ssh/cli/test_commands.py
+++ b/tests/ssh/cli/test_commands.py
@@ -1,0 +1,137 @@
+"""Tests for the Typer-based SSH CLI commands (``srunx ssh ...``)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.ssh.cli.commands import ssh_app
+from srunx.ssh.core.config import ConfigManager, MountConfig, ServerProfile
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def config_with_mount(tmp_path: Path) -> tuple[str, str, str]:
+    """Write a config with one profile + one mount.
+
+    Returns ``(config_path, resolved_local, remote)`` so tests can assert
+    the exact paths the command hands to rsync.
+    """
+    cfg_path = tmp_path / "config.json"
+    local_dir = tmp_path / "project"
+    local_dir.mkdir()
+    remote = "/remote/project"
+
+    cm = ConfigManager(str(cfg_path))
+    profile = ServerProfile(
+        hostname="dgx.example.com",
+        username="researcher",
+        key_filename="~/.ssh/id_rsa",
+        mounts=[MountConfig(name="mnt", local=str(local_dir), remote=remote)],
+    )
+    cm.add_profile("prof", profile)
+
+    # local is resolved by MountConfig's validator; read it back so
+    # assertions compare against the exact value the command will use.
+    stored = cm.get_profile("prof")
+    assert stored is not None
+    resolved_local = stored.mounts[0].local
+    return str(cfg_path), resolved_local, remote
+
+
+@pytest.fixture
+def mock_rsync():
+    """Patch RsyncClient so no real rsync/ssh runs; expose the instance."""
+    with patch("srunx.sync.rsync.RsyncClient") as mock_cls:
+        instance = mock_cls.return_value
+        instance.push.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        instance.pull.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        yield instance
+
+
+class TestSyncDirection:
+    def test_default_is_push_local_to_remote(
+        self,
+        runner: CliRunner,
+        config_with_mount: tuple[str, str, str],
+        mock_rsync: MagicMock,
+    ):
+        cfg, local, remote = config_with_mount
+        result = runner.invoke(ssh_app, ["sync", "prof", "mnt", "--config", cfg])
+
+        assert result.exit_code == 0, result.output
+        mock_rsync.push.assert_called_once()
+        mock_rsync.pull.assert_not_called()
+        args, kwargs = mock_rsync.push.call_args
+        assert args == (local, remote)
+        assert kwargs["dry_run"] is False
+        assert kwargs["itemize"] is False
+
+    def test_pull_reverses_to_remote_to_local(
+        self,
+        runner: CliRunner,
+        config_with_mount: tuple[str, str, str],
+        mock_rsync: MagicMock,
+    ):
+        cfg, local, remote = config_with_mount
+        result = runner.invoke(
+            ssh_app, ["sync", "prof", "mnt", "--config", cfg, "--pull"]
+        )
+
+        assert result.exit_code == 0, result.output
+        mock_rsync.pull.assert_called_once()
+        mock_rsync.push.assert_not_called()
+        # pull(remote_path, local_path): source is remote, dest is local.
+        # Remote source carries a trailing slash so rsync copies the
+        # mount's contents into local rather than nesting it a level deeper.
+        args, kwargs = mock_rsync.pull.call_args
+        assert args == (remote.rstrip("/") + "/", local)
+        assert "remote → local (pull)" in result.output
+
+
+class TestSyncDryRun:
+    def test_push_dry_run_enables_itemize(
+        self,
+        runner: CliRunner,
+        config_with_mount: tuple[str, str, str],
+        mock_rsync: MagicMock,
+    ):
+        cfg, _, _ = config_with_mount
+        result = runner.invoke(
+            ssh_app, ["sync", "prof", "mnt", "--config", cfg, "--dry-run"]
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_rsync.push.call_args.kwargs
+        assert kwargs["dry_run"] is True
+        assert kwargs["itemize"] is True
+
+    def test_pull_dry_run_enables_itemize(
+        self,
+        runner: CliRunner,
+        config_with_mount: tuple[str, str, str],
+        mock_rsync: MagicMock,
+    ):
+        cfg, _, _ = config_with_mount
+        result = runner.invoke(
+            ssh_app, ["sync", "prof", "mnt", "--config", cfg, "--pull", "-n"]
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_rsync.pull.call_args.kwargs
+        assert kwargs["dry_run"] is True
+        assert kwargs["itemize"] is True
+
+
+class TestSyncHelp:
+    def test_help_lists_pull_flag(self, runner: CliRunner):
+        result = runner.invoke(ssh_app, ["sync", "--help"])
+        assert result.exit_code == 0
+        assert "--pull" in result.output


### PR DESCRIPTION
## 概要

`srunx ssh sync` はこれまで local→remote（push）方向のみでした。逆方向（remote→local）を **オプショナル** にする `--pull` フラグを追加します。本体の `RsyncClient.pull()` は既に実装・テスト済みだったため、変更は CLI 層に閉じています。

```bash
srunx ssh sync                          # push (従来通り, local→remote)
srunx ssh sync --pull                   # pull (remote→local)
srunx ssh sync pyxis ml-project --pull --dry-run   # pull のプレビュー
```

## 変更点

- **`--pull` フラグ追加**（`src/srunx/ssh/cli/commands.py`）。デフォルトは従来の push のままで、既存挙動は不変。
- pull 時は remote 側ソースに**末尾スラッシュ**を付与し、push と対称に「中身」を local へ展開（付けないと rsync 仕様で1階層ネストするため）。
- 同期前の表示に方向を示す `Direction:` 行を追加。
- **dry-run の改善**: 両方向で `itemize=dry_run` を渡し、`--dry-run` 時に変更ファイル一覧が出るように。これまで push の dry-run は何も出ず常に "No changes needed" 表示だった軽微な難点も解消。

## 安全性（意図的な非対称）

- push: 既定で remote の余分なファイルを削除（`--delete`、従来通り）
- pull: ローカルファイルは**削除しない**（`delete=False`）。ローカルの作業物を不意に消さない安全側の既定。

## テスト

- 新規 `tests/ssh/cli/test_commands.py`: push がデフォルト / `--pull` で pull に切替 / dry-run で `itemize` が立つ / pull ソースの末尾スラッシュ / `--help` に `--pull` が出る、をカバー。
- `tests/ssh` + `tests/sync`: 234 passed。
- 全体（`tests/mcp` は当環境で `mcp` 拡張未インストールのため除外）: 1961 passed, 2 skipped。
- `mypy .` / `ruff check .` / `ruff format --check .`: クリーン。
- Codex レビュー（gpt-5.5, high effort）: 指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FUB4sGwj4QtGge87YuDXJ