### PR TITLE
feat(ssh): enforce per-profile mount uniqueness (name + local)

### DIFF
--- a/src/srunx/ssh/cli/profile_impl.py
+++ b/src/srunx/ssh/cli/profile_impl.py
@@ -533,15 +533,7 @@ def add_mount_impl(
             console.print(f"[red]Error: Profile '{profile_name}' not found[/red]")
             raise typer.Exit(1)
 
-        # Check if mount name already exists
-        for mount in profile.mounts:
-            if mount.name == name:
-                console.print(
-                    f"[red]Error: Mount '{name}' already exists for profile '{profile_name}'[/red]"
-                )
-                raise typer.Exit(1)
-
-        # Create MountConfig (triggers path validation)
+        # Create MountConfig (triggers path validation + ``local`` resolution)
         mount = MountConfig(
             name=name,
             local=local,
@@ -549,8 +541,14 @@ def add_mount_impl(
             exclude_patterns=exclude_patterns or [],
         )
 
-        # Add mount to profile
-        success = config_manager.add_profile_mount(profile_name, mount)
+        # Name/local uniqueness is enforced in the shared add path
+        # (ConfigManager.add_profile_mount), which raises ValueError on a
+        # collision so CLI and Web API share one guarantee.
+        try:
+            success = config_manager.add_profile_mount(profile_name, mount)
+        except ValueError as e:
+            console.print(f"[red]Error: {e}[/red]")
+            raise typer.Exit(1) from e
 
         if success:
             console.print(

--- a/src/srunx/ssh/core/config.py
+++ b/src/srunx/ssh/core/config.py
@@ -265,15 +265,40 @@ class ConfigManager:
         return False
 
     def add_profile_mount(self, profile_name: str, mount: MountConfig) -> bool:
-        """Add a mount to a profile."""
-        if profile_name in self.config_data.get("profiles", {}):
-            profile_data = self.config_data["profiles"][profile_name]
-            if "mounts" not in profile_data:
-                profile_data["mounts"] = []
-            profile_data["mounts"].append(mount.model_dump())
-            self.save_config()
-            return True
-        return False
+        """Add a mount to a profile.
+
+        Enforces two per-profile uniqueness invariants here (the shared
+        add path) rather than in the CLI, so every entry point — CLI,
+        Web API, future callers — gets the same guarantee:
+
+        * mount names are unique;
+        * ``local`` roots are unique. ``MountConfig`` resolves ``local``
+          to an absolute path, so the check catches ``~/x`` vs
+          ``/Users/me/x``. Two mounts sharing a local root would make
+          ``ssh sync``'s cwd auto-detection ambiguous (first match
+          silently wins).
+
+        Raises:
+            ValueError: When the mount name or local path collides with
+                an existing mount on the profile.
+        """
+        if profile_name not in self.config_data.get("profiles", {}):
+            return False
+        profile_data = self.config_data["profiles"][profile_name]
+        existing = profile_data.get("mounts", [])
+        for m in existing:
+            if m.get("name") == mount.name:
+                raise ValueError(
+                    f"Mount '{mount.name}' already exists for profile '{profile_name}'"
+                )
+            if m.get("local") == mount.local:
+                raise ValueError(
+                    f"Local path '{mount.local}' is already mounted as "
+                    f"'{m.get('name')}' in profile '{profile_name}'"
+                )
+        profile_data.setdefault("mounts", []).append(mount.model_dump())
+        self.save_config()
+        return True
 
     def remove_profile_mount(self, profile_name: str, mount_name: str) -> bool:
         """Remove a mount from a profile by name."""

--- a/src/srunx/web/routers/config.py
+++ b/src/srunx/web/routers/config.py
@@ -340,7 +340,11 @@ async def add_profile_mount(name: str, body: MountCreateRequest) -> dict[str, An
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
 
-    cm.add_profile_mount(name, mount)
+    try:
+        cm.add_profile_mount(name, mount)
+    except ValueError as e:
+        # Duplicate mount name or local path on this profile.
+        raise HTTPException(status_code=409, detail=str(e)) from e
     return mount.model_dump()
 
 

--- a/tests/ssh/cli/test_commands.py
+++ b/tests/ssh/cli/test_commands.py
@@ -146,6 +146,46 @@ class TestRoundTrip:
         assert listed.exit_code == 0
         assert "data" in listed.output
 
+    def test_mount_add_rejects_duplicate_local(self, tmp_path: Path):
+        cfg = _cfg(tmp_path)
+        runner.invoke(
+            ssh_app,
+            ["add", "--profile", "dgx", "--ssh-host", "dgx-host", "--config", cfg],
+        )
+
+        def _add(name: str, local: str, remote: str):
+            return runner.invoke(
+                ssh_app,
+                [
+                    "mount",
+                    "add",
+                    "--profile",
+                    "dgx",
+                    "--mount",
+                    name,
+                    "--local",
+                    local,
+                    "--remote",
+                    remote,
+                    "--config",
+                    cfg,
+                ],
+            )
+
+        first = _add("data", str(tmp_path), "/remote/data")
+        assert first.exit_code == 0, first.output
+
+        # Same local, different name + remote -> rejected.
+        dup = _add("data2", str(tmp_path), "/remote/other")
+        assert dup.exit_code == 1
+        assert "already mounted" in _strip_ansi(dup.output)
+
+        # A distinct local still succeeds.
+        other_dir = tmp_path / "sub"
+        other_dir.mkdir()
+        ok = _add("data3", str(other_dir), "/remote/sub")
+        assert ok.exit_code == 0, ok.output
+
     def test_env_set_list_via_flags(self, tmp_path: Path):
         cfg = _cfg(tmp_path)
         runner.invoke(

--- a/tests/ssh/core/test_config.py
+++ b/tests/ssh/core/test_config.py
@@ -269,6 +269,32 @@ class TestMountConfigExcludePatterns:
         assert loaded_profile is not None
         assert loaded_profile.mounts[0].exclude_patterns == ()
 
+    def test_add_profile_mount_rejects_duplicate_name(self, temp_config_file):
+        cm = ConfigManager(temp_config_file)
+        cm.add_profile(
+            "p", ServerProfile(hostname="h", username="u", key_filename="/k")
+        )
+        cm.add_profile_mount("p", MountConfig(name="m", local="/tmp/a", remote="/r/a"))
+
+        with pytest.raises(ValueError, match="already exists"):
+            cm.add_profile_mount(
+                "p", MountConfig(name="m", local="/tmp/b", remote="/r/b")
+            )
+
+    def test_add_profile_mount_rejects_duplicate_local(self, temp_config_file):
+        cm = ConfigManager(temp_config_file)
+        cm.add_profile(
+            "p", ServerProfile(hostname="h", username="u", key_filename="/k")
+        )
+        cm.add_profile_mount("p", MountConfig(name="m", local="/tmp/a", remote="/r/a"))
+
+        # Same local under a different name + remote is rejected at the
+        # shared path, so the Web API inherits the guard too.
+        with pytest.raises(ValueError, match="already mounted"):
+            cm.add_profile_mount(
+                "p", MountConfig(name="m2", local="/tmp/a", remote="/r/other")
+            )
+
 
 class TestMountConfigImmutability:
     """Verify frozen=True + tuple exclude_patterns cannot be mutated.

--- a/tests/web/test_router_config.py
+++ b/tests/web/test_router_config.py
@@ -137,3 +137,35 @@ class TestSSHStatus:
             data = resp.json()
             assert data["connected"] is False
             assert data["profile_name"] is None
+
+
+class TestAddProfileMount:
+    """The Web API shares the CLI's per-profile uniqueness guard because
+    both go through ConfigManager.add_profile_mount."""
+
+    def _seed_profile_with_mount(self) -> None:
+        from srunx.ssh.core.config import ConfigManager, MountConfig, ServerProfile
+
+        cm = ConfigManager()
+        cm.add_profile(
+            "p", ServerProfile(hostname="h", username="u", key_filename="/k")
+        )
+        cm.add_profile_mount("p", MountConfig(name="m", local="/tmp/a", remote="/r/a"))
+
+    def test_rejects_duplicate_local(self, client: TestClient) -> None:
+        self._seed_profile_with_mount()
+        resp = client.post(
+            "/api/config/ssh/profiles/p/mounts",
+            json={"name": "m2", "local": "/tmp/a", "remote": "/r/other"},
+        )
+        assert resp.status_code == 409
+        assert "already mounted" in resp.json()["detail"]
+
+    def test_rejects_duplicate_name(self, client: TestClient) -> None:
+        self._seed_profile_with_mount()
+        resp = client.post(
+            "/api/config/ssh/profiles/p/mounts",
+            json={"name": "m", "local": "/tmp/b", "remote": "/r/b"},
+        )
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"]


### PR DESCRIPTION
## 概要

SSH プロファイルのマウントについて、**同一プロファイル内で `local` ルートの重複を禁止**します。あわせて、これまで CLI でしか効いていなかった「マウント名の重複チェック」も共有パスに集約し、CLI・Web API のどちらから追加しても同じ不変条件が保証されるようにしました。

## 背景 / 問題

- 1つのプロファイルに同じ `local` を指す複数マウントを登録できてしまい、`ssh sync`（`--mount` 省略時）の **cwd 自動検出が曖昧**になっていた（リスト先頭が黙って選ばれ、もう片方には永遠に同期されない）。
- CLI はマウント**名**の重複しか見ておらず、Web API (`POST /ssh/profiles/{name}/mounts`) は `add_profile_mount` を直叩きしていたため、名前重複すらバイパスしていた。

## 変更点

| ファイル | 内容 |
|---|---|
| `ssh/core/config.py` | `ConfigManager.add_profile_mount` に**名前重複・local重複の両チェックを集約**し、衝突時は `ValueError` を送出 |
| `ssh/cli/profile_impl.py` | CLI 側の手動チェックを削除し、共有パスの `ValueError` を捕捉してエラー終了（DRY化） |
| `web/routers/config.py` | `ValueError` を **409 Conflict** に変換 |

`local` は `MountConfig` で絶対パスに解決されるため、`~/x` と `/Users/me/x` の表記違いも同一視して弾きます。`remote` の重複は引き続き許可（同じ remote に複数 local を持たせ、`ssh sync --mount <name>` で送る local を選択できる）。

## テスト

- 共有パス: 名前重複／local重複の拒否 (`tests/ssh/core/test_config.py`)
- CLI: local重複拒否＋別localは成功 (`tests/ssh/cli/test_commands.py`)
- Web API: 名前重複／local重複で 409 (`tests/web/test_router_config.py`)

`pytest` 1163 passed / `mypy` クリーン / `ruff` クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)