### PR TITLE
feat(env): job-level --env via sbatch process env + --export=ALL

### DIFF
--- a/src/srunx/cli/commands/jobs/sbatch.py
+++ b/src/srunx/cli/commands/jobs/sbatch.py
@@ -309,15 +309,19 @@ def sbatch(
 
     job: Job | ShellJob
     if script is not None:
-        # ShellJob's schema is intentionally thin: it only records the
-        # script path + script_vars. Resource / environment configuration
-        # travels with the script itself rather than the model, so we do
-        # not forward ``resources`` / ``environment`` / ``log_dir`` /
-        # ``work_dir`` here. Those CLI flags are accepted for UX symmetry
-        # with --wrap submits but are no-ops under positional script mode.
+        # ShellJob's schema is intentionally thin: it records the script
+        # path + script_vars. Resource configuration (``resources`` /
+        # ``log_dir`` / ``work_dir``) still travels with the script itself
+        # rather than the model, so those CLI flags remain no-ops under
+        # positional script mode. ``environment`` IS forwarded: env_vars
+        # propagate via the submission environment (sbatch process env +
+        # --export=ALL locally / remote export prefix + --export=ALL over
+        # SSH), so --env is effective for positional scripts identically to
+        # --wrap.
         shell_data: dict[str, Any] = {
             "name": name,
             "script_path": str(script),
+            "environment": environment,
         }
         job = ShellJob.model_validate(shell_data)
     else:

--- a/src/srunx/domain/jobs.py
+++ b/src/srunx/domain/jobs.py
@@ -227,6 +227,30 @@ class JobEnvironment(BaseModel):
         default_factory=dict, description="Environment variables"
     )
 
+    @field_validator("env_vars")
+    @classmethod
+    def validate_env_var_keys(cls, v: dict[str, str]) -> dict[str, str]:
+        """Validate env var keys at the single domain boundary (CLI/Web/MCP).
+
+        Keys must be valid shell identifiers and must not collide with the
+        reserved scheduler namespaces. The identifier regex also rejects
+        empty keys and keys containing newline/NUL.
+        """
+        for key in v:
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                raise ValueError(
+                    f"Invalid environment variable name: '{key}'. "
+                    "Must be a valid identifier (letters, digits, underscores; "
+                    "no leading digit, no whitespace/newline/NUL)."
+                )
+            if key.startswith(("SLURM_", "SBATCH_")):
+                raise ValueError(
+                    f"Invalid environment variable name: '{key}'. "
+                    "The 'SLURM_' and 'SBATCH_' prefixes are reserved by the "
+                    "scheduler and cannot be set via env_vars."
+                )
+        return v
+
     @model_validator(mode="before")
     @classmethod
     def apply_config_defaults(cls, data: dict) -> dict:
@@ -281,6 +305,10 @@ class BaseJob(BaseModel):
                     "Must be a valid identifier (letters, digits, underscores)."
                 )
         return v
+
+    environment: JobEnvironment = Field(
+        default_factory=JobEnvironment, description="Environment setup"
+    )
 
     retry: int = Field(
         default=0, ge=0, description="Number of retry attempts on failure"
@@ -518,9 +546,6 @@ class Job(BaseJob):
     command: str | list[str] = Field(description="Command to execute")
     resources: JobResource = Field(
         default_factory=JobResource, description="Resource requirements"
-    )
-    environment: JobEnvironment = Field(
-        default_factory=JobEnvironment, description="Environment setup"
     )
     log_dir: str = Field(
         default_factory=lambda: os.getenv("SLURM_LOG_DIR", "logs"),

--- a/src/srunx/runtime/rendering.py
+++ b/src/srunx/runtime/rendering.py
@@ -612,21 +612,23 @@ def _build_environment_setup(
 
     Returns:
         A 3-tuple of (env_setup_lines, srun_args, launch_prefix).
-        - env_setup_lines: Shell setup including env vars, conda/venv activation,
-          and container prelude (if any).
+        - env_setup_lines: Shell setup for conda/venv activation and the
+          container prelude (if any).
         - srun_args: Flags passed to srun (Pyxis uses this).
         - launch_prefix: Command wrapper (Apptainer uses this).
+
+    Two-route propagation (SRP): ``env_vars`` are intentionally NOT rendered
+    into the script body here. They travel via the submission environment —
+    the sbatch launching process env + ``sbatch --export=ALL`` (local adapter)
+    or the remote ``export KEY='value' && ...`` prefix + ``--export=ALL``
+    (SSH adapter). Only conda/venv activation and the container prelude are
+    compute-node shell activation and so belong in the script body.
     """
     from srunx.containers import get_runtime
 
     setup_lines: list[str] = []
 
-    # 1. Environment variables (single-quoted to prevent shell injection)
-    for key, value in environment.env_vars.items():
-        escaped_value = str(value).replace("'", "'\\''")
-        setup_lines.append(f"export {key}='{escaped_value}'")
-
-    # 2. Conda/venv activation (independent of container)
+    # Conda/venv activation (independent of container)
     if environment.conda:
         home_dir = Path.home()
         escaped_conda = environment.conda.replace("'", "'\\''")
@@ -641,7 +643,7 @@ def _build_environment_setup(
         escaped_venv = environment.venv.replace("'", "'\\''")
         setup_lines.append(f"source '{escaped_venv}'/bin/activate")
 
-    # 3. Container setup (independent of conda/venv)
+    # Container setup (independent of conda/venv)
     # Only process container if it has an image — a runtime-only container
     # (no image) is not actionable and would generate broken commands.
     srun_args = ""

--- a/src/srunx/slurm/clients/local.py
+++ b/src/srunx/slurm/clients/local.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import glob
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import time
@@ -31,6 +32,34 @@ if TYPE_CHECKING:
     from srunx.slurm.protocols import JobSnapshot, LogChunk
 
 logger = get_logger(__name__)
+
+
+def _sbatch_invocation(
+    script_path: str, env_vars: dict[str, str]
+) -> tuple[list[str], dict[str, str] | None]:
+    """Build the local ``sbatch`` argv + subprocess environment.
+
+    Job-level env vars are realized by composing the submitter process
+    environment and forcing ``--export=ALL`` so SLURM propagates them — this
+    SLURM-specific realization is confined to this adapter (DIP).
+
+    When no env vars are requested we deliberately leave the export policy
+    untouched: no ``--export`` flag (so a script's own ``#SBATCH
+    --export=NONE`` / site default still wins) and ``env=None`` so the child
+    inherits the parent environment unchanged.
+
+    When env vars ARE present we resolve the ``sbatch`` binary against the
+    *launcher's* PATH up front, so a job-level ``PATH`` override (which we
+    still propagate to the job via ``--export=ALL``) can't hide the ``sbatch``
+    executable from the launcher itself.
+    """
+    if not env_vars:
+        return ["sbatch", "--parsable", script_path], None
+    sbatch_bin = shutil.which("sbatch") or "sbatch"
+    return (
+        [sbatch_bin, "--parsable", "--export=ALL", script_path],
+        {**os.environ, **env_vars},
+    )
 
 
 class LocalClient:
@@ -112,8 +141,13 @@ class LocalClient:
                 )
                 logger.debug(f"Generated SLURM script at: {script_path}")
 
-                # Submit job with sbatch --parsable for reliable job ID extraction
-                sbatch_cmd = ["sbatch", "--parsable", script_path]
+                # Submit job with sbatch --parsable for reliable job ID
+                # extraction. --export=ALL + composed env applies ONLY when
+                # job env vars are present, so plain submits keep the script's
+                # / site's export policy (see _sbatch_invocation).
+                sbatch_cmd, proc_env = _sbatch_invocation(
+                    script_path, job.environment.env_vars
+                )
                 if job.environment.container:
                     logger.debug(f"Using container: {job.environment.container}")
 
@@ -125,6 +159,7 @@ class LocalClient:
                         capture_output=True,
                         text=True,
                         check=True,
+                        env=proc_env,
                     )
                 except subprocess.CalledProcessError as e:
                     logger.error(f"Failed to submit job '{job.name}': {e}")
@@ -139,12 +174,18 @@ class LocalClient:
                 script_path = render_shell_job_script(
                     job.script_path, job, temp_dir, verbose
                 )
+                # --export=ALL + composed env only when env vars are present
+                # (see _sbatch_invocation) — Job branch documents the rationale.
+                sbatch_cmd, proc_env = _sbatch_invocation(
+                    script_path, job.environment.env_vars
+                )
                 try:
                     result = subprocess.run(
-                        ["sbatch", "--parsable", script_path],
+                        sbatch_cmd,
                         capture_output=True,
                         text=True,
                         check=True,
+                        env=proc_env,
                     )
                 except subprocess.CalledProcessError as e:
                     logger.error(f"Failed to submit job '{job.script_path}': {e}")

--- a/src/srunx/slurm/clients/ssh.py
+++ b/src/srunx/slurm/clients/ssh.py
@@ -409,6 +409,8 @@ class SlurmSSHClient:
         script_content: str,
         job_name: str | None = None,
         dependency: str | None = None,
+        *,
+        job_env_vars: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Submit a job via sbatch. Returns job info dict.
 
@@ -417,11 +419,19 @@ class SlurmSSHClient:
         ``web.routers.templates``). New code should call :meth:`submit`
         with a :class:`~srunx.domain.Job` instance. This alias will
         remain until those routers migrate to the Protocol surface.
+
+        ``job_env_vars`` carries job-level environment overrides to the
+        remote ``sbatch`` export prefix (env is no longer baked into the
+        rendered script body), so callers that build a ``JobEnvironment``
+        must forward its ``env_vars`` here or those variables are dropped.
         """
         with self._io_lock:
             self._ensure_connected()
             result = self._client.slurm.submit_sbatch_job(
-                script_content, job_name=job_name, dependency=dependency
+                script_content,
+                job_name=job_name,
+                dependency=dependency,
+                job_env_vars=job_env_vars,
             )
         if result is None:
             raise RuntimeError("sbatch submission failed")
@@ -469,6 +479,13 @@ class SlurmSSHClient:
         """
         from srunx.domain import JobStatus, ShellJob
 
+        # Job-level env rides on the real job instance (``callbacks_job``); the
+        # SSH adapter realizes it as the remote export prefix + ``--export=ALL``.
+        # ISP — no env param on the JobOperations surface. Legacy callers that
+        # pass no job (``callbacks_job is None``) carry no job-level env.
+        job_env_vars = (
+            callbacks_job.environment.env_vars if callbacks_job is not None else None
+        )
         with self._io_lock:
             self._ensure_connected()
             result = self._client.slurm.submit_remote_sbatch_file(
@@ -477,6 +494,7 @@ class SlurmSSHClient:
                 job_name=job_name,
                 dependency=dependency,
                 extra_sbatch_args=extra_sbatch_args,
+                job_env_vars=job_env_vars,
             )
         if result is None or not result.job_id:
             raise RuntimeError("remote sbatch submission failed")
@@ -689,8 +707,13 @@ class SlurmSSHClient:
         try:
             with self._io_lock:
                 self._ensure_connected()
+                # Job-level env rides on ``job.environment`` (ISP — no env
+                # params on the JobOperations.submit protocol); the SSH adapter
+                # realizes it as the remote export prefix + ``--export=ALL``.
                 result = self._client.slurm.submit_sbatch_job(
-                    script_content, job_name=job.name
+                    script_content,
+                    job_name=job.name,
+                    job_env_vars=job.environment.env_vars,
                 )
         except paramiko.AuthenticationException as exc:
             raise TransportAuthError(f"SSH authentication failed: {exc}") from exc
@@ -1087,15 +1110,22 @@ class SlurmSSHClient:
                     script_content = f.read()
 
             # --- 2. Submit via SSH ---
+            # Job-level env rides on ``job.environment`` (ISP — no env params
+            # on the JobOperations.submit protocol); the SSH adapter realizes
+            # it as the remote export prefix + ``--export=ALL``.
+            job_env_vars = job.environment.env_vars
             if in_place_remote_path is not None:
                 result = self._client.slurm.submit_remote_sbatch_file(
                     in_place_remote_path,
                     submit_cwd=in_place_submit_cwd,
                     job_name=job.name,
+                    job_env_vars=job_env_vars,
                 )
             else:
                 result = self._client.slurm.submit_sbatch_job(
-                    script_content, job_name=job.name
+                    script_content,
+                    job_name=job.name,
+                    job_env_vars=job_env_vars,
                 )
             if result is None or not result.job_id:
                 raise RuntimeError(f"Failed to submit job '{job.name}' via SSH")

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -109,9 +109,7 @@ class SlurmRemoteClient:
         else:
             return command
 
-    def _get_slurm_env_setup(
-        self, job_env_vars: dict[str, str] | None = None
-    ) -> str:
+    def _get_slurm_env_setup(self, job_env_vars: dict[str, str] | None = None) -> str:
         """Get environment setup commands for SLURM execution.
 
         Job-level ``job_env_vars`` merge into the same ``export KEY='value'``

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -109,8 +109,18 @@ class SlurmRemoteClient:
         else:
             return command
 
-    def _get_slurm_env_setup(self) -> str:
-        """Get environment setup commands for SLURM execution."""
+    def _get_slurm_env_setup(
+        self, job_env_vars: dict[str, str] | None = None
+    ) -> str:
+        """Get environment setup commands for SLURM execution.
+
+        Job-level ``job_env_vars`` merge into the same ``export KEY='value'``
+        prefix as the profile's ``custom_env_vars``, with job keys taking
+        precedence over profile keys (``{**profile, **job}``). This is the
+        SSH realization of the submission-environment route (the local
+        adapter uses the sbatch process env instead); both pair it with
+        ``--export=ALL`` on the remote sbatch.
+        """
         env_commands = [
             "cd ~",
             "source /etc/profile 2>/dev/null || true",
@@ -123,7 +133,8 @@ class SlurmRemoteClient:
             'export PATH="$PATH:/usr/local/bin:/opt/slurm/bin:/cluster/slurm/bin" 2>/dev/null || true',
         ]
 
-        for key, value in self._conn.custom_env_vars.items():
+        merged_env_vars = {**self._conn.custom_env_vars, **(job_env_vars or {})}
+        for key, value in merged_env_vars.items():
             escaped_value = value.replace("'", "'\\''")
             env_commands.append(f"export {key}='{escaped_value}'")
             self.logger.debug(f"Adding custom environment variable: {key}={value}")
@@ -150,9 +161,11 @@ class SlurmRemoteClient:
     # Command execution
     # ------------------------------------------------------------------
 
-    def execute_slurm_command(self, command: str) -> tuple[str, str, int]:
+    def execute_slurm_command(
+        self, command: str, job_env_vars: dict[str, str] | None = None
+    ) -> tuple[str, str, int]:
         """Execute a SLURM command with proper environment."""
-        env_setup = self._get_slurm_env_setup()
+        env_setup = self._get_slurm_env_setup(job_env_vars)
 
         if self._slurm_path:
             slurm_commands = [
@@ -193,6 +206,8 @@ class SlurmRemoteClient:
         script_content: str,
         job_name: str | None = None,
         dependency: str | None = None,
+        *,
+        job_env_vars: dict[str, str] | None = None,
     ) -> SlurmJob | None:
         """Submit an sbatch job with script content."""
         try:
@@ -210,6 +225,14 @@ class SlurmRemoteClient:
                 return None
 
             cmd = f"{self._get_slurm_command('sbatch')}"
+            # --export=ALL propagates the submission environment (job env_vars
+            # merged into the export prefix) to the job — SLURM-specific
+            # realization confined to this adapter (DIP). Applied ONLY when
+            # job env vars are present so a plain submit keeps the script's /
+            # site's export policy intact (a command-line --export overrides
+            # the script's own #SBATCH --export directive).
+            if job_env_vars:
+                cmd += " --export=ALL"
             if job_name:
                 safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
                 cmd += f" --job-name={safe_name}"
@@ -219,7 +242,9 @@ class SlurmRemoteClient:
                 cmd += f" --dependency={dependency}"
             cmd += f" {remote_script_path}"
 
-            stdout, stderr, exit_code = self.execute_slurm_command(cmd)
+            stdout, stderr, exit_code = self.execute_slurm_command(
+                cmd, job_env_vars=job_env_vars
+            )
             if exit_code == 0:
                 match = re.search(r"Submitted batch job (\d+)", stdout)
                 if match:
@@ -313,6 +338,7 @@ class SlurmRemoteClient:
         job_name: str | None = None,
         dependency: str | None = None,
         extra_sbatch_args: list[str] | None = None,
+        job_env_vars: dict[str, str] | None = None,
     ) -> SlurmJob | None:
         """Submit a script that already exists on the remote cluster.
 
@@ -344,6 +370,14 @@ class SlurmRemoteClient:
                 return None
 
             cmd_parts: list[str] = [self._get_slurm_command("sbatch")]
+            # --export=ALL propagates the submission environment (job env_vars
+            # merged into the export prefix) to the job — SLURM-specific
+            # realization confined to this adapter (DIP). Applied ONLY when job
+            # env vars are present: this in-place path is documented to
+            # preserve the user's own #SBATCH directives, and a command-line
+            # --export would override the script's #SBATCH --export=NONE.
+            if job_env_vars:
+                cmd_parts.append("--export=ALL")
             if job_name:
                 safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
                 cmd_parts.append(f"--job-name={shlex.quote(safe_name)}")
@@ -364,7 +398,9 @@ class SlurmRemoteClient:
             if submit_cwd:
                 cmd = f"cd {shlex.quote(submit_cwd)} && {cmd}"
 
-            stdout, stderr, exit_code = self.execute_slurm_command(cmd)
+            stdout, stderr, exit_code = self.execute_slurm_command(
+                cmd, job_env_vars=job_env_vars
+            )
             if exit_code == 0:
                 match = re.search(r"Submitted batch job (\d+)", stdout)
                 if match:

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -59,8 +59,22 @@ async def preview_script(req: ScriptPreviewRequest) -> ScriptPreviewResponse:
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
 
-    resources = JobResource(**(req.resources or {}))
-    environment = JobEnvironment(**(req.environment or {}))
+    from pydantic import ValidationError
+
+    try:
+        resources = JobResource(**(req.resources or {}))
+        environment = JobEnvironment(**(req.environment or {}))
+    except ValidationError as e:
+        # Surface domain validation (e.g. invalid env-var keys) as a clean
+        # 422 instead of a 500 — the env_vars key validator lives on
+        # JobEnvironment, so a bad key reaches here as a ValidationError.
+        raise HTTPException(
+            status_code=422,
+            detail=[
+                {"loc": list(x["loc"]), "msg": x["msg"], "type": x["type"]}
+                for x in e.errors()
+            ],
+        ) from e
     job = Job(
         name=req.name,
         command=req.command,

--- a/src/srunx/web/routers/templates.py
+++ b/src/srunx/web/routers/templates.py
@@ -96,8 +96,21 @@ async def apply_template(
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
 
-    resources = JobResource(**(req.resources or {}))
-    environment = JobEnvironment(**(req.environment or {}))
+    from pydantic import ValidationError
+
+    try:
+        resources = JobResource(**(req.resources or {}))
+        environment = JobEnvironment(**(req.environment or {}))
+    except ValidationError as e:
+        # Invalid env-var keys (validated on JobEnvironment) surface as a
+        # clean 422 rather than a 500.
+        raise HTTPException(
+            status_code=422,
+            detail=[
+                {"loc": list(x["loc"]), "msg": x["msg"], "type": x["type"]}
+                for x in e.errors()
+            ],
+        ) from e
     job = Job(
         name=req.job_name,
         command=req.command,

--- a/src/srunx/web/routers/templates.py
+++ b/src/srunx/web/routers/templates.py
@@ -138,7 +138,11 @@ async def apply_template(
 
     try:
         result = await anyio.to_thread.run_sync(
-            lambda: adapter.submit_job(script_content, job_name=req.job_name)
+            lambda: adapter.submit_job(
+                script_content,
+                job_name=req.job_name,
+                job_env_vars=job.environment.env_vars,
+            )
         )
     except Exception as e:
         raise HTTPException(status_code=502, detail=f"sbatch failed: {e}") from e

--- a/src/srunx/web/services/workflow_submission.py
+++ b/src/srunx/web/services/workflow_submission.py
@@ -272,12 +272,17 @@ async def submit_jobs_bfs(
                     cwd: str = submit_cwd,
                     n: str = current_name,
                     d: str | None = dependency,
+                    cj: Any = current_job,
                 ) -> int:
+                    # Pass the real job as ``callbacks_job`` so the adapter
+                    # forwards its ``environment.env_vars`` to the remote
+                    # ``sbatch`` (env is no longer baked into the script body).
                     submitted_obj = adapter.submit_remote_sbatch(
                         rp,
                         submit_cwd=cwd,
                         job_name=n,
                         dependency=d,
+                        callbacks_job=cj,
                     )
                     if submitted_obj is None or submitted_obj.job_id is None:
                         raise RuntimeError("remote sbatch returned no job_id")
@@ -288,7 +293,10 @@ async def submit_jobs_bfs(
                 result = await anyio.to_thread.run_sync(
                     lambda s=scripts[current_name],  # type: ignore[misc]
                     n=current_name,
-                    d=dependency: adapter.submit_job(s, job_name=n, dependency=d)
+                    d=dependency,
+                    e=current_job.environment.env_vars: adapter.submit_job(
+                        s, job_name=n, dependency=d, job_env_vars=e
+                    )
                 )
                 slurm_id = int(result["job_id"])
             submitted[current_name] = str(slurm_id)

--- a/tests/cli/commands/jobs/test_sbatch.py
+++ b/tests/cli/commands/jobs/test_sbatch.py
@@ -1,0 +1,67 @@
+"""Tests for ``srunx sbatch`` job-building (env forwarding).
+
+Focus: REQ-3 / AC-4 — a positional-script submission must forward the
+built ``JobEnvironment`` into the ``ShellJob`` instead of dropping it, so
+``--env`` is effective for scripts identically to ``--wrap``.
+
+We patch ``_submit_via_transport`` to capture the *built* job (and patch
+``resolve_transport`` to a no-op context) so the assertion is on the model
+the CLI constructed, not on any real SLURM/SSH I/O.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli.main import app
+from srunx.domain import ShellJob
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@contextmanager
+def _fake_resolve_transport(*args, **kwargs):
+    rt = MagicMock()
+    rt.transport_type = "ssh"  # keeps `client` None (no local Slurm build)
+    rt.profile_name = "test-profile"
+    rt.scheduler_key = "ssh:test-profile"
+    yield rt
+
+
+def test_positional_script_forwards_env_to_shell_job(runner, tmp_path):
+    script = tmp_path / "run.sh"
+    script.write_text("#!/bin/bash\necho hi\n")
+
+    captured: dict[str, object] = {}
+
+    def fake_submit(*, job, **kwargs):
+        captured["job"] = job
+        job.job_id = 12345
+        return job
+
+    with (
+        patch(
+            "srunx.cli.commands.jobs.sbatch.resolve_transport",
+            _fake_resolve_transport,
+        ),
+        patch(
+            "srunx.cli.commands.jobs.sbatch._submit_via_transport",
+            side_effect=fake_submit,
+        ),
+    ):
+        result = runner.invoke(
+            app,
+            ["sbatch", str(script), "--env", "FOO=bar", "--profile", "test-profile"],
+        )
+
+    assert result.exit_code == 0, result.output
+    built = captured["job"]
+    assert isinstance(built, ShellJob)
+    assert built.environment.env_vars == {"FOO": "bar"}

--- a/tests/domain/test_jobs.py
+++ b/tests/domain/test_jobs.py
@@ -128,6 +128,29 @@ class TestJobEnvironment:
         assert env.container is None
         assert env.env_vars["TEST"] == "value"
 
+    def test_env_vars_valid_mapping_preserved(self):
+        """AC-3: a valid env_vars mapping constructs and is preserved."""
+        env = JobEnvironment(env_vars={"FOO": "bar", "_BAZ2": "qux"})
+        assert env.env_vars == {"FOO": "bar", "_BAZ2": "qux"}
+
+    @pytest.mark.parametrize("bad_key", ["1BAD", "", "FOO BAR", "FOO-BAR", "FOO.BAR"])
+    def test_env_vars_invalid_identifier_rejected(self, bad_key):
+        """AC-1: keys that are not valid identifiers raise ValueError."""
+        with pytest.raises(ValidationError):
+            JobEnvironment(env_vars={bad_key: "x"})
+
+    @pytest.mark.parametrize("bad_key", ["FOO\nBAR", "FOO\x00BAR"])
+    def test_env_vars_newline_or_nul_rejected(self, bad_key):
+        """AC-1: keys with newline/NUL are rejected by the identifier regex."""
+        with pytest.raises(ValidationError):
+            JobEnvironment(env_vars={bad_key: "x"})
+
+    @pytest.mark.parametrize("bad_key", ["SLURM_FOO", "SBATCH_FOO"])
+    def test_env_vars_reserved_prefix_rejected(self, bad_key):
+        """AC-2: SLURM_/SBATCH_ prefixed keys are rejected."""
+        with pytest.raises(ValidationError):
+            JobEnvironment(env_vars={bad_key: "x"})
+
 
 class TestContainerResource:
     """Test ContainerResource model updates (T6.2)."""
@@ -459,6 +482,14 @@ class TestShellJob:
         with pytest.raises(ValidationError):
             # Missing path
             ShellJob()
+
+    def test_shell_job_carries_environment_env_vars(self):
+        """REQ-2: ShellJob inherits `environment` from BaseJob and carries env_vars."""
+        job = ShellJob(
+            script_path="/path/to/script.sh",
+            environment=JobEnvironment(env_vars={"FOO": "bar"}),
+        )
+        assert job.environment.env_vars == {"FOO": "bar"}
 
 
 class TestStatusThrottle:

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -93,10 +93,12 @@ class TestTemplateRendering:
             assert "#SBATCH --time=8:00:00" in content
             assert "#SBATCH --partition=gpu" in content
 
-            # Verify environment setup
+            # Verify environment setup: conda activation stays in the body,
+            # but env_vars are no longer baked in — they travel via the
+            # submission environment (sbatch process env + --export=ALL).
             assert "conda activate 'pytorch'" in content
-            assert "export CUDA_VISIBLE_DEVICES='0,1,2,3'" in content
-            assert "export OMP_NUM_THREADS='8'" in content
+            assert "export CUDA_VISIBLE_DEVICES=" not in content
+            assert "export OMP_NUM_THREADS=" not in content
 
             # Verify command
             assert "python train.py --epochs 100" in content

--- a/tests/runtime/test_rendering.py
+++ b/tests/runtime/test_rendering.py
@@ -950,57 +950,62 @@ class TestPerJobTemplate:
 class TestShellInjectionPrevention:
     """Test that shell injection is prevented in rendered scripts."""
 
-    def test_env_vars_semicolon_injection(self, temp_dir):
-        """Semicolons in env var values must not break out of the export statement."""
-        template_path = get_template_path("base")
-        job = Job(
-            name="injection_test",
-            command=["echo", "hello"],
-            environment=JobEnvironment(
-                env_vars={"EVIL": "foo; rm -rf /"},
-            ),
-            log_dir="",
-            work_dir="",
-        )
-        script_path = render_job_script(template_path, job, temp_dir)
-        content = Path(script_path).read_text()
-        # The value must be single-quoted, preventing the semicolon from executing
-        assert "export EVIL='foo; rm -rf /'" in content
-        # Must NOT contain unquoted export
-        assert "export EVIL=foo;" not in content
+    def test_env_vars_not_baked_into_script_body(self, temp_dir):
+        """AC-5: env_vars are no longer rendered as `export KEY=` lines.
 
-    def test_env_vars_command_substitution_injection(self, temp_dir):
-        """Command substitution in env var values must be quoted."""
+        env_vars now travel via the submission environment (sbatch process
+        env + --export=ALL locally / remote export prefix over SSH), so the
+        rendered script body must contain no `export FOO=` line for them —
+        the former script-body injection surface is gone.
+        """
         template_path = get_template_path("base")
         job = Job(
-            name="subst_test",
+            name="env_no_bake",
             command=["echo", "hello"],
             environment=JobEnvironment(
-                env_vars={"CMD": "$(whoami)"},
+                env_vars={"FOO": "bar", "EVIL": "foo; rm -rf /"},
             ),
             log_dir="",
             work_dir="",
         )
         script_path = render_job_script(template_path, job, temp_dir)
         content = Path(script_path).read_text()
-        assert "export CMD='$(whoami)'" in content
+        assert "export FOO=" not in content
+        assert "export EVIL=" not in content
 
-    def test_env_vars_single_quote_escaping(self, temp_dir):
-        """Single quotes within values must be properly escaped."""
+    def test_shell_job_env_vars_not_baked_into_script_body(self, temp_dir, tmp_path):
+        """AC-5: ShellJob bodies also do not bake in env_vars export lines."""
+        from srunx.domain import ShellJob
+        from srunx.runtime.rendering import render_shell_job_script
+
+        user_script = tmp_path / "run.sh"
+        user_script.write_text("#!/bin/bash\necho hi\n")
+        job = ShellJob(
+            name="shell_env_no_bake",
+            script_path=str(user_script),
+            environment=JobEnvironment(env_vars={"FOO": "bar"}),
+        )
+        script_path = render_shell_job_script(str(user_script), job, temp_dir)
+        content = Path(script_path).read_text()
+        assert "export FOO=" not in content
+
+    def test_conda_activation_still_rendered_with_env_vars(self, temp_dir):
+        """AC-5: conda/venv activation lines remain even when env_vars are set."""
         template_path = get_template_path("base")
         job = Job(
-            name="quote_test",
+            name="env_with_conda",
             command=["echo", "hello"],
             environment=JobEnvironment(
-                env_vars={"MSG": "it's working"},
+                conda="my_env",
+                env_vars={"FOO": "bar"},
             ),
             log_dir="",
             work_dir="",
         )
         script_path = render_job_script(template_path, job, temp_dir)
         content = Path(script_path).read_text()
-        # Single quote must be escaped as '\'' within single-quoted string
-        assert "export MSG='it'\\''s working'" in content
+        assert "conda activate 'my_env'" in content
+        assert "export FOO=" not in content
 
     def test_conda_name_injection(self, temp_dir):
         """Conda env name with special chars must be quoted."""

--- a/tests/slurm/clients/test_local.py
+++ b/tests/slurm/clients/test_local.py
@@ -1,0 +1,153 @@
+"""Tests for srunx.slurm.clients.local.LocalClient.
+
+Focus: the submission-environment route (REQ-5). Local submit must invoke
+sbatch with ``--export=ALL`` and a process environment composed as
+``{**os.environ, **job.environment.env_vars}`` for both the Job and the
+ShellJob branch. ``subprocess.run`` is mocked at the call site so we can
+inspect the argv and the ``env=`` mapping.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from srunx.domain import Job, JobEnvironment, ShellJob
+from srunx.slurm.clients.local import LocalClient
+
+
+def _fake_run_result(job_id: str = "12345") -> MagicMock:
+    result = MagicMock()
+    result.stdout = job_id
+    result.stderr = ""
+    result.returncode = 0
+    return result
+
+
+@pytest.fixture
+def client() -> LocalClient:
+    return LocalClient()
+
+
+class TestLocalSubmitExportAll:
+    def test_job_branch_export_all_and_merged_env(self, client):
+        job = Job(
+            name="job_export_test",
+            command=["echo", "hi"],
+            environment=JobEnvironment(env_vars={"FOO": "bar"}),
+            log_dir="",
+            work_dir="",
+        )
+        with patch(
+            "srunx.slurm.clients.local.subprocess.run",
+            return_value=_fake_run_result(),
+        ) as mock_run:
+            client.submit(job)
+
+        args, kwargs = mock_run.call_args
+        argv = args[0]
+        assert "--export=ALL" in argv
+        passed_env = kwargs["env"]
+        # Merged over os.environ, with the job env_var present.
+        assert passed_env["FOO"] == "bar"
+        for key in os.environ:
+            assert key in passed_env
+
+    def test_shell_job_branch_export_all_and_merged_env(self, client, tmp_path):
+        user_script = tmp_path / "run.sh"
+        user_script.write_text("#!/bin/bash\necho hi\n")
+        job = ShellJob(
+            name="shell_export_test",
+            script_path=str(user_script),
+            environment=JobEnvironment(env_vars={"FOO": "bar"}),
+        )
+        with patch(
+            "srunx.slurm.clients.local.subprocess.run",
+            return_value=_fake_run_result(),
+        ) as mock_run:
+            client.submit(job)
+
+        args, kwargs = mock_run.call_args
+        argv = args[0]
+        assert "--export=ALL" in argv
+        passed_env = kwargs["env"]
+        assert passed_env["FOO"] == "bar"
+        for key in os.environ:
+            assert key in passed_env
+
+
+class TestLocalSubmitNoEnvPreservesExportPolicy:
+    """No --env → leave the script's / site's export policy untouched.
+
+    A command-line ``--export`` overrides a script's own ``#SBATCH
+    --export=NONE``, so we must NOT force ``--export=ALL`` (nor override the
+    child env) when no job env vars were requested.
+    """
+
+    def test_job_branch_no_env(self, client):
+        job = Job(
+            name="plain_job",
+            command=["echo", "hi"],
+            log_dir="",
+            work_dir="",
+        )
+        with patch(
+            "srunx.slurm.clients.local.subprocess.run",
+            return_value=_fake_run_result(),
+        ) as mock_run:
+            client.submit(job)
+
+        args, kwargs = mock_run.call_args
+        assert "--export=ALL" not in args[0]
+        assert kwargs["env"] is None
+
+    def test_shell_job_branch_no_env(self, client, tmp_path):
+        user_script = tmp_path / "run.sh"
+        user_script.write_text("#!/bin/bash\necho hi\n")
+        job = ShellJob(name="plain_shell", script_path=str(user_script))
+        with patch(
+            "srunx.slurm.clients.local.subprocess.run",
+            return_value=_fake_run_result(),
+        ) as mock_run:
+            client.submit(job)
+
+        args, kwargs = mock_run.call_args
+        assert "--export=ALL" not in args[0]
+        assert kwargs["env"] is None
+
+    def test_job_path_override_does_not_break_sbatch_resolution(self, client):
+        """A job-level PATH override must not hide sbatch from the launcher.
+
+        ``subprocess.run`` resolves the executable via ``env["PATH"]``; if we
+        passed the job's PATH there, a PATH without the SLURM bin dir would
+        fail submission before queueing. The launcher must resolve sbatch
+        against its own PATH (abs path) while the job still receives PATH via
+        --export=ALL.
+        """
+        job = Job(
+            name="path_job",
+            command=["echo", "hi"],
+            environment=JobEnvironment(env_vars={"PATH": "/custom/bin"}),
+            log_dir="",
+            work_dir="",
+        )
+        with (
+            patch(
+                "srunx.slurm.clients.local.shutil.which",
+                return_value="/opt/slurm/bin/sbatch",
+            ),
+            patch(
+                "srunx.slurm.clients.local.subprocess.run",
+                return_value=_fake_run_result(),
+            ) as mock_run,
+        ):
+            client.submit(job)
+
+        args, kwargs = mock_run.call_args
+        # Launcher invokes the abs-resolved sbatch (not bare "sbatch").
+        assert args[0][0] == "/opt/slurm/bin/sbatch"
+        # The job still receives the overridden PATH via --export=ALL.
+        assert kwargs["env"]["PATH"] == "/custom/bin"
+        assert "--export=ALL" in args[0]

--- a/tests/slurm/clients/test_ssh_remote_sbatch.py
+++ b/tests/slurm/clients/test_ssh_remote_sbatch.py
@@ -202,3 +202,57 @@ def test_submit_remote_sbatch_forwards_extra_args() -> None:
     call_kwargs = inner.call_args.kwargs
     assert call_kwargs["extra_sbatch_args"] == ["--nodes=4", "--gpus-per-node=2"]
     assert call_kwargs["submit_cwd"] == "/r"
+
+
+def test_submit_remote_sbatch_forwards_job_env_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--env`` must reach the in-place remote sbatch (regression guard).
+
+    The IN_PLACE CLI path goes through ``submit_remote_sbatch`` (it passes
+    ``callbacks_job=job``); the job's ``environment.env_vars`` must be forwarded
+    to ``submit_remote_sbatch_file`` or ``--env`` is silently dropped on the
+    primary CLI SSH path.
+    """
+    from srunx.domain import JobEnvironment
+
+    adapter = _bare_adapter()
+    inner = MagicMock()
+    inner_result = MagicMock(spec=["job_id", "name"])
+    inner_result.job_id = "55"
+    inner_result.name = "train"
+    inner.return_value = inner_result
+    adapter._client.slurm.submit_remote_sbatch_file = inner  # type: ignore[method-assign]
+    monkeypatch.setattr(adapter, "_record_job_submission", lambda *a, **kw: None)
+
+    job = ShellJob(
+        name="train",
+        script_path="/cluster/share/ml/train.sh",
+        environment=JobEnvironment(env_vars={"FOO": "bar"}),
+    )
+    adapter.submit_remote_sbatch(
+        "/cluster/share/ml/train.sh",
+        submit_cwd="/cluster/share/ml",
+        job_name="train",
+        callbacks_job=job,
+    )
+
+    assert inner.call_args.kwargs["job_env_vars"] == {"FOO": "bar"}
+
+
+def test_submit_remote_sbatch_no_job_forwards_none_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy callers without a job carry no job-level env (None, not crash)."""
+    adapter = _bare_adapter()
+    inner = MagicMock()
+    inner_result = MagicMock(spec=["job_id", "name"])
+    inner_result.job_id = "56"
+    inner_result.name = "x"
+    inner.return_value = inner_result
+    adapter._client.slurm.submit_remote_sbatch_file = inner  # type: ignore[method-assign]
+    monkeypatch.setattr(adapter, "_record_job_submission", lambda *a, **kw: None)
+
+    adapter.submit_remote_sbatch("/r/x.sh")
+
+    assert inner.call_args.kwargs["job_env_vars"] is None

--- a/tests/slurm/clients/test_ssh_run.py
+++ b/tests/slurm/clients/test_ssh_run.py
@@ -92,7 +92,9 @@ class TestSSHAdapterRun:
 
         submit_calls: list[dict[str, object]] = []
 
-        def fake_submit(script_content: str, *, job_name=None, dependency=None):
+        def fake_submit(
+            script_content: str, *, job_name=None, dependency=None, job_env_vars=None
+        ):
             submit_calls.append({"content": script_content, "name": job_name})
             sj = MagicMock()
             sj.job_id = "42"
@@ -603,7 +605,9 @@ class TestSSHAdapterRunSubmissionContext:
 
         captured: dict[str, object] = {}
 
-        def fake_submit(script_content: str, *, job_name=None, dependency=None):
+        def fake_submit(
+            script_content: str, *, job_name=None, dependency=None, job_env_vars=None
+        ):
             captured["content"] = script_content
             sj = MagicMock()
             sj.job_id = "1"
@@ -661,7 +665,9 @@ class TestSSHAdapterRunSubmissionContext:
 
         captured: dict[str, object] = {}
 
-        def fake_submit(script_content: str, *, job_name=None, dependency=None):
+        def fake_submit(
+            script_content: str, *, job_name=None, dependency=None, job_env_vars=None
+        ):
             captured["content"] = script_content
             sj = MagicMock()
             sj.job_id = "2"
@@ -708,7 +714,9 @@ class TestSSHAdapterRunSubmissionContext:
 
         captured: dict[str, object] = {}
 
-        def fake_submit(script_content: str, *, job_name=None, dependency=None):
+        def fake_submit(
+            script_content: str, *, job_name=None, dependency=None, job_env_vars=None
+        ):
             captured["content"] = script_content
             sj = MagicMock()
             sj.job_id = "3"
@@ -756,7 +764,9 @@ class TestSSHAdapterRunSubmissionContext:
             log_dir="",
         )
 
-        def fake_submit(script_content: str, *, job_name=None, dependency=None):
+        def fake_submit(
+            script_content: str, *, job_name=None, dependency=None, job_env_vars=None
+        ):
             sj = MagicMock()
             sj.job_id = "4242"
             sj.name = job_name
@@ -869,3 +879,49 @@ class TestIsConnected:
             "boom"
         )
         assert adapter.is_connected is False
+
+
+class TestSubmitForwardsJobEnv:
+    """``submit`` (TEMP_UPLOAD CLI path) must forward ``--env`` (regression guard).
+
+    ``rt.job_ops.submit`` is the live CLI SSH path for the tmp-upload mode; the
+    job's ``environment.env_vars`` must reach ``submit_sbatch_job`` or ``--env``
+    is silently dropped there.
+    """
+
+    def test_submit_forwards_job_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        from srunx.domain import JobEnvironment, ShellJob
+
+        script = tmp_path / "train.sh"
+        script.write_text("#!/bin/bash\necho hi\n")
+
+        adapter = _bare_adapter()
+        job = ShellJob(
+            name="train",
+            script_path=str(script),
+            environment=JobEnvironment(env_vars={"FOO": "bar"}),
+        )
+
+        captured: dict[str, object] = {}
+
+        def fake_submit(
+            script_content: str, *, job_name=None, dependency=None, job_env_vars=None
+        ):
+            captured["job_env_vars"] = job_env_vars
+            sj = MagicMock()
+            sj.job_id = "9"
+            sj.name = job_name
+            return sj
+
+        adapter._client.slurm.submit_sbatch_job = fake_submit  # type: ignore[method-assign,assignment]
+        monkeypatch.setattr(
+            SlurmSSHClient,
+            "_record_job_submission",
+            staticmethod(lambda *a, **k: None),
+        )
+
+        adapter.submit(job)
+
+        assert captured["job_env_vars"] == {"FOO": "bar"}

--- a/tests/slurm/test_local.py
+++ b/tests/slurm/test_local.py
@@ -147,6 +147,8 @@ class TestSlurm:
             call for call in mock_run.call_args_list if "sbatch" in call[0][0]
         ]
         assert len(sbatch_calls) >= 1
+        # No --env was supplied, so the export policy is left untouched:
+        # plain `sbatch --parsable <script>` with no --export flag.
         assert sbatch_calls[0][0][0] == ["sbatch", "--parsable", "/tmp/shell_job.slurm"]
 
     @patch("time.sleep")

--- a/tests/slurm/test_ssh_executor_pool.py
+++ b/tests/slurm/test_ssh_executor_pool.py
@@ -324,7 +324,9 @@ class TestRenderParity:
 
         captured: dict[str, str] = {}
 
-        def fake_submit(script_content: str, *, job_name=None, dependency=None):
+        def fake_submit(
+            script_content: str, *, job_name=None, dependency=None, job_env_vars=None
+        ):
             captured["script"] = script_content
             slurm_job = MagicMock()
             slurm_job.job_id = "99999"

--- a/tests/ssh/core/test_slurm.py
+++ b/tests/ssh/core/test_slurm.py
@@ -10,6 +10,7 @@ graph for us) but exercises the slurm component directly via
   file ops the slurm component calls back into.
 """
 
+import shlex
 from unittest.mock import Mock, patch
 
 import pytest
@@ -116,6 +117,114 @@ class TestSubmitSbatchJob:
 
         job = client.slurm.submit_sbatch_job(script_content, job_name="test_job")
         assert job is None
+
+
+class TestJobEnvPropagation:
+    """AC-7: job env_vars ride into the remote env prefix + --export=ALL.
+
+    Mocks ``connection.execute_command`` so we can inspect the *full* shell
+    command (env prefix + sbatch) that gets sent to the remote — the env
+    prefix is assembled in ``execute_slurm_command`` / ``_get_slurm_env_setup``,
+    which we exercise for real here.
+    """
+
+    def _capture_remote_command(self, client):
+        captured: dict[str, str] = {}
+
+        def fake_execute(cmd: str):
+            captured["cmd"] = cmd
+            # execute_slurm_command wraps the real command in
+            # ``bash -l -c '<inner>'``; the inner command's own single quotes
+            # are re-escaped by that outer wrapper. Unwrap with shlex so
+            # assertions see the de-escaped command actually run on the remote.
+            try:
+                parts = shlex.split(cmd)
+                captured["inner"] = parts[-1] if parts else cmd
+            except ValueError:
+                captured["inner"] = cmd
+            return ("Submitted batch job 12345", "", 0)
+
+        client.connection.execute_command = Mock(side_effect=fake_execute)
+        client.slurm._get_slurm_command = Mock(return_value="sbatch")
+        return captured
+
+    def test_temp_upload_path_env_prefix_and_export_all(self, client):
+        client.files.write_remote_file = Mock()
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = self._capture_remote_command(client)
+
+        job = client.slurm.submit_sbatch_job(
+            "#!/bin/bash\necho hi",
+            job_name="test_job",
+            job_env_vars={"FOO": "bar"},
+        )
+
+        assert job is not None and job.job_id == "12345"
+        assert "export FOO='bar'" in captured["inner"]
+        assert "--export=ALL" in captured["inner"]
+
+    def test_in_place_path_env_prefix_and_export_all(self, client):
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = self._capture_remote_command(client)
+
+        job = client.slurm.submit_remote_sbatch_file(
+            "/remote/run.sh",
+            job_name="test_job",
+            job_env_vars={"FOO": "bar"},
+        )
+
+        assert job is not None and job.job_id == "12345"
+        assert "export FOO='bar'" in captured["inner"]
+        assert "--export=ALL" in captured["inner"]
+
+    def test_env_value_single_quote_escaped(self, client):
+        client.files.write_remote_file = Mock()
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = self._capture_remote_command(client)
+
+        client.slurm.submit_sbatch_job(
+            "#!/bin/bash\necho hi",
+            job_name="test_job",
+            job_env_vars={"MSG": "it's working"},
+        )
+
+        # Single quote escaped as '\'' within the single-quoted value.
+        assert "export MSG='it'\\''s working'" in captured["inner"]
+
+    def test_job_env_overrides_profile_custom_env(self, client):
+        client.connection.custom_env_vars = {"FOO": "profile"}
+        client.files.write_remote_file = Mock()
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = self._capture_remote_command(client)
+
+        client.slurm.submit_sbatch_job(
+            "#!/bin/bash\necho hi",
+            job_name="test_job",
+            job_env_vars={"FOO": "job"},
+        )
+
+        # Job key wins ({**profile, **job}); only the job value is exported.
+        assert "export FOO='job'" in captured["inner"]
+        assert "export FOO='profile'" not in captured["inner"]
+
+    def test_no_job_env_omits_export_all_temp_upload(self, client):
+        """No job env → no --export=ALL, so the script's export policy wins."""
+        client.files.write_remote_file = Mock()
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = self._capture_remote_command(client)
+
+        client.slurm.submit_sbatch_job("#!/bin/bash\necho hi", job_name="test_job")
+
+        assert "--export=ALL" not in captured["inner"]
+
+    def test_no_job_env_omits_export_all_in_place(self, client):
+        """In-place path must preserve the user's own #SBATCH directives."""
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = self._capture_remote_command(client)
+
+        client.slurm.submit_remote_sbatch_file("/remote/run.sh", job_name="test_job")
+
+        assert "--export=ALL" not in captured["inner"]
 
 
 class TestCleanupJobFiles:

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -1733,6 +1733,18 @@ class TestScriptPreview:
         assert "ml_env" in script
         assert data["template_used"] == "base"
 
+    def test_preview_invalid_env_key_returns_422(self, client: TestClient) -> None:
+        """An invalid env-var key surfaces as 422, not a 500."""
+        resp = client.post(
+            "/api/jobs/preview",
+            json={
+                "name": "bad-env",
+                "command": ["echo", "hi"],
+                "environment": {"env_vars": {"SLURM_FOO": "x"}},
+            },
+        )
+        assert resp.status_code == 422
+
     def test_preview_with_specific_template(self, client: TestClient) -> None:
         """Preview with template_name='base' uses the base template."""
         resp = client.post(
@@ -1850,6 +1862,19 @@ class TestTemplatesRouter:
         assert "script" in data
         assert data["template_used"] == "base"
         assert "#!/bin/bash" in data["script"]
+
+    def test_apply_invalid_env_key_returns_422(self, client: TestClient) -> None:
+        """An invalid env-var key surfaces as 422, not a 500."""
+        resp = client.post(
+            "/api/templates/base/apply",
+            json={
+                "command": ["echo", "hi"],
+                "job_name": "bad-env",
+                "environment": {"env_vars": {"bad-key": "x"}},
+                "preview_only": True,
+            },
+        )
+        assert resp.status_code == 422
 
     def test_apply_submits_job(
         self, client: TestClient, mock_adapter: MagicMock

--- a/tests/web/test_routers.py
+++ b/tests/web/test_routers.py
@@ -747,7 +747,9 @@ class TestWorkflowsRouter:
         # Mock submit_job to return incrementing job IDs
         call_count = 0
 
-        def mock_submit(script_content, job_name=None, dependency=None):
+        def mock_submit(
+            script_content, job_name=None, dependency=None, job_env_vars=None
+        ):
             nonlocal call_count
             call_count += 1
             return {
@@ -823,7 +825,9 @@ class TestWorkflowsRouter:
 
         call_count = 0
 
-        def mock_submit(script_content, job_name=None, dependency=None):
+        def mock_submit(
+            script_content, job_name=None, dependency=None, job_env_vars=None
+        ):
             nonlocal call_count
             call_count += 1
             return {
@@ -1130,7 +1134,9 @@ class TestWorkflowsRouter:
         # sbatch outage between siblings.
         call_count = 0
 
-        def mock_submit(script_content, job_name=None, dependency=None):
+        def mock_submit(
+            script_content, job_name=None, dependency=None, job_env_vars=None
+        ):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -1925,6 +1931,7 @@ class TestWorkflowExecutionControl:
             script_content: str,
             job_name: str | None = None,
             dependency: str | None = None,
+            job_env_vars: dict | None = None,
         ) -> dict:
             counter["n"] += 1
             return {
@@ -2353,7 +2360,9 @@ class TestWorkflowsRouterInPlace:
 
         counter = {"n": 0}
 
-        def fake_submit(script_content, job_name=None, dependency=None):
+        def fake_submit(
+            script_content, job_name=None, dependency=None, job_env_vars=None
+        ):
             counter["n"] += 1
             return {
                 "name": job_name or "job",


### PR DESCRIPTION
## 背景

`srunx sbatch --env KEY=VALUE` には3つの問題があった:

1. **`--wrap` のときだけ有効** — 位置引数スクリプト（ShellJob）では黙って no-op。
2. **スクリプト本文に焼き込み** — env をレンダリング済み SLURM スクリプトに `export KEY='value'` 行として埋め込んでいた（SSH 経由では remote の temp に平文残留）。
3. **キー未検証** — CLI/Web/MCP すべてが任意キーを受理（キー経由のシェル注入余地）。

## 変更

`--env` をスケジューラ非依存の **job-level environment** として再設計:

- **キー検証を `JobEnvironment`（domain）境界に集約** — `^[A-Za-z_][A-Za-z0-9_]*$`、`SLURM_`/`SBATCH_` プレフィックス拒否。CLI/Web/MCP を単一境界でカバー。
- **`environment` を `BaseJob` へ引き上げ** — `ShellJob` でも `--env` が `--wrap` と同じ意味に（no-op 廃止）。
- **スクリプト本文への焼き込みを廃止** — local は `subprocess.run(env={**os.environ, **env_vars})`、SSH は remote の `export KEY='value'` 前置（job キーが profile `custom_env_vars` より優先、single-quote エスケープ）で実現。
- **`--export=ALL` は env_vars が非空のときだけ付与** — bare submit はスクリプト/サイトの export ポリシーを保持（コマンドライン `--export` は `#SBATCH --export=NONE` を上書きするため）。local で env 指定時は `sbatch` を launcher の PATH で絶対解決し、job の `PATH` 上書きが launcher を壊さないようにした。
- **全投入経路に env を配線** — local / SSH temp-upload / SSH in-place / workflow / legacy `submit_job` alias / Web workflow + template（後者2つは焼き込み廃止後に env を落としていた）。

conda/venv/container は計算ノードの activation として本文に残す（別経路・SRP）。`--export=ALL` の realize は SLURM アダプタ層に限定（DIP）、`JobOperations.submit` シグネチャは不変（ISP）。

### スコープ外（意図的に未実装）
`--secret-env` と native の `--export <SPEC>` フラグは作っていない。将来追加できるよう境界だけ綺麗に保った。

## テスト

- 全投入経路の env 転送、キー検証、本文非焼き込み、escape、export ポリシー保持、PATH 解決のガードテストを追加。
- フルスイート **2144 passed, 2 skipped**、`mypy .` クリーン、`ruff check .` クリーン。

## レビュー

Claude サブエージェント（post-impl + spec-compliance + delta）+ Codex の独立レビューを実施。Codex が無条件 `--export=ALL` による退行3件（`#SBATCH --export=NONE` 上書き×2、`--env PATH=...` での sbatch 解決失敗）を検出し、すべて修正・ガードテスト追加済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)