### PR TITLE
fix(ssh): resolve ssh_host alias in banner + squeue fallback for tail logs

### DIFF
--- a/src/srunx/ssh/core/log_reader.py
+++ b/src/srunx/ssh/core/log_reader.py
@@ -90,10 +90,17 @@ class RemoteLogReader:
             # genuinely no output) and return straight away. Falling
             # through to pattern search here would log a misleading
             # "No log files found" warning even though the path is known.
-            if stdout_path:
-                output_content, new_stdout_offset = self._read_file_from_offset(
-                    stdout_path, stdout_offset, last_n=last_n
-                )
+            #
+            # Treat *either* stream path as authoritative: a job that
+            # only configures ``StdErr`` (or has ``StdOut=/dev/null``
+            # and only writes useful content to ``StdErr``) still has a
+            # known log location SLURM gave us — falling through to
+            # pattern search would drop it on the floor.
+            if stdout_path or stderr_path:
+                if stdout_path:
+                    output_content, new_stdout_offset = self._read_file_from_offset(
+                        stdout_path, stdout_offset, last_n=last_n
+                    )
                 if stderr_path and stderr_path != stdout_path:
                     error_content, new_stderr_offset = self._read_file_from_offset(
                         stderr_path, stderr_offset, last_n=last_n

--- a/src/srunx/ssh/core/log_reader.py
+++ b/src/srunx/ssh/core/log_reader.py
@@ -74,20 +74,32 @@ class RemoteLogReader:
             new_stdout_offset = stdout_offset
             new_stderr_offset = stderr_offset
 
-            # 1. Try scontrol to get actual log paths
+            # 1. Try scontrol to get actual log paths.
             stdout_path, stderr_path = self._get_log_paths_from_scontrol(safe_job_id)
 
+            # 2. squeue --Format fallback when scontrol is unavailable
+            # (some clusters allow squeue but restrict scontrol).
+            # ``StdOut`` / ``StdErr`` fields exist in modern SLURM
+            # squeue and surface the same paths scontrol would.
+            if not stdout_path:
+                stdout_path, stderr_path = self._get_log_paths_from_squeue(
+                    safe_job_id
+                )
+
+            # SLURM itself told us where the log lives → that path is
+            # the source of truth. Read whatever is there (possibly
+            # empty: job just started, buffer not yet flushed, or
+            # genuinely no output) and return straight away. Falling
+            # through to pattern search here would log a misleading
+            # "No log files found" warning even though the path is known.
             if stdout_path:
                 output_content, new_stdout_offset = self._read_file_from_offset(
                     stdout_path, stdout_offset, last_n=last_n
                 )
-
-            if stderr_path and stderr_path != stdout_path:
-                error_content, new_stderr_offset = self._read_file_from_offset(
-                    stderr_path, stderr_offset, last_n=last_n
-                )
-
-            if output_content or error_content:
+                if stderr_path and stderr_path != stdout_path:
+                    error_content, new_stderr_offset = self._read_file_from_offset(
+                        stderr_path, stderr_offset, last_n=last_n
+                    )
                 return (
                     output_content,
                     error_content,
@@ -95,7 +107,11 @@ class RemoteLogReader:
                     new_stderr_offset,
                 )
 
-            # 2. Fallback: pattern-based file search (full read)
+            # 3. Last resort: pattern-based file search (full read).
+            # Only reached when neither scontrol nor squeue could be
+            # used to discover the path — typically a completed job
+            # whose record slurmctld has already evicted, or a cluster
+            # that restricts both query commands.
             out, err = self._get_job_output_by_pattern(safe_job_id, safe_job_name)
             return out, err, len(out.encode()), len(err.encode())
 
@@ -349,6 +365,41 @@ class RemoteLogReader:
                 elif token.startswith("StdErr="):
                     stderr_path = token.split("=", 1)[1]
         return stdout_path, stderr_path
+
+    def _get_log_paths_from_squeue(
+        self, job_id: str
+    ) -> tuple[str | None, str | None]:
+        """Query ``squeue -O StdOut,StdErr`` for log paths.
+
+        Fallback for clusters that restrict ``scontrol`` but still allow
+        ``squeue``. Uses the long-format ``-O`` specifier with an
+        explicit field width so even multi-hundred-character paths
+        survive without truncation. Each field is fetched in its own
+        squeue call so a path containing whitespace cannot blur the
+        StdOut/StdErr boundary.
+
+        SLURM emits ``(null)`` (and occasionally ``N/A``) for unset
+        fields; both are normalised to ``None`` so they cannot leak
+        downstream as if they were real filesystem paths.
+        """
+        quoted_id = shlex.quote(job_id)
+
+        def _fetch(field: str) -> str | None:
+            # 2048 is generous: standard SLURM paths sit well under
+            # 256 chars, but log paths embedded inside Lustre / GPFS
+            # mount points can grow. Padding cost is per-query only.
+            stdout, _, rc = self._slurm.execute_slurm_command(
+                f"squeue -h -j {quoted_id} -O {shlex.quote(field + ':2048')} "
+                "2>/dev/null"
+            )
+            if rc != 0:
+                return None
+            value = stdout.strip()
+            if not value or value in {"N/A", "(null)"}:
+                return None
+            return value
+
+        return _fetch("StdOut"), _fetch("StdErr")
 
     def _get_job_output_by_pattern(
         self, safe_job_id: str, safe_job_name: str | None

--- a/src/srunx/ssh/core/log_reader.py
+++ b/src/srunx/ssh/core/log_reader.py
@@ -82,9 +82,7 @@ class RemoteLogReader:
             # ``StdOut`` / ``StdErr`` fields exist in modern SLURM
             # squeue and surface the same paths scontrol would.
             if not stdout_path:
-                stdout_path, stderr_path = self._get_log_paths_from_squeue(
-                    safe_job_id
-                )
+                stdout_path, stderr_path = self._get_log_paths_from_squeue(safe_job_id)
 
             # SLURM itself told us where the log lives → that path is
             # the source of truth. Read whatever is there (possibly
@@ -366,9 +364,7 @@ class RemoteLogReader:
                     stderr_path = token.split("=", 1)[1]
         return stdout_path, stderr_path
 
-    def _get_log_paths_from_squeue(
-        self, job_id: str
-    ) -> tuple[str | None, str | None]:
+    def _get_log_paths_from_squeue(self, job_id: str) -> tuple[str | None, str | None]:
         """Query ``squeue -O StdOut,StdErr`` for log paths.
 
         Fallback for clusters that restrict ``scontrol`` but still allow

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -247,6 +247,14 @@ def _format_ssh_banner_body(*, profile_name: str, source_display: str) -> str:
     user to remember what ``<profile_name>`` maps to. Profile name and
     decision source are kept as parenthetical metadata.
 
+    When the profile is an ``ssh_host`` alias (``username``/``hostname``
+    blank because the real connection info lives in ``~/.ssh/config``),
+    fall through the same resolution path the SSH connection layer
+    uses: parse ``~/.ssh/config`` via :func:`get_ssh_config_host` and
+    render the resolved ``user@host[:port]``. Without this fallback the
+    banner emits ``@`` for alias-only profiles even though the
+    underlying connection succeeds.
+
     Falls back to ``SSH profile: <name>`` when the profile lookup
     fails (config file missing, profile removed, import error) — the
     banner must never raise, even from a degraded state.
@@ -257,9 +265,42 @@ def _format_ssh_banner_body(*, profile_name: str, source_display: str) -> str:
             f"[bold]SSH profile: {profile_name}[/bold]  "
             f"[dim italic]({source_display})[/dim italic]"
         )
-    target = f"{profile.username}@{profile.hostname}"
-    if profile.port != 22:
-        target += f":{profile.port}"
+
+    username = profile.username
+    hostname = profile.hostname
+    port = profile.port
+    if (not username or not hostname) and profile.ssh_host:
+        try:
+            from srunx.ssh.core.ssh_config import get_ssh_config_host
+
+            resolved = get_ssh_config_host(profile.ssh_host)
+        except Exception as exc:  # noqa: BLE001 — banner must never raise
+            logger.debug(
+                "ssh_config lookup for alias %r failed: %s", profile.ssh_host, exc
+            )
+            resolved = None
+        if resolved is not None:
+            username = username or resolved.user
+            hostname = hostname or resolved.hostname
+            # ServerProfile.port defaults to 22; only override when the
+            # profile hasn't been explicitly customised and the ssh_config
+            # Host block specifies a non-default port.
+            if profile.port == 22 and resolved.port != 22:
+                port = resolved.port
+
+    if username and hostname:
+        target = f"{username}@{hostname}"
+        if port != 22:
+            target += f":{port}"
+    elif profile.ssh_host:
+        # ssh_config に該当 Host が無くても alias 名は手掛かりになる
+        target = profile.ssh_host
+    else:
+        return (
+            f"[bold]SSH profile: {profile_name}[/bold]  "
+            f"[dim italic]({source_display})[/dim italic]"
+        )
+
     if profile.proxy_jump:
         target += f" via {profile.proxy_jump}"
     return (

--- a/tests/ssh/cli/test_commands.py
+++ b/tests/ssh/cli/test_commands.py
@@ -77,18 +77,25 @@ class TestSshTestFlags:
     def test_no_transient_connection_flags(self):
         result = runner.invoke(ssh_app, ["test", "--help"])
         assert result.exit_code == 0
-        assert "--hostname" not in result.output
-        assert "--username" not in result.output
-        assert "--key-file" not in result.output
+        # Strip ANSI before substring checks: under CI's render width Rich
+        # emits e.g. ``\x1b[1;2m-\x1b[0m\x1b[1;2m-profile\x1b[0m`` which
+        # splits ``--profile`` across reset+style sequences and breaks a
+        # naive ``"--profile" in output`` check even though the flag is in
+        # fact rendered.
+        output = _strip_ansi(result.output)
+        assert "--hostname" not in output
+        assert "--username" not in output
+        assert "--key-file" not in output
         # --profile present, --host alias kept.
-        assert "--profile" in result.output
-        assert "--host" in result.output
+        assert "--profile" in output
+        assert "--host" in output
 
     def test_profile_has_no_short_p_flag(self):
         # `-p` is reserved for --partition across srunx; ssh test must not bind it.
         result = runner.invoke(ssh_app, ["test", "--help"])
-        assert " -p " not in result.output
-        assert "-p," not in result.output
+        output = _strip_ansi(result.output)
+        assert " -p " not in output
+        assert "-p," not in output
 
 
 class TestRoundTrip:

--- a/tests/ssh/core/test_log_reader.py
+++ b/tests/ssh/core/test_log_reader.py
@@ -159,3 +159,170 @@ class TestGetLogPathsFromScontrol:
 
         assert stdout_path is None
         assert stderr_path is None
+
+
+class TestScontrolFoundButFileEmpty:
+    """scontrol gave us a real StdOut path — trust it even if the file is empty.
+
+    Regression guard: the previous flow fell through to pattern-based
+    file search whenever the scontrol-reported StdOut/StdErr files
+    happened to be empty (very common in the first seconds of a job),
+    which logged a misleading ``No log files found ... using common
+    patterns`` warning even though SLURM itself reported the exact log
+    path.
+    """
+
+    def test_empty_stdout_no_pattern_fallback_no_warning(self, client, caplog):
+        scontrol_output = "StdOut=/logs/job.log StdErr=/logs/job.err\n"
+        calls: list[str] = []
+
+        def _exec(cmd: str):
+            calls.append(cmd)
+            if "scontrol" in cmd:
+                return (scontrol_output, "", 0)
+            # tail / cat on the StdOut/StdErr path → empty file
+            if "job.log" in cmd or "job.err" in cmd:
+                if "wc -c" in cmd:
+                    return ("0\n", "", 0)
+                return ("", "", 0)
+            return ("", "", 1)
+
+        client.connection.execute_command = Mock(side_effect=_exec)
+
+        with caplog.at_level("WARNING"):
+            stdout, stderr, out_off, err_off = client.logs.get_job_output("12345")
+
+        assert stdout == ""
+        assert stderr == ""
+        assert out_off == 0
+        assert err_off == 0
+        # No fallback pattern search: zero ``find`` shellouts.
+        assert not any("find " in c for c in calls)
+        # And no misleading "No log files found" warning.
+        assert not any("No log files found" in rec.message for rec in caplog.records)
+
+    def test_only_stdout_path_stderr_remains_empty(self, client):
+        """scontrol returned StdOut only (no StdErr line) → stderr=""."""
+        scontrol_output = "StdOut=/logs/out.log\n"
+
+        def _exec(cmd: str):
+            if "scontrol" in cmd:
+                return (scontrol_output, "", 0)
+            if "out.log" in cmd:
+                if "wc -c" in cmd:
+                    return ("12\n", "", 0)
+                return ("hello world\n", "", 0)
+            return ("", "", 1)
+
+        client.connection.execute_command = Mock(side_effect=_exec)
+
+        stdout, stderr, out_off, err_off = client.logs.get_job_output("12345")
+
+        assert "hello world" in stdout
+        assert stderr == ""
+        assert out_off == 12
+        # stderr_offset stays at the input (0) when no path is known.
+        assert err_off == 0
+
+
+class TestSqueueFallback:
+    """scontrol unavailable on the cluster → fall back to ``squeue -O``.
+
+    Some sites (e.g. multi-tenant managed SLURM) lock down scontrol but
+    leave squeue open. The fallback chain must surface log paths via
+    squeue before resorting to pattern-based file search and emitting
+    the misleading "No log files found" warning.
+    """
+
+    def test_scontrol_fails_squeue_returns_path(self, client, caplog):
+        """scontrol fails → squeue path used → no pattern fallback, no warning."""
+        calls: list[str] = []
+
+        def _exec(cmd: str):
+            calls.append(cmd)
+            if "scontrol" in cmd:
+                return ("", "permission denied", 1)
+            if "squeue" in cmd and "StdOut" in cmd:
+                # squeue -O pads to the requested width; mimic real output.
+                return ("/data/logs/run.out" + " " * 2030 + "\n", "", 0)
+            if "squeue" in cmd and "StdErr" in cmd:
+                return ("/data/logs/run.err" + " " * 2030 + "\n", "", 0)
+            if "/data/logs/run.out" in cmd:
+                if "wc -c" in cmd:
+                    return ("20\n", "", 0)
+                return ("epoch 1 done\n", "", 0)
+            if "/data/logs/run.err" in cmd:
+                if "wc -c" in cmd:
+                    return ("5\n", "", 0)
+                return ("WARN\n", "", 0)
+            return ("", "", 1)
+
+        client.connection.execute_command = Mock(side_effect=_exec)
+
+        with caplog.at_level("WARNING"):
+            stdout, stderr, out_off, err_off = client.logs.get_job_output("99")
+
+        assert "epoch 1 done" in stdout
+        assert "WARN" in stderr
+        assert out_off == 20
+        assert err_off == 5
+        # No fallback pattern search means no `find` shellouts.
+        assert not any("find " in c for c in calls)
+        assert not any("No log files found" in rec.message for rec in caplog.records)
+
+    def test_squeue_null_values_trigger_pattern_fallback(self, client):
+        """squeue prints ``(null)`` for unset fields → treat as not-found."""
+
+        def _exec(cmd: str):
+            if "scontrol" in cmd:
+                return ("", "denied", 1)
+            if "squeue" in cmd and "StdOut" in cmd:
+                return ("(null)" + " " * 2042 + "\n", "", 0)
+            if "squeue" in cmd and "StdErr" in cmd:
+                return ("N/A" + " " * 2045 + "\n", "", 0)
+            if "find" in cmd and "slurm-99.out" in cmd:
+                return ("/tmp/slurm-99.out\n", "", 0)
+            if "cat" in cmd and "/tmp/slurm-99.out" in cmd:
+                return ("pattern hit\n", "", 0)
+            return ("", "", 1)
+
+        client.connection.execute_command = Mock(side_effect=_exec)
+
+        stdout, _, _, _ = client.logs.get_job_output("99")
+
+        assert "pattern hit" in stdout
+
+    def test_squeue_path_stripped_of_padding(self, client):
+        """The padded squeue output must be trimmed before use."""
+        captured: list[str] = []
+
+        def _exec(cmd: str):
+            captured.append(cmd)
+            if "scontrol" in cmd:
+                return ("", "denied", 1)
+            if "squeue" in cmd and "StdOut" in cmd:
+                # Real-world width padding: trailing spaces only.
+                return ("/x/y/z.log" + " " * 2038 + "\n", "", 0)
+            if "squeue" in cmd and "StdErr" in cmd:
+                return ("(null)" + " " * 2042 + "\n", "", 0)
+            if cmd.startswith("tail -n ") and "/x/y/z.log" in cmd:
+                return ("ok\n", "", 0)
+            if "wc -c" in cmd and "/x/y/z.log" in cmd:
+                return ("3\n", "", 0)
+            return ("", "", 1)
+
+        client.connection.execute_command = Mock(side_effect=_exec)
+        stdout, _, out_off, _ = client.logs.get_job_output("42", last_n=10)
+        assert stdout == "ok\n"
+        assert out_off == 3
+        # The path used in the tail command must be the stripped form,
+        # never the padded one (would shell out to a non-existent file).
+        tail_calls = [c for c in captured if c.startswith("tail -n ")]
+        assert tail_calls, "expected a tail -n call"
+        # shlex.quote keeps safe paths unquoted, so a stripped path
+        # appears verbatim followed by ` 2>/dev/null`.
+        assert any("tail -n 10 /x/y/z.log 2>/dev/null" == c for c in tail_calls)
+        # And no tail call carries the padding bytes (would look like
+        # ``tail -n 10 /x/y/z.log<lots of spaces>`` if strip was missed).
+        for c in tail_calls:
+            assert "/x/y/z.log  " not in c

--- a/tests/ssh/core/test_log_reader.py
+++ b/tests/ssh/core/test_log_reader.py
@@ -270,8 +270,45 @@ class TestSqueueFallback:
         assert not any("find " in c for c in calls)
         assert not any("No log files found" in rec.message for rec in caplog.records)
 
+    def test_stderr_only_path_is_read_without_pattern_fallback(self, client, caplog):
+        """``StdOut=(null)`` but ``StdErr=<path>`` → read stderr, no warning.
+
+        Regression guard: earlier the read block was gated on
+        ``stdout_path`` alone, so a configured stderr path with no
+        stdout (job sends useful output only to stderr, or
+        ``StdOut=/dev/null``) was silently dropped on the floor and
+        ``srunx tail`` fell through to pattern search.
+        """
+        calls: list[str] = []
+
+        def _exec(cmd: str):
+            calls.append(cmd)
+            if "scontrol" in cmd:
+                return ("", "denied", 1)
+            if "squeue" in cmd and "StdOut" in cmd:
+                return ("(null)" + " " * 2042 + "\n", "", 0)
+            if "squeue" in cmd and "StdErr" in cmd:
+                return ("/data/logs/run.err" + " " * 2030 + "\n", "", 0)
+            if "/data/logs/run.err" in cmd:
+                if "wc -c" in cmd:
+                    return ("9\n", "", 0)
+                return ("stderr ok\n", "", 0)
+            return ("", "", 1)
+
+        client.connection.execute_command = Mock(side_effect=_exec)
+
+        with caplog.at_level("WARNING"):
+            stdout, stderr, out_off, err_off = client.logs.get_job_output("77")
+
+        assert stdout == ""
+        assert "stderr ok" in stderr
+        assert err_off == 9
+        # SLURM-reported path wins → no pattern fallback, no warning.
+        assert not any("find " in c for c in calls)
+        assert not any("No log files found" in rec.message for rec in caplog.records)
+
     def test_squeue_null_values_trigger_pattern_fallback(self, client):
-        """squeue prints ``(null)`` for unset fields → treat as not-found."""
+        """Both ``StdOut`` and ``StdErr`` unset → fall through to pattern search."""
 
         def _exec(cmd: str):
             if "scontrol" in cmd:

--- a/tests/transport/test_registry.py
+++ b/tests/transport/test_registry.py
@@ -364,9 +364,7 @@ class TestSSHBannerBody:
 
     def test_ssh_host_alias_only_resolves_via_ssh_config(self, monkeypatch):
         profile = self._stub_profile(ssh_host="gmo")
-        monkeypatch.setattr(
-            _registry, "_lookup_profile_silently", lambda name: profile
-        )
+        monkeypatch.setattr(_registry, "_lookup_profile_silently", lambda name: profile)
         resolved = MagicMock(
             user="user_00028_557dc2",
             hostname="connect.gpucloud.gmo",
@@ -391,9 +389,7 @@ class TestSSHBannerBody:
             hostname="dgx.example.com",
             ssh_host="dgx",  # ssh_host set, but real fields take precedence
         )
-        monkeypatch.setattr(
-            _registry, "_lookup_profile_silently", lambda name: profile
-        )
+        monkeypatch.setattr(_registry, "_lookup_profile_silently", lambda name: profile)
         with patch(
             "srunx.ssh.core.ssh_config.get_ssh_config_host",
         ) as lookup:
@@ -409,9 +405,7 @@ class TestSSHBannerBody:
     ):
         """No matching ``Host`` in ``~/.ssh/config`` → show alias name."""
         profile = self._stub_profile(ssh_host="orphan")
-        monkeypatch.setattr(
-            _registry, "_lookup_profile_silently", lambda name: profile
-        )
+        monkeypatch.setattr(_registry, "_lookup_profile_silently", lambda name: profile)
         with patch(
             "srunx.ssh.core.ssh_config.get_ssh_config_host",
             return_value=None,
@@ -428,9 +422,7 @@ class TestSSHBannerBody:
     def test_ssh_config_lookup_exception_does_not_raise(self, monkeypatch):
         """The banner must never crash from a degraded ssh_config state."""
         profile = self._stub_profile(ssh_host="gmo")
-        monkeypatch.setattr(
-            _registry, "_lookup_profile_silently", lambda name: profile
-        )
+        monkeypatch.setattr(_registry, "_lookup_profile_silently", lambda name: profile)
         with patch(
             "srunx.ssh.core.ssh_config.get_ssh_config_host",
             side_effect=RuntimeError("ssh_config exploded"),
@@ -443,12 +435,8 @@ class TestSSHBannerBody:
         assert "gmo" in body
 
     def test_default_port_omitted_for_user_at_host(self, monkeypatch):
-        profile = self._stub_profile(
-            username="bob", hostname="example.com", port=22
-        )
-        monkeypatch.setattr(
-            _registry, "_lookup_profile_silently", lambda name: profile
-        )
+        profile = self._stub_profile(username="bob", hostname="example.com", port=22)
+        monkeypatch.setattr(_registry, "_lookup_profile_silently", lambda name: profile)
         body = _registry._format_ssh_banner_body(
             profile_name="example",
             source_display="via --profile",

--- a/tests/transport/test_registry.py
+++ b/tests/transport/test_registry.py
@@ -328,3 +328,138 @@ class TestTransportPolicy:
         assert peek_scheduler_key(policy=policy) == "local"
         # Explicit profile is never gated.
         assert peek_scheduler_key(profile="prod", policy=policy) == "ssh:prod"
+
+
+class TestSSHBannerBody:
+    """``_format_ssh_banner_body`` must surface a useful ``user@host``.
+
+    Regression guard: profiles that delegate to a ``Host`` block in
+    ``~/.ssh/config`` (``ssh_host`` alias with blank ``username`` /
+    ``hostname``) used to render as a literal ``@`` because the banner
+    never consulted ssh_config the way the SSH connection layer does.
+    """
+
+    def _stub_profile(
+        self,
+        *,
+        username: str = "",
+        hostname: str = "",
+        port: int = 22,
+        ssh_host: str | None = None,
+        proxy_jump: str | None = None,
+    ):
+        """Build a minimal ServerProfile stand-in for the banner formatter.
+
+        The formatter only reads a fixed set of fields; using a
+        ``MagicMock`` keeps the test independent of pydantic validation
+        rules on ``ServerProfile`` (which require key_filename etc.).
+        """
+        profile = MagicMock()
+        profile.username = username
+        profile.hostname = hostname
+        profile.port = port
+        profile.ssh_host = ssh_host
+        profile.proxy_jump = proxy_jump
+        return profile
+
+    def test_ssh_host_alias_only_resolves_via_ssh_config(self, monkeypatch):
+        profile = self._stub_profile(ssh_host="gmo")
+        monkeypatch.setattr(
+            _registry, "_lookup_profile_silently", lambda name: profile
+        )
+        resolved = MagicMock(
+            user="user_00028_557dc2",
+            hostname="connect.gpucloud.gmo",
+            port=8822,
+        )
+        with patch(
+            "srunx.ssh.core.ssh_config.get_ssh_config_host",
+            return_value=resolved,
+        ) as lookup:
+            body = _registry._format_ssh_banner_body(
+                profile_name="gmo",
+                source_display="via current profile",
+            )
+        lookup.assert_called_once_with("gmo")
+        assert "user_00028_557dc2@connect.gpucloud.gmo:8822" in body
+        assert "(profile: gmo · via current profile)" in body
+        assert "@[/cyan]" not in body  # no empty-target leak
+
+    def test_explicit_hostname_username_skips_ssh_config(self, monkeypatch):
+        profile = self._stub_profile(
+            username="alice",
+            hostname="dgx.example.com",
+            ssh_host="dgx",  # ssh_host set, but real fields take precedence
+        )
+        monkeypatch.setattr(
+            _registry, "_lookup_profile_silently", lambda name: profile
+        )
+        with patch(
+            "srunx.ssh.core.ssh_config.get_ssh_config_host",
+        ) as lookup:
+            body = _registry._format_ssh_banner_body(
+                profile_name="dgx",
+                source_display="via --profile",
+            )
+        lookup.assert_not_called()
+        assert "alice@dgx.example.com" in body
+
+    def test_ssh_host_alias_fallback_when_ssh_config_lookup_returns_none(
+        self, monkeypatch
+    ):
+        """No matching ``Host`` in ``~/.ssh/config`` → show alias name."""
+        profile = self._stub_profile(ssh_host="orphan")
+        monkeypatch.setattr(
+            _registry, "_lookup_profile_silently", lambda name: profile
+        )
+        with patch(
+            "srunx.ssh.core.ssh_config.get_ssh_config_host",
+            return_value=None,
+        ):
+            body = _registry._format_ssh_banner_body(
+                profile_name="orphan",
+                source_display="via --profile",
+            )
+        assert "Connected to" in body
+        # The alias itself becomes the target so the banner still has
+        # *something* identifiable to show.
+        assert "orphan" in body
+
+    def test_ssh_config_lookup_exception_does_not_raise(self, monkeypatch):
+        """The banner must never crash from a degraded ssh_config state."""
+        profile = self._stub_profile(ssh_host="gmo")
+        monkeypatch.setattr(
+            _registry, "_lookup_profile_silently", lambda name: profile
+        )
+        with patch(
+            "srunx.ssh.core.ssh_config.get_ssh_config_host",
+            side_effect=RuntimeError("ssh_config exploded"),
+        ):
+            body = _registry._format_ssh_banner_body(
+                profile_name="gmo",
+                source_display="via --profile",
+            )
+        # Falls back to the alias-name path.
+        assert "gmo" in body
+
+    def test_default_port_omitted_for_user_at_host(self, monkeypatch):
+        profile = self._stub_profile(
+            username="bob", hostname="example.com", port=22
+        )
+        monkeypatch.setattr(
+            _registry, "_lookup_profile_silently", lambda name: profile
+        )
+        body = _registry._format_ssh_banner_body(
+            profile_name="example",
+            source_display="via --profile",
+        )
+        assert "bob@example.com" in body
+        assert ":22" not in body
+
+    def test_no_profile_returns_fallback(self, monkeypatch):
+        monkeypatch.setattr(_registry, "_lookup_profile_silently", lambda name: None)
+        body = _registry._format_ssh_banner_body(
+            profile_name="ghost",
+            source_display="via --profile",
+        )
+        assert "SSH profile: ghost" in body


### PR DESCRIPTION
## Summary

Two SSH UX bugs surfaced while tailing a job on a cluster that uses an
`~/.ssh/config` alias and restricts `scontrol`:

- The transport banner rendered `Connected to @` for `ssh_host`-only
  profiles because `_format_ssh_banner_body` only read
  `ServerProfile.username`/`hostname` (both blank) and never consulted
  the SSH config the way the connection layer does.
- `srunx tail <job_id>` printed `WARNING | No log files found … using
  common patterns` even when the job was running, because the fallback
  to pattern-based file search fired both when scontrol was unavailable
  **and** when scontrol succeeded but the log file was still empty.

## Changes

- **`src/srunx/transport/registry.py`** — `_format_ssh_banner_body`
  now resolves `profile.ssh_host` via `get_ssh_config_host` when
  `username`/`hostname` are blank, rendering `user@host[:port]` for
  alias-only profiles. Degrades to the alias name and finally the
  existing `SSH profile: <name>` label so a broken ssh_config never
  raises.
- **`src/srunx/ssh/core/log_reader.py`** —
  - `get_job_output` trusts the scontrol-reported path even when the
    file is empty (no more silent fallback to pattern search → no more
    misleading warning).
  - New `_get_log_paths_from_squeue` runs
    `squeue -h -j <id> -O StdOut:2048` / `StdErr:2048`, strips padding,
    normalises `(null)`/`N/A` to `None`. This is the fallback for
    clusters that allow `squeue` but restrict `scontrol`.
  - Pattern-based search stays as the final fallback (completed jobs
    evicted from slurmctld, or clusters that restrict both query
    commands).

## Test plan

- [x] `uv run pytest tests/ssh/core/test_log_reader.py tests/transport/test_registry.py -q` (12 + 29 = 41 pass)
- [x] `uv run pytest -q` full suite (2112 pass, 2 skipped)
- [x] `uv run ruff check src/srunx/ssh/core/log_reader.py src/srunx/transport/registry.py tests/...`
- [x] `uv run mypy src/srunx/ssh/core/log_reader.py src/srunx/transport/registry.py`
- New tests:
  - `TestSSHBannerBody` (6 cases): alias→ssh_config resolution; explicit
    `hostname`+`username` skips ssh_config; alias-fallback when ssh_config
    lookup returns None / raises; default port omitted; nil-profile path.
  - `TestScontrolFoundButFileEmpty` (2 cases): scontrol path returned +
    empty file → no warning, no pattern fallback; StdOut-only path.
  - `TestSqueueFallback` (3 cases): scontrol fails + squeue succeeds →
    used; squeue `(null)` / `N/A` → falls through to pattern search;
    padding stripped before tail command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP7L9qNmnmRkwov2posavK