### PR TITLE
feat(ssh): add `ssh secret` per-profile secret store; remove unsafe `ssh env`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,11 +136,41 @@ mount names via `--mount` (no `profile` / `mount` positional sub-noun).
 - `uv run srunx ssh mount add --profile <profile> --mount <name> --local <path> --remote <path>` - Add mount point
 - `uv run srunx ssh mount list --profile <profile>` - List mount points
 - `uv run srunx ssh mount remove --profile <profile> --mount <name>` - Remove mount point
+- `uv run srunx ssh secret set <KEY> --profile <profile>` - Store a secret for a profile (value via hidden getpass prompt, or `--from-env VAR`; NO inline value argument)
+- `uv run srunx ssh secret list [--profile <profile>]` - List secret KEY names for a profile (values are never printed)
+- `uv run srunx ssh secret unset <KEY> --profile <profile>` - Remove a secret from a profile
 - `uv run srunx ssh test --profile <name>` - Test connectivity for a profile
 - `uv run srunx ssh test --host <alias>` - Test an `~/.ssh/config` host alias
 - `uv run srunx ssh sync` - Sync current directory's mount (auto-detect profile and mount from cwd)
 - `uv run srunx ssh sync --profile <profile> --mount <name>` - Sync a specific mount
 - `uv run srunx ssh sync --dry-run` - Preview sync without transferring
+
+##### Account secrets (`ssh secret`)
+Secrets (API keys etc.) are stored in a single **remote** `0600` file per
+account (not per profile), `$HOME/.config/srunx/secrets.env` (parent dir
+`~/.config/srunx` is `0700`), as `export KEY='...'` lines. The path is keyed by
+remote account (`$HOME`), not by local profile name — the SSH connection you
+pick via `--profile` selects the account, so the same file is shared by any
+profile pointing at that account (this avoids rename-orphaning and profile-name
+mismatches between machines). The value is captured only via a hidden getpass
+prompt or `--from-env VAR` — never an inline command argument — and never
+lands in the local `config.json`, command-line args, or log output. Writes are
+atomic (temp file in the same dir + `mv`) with a symlink/foreign-owner guard.
+`secret list` prints KEY names only. The old `srunx ssh env` /
+profile-`custom_env_vars` mechanism (which stored env vars in local plaintext
+config) has been removed entirely with no backward-compat shim; a legacy
+`config.json` that still carries a profile `env_vars` block still loads (the
+stray key is silently dropped).
+
+On submit over SSH, when the profile's secret file exists srunx sources it into
+the submission shell — `if [ -r '<path>' ]; then set -a; . '<path>'; set +a; fi`
+(non-blocking: always exits 0 so an unreadable/removed file never fails the
+actual squeue/scancel/sbatch) — before the job-level `--env` exports (a `--env`
+key still wins over a same-named secret). Because the secret must reach the job, `--export=ALL` is added to the
+remote `sbatch` whenever job env vars are present **or** the secret file exists;
+that deliberately overrides a script's own `#SBATCH --export=NONE`. With neither
+job env vars nor a secret file, `--export=ALL` is not added and the script's own
+export policy wins.
 
 #### Workflows
 - `uv run srunx flow run <yaml_file>` - Execute workflow from YAML

--- a/src/srunx/slurm/clients/_ssh_types.py
+++ b/src/srunx/slurm/clients/_ssh_types.py
@@ -71,5 +71,4 @@ class SlurmSSHClientSpec:
     key_filename: str | None
     port: int
     proxy_jump: str | None = None
-    env_vars: tuple[tuple[str, str], ...] = ()
     mounts: tuple[MountConfig, ...] = field(default_factory=tuple)

--- a/src/srunx/slurm/clients/ssh.py
+++ b/src/srunx/slurm/clients/ssh.py
@@ -96,7 +96,6 @@ class SlurmSSHClient:
         key_filename: str | None = None,
         port: int = 22,
         proxy_jump: str | None = None,
-        env_vars: dict[str, str] | None = None,
         mounts: Sequence[MountConfig] | None = None,
         callbacks: Sequence[Callback] | None = None,
         submission_source: str = "web",
@@ -124,7 +123,6 @@ class SlurmSSHClient:
         self._key_filename: str | None = None
         self._port: int = port
         self._proxy_jump: str | None = None
-        self._env_vars: dict[str, str] = dict(env_vars) if env_vars else {}
         self._mounts: tuple[MountConfig, ...] = (
             tuple(mounts) if mounts is not None else ()
         )
@@ -140,8 +138,6 @@ class SlurmSSHClient:
                 raise ValueError(f"SSH profile '{profile_name}' not found")
 
             self._mounts = tuple(profile.mounts) if profile.mounts else ()
-            if profile.env_vars:
-                self._env_vars = dict(profile.env_vars)
 
             # Resolve connection: ssh_host (from ~/.ssh/config) or direct fields.
             if profile.ssh_host:
@@ -162,7 +158,7 @@ class SlurmSSHClient:
                     key_filename=self._key_filename,
                     port=self._port,
                     proxy_jump=self._proxy_jump,
-                    env_vars=self._env_vars or None,
+                    profile_name=profile_name,
                 )
             else:
                 # Resolve hostname via ~/.ssh/config if it's an alias.
@@ -193,7 +189,7 @@ class SlurmSSHClient:
                     key_filename=resolved_key,
                     port=resolved_port,
                     proxy_jump=resolved_proxy,
-                    env_vars=self._env_vars or None,
+                    profile_name=profile_name,
                 )
         elif hostname and username:
             self._hostname = hostname
@@ -207,7 +203,7 @@ class SlurmSSHClient:
                 key_filename=key_filename,
                 port=port,
                 proxy_jump=proxy_jump,
-                env_vars=self._env_vars or None,
+                profile_name=self._profile_name,
             )
         else:
             raise ValueError("Either profile_name or (hostname, username) required")
@@ -245,7 +241,6 @@ class SlurmSSHClient:
             key_filename=self._key_filename,
             port=self._port,
             proxy_jump=self._proxy_jump,
-            env_vars=tuple(sorted(self._env_vars.items())),
             mounts=self._mounts,
         )
 
@@ -286,12 +281,17 @@ class SlurmSSHClient:
             key_filename=spec.key_filename,
             port=spec.port,
             proxy_jump=spec.proxy_jump,
-            env_vars=dict(spec.env_vars) if spec.env_vars else None,
             mounts=list(spec.mounts) if spec.mounts else None,
             callbacks=callbacks,
             submission_source=submission_source,
         )
         client._profile_name = spec.profile_name
+        # Rebind the profile on the inner SSH adapter so account secret
+        # behaviour is enabled for pooled sweep clones (the ctor above ran the
+        # direct-hostname branch with ``profile_name=None`` to avoid the
+        # ConfigManager re-parse). The secret file path itself is account
+        # scoped; the profile name here only flips secret behaviour on.
+        client._client.bind_profile_name(spec.profile_name)
         return client
 
     @property

--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -12,7 +12,7 @@ Command surface (flat — there is no ``profile`` sub-app):
     srunx ssh test    [--profile NAME] [--host ALIAS]
     srunx ssh sync    [--profile NAME] [--mount MOUNT]
     srunx ssh mount add|list|remove  --profile NAME [--mount MOUNT] [...]
-    srunx ssh env  set|unset|list    --profile NAME [KEY] [VALUE]
+    srunx ssh secret  set|list|unset  --profile NAME [KEY]
 
 The profile is named with ``--profile`` everywhere (never a positional, never
 ``-p`` — ``-p`` is reserved for ``--partition`` across srunx). A mount is named
@@ -37,7 +37,7 @@ from .profile_impl import add_profile_impl
 console = Console()
 
 # Create the main SSH app. Profile lifecycle verbs live directly under it;
-# only the per-profile sub-entities (mounts, env vars) keep a one-level group.
+# only the per-profile sub-entities (mounts, secrets) keep a one-level group.
 ssh_app = typer.Typer(
     name="ssh",
     help="Manage SSH connection profiles, sync mounts, and test connections",
@@ -153,7 +153,7 @@ def test_connection(
         with Status(
             "[bold yellow]Testing connection...[/bold yellow]", console=console
         ):
-            client = _create_ssh_client(connection_params, {}, verbose)
+            client = _create_ssh_client(connection_params, verbose)
             result = client.test_connection()
 
         # Display results
@@ -515,48 +515,61 @@ def update_profile(
 
 
 # ---------------------------------------------------------------------------
-# Environment variable management for profiles (``ssh env ...``)
+# Secret management for profiles (``ssh secret ...``)
 # ---------------------------------------------------------------------------
-env_app = typer.Typer(
-    name="env",
-    help="Manage environment variables for a profile",
+secret_app = typer.Typer(
+    name="secret",
+    help="Manage account secrets stored in a remote 0600 file",
 )
-ssh_app.add_typer(env_app, name="env")
+ssh_app.add_typer(secret_app, name="secret")
 
 
-@env_app.command("set")
-def set_env_var(
+@secret_app.command("set")
+def set_secret(
     profile: _ProfileRequired,
-    key: Annotated[str, typer.Argument(help="Environment variable name")],
-    value: Annotated[str, typer.Argument(help="Environment variable value")],
+    key: Annotated[str, typer.Argument(help="Secret name (shell identifier)")],
+    from_env: Annotated[
+        str | None,
+        typer.Option(
+            "--from-env",
+            help="Read the value from this local environment variable "
+            "instead of prompting",
+        ),
+    ] = None,
     config: _ConfigOpt = None,
 ):
-    """Set an environment variable for a profile."""
-    from .profile_impl import set_env_var_impl
+    """Set a secret for a profile.
 
-    set_env_var_impl(profile, key, value, config)
+    The value is read via a hidden getpass prompt by default, or from a local
+    environment variable with ``--from-env VAR``. No inline value argument is
+    accepted — the secret never lands in your shell history or the process
+    argument list.
+    """
+    from .secret_impl import set_secret_impl
 
-
-@env_app.command("unset")
-def unset_env_var(
-    profile: _ProfileRequired,
-    key: Annotated[str, typer.Argument(help="Environment variable name")],
-    config: _ConfigOpt = None,
-):
-    """Unset an environment variable for a profile."""
-    from .profile_impl import unset_env_var_impl
-
-    unset_env_var_impl(profile, key, config)
+    set_secret_impl(profile, key, from_env, config)
 
 
-@env_app.command("list")
-def list_env_vars(profile: _ProfileOptional = None, config: _ConfigOpt = None):
-    """List environment variables for a profile (defaults to current)."""
-    from .profile_impl import list_env_vars_impl
+@secret_app.command("list")
+def list_secrets(profile: _ProfileOptional = None, config: _ConfigOpt = None):
+    """List secret names for a profile (defaults to current). Values are never shown."""
+    from .secret_impl import list_secrets_impl
 
     config_manager = ConfigManager(config)
     profile_name = _resolve_optional_profile(profile, config_manager)
-    list_env_vars_impl(profile_name, config)
+    list_secrets_impl(profile_name, config)
+
+
+@secret_app.command("unset")
+def unset_secret(
+    profile: _ProfileRequired,
+    key: Annotated[str, typer.Argument(help="Secret name to remove")],
+    config: _ConfigOpt = None,
+):
+    """Remove a secret from a profile."""
+    from .secret_impl import unset_secret_impl
+
+    unset_secret_impl(profile, key, config)
 
 
 # ---------------------------------------------------------------------------
@@ -727,9 +740,7 @@ def _determine_connection_params(
     raise typer.Exit(1)
 
 
-def _create_ssh_client(
-    connection_params: dict, env_vars: dict[str, str], verbose: bool
-) -> SSHSlurmClient:
+def _create_ssh_client(connection_params: dict, verbose: bool) -> SSHSlurmClient:
     """Create SSH SLURM client with proper type handling."""
     hostname = str(connection_params["hostname"])
     username = str(connection_params["username"])
@@ -746,6 +757,5 @@ def _create_ssh_client(
         key_filename=key_filename,
         port=port,
         proxy_jump=proxy_jump,
-        env_vars=env_vars,
         verbose=verbose,
     )

--- a/src/srunx/ssh/cli/profile_impl.py
+++ b/src/srunx/ssh/cli/profile_impl.py
@@ -117,7 +117,6 @@ def add_profile_impl(
             description=description,
             ssh_host=ssh_host,
             proxy_jump=proxy_jump,
-            env_vars={},
         )
 
         # Add the profile
@@ -286,23 +285,6 @@ def show_profile_impl(name: str | None = None, config: str | None = None):
             details.append("\n[bold green]Description:[/bold green]")
             details.append(f"  {profile.description}")
 
-        # Environment variables
-        if profile.env_vars:
-            details.append("\n[bold yellow]Environment Variables:[/bold yellow]")
-            for key, value in profile.env_vars.items():
-                # Hide sensitive values
-                if any(
-                    sensitive in key.upper()
-                    for sensitive in ["TOKEN", "KEY", "SECRET", "PASSWORD"]
-                ):
-                    display_value = "***HIDDEN***"
-                else:
-                    display_value = value
-                details.append(f"  {key}={display_value}")
-        else:
-            details.append("\n[bold yellow]Environment Variables:[/bold yellow]")
-            details.append("  [dim]None configured[/dim]")
-
         # Current profile indicator
         current_profile_name = config_manager.get_current_profile_name()
         title = f"Profile: {profile_name}"
@@ -387,126 +369,6 @@ def update_profile_impl(
         else:
             console.print(f"[red]❌ Failed to update profile '{name}'[/red]")
             raise typer.Exit(1)
-
-    except Exception as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1) from e
-
-
-def set_env_var_impl(
-    profile_name: str, key: str, value: str, config: str | None = None
-):
-    """Implementation for setting an environment variable for a profile."""
-    try:
-        config_manager = ConfigManager(config)
-
-        # Check if profile exists
-        profile = config_manager.get_profile(profile_name)
-        if not profile:
-            console.print(f"[red]Error: Profile '{profile_name}' not found[/red]")
-            raise typer.Exit(1)
-
-        # Set environment variable
-        success = config_manager.set_profile_env_var(profile_name, key, value)
-
-        if success:
-            # Hide sensitive values in output
-            if any(
-                sensitive in key.upper()
-                for sensitive in ["TOKEN", "KEY", "SECRET", "PASSWORD"]
-            ):
-                display_value = "***HIDDEN***"
-            else:
-                display_value = value
-
-            console.print(
-                f"[green]✅ Environment variable set for profile '{profile_name}'[/green]"
-            )
-            console.print(f"[dim]{key}={display_value}[/dim]")
-        else:
-            console.print(
-                f"[red]❌ Failed to set environment variable for profile '{profile_name}'[/red]"
-            )
-            raise typer.Exit(1)
-
-    except Exception as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1) from e
-
-
-def unset_env_var_impl(profile_name: str, key: str, config: str | None = None):
-    """Implementation for unsetting an environment variable for a profile."""
-    try:
-        config_manager = ConfigManager(config)
-
-        # Check if profile exists
-        profile = config_manager.get_profile(profile_name)
-        if not profile:
-            console.print(f"[red]Error: Profile '{profile_name}' not found[/red]")
-            raise typer.Exit(1)
-
-        # Check if environment variable exists
-        if not profile.env_vars or key not in profile.env_vars:
-            console.print(
-                f"[yellow]Environment variable '{key}' not set for profile '{profile_name}'[/yellow]"
-            )
-            return
-
-        # Unset environment variable
-        success = config_manager.unset_profile_env_var(profile_name, key)
-
-        if success:
-            console.print(
-                f"[green]✅ Environment variable '{key}' removed from profile '{profile_name}'[/green]"
-            )
-        else:
-            console.print(
-                f"[red]❌ Failed to remove environment variable '{key}' from profile '{profile_name}'[/red]"
-            )
-            raise typer.Exit(1)
-
-    except Exception as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1) from e
-
-
-def list_env_vars_impl(profile_name: str, config: str | None = None):
-    """Implementation for listing environment variables for a profile."""
-    try:
-        config_manager = ConfigManager(config)
-
-        # Check if profile exists
-        profile = config_manager.get_profile(profile_name)
-        if not profile:
-            console.print(f"[red]Error: Profile '{profile_name}' not found[/red]")
-            raise typer.Exit(1)
-
-        if not profile.env_vars:
-            console.print(
-                f"[yellow]No environment variables set for profile '{profile_name}'[/yellow]"
-            )
-            console.print(
-                "[dim]Use 'srunx ssh env set' to add environment variables[/dim]"
-            )
-            return
-
-        # Create table
-        table = Table(title=f"Environment Variables for Profile '{profile_name}'")
-        table.add_column("Variable", style="cyan", no_wrap=True)
-        table.add_column("Value", style="green")
-
-        for key, value in profile.env_vars.items():
-            # Hide sensitive values
-            if any(
-                sensitive in key.upper()
-                for sensitive in ["TOKEN", "KEY", "SECRET", "PASSWORD"]
-            ):
-                display_value = "***HIDDEN***"
-            else:
-                display_value = value
-            table.add_row(key, display_value)
-
-        console.print(table)
 
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")

--- a/src/srunx/ssh/cli/secret_impl.py
+++ b/src/srunx/ssh/cli/secret_impl.py
@@ -1,0 +1,181 @@
+"""CLI implementations for ``srunx ssh secret set/list/unset``.
+
+Thin wrappers over :class:`srunx.ssh.core.secret_store.RemoteSecretStore`:
+acquire the value (hidden getpass prompt or ``--from-env``), validate the KEY
+and value, then drive the store. Secret values are NEVER printed — success
+messages and ``list`` output name only the KEY.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ..core.config import ConfigManager
+from ..core.connection import SSHConnection
+from ..core.file_manager import RemoteFileManager
+from ..core.secret_store import RemoteSecretStore, _validate_key, _validate_value
+from ..core.ssh_config import get_ssh_config_host
+
+console = Console()
+
+
+def _build_store(
+    profile_name: str, config: str | None
+) -> tuple[SSHConnection, RemoteSecretStore]:
+    """Resolve the profile's connection and return a (connection, store) pair.
+
+    The connection is NOT yet connected — the caller opens it. Raises
+    ``typer.Exit`` when the profile is missing.
+    """
+    config_manager = ConfigManager(config)
+    profile = config_manager.get_profile(profile_name)
+    if not profile:
+        console.print(f"[red]Error: Profile '{profile_name}' not found[/red]")
+        raise typer.Exit(1)
+
+    # Resolve connection params: ssh_host alias (from ~/.ssh/config) or direct.
+    if profile.ssh_host:
+        ssh_host = get_ssh_config_host(profile.ssh_host, None)
+        if not ssh_host:
+            console.print(
+                f"[red]Error: SSH host '{profile.ssh_host}' not found in ~/.ssh/config[/red]"
+            )
+            raise typer.Exit(1)
+        hostname = ssh_host.hostname or profile.ssh_host
+        username = ssh_host.user or ""
+        key_filename = ssh_host.identity_file
+        port = ssh_host.port or 22
+        proxy_jump = ssh_host.proxy_jump
+    else:
+        hostname = profile.hostname
+        username = profile.username
+        key_filename = profile.key_filename or None
+        port = profile.port
+        proxy_jump = profile.proxy_jump
+        resolved = get_ssh_config_host(profile.hostname, None)
+        if resolved and resolved.hostname:
+            hostname = resolved.hostname
+            if resolved.identity_file and not key_filename:
+                key_filename = resolved.identity_file
+            if resolved.port:
+                port = resolved.port
+            if resolved.proxy_jump and not proxy_jump:
+                proxy_jump = resolved.proxy_jump
+
+    connection = SSHConnection(
+        hostname=hostname,
+        username=username,
+        key_filename=key_filename,
+        port=port,
+        proxy_jump=proxy_jump,
+    )
+    files = RemoteFileManager(connection)
+    store = RemoteSecretStore(connection, files)
+    return connection, store
+
+
+def set_secret_impl(
+    profile_name: str,
+    key: str,
+    from_env: str | None,
+    config: str | None = None,
+) -> None:
+    """Set a secret for a profile.
+
+    Value acquisition: ``--from-env VAR`` reads ``os.environ[VAR]``; the
+    default path prompts with a hidden getpass. The value is never echoed.
+    """
+    try:
+        # Validate the KEY before touching the network or reading a value.
+        try:
+            _validate_key(key)
+        except ValueError as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+            raise typer.Exit(1) from exc
+
+        # Acquire the value.
+        if from_env is not None:
+            if from_env not in os.environ:
+                console.print(
+                    f"[red]Error: environment variable '{from_env}' is not set[/red]"
+                )
+                raise typer.Exit(1)
+            value = os.environ[from_env]
+        else:
+            value = getpass.getpass(f"Secret for {key}: ")
+
+        try:
+            _validate_value(value)
+        except ValueError as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+            raise typer.Exit(1) from exc
+
+        connection, store = _build_store(profile_name, config)
+        with connection:
+            store.set_secret(key, value)
+
+        console.print(
+            f"[green]✅ Secret '{key}' stored for profile '{profile_name}'[/green]"
+        )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1) from e
+
+
+def list_secrets_impl(profile_name: str, config: str | None = None) -> None:
+    """List secret KEY names for a profile. Values are never printed."""
+    try:
+        connection, store = _build_store(profile_name, config)
+        with connection:
+            keys = store.list_keys()
+
+        if not keys:
+            console.print(
+                f"[yellow]No secrets set for profile '{profile_name}'[/yellow]"
+            )
+            console.print("[dim]Use 'srunx ssh secret set' to add a secret[/dim]")
+            return
+
+        table = Table(title=f"Secrets for Profile '{profile_name}'")
+        table.add_column("Name", style="cyan", no_wrap=True)
+        for key in keys:
+            table.add_row(key)
+        console.print(table)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1) from e
+
+
+def unset_secret_impl(profile_name: str, key: str, config: str | None = None) -> None:
+    """Remove a secret from a profile."""
+    try:
+        try:
+            _validate_key(key)
+        except ValueError as exc:
+            console.print(f"[red]Error: {exc}[/red]")
+            raise typer.Exit(1) from exc
+
+        connection, store = _build_store(profile_name, config)
+        with connection:
+            store.unset_secret(key)
+
+        console.print(
+            f"[green]✅ Secret '{key}' removed from profile '{profile_name}'[/green]"
+        )
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1) from e

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -73,7 +73,7 @@ class SSHSlurmClient:
         port: int = 22,
         proxy_jump: str | None = None,
         ssh_config_path: str | None = None,
-        env_vars: dict[str, str] | None = None,
+        profile_name: str | None = None,
         verbose: bool = False,
     ):
         self.hostname = hostname
@@ -83,6 +83,7 @@ class SSHSlurmClient:
         self.port = port
         self.proxy_jump = proxy_jump
         self.ssh_config_path = ssh_config_path
+        self.profile_name = profile_name
         self.logger = _logger
         self.verbose = verbose
 
@@ -95,10 +96,11 @@ class SSHSlurmClient:
             proxy_jump=proxy_jump,
             ssh_config_path=ssh_config_path,
             verbose=verbose,
-            env_vars=env_vars,
         )
         self.files = RemoteFileManager(self.connection)
-        self.slurm = SlurmRemoteClient(self.connection, self.files)
+        self.slurm = SlurmRemoteClient(
+            self.connection, self.files, profile_name=profile_name
+        )
         self.logs = RemoteLogReader(self.connection, self.slurm)
 
         # RsyncClient for project sync (key-based auth only).
@@ -138,6 +140,18 @@ class SSHSlurmClient:
             # PATH-resolved binaries even if path discovery failed).
             self.logger.warning(f"SLURM initialization failed: {exc}")
         return True
+
+    def bind_profile_name(self, profile_name: str | None) -> None:
+        """(Re)bind the SSH profile to enable/disable account secrets.
+
+        Delegates to :meth:`SlurmRemoteClient.bind_profile_name`. Used by the
+        sweep pool clone path (:meth:`SlurmSSHClient.from_spec`) where the
+        adapter is built without a profile to avoid a ConfigManager re-parse.
+        The profile name only gates secret behaviour on/off; the secret file
+        itself is account (``$HOME``) scoped.
+        """
+        self.profile_name = profile_name
+        self.slurm.bind_profile_name(profile_name)
 
     def disconnect(self) -> None:
         self.connection.disconnect()

--- a/src/srunx/ssh/core/config.py
+++ b/src/srunx/ssh/core/config.py
@@ -76,6 +76,11 @@ class MountConfig(BaseModel):
 
 
 class ServerProfile(BaseModel):
+    # ``extra="ignore"`` (the Pydantic v2 default, made explicit here) drops
+    # any stray keys in a legacy ``config.json`` — notably the removed
+    # ``env_vars`` block — so old configs still load without error (REQ-11).
+    model_config = ConfigDict(extra="ignore")
+
     hostname: str = Field(..., description="The hostname of the server")
     username: str = Field(..., description="The username of the server")
     key_filename: str = Field(..., description="The key filename of the server")
@@ -86,9 +91,6 @@ class ServerProfile(BaseModel):
     )
     proxy_jump: str | None = Field(
         None, description="The ProxyJump host name if using ProxyJump"
-    )
-    env_vars: dict[str, str] | None = Field(
-        None, description="The environment variables for this profile"
     )
     mounts: list[MountConfig] = Field(
         default=[], description="Local-to-remote path mappings for project directories"
@@ -241,28 +243,6 @@ class ConfigManager:
 
     def expand_path(self, path: str) -> str:
         return os.path.expanduser(path)
-
-    def set_profile_env_var(self, profile_name: str, key: str, value: str) -> bool:
-        """Set an environment variable for a profile."""
-        if profile_name in self.config_data.get("profiles", {}):
-            profile_data = self.config_data["profiles"][profile_name]
-            if "env_vars" not in profile_data:
-                profile_data["env_vars"] = {}
-            profile_data["env_vars"][key] = value
-            self.save_config()
-            return True
-        return False
-
-    def unset_profile_env_var(self, profile_name: str, key: str) -> bool:
-        """Unset an environment variable for a profile."""
-        if profile_name in self.config_data.get("profiles", {}):
-            profile_data = self.config_data["profiles"][profile_name]
-            env_vars = profile_data.get("env_vars", {})
-            if key in env_vars:
-                del env_vars[key]
-                self.save_config()
-                return True
-        return False
 
     def add_profile_mount(self, profile_name: str, mount: MountConfig) -> bool:
         """Add a mount to a profile.

--- a/src/srunx/ssh/core/connection.py
+++ b/src/srunx/ssh/core/connection.py
@@ -33,7 +33,6 @@ class SSHConnection:
         ssh_config_path: str | None = None,
         verbose: bool = False,
         temp_dir: str | None = None,
-        env_vars: dict[str, str] | None = None,
     ):
         self.hostname = hostname
         self.username = username
@@ -47,7 +46,6 @@ class SSHConnection:
         self.proxy_client: ProxySSHClient | None = None
         self.logger = _logger
         self.temp_dir: str = temp_dir or os.getenv("SRUNX_TEMP_DIR") or "/tmp/srunx"
-        self.custom_env_vars: dict[str, str] = env_vars or {}
         self.verbose = verbose
         self._last_error: Exception | None = None
 

--- a/src/srunx/ssh/core/secret_store.py
+++ b/src/srunx/ssh/core/secret_store.py
@@ -1,0 +1,374 @@
+"""Per-account remote secret file manager (SSH-layer / transport concern).
+
+Owns ``$HOME/.config/srunx/secrets.env`` on the remote cluster with a ``0700``
+``~/.config/srunx`` directory and a ``0600`` file. The file is keyed by remote
+account (``$HOME``) rather than by local profile name: secrets are only ever
+needed per remote account, and encoding the local profile name in the path
+would orphan the file on rename and produce "not found" surprises when two
+machines use different profile names for the same account. Secrets are stored
+as ``export KEY='<single-quote-escaped>'`` lines (one per key) and delivered by
+sourcing the file in the SSH submission shell (see
+:meth:`SlurmRemoteClient._get_slurm_env_setup`).
+
+Design constraints (see ``.golem/specs/ssh-secret-store/spec.md``):
+
+* Secrets never touch local ``config.json``, command-line arguments, or logs —
+  only SFTP writes and the submit-shell ``source`` carry the value.
+* Writes are atomic: the full new file is re-rendered from validated records
+  to a temp path in the same directory, ``chmod 0600`` (exit-code-checked,
+  must succeed before publishing), then ``mv`` over the target (torn-file
+  prevention). The store refuses to write if the target, temp path, or the
+  ``~/.config/srunx`` directory itself is a symlink, owned by another user, or
+  of an owner it cannot determine (fail-closed). ``mkdir`` / ``chmod`` / ``mv``
+  exit codes are all checked; any failure aborts before the next step.
+* The file is a *sourced* shell script, so it is re-rendered from validated
+  ``export KEY='...'`` records only — an unrecognised line (manual edit /
+  corruption) is rejected rather than silently preserved, so tampering is
+  surfaced instead of being carried into an executed shell.
+* Single-user cluster assumption — no remote exclusive lock (temp+rename
+  atomicity is sufficient; a rare lost write under simultaneous edits is
+  accepted per spec).
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import uuid
+from typing import TYPE_CHECKING
+
+from srunx.common.logging import get_logger
+
+if TYPE_CHECKING:
+    from .connection import SSHConnection
+    from .file_manager import RemoteFileManager
+
+_logger = get_logger(__name__)
+
+# KEY validation — parity with ``JobEnvironment.validate_env_var_keys``
+# (``domain/jobs.py``): valid shell identifier, no reserved scheduler prefix.
+_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Parse ``export KEY=...`` lines to recover key names (values never surfaced).
+_EXPORT_LINE_RE = re.compile(r"^export ([A-Za-z_][A-Za-z0-9_]*)=")
+
+# Full recognised record: ``export KEY='<single-quote-escaped value>'``. The
+# value body is any run of non-single-quote chars interspersed with the
+# ``'\''`` escape sequence — the exact shape :meth:`_render` emits. Anything a
+# line does not match is treated as tampering (see :meth:`_parse_records`).
+_RECORD_RE = re.compile(r"^export ([A-Za-z_][A-Za-z0-9_]*)='((?:[^']|'\\'')*)'$")
+
+
+def _validate_key(key: str) -> None:
+    """Validate a secret KEY (identifier + reserved-prefix rules)."""
+    if not _KEY_RE.match(key):
+        raise ValueError(
+            f"Invalid secret name: {key!r}. "
+            "Must be a valid identifier (letters, digits, underscores; "
+            "no leading digit, no whitespace/newline/NUL)."
+        )
+    if key.startswith(("SLURM_", "SBATCH_")):
+        raise ValueError(
+            f"Invalid secret name: {key!r}. "
+            "The 'SLURM_' and 'SBATCH_' prefixes are reserved by the "
+            "scheduler and cannot be set as secrets."
+        )
+
+
+def _validate_value(value: str) -> None:
+    """Reject multi-line / control-character values (single-line guard)."""
+    if any(c in value for c in ("\n", "\r")) or any(
+        ord(c) < 32 and c != "\t" for c in value
+    ):
+        raise ValueError(
+            "Secret value must be a single line without control characters."
+        )
+
+
+def _sq_escape(value: str) -> str:
+    """Escape a value for embedding inside a single-quoted shell string."""
+    return value.replace("'", "'\\''")
+
+
+def _sq_unescape(escaped: str) -> str:
+    """Inverse of :func:`_sq_escape` — recover the raw value from a record."""
+    return escaped.replace("'\\''", "'")
+
+
+class RemoteSecretStore:
+    """Manages one remote account's secret file over an SSH connection.
+
+    The file path is account-scoped (``$HOME/.config/srunx/secrets.env``) and
+    carries no local profile name — the connection selects the account, so no
+    profile identity is threaded in here.
+    """
+
+    def __init__(
+        self,
+        connection: SSHConnection,
+        files: RemoteFileManager,
+    ) -> None:
+        self._conn = connection
+        self._files = files
+        self.logger = _logger
+        self._resolved_path: str | None = None
+
+    # ------------------------------------------------------------------
+    # Path derivation
+    # ------------------------------------------------------------------
+
+    def secret_path(self) -> str:
+        """Return the deterministic, ``$HOME``-resolved remote secret path.
+
+        ``~/.config/srunx/secrets.env`` with ``$HOME`` expanded to a concrete
+        absolute path (via ``echo $HOME``) so the result can be embedded in
+        single-quoted shell commands without further expansion. Cached after
+        the first resolution.
+        """
+        if self._resolved_path is None:
+            stdout, _stderr, exit_code = self._conn.execute_command('echo "$HOME"')
+            home = stdout.strip()
+            if exit_code != 0 or not home:
+                raise RuntimeError("Failed to resolve remote $HOME for secret path")
+            self._resolved_path = f"{home}/.config/srunx/secrets.env"
+        return self._resolved_path
+
+    def _secret_dir(self) -> str:
+        return self.secret_path().rsplit("/", 1)[0]
+
+    def _run_checked(self, command: str, error_context: str) -> None:
+        """Run a remote command and raise if its exit code is non-zero.
+
+        Used for the setup steps (``mkdir`` / ``chmod`` / ``mv``) whose failure
+        must abort the write rather than silently proceed to the next step.
+        """
+        _stdout, stderr, exit_code = self._conn.execute_command(command)
+        if exit_code != 0:
+            raise RuntimeError(f"{error_context}: {stderr.strip()}")
+
+    # ------------------------------------------------------------------
+    # Read helpers
+    # ------------------------------------------------------------------
+
+    def exists(self) -> bool:
+        """True if the secret file is present on the remote."""
+        return self._files.file_exists(self.secret_path())
+
+    def _read(self) -> str:
+        """Return the current file contents.
+
+        Empty string *only* when the file is absent. A file that exists but
+        cannot be read (chmod 000, ACL, transient read error) raises rather
+        than being conflated with "absent" — otherwise ``set``/``unset`` would
+        re-render the file from an empty record set and wipe every existing
+        secret. The error message never includes the file contents.
+        """
+        if not self.exists():
+            return ""
+        quoted = shlex.quote(self.secret_path())
+        stdout, _stderr, exit_code = self._conn.execute_command(f"cat {quoted}")
+        if exit_code != 0:
+            raise RuntimeError(
+                f"Refusing to modify secret file: {self.secret_path()} exists "
+                "but could not be read. Fix its permissions/ownership before "
+                "setting/unsetting secrets."
+            )
+        return stdout
+
+    @staticmethod
+    def _parse_keys(content: str) -> list[str]:
+        keys: list[str] = []
+        for line in content.splitlines():
+            match = _EXPORT_LINE_RE.match(line.strip())
+            if match:
+                keys.append(match.group(1))
+        return keys
+
+    @staticmethod
+    def _parse_records(content: str) -> dict[str, str]:
+        """Parse the file into an ordered KEY -> raw-value mapping.
+
+        Only fully recognised ``export KEY='...'`` records are accepted; any
+        line the store did not itself emit (a manual edit, a stray comment, a
+        malformed record) is rejected so the tampering surfaces instead of
+        being silently dropped. Blank lines are ignored. Values are recovered
+        from their single-quote escaping so a round-trip preserves them.
+        """
+        records: dict[str, str] = {}
+        for raw_line in content.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            match = _RECORD_RE.match(line)
+            if match is None:
+                raise RuntimeError(
+                    "Refusing to modify secret file: it contains a line this "
+                    "store did not write (manual edit or corruption). Fix or "
+                    "remove the file before setting/unsetting secrets."
+                )
+            records[match.group(1)] = _sq_unescape(match.group(2))
+        return records
+
+    @staticmethod
+    def _render(records: dict[str, str]) -> str:
+        """Re-emit the file from validated records only (source-safe)."""
+        lines = [
+            f"export {key}='{_sq_escape(value)}'" for key, value in records.items()
+        ]
+        return "\n".join(lines) + "\n" if lines else ""
+
+    def list_keys(self) -> list[str]:
+        """Return the stored KEY names only — never the values."""
+        return self._parse_keys(self._read())
+
+    # ------------------------------------------------------------------
+    # Guard
+    # ------------------------------------------------------------------
+
+    def _assert_safe_target(self, path: str) -> None:
+        """Refuse to write when *path* is a symlink or owned by another user.
+
+        ``stat`` gives us the owner uid; ``-h`` detects a symlink. A missing
+        path is fine (we're about to create it). Any owner other than the
+        connecting user — or an owner we cannot determine — is rejected
+        (fail-closed).
+        """
+        quoted = shlex.quote(path)
+        # ``%u`` = owner uid; guard the whole probe so a missing file yields
+        # a clean "ABSENT" rather than a stat error.
+        cmd = (
+            f"if [ -h {quoted} ]; then echo SYMLINK; "
+            f"elif [ -e {quoted} ]; then "
+            f"stat -c %u {quoted} 2>/dev/null || stat -f %u {quoted} 2>/dev/null; "
+            f"else echo ABSENT; fi"
+        )
+        stdout, _stderr, _exit_code = self._conn.execute_command(cmd)
+        result = stdout.strip()
+        if result == "SYMLINK":
+            raise RuntimeError(f"Refusing to write secret: {path} is a symlink.")
+        if result == "ABSENT":
+            return
+        if result == "":
+            # ``[ -e ]`` was true but neither stat form yielded an owner uid —
+            # we cannot prove ownership, so refuse (fail-closed).
+            raise RuntimeError(
+                f"Refusing to write secret: cannot determine owner of {path}."
+            )
+        # ``result`` is the owner uid — compare against the connecting user's uid.
+        me, _stderr, _exit_code = self._conn.execute_command("id -u")
+        me = me.strip()
+        if not me:
+            raise RuntimeError(
+                f"Refusing to write secret: cannot determine connecting user "
+                f"to verify ownership of {path}."
+            )
+        if me != result:
+            raise RuntimeError(
+                f"Refusing to write secret: {path} is owned by another user."
+            )
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def _ensure_secure_dir(self) -> None:
+        """Create ``~/.config/srunx`` as ``0700`` and verify it is safe to use.
+
+        This is the secret file's parent directory. Its ``0700`` mode is what
+        secures the brief window during :meth:`_atomic_write` where the SFTP
+        temp file may momentarily be ``0644`` before the explicit
+        ``chmod 600``. The directory is guarded (symlink / foreign-owner /
+        undetermined owner rejected) *before* and *after* ``mkdir`` so a
+        pre-existing directory that is a symlink or owned by someone else is
+        refused, and the ``chmod 700`` exit code is checked.
+        """
+        secret_dir = self._secret_dir()
+        # Refuse if a pre-existing entry at the dir path is unsafe.
+        self._assert_safe_target(secret_dir)
+        quoted_dir = shlex.quote(secret_dir)
+        self._run_checked(
+            f"mkdir -p {quoted_dir}",
+            f"Failed to create secrets directory {secret_dir}",
+        )
+        self._run_checked(
+            f"chmod 700 {quoted_dir}",
+            f"Failed to chmod 0700 secrets directory {secret_dir}",
+        )
+        # Re-check after mkdir in case the path was created as/into a symlink.
+        self._assert_safe_target(secret_dir)
+
+    def _atomic_write(self, new_content: str, error_context: str) -> None:
+        """Write *new_content* to the target atomically (temp + rename).
+
+        The temp file lives inside the ``0700`` ``~/.config/srunx`` directory
+        (whose mode and ownership are verified in :meth:`_ensure_secure_dir`),
+        so no other
+        user can traverse into it and read the temp during the brief window
+        between the SFTP create (which may momentarily be ``0644``) and the
+        explicit ``chmod 600``. That ``chmod 600`` is exit-code-checked and
+        must succeed *before* the ``mv`` — a chmod failure raises and never
+        proceeds to rename, so a wrongly-permissioned file is never published
+        to the target path. Every setup command's exit code is checked.
+        """
+        target = self.secret_path()
+        secret_dir = self._secret_dir()
+
+        self._ensure_secure_dir()
+
+        temp_path = f"{secret_dir}/.secrets.{uuid.uuid4().hex[:8]}.tmp"
+        self._assert_safe_target(temp_path)
+        self._assert_safe_target(target)
+
+        quoted_temp = shlex.quote(temp_path)
+        self._files.write_remote_file(temp_path, new_content)
+        # Confirm 0600 before publishing; failure aborts before ``mv``.
+        try:
+            self._run_checked(
+                f"chmod 600 {quoted_temp}",
+                f"Failed to chmod 0600 temp secret file {temp_path}",
+            )
+        except RuntimeError:
+            self._files.cleanup_file(temp_path)
+            raise
+        quoted_target = shlex.quote(target)
+        # Atomic replace — mv within the same directory is a rename(2).
+        _stdout, stderr, exit_code = self._conn.execute_command(
+            f"mv -f {quoted_temp} {quoted_target}"
+        )
+        if exit_code != 0:
+            # Best-effort temp cleanup so a failed rename doesn't litter.
+            self._files.cleanup_file(temp_path)
+            raise RuntimeError(f"{error_context}: {stderr.strip()}")
+
+    def set_secret(self, key: str, value: str) -> None:
+        """Upsert one KEY into the secret file (atomic temp+rename).
+
+        Validates the KEY (identifier + reserved-prefix) and the single-line
+        value, parses the current file into validated records (rejecting any
+        unrecognised line), upserts this KEY, re-renders the file from records
+        only, then writes it atomically under a tight umask.
+        """
+        _validate_key(key)
+        _validate_value(value)
+
+        records = self._parse_records(self._read())
+        records[key] = value
+        new_content = self._render(records)
+
+        self._atomic_write(new_content, f"Failed to store secret {key!r}")
+
+    def unset_secret(self, key: str) -> None:
+        """Remove KEY via temp+rename; delete the file if it empties."""
+        if not self.exists():
+            return
+        records = self._parse_records(self._read())
+        records.pop(key, None)
+
+        target = self.secret_path()
+        # File empties out -> remove it entirely (REQ-6 / REQ-N1).
+        if not records:
+            self._files.cleanup_file(target)
+            return
+
+        new_content = self._render(records)
+        self._atomic_write(new_content, f"Failed to remove secret {key!r}")

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 # Imported at module level so the facade can reference it
 from .client_types import SlurmJob  # noqa: F401  re-exported for convenience
+from .secret_store import RemoteSecretStore
 from .utils import query_slurm_job_state
 
 _logger = get_logger(__name__)
@@ -32,11 +33,57 @@ class SlurmRemoteClient:
         self,
         connection: SSHConnection,
         file_manager: RemoteFileManager,
+        *,
+        profile_name: str | None = None,
     ) -> None:
         self._conn = connection
         self._files = file_manager
         self.logger = _logger
         self._slurm_path: str | None = None
+        # A bound profile enables secret behaviour: the account's remote
+        # secret file (``~/.config/srunx/secrets.env``, stored via
+        # ``srunx ssh secret``) is sourced into the submission shell (see
+        # ``_get_slurm_env_setup``) and triggers ``--export=ALL``. The profile
+        # name only acts as an on/off gate here — the file path is account
+        # (``$HOME``) scoped, so it is not threaded into the store. ``None``
+        # (legacy direct-hostname clients) → no secret behaviour, safe default.
+        self._secret_store: RemoteSecretStore | None = (
+            RemoteSecretStore(connection, file_manager)
+            if profile_name is not None
+            else None
+        )
+
+    def bind_profile_name(self, profile_name: str | None) -> None:
+        """(Re)bind the profile to enable/disable the account secret store.
+
+        Used by :meth:`SlurmSSHClient.from_spec`'s pooled-clone path, which
+        constructs the adapter via the direct-hostname branch (no profile) to
+        skip the ConfigManager re-parse, then binds the resolved profile here.
+        The profile name gates secret behaviour on/off; the secret file path
+        is account-scoped, so the name is not stored. ``None`` clears any
+        secret behaviour.
+        """
+        self._secret_store = (
+            RemoteSecretStore(self._conn, self._files)
+            if profile_name is not None
+            else None
+        )
+
+    def _secret_file_exists(self) -> bool:
+        """True when this account has a secret file on the remote.
+
+        Confined to the SSH adapter (DIP): both the ``source`` prefix and the
+        ``--export=ALL`` decision consult this. Best-effort — any transport
+        hiccup is treated as "no secret file" so a probe failure never blocks
+        submission.
+        """
+        if self._secret_store is None:
+            return False
+        try:
+            return self._secret_store.exists()
+        except Exception as exc:  # noqa: BLE001
+            self.logger.debug(f"Secret file existence probe failed: {exc}")
+            return False
 
     # ------------------------------------------------------------------
     # Initialization (called after connect())
@@ -109,15 +156,29 @@ class SlurmRemoteClient:
         else:
             return command
 
-    def _get_slurm_env_setup(self, job_env_vars: dict[str, str] | None = None) -> str:
+    def _get_slurm_env_setup(
+        self,
+        job_env_vars: dict[str, str] | None = None,
+        *,
+        source_secret: bool | None = None,
+    ) -> str:
         """Get environment setup commands for SLURM execution.
 
-        Job-level ``job_env_vars`` merge into the same ``export KEY='value'``
-        prefix as the profile's ``custom_env_vars``, with job keys taking
-        precedence over profile keys (``{**profile, **job}``). This is the
-        SSH realization of the submission-environment route (the local
-        adapter uses the sbatch process env instead); both pair it with
-        ``--export=ALL`` on the remote sbatch.
+        When the account has a secret file (``srunx ssh secret``), it is
+        sourced into the submission shell so its exports enter the job
+        environment. Job-level ``job_env_vars`` are then exported as an
+        ``export KEY='value'`` prefix (job values win over anything the
+        secret file set for the same key). This is the SSH realization of
+        the submission-environment route (the local adapter uses the sbatch
+        process env instead); both pair it with ``--export=ALL`` on the
+        remote sbatch. Secret sourcing / ``--export=ALL`` are confined to
+        this adapter (DIP).
+
+        ``source_secret`` lets the caller reuse a single existence probe for
+        both the ``source`` prefix here and the ``--export=ALL`` decision in
+        the submit methods (atomicity — one probe, one truth). When ``None``
+        the probe is performed here (e.g. the ``execute_slurm_command`` path
+        for squeue/sacct/etc., which have no ``--export`` decision).
         """
         env_commands = [
             "cd ~",
@@ -131,13 +192,47 @@ class SlurmRemoteClient:
             'export PATH="$PATH:/usr/local/bin:/opt/slurm/bin:/cluster/slurm/bin" 2>/dev/null || true',
         ]
 
-        merged_env_vars = {**self._conn.custom_env_vars, **(job_env_vars or {})}
-        for key, value in merged_env_vars.items():
+        if source_secret is None:
+            source_secret = self._secret_file_exists()
+
+        # Source the account's secret file (0600, remote-only) before the
+        # job-level exports so a job env key can still override a secret with
+        # the same name. ``set -a`` exports every var the file defines. The
+        # path (with ``$HOME`` already resolved to a concrete absolute path by
+        # ``RemoteSecretStore.secret_path``) is passed through ``shlex.quote``
+        # so a home dir containing spaces or shell metacharacters stays safe.
+        #
+        # Non-blocking ``if [ -r ]; then ... fi`` form (always exits 0): a
+        # ``&&`` chain would fail the whole command line — and thus skip the
+        # actual squeue/scancel/sbatch — if the file became unreadable or was
+        # removed between the existence probe and execution. Job-management
+        # commands must run regardless of secret-file readability. The one
+        # accepted consequence is that a submit whose secret file is
+        # (rarely, on misconfiguration) unreadable at run time proceeds
+        # *without* the secret rather than blocking — preferred over a
+        # blocked submission.
+        if source_secret and self._secret_store is not None:
+            secret_path = self._quoted_secret_path()
+            env_commands.append(
+                f"if [ -r {secret_path} ]; then set -a; . {secret_path}; set +a; fi"
+            )
+
+        for key, value in (job_env_vars or {}).items():
             escaped_value = value.replace("'", "'\\''")
             env_commands.append(f"export {key}='{escaped_value}'")
-            self.logger.debug(f"Adding custom environment variable: {key}={value}")
+            self.logger.debug(f"Adding job environment variable: {key}")
 
         return " && ".join(env_commands)
+
+    def _quoted_secret_path(self) -> str:
+        """Return the secret path as a single shell-safe token.
+
+        ``RemoteSecretStore.secret_path()`` resolves ``$HOME`` to a concrete
+        absolute path via ``echo $HOME``; we pass the whole resolved path
+        through ``shlex.quote`` so spaces / shell metacharacters in it survive.
+        """
+        assert self._secret_store is not None
+        return shlex.quote(self._secret_store.secret_path())
 
     def _verify_slurm_setup(self) -> None:
         """Verify that SLURM commands are working properly."""
@@ -160,10 +255,20 @@ class SlurmRemoteClient:
     # ------------------------------------------------------------------
 
     def execute_slurm_command(
-        self, command: str, job_env_vars: dict[str, str] | None = None
+        self,
+        command: str,
+        job_env_vars: dict[str, str] | None = None,
+        *,
+        source_secret: bool | None = None,
     ) -> tuple[str, str, int]:
-        """Execute a SLURM command with proper environment."""
-        env_setup = self._get_slurm_env_setup(job_env_vars)
+        """Execute a SLURM command with proper environment.
+
+        ``source_secret`` is forwarded to :meth:`_get_slurm_env_setup` so a
+        submit method that already probed for the secret file can reuse that
+        single result for both the ``source`` prefix and its ``--export=ALL``
+        decision (see the submit methods). ``None`` re-probes locally.
+        """
+        env_setup = self._get_slurm_env_setup(job_env_vars, source_secret=source_secret)
 
         if self._slurm_path:
             slurm_commands = [
@@ -222,14 +327,21 @@ class SlurmRemoteClient:
                 self.logger.error(f"Script validation failed: {validation_msg}")
                 return None
 
+            # Probe the secret file exactly once and reuse the result for both
+            # the --export=ALL decision here and the ``source`` prefix inside
+            # execute_slurm_command (atomicity — one probe, one truth).
+            secret_present = self._secret_file_exists()
+
             cmd = f"{self._get_slurm_command('sbatch')}"
             # --export=ALL propagates the submission environment (job env_vars
-            # merged into the export prefix) to the job — SLURM-specific
-            # realization confined to this adapter (DIP). Applied ONLY when
-            # job env vars are present so a plain submit keeps the script's /
-            # site's export policy intact (a command-line --export overrides
-            # the script's own #SBATCH --export directive).
-            if job_env_vars:
+            # in the export prefix + any sourced account secret file) to the
+            # job — SLURM-specific realization confined to this adapter (DIP).
+            # Applied when job env vars are present OR the account has a secret
+            # file, so a plain submit with neither keeps the script's / site's
+            # export policy intact. When applied it overrides the script's own
+            # #SBATCH --export directive (including --export=NONE) — that is the
+            # intended "deliver the secret" behaviour.
+            if job_env_vars or secret_present:
                 cmd += " --export=ALL"
             if job_name:
                 safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
@@ -241,7 +353,7 @@ class SlurmRemoteClient:
             cmd += f" {remote_script_path}"
 
             stdout, stderr, exit_code = self.execute_slurm_command(
-                cmd, job_env_vars=job_env_vars
+                cmd, job_env_vars=job_env_vars, source_secret=secret_present
             )
             if exit_code == 0:
                 match = re.search(r"Submitted batch job (\d+)", stdout)
@@ -367,14 +479,21 @@ class SlurmRemoteClient:
                 self.logger.error(f"Remote script validation failed: {validation_msg}")
                 return None
 
+            # Probe the secret file exactly once and reuse the result for both
+            # the --export=ALL decision here and the ``source`` prefix inside
+            # execute_slurm_command (atomicity — one probe, one truth).
+            secret_present = self._secret_file_exists()
+
             cmd_parts: list[str] = [self._get_slurm_command("sbatch")]
             # --export=ALL propagates the submission environment (job env_vars
-            # merged into the export prefix) to the job — SLURM-specific
-            # realization confined to this adapter (DIP). Applied ONLY when job
-            # env vars are present: this in-place path is documented to
-            # preserve the user's own #SBATCH directives, and a command-line
-            # --export would override the script's #SBATCH --export=NONE.
-            if job_env_vars:
+            # in the export prefix + any sourced account secret file) to the
+            # job — SLURM-specific realization confined to this adapter (DIP).
+            # This in-place path is otherwise documented to preserve the user's
+            # own #SBATCH directives, so --export=ALL is applied only when job
+            # env vars are present OR the account has a secret file; when
+            # applied it deliberately overrides the script's #SBATCH
+            # --export=NONE so the secret reaches the job.
+            if job_env_vars or secret_present:
                 cmd_parts.append("--export=ALL")
             if job_name:
                 safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", job_name)
@@ -397,7 +516,7 @@ class SlurmRemoteClient:
                 cmd = f"cd {shlex.quote(submit_cwd)} && {cmd}"
 
             stdout, stderr, exit_code = self.execute_slurm_command(
-                cmd, job_env_vars=job_env_vars
+                cmd, job_env_vars=job_env_vars, source_secret=secret_present
             )
             if exit_code == 0:
                 match = re.search(r"Submitted batch job (\d+)", stdout)

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -565,7 +565,7 @@ def _build_ssh_handle(
 
     # Build the pool off the adapter's own connection spec so pooled
     # clones inherit the exact same resolved hostname / identity file /
-    # proxy_jump / env_vars the singleton adapter uses. Pooled clones
+    # proxy_jump / profile_name the singleton adapter uses. Pooled clones
     # also pick up the same callback list so per-cell jobs in the
     # workflow / sweep path fire ``on_job_submitted`` (including
     # :class:`NotificationWatchCallback`) with the adapter's

--- a/src/srunx/web/frontend/src/lib/types.ts
+++ b/src/srunx/web/frontend/src/lib/types.ts
@@ -68,11 +68,7 @@ export type Workflow = {
 /* ── Workflow run ─────────────────────────────── */
 
 export type WorkflowRunStatus =
-  | "pending"
-  | "running"
-  | "completed"
-  | "failed"
-  | "cancelled";
+  "pending" | "running" | "completed" | "failed" | "cancelled";
 
 export type WorkflowRun = {
   id: string;
@@ -89,12 +85,7 @@ export type WorkflowRun = {
 /* ── Sweep runs ───────────────────────────────── */
 
 export type SweepStatus =
-  | "pending"
-  | "running"
-  | "draining"
-  | "completed"
-  | "failed"
-  | "cancelled";
+  "pending" | "running" | "draining" | "completed" | "failed" | "cancelled";
 
 export type SweepSubmissionSource = "cli" | "web" | "mcp";
 
@@ -305,10 +296,7 @@ export type NotificationConfig = {
 /* ── Notification endpoints / subscriptions / deliveries ─── */
 
 export type EndpointKind =
-  | "slack_webhook"
-  | "generic_webhook"
-  | "email"
-  | "slack_bot";
+  "slack_webhook" | "generic_webhook" | "email" | "slack_bot";
 
 export type Endpoint = {
   id: number;
@@ -320,10 +308,7 @@ export type Endpoint = {
 };
 
 export type NotificationPreset =
-  | "terminal"
-  | "running_and_terminal"
-  | "all"
-  | "digest";
+  "terminal" | "running_and_terminal" | "all" | "digest";
 
 export type Subscription = {
   id: number;
@@ -334,10 +319,7 @@ export type Subscription = {
 };
 
 export type WatchKind =
-  | "job"
-  | "workflow_run"
-  | "resource_threshold"
-  | "scheduled_report";
+  "job" | "workflow_run" | "resource_threshold" | "scheduled_report";
 
 export type Watch = {
   id: number;
@@ -389,7 +371,6 @@ export type SSHProfile = {
   description: string | null;
   ssh_host: string | null;
   proxy_jump: string | null;
-  env_vars: Record<string, string> | null;
   mounts: SSHMountConfig[];
 };
 

--- a/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
+++ b/src/srunx/web/frontend/src/pages/settings/SSHProfilesTab.tsx
@@ -93,8 +93,6 @@ export function SSHProfilesTab() {
     remote: "",
   });
   const [newMountExcludes, setNewMountExcludes] = useState("");
-  const [newEnvKey, setNewEnvKey] = useState("");
-  const [newEnvValue, setNewEnvValue] = useState("");
   const [connStatus, setConnStatus] = useState<SSHConnectionStatus | null>(
     null,
   );
@@ -263,34 +261,6 @@ export function SSHProfilesTab() {
       await load();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to remove mount");
-    }
-  };
-
-  const handleAddEnvVar = async (profileName: string) => {
-    if (!newEnvKey.trim()) return;
-    try {
-      const profile = data?.profiles[profileName];
-      if (!profile) return;
-      const envVars = { ...(profile.env_vars ?? {}), [newEnvKey]: newEnvValue };
-      await configApi.updateSSHProfile(profileName, { env_vars: envVars });
-      setNewEnvKey("");
-      setNewEnvValue("");
-      await load();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to add env var");
-    }
-  };
-
-  const handleRemoveEnvVar = async (profileName: string, key: string) => {
-    try {
-      const profile = data?.profiles[profileName];
-      if (!profile) return;
-      const envVars = { ...(profile.env_vars ?? {}) };
-      delete envVars[key];
-      await configApi.updateSSHProfile(profileName, { env_vars: envVars });
-      await load();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to remove env var");
     }
   };
 
@@ -814,135 +784,6 @@ export function SSHProfilesTab() {
                         fontSize: "0.8rem",
                       }}
                     />
-                  </div>
-                </div>
-
-                {/* Profile Env Vars */}
-                <div
-                  style={{
-                    borderTop: "1px solid var(--border-ghost)",
-                    paddingTop: "var(--sp-4)",
-                    marginTop: "var(--sp-4)",
-                  }}
-                >
-                  <span
-                    style={{
-                      fontSize: "0.75rem",
-                      fontWeight: 500,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                      color: "var(--text-muted)",
-                      marginBottom: "var(--sp-3)",
-                      display: "block",
-                    }}
-                  >
-                    Environment Variables
-                  </span>
-                  {Object.entries(profile.env_vars ?? {}).map(([k, v]) => (
-                    <div
-                      key={k}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "var(--sp-2)",
-                        padding: "var(--sp-2) var(--sp-3)",
-                        background: "var(--bg-base)",
-                        borderRadius: "var(--radius-md)",
-                        border: "1px solid var(--border-ghost)",
-                        marginBottom: "var(--sp-2)",
-                      }}
-                    >
-                      <span
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "0.8rem",
-                          color: "var(--accent)",
-                          minWidth: 100,
-                        }}
-                      >
-                        {k}
-                      </span>
-                      <span
-                        style={{
-                          color: "var(--text-muted)",
-                          fontSize: "0.8rem",
-                        }}
-                      >
-                        =
-                      </span>
-                      <span
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: "0.8rem",
-                          color: "var(--text-secondary)",
-                          flex: 1,
-                        }}
-                      >
-                        {v}
-                      </span>
-                      <button
-                        onClick={() => handleRemoveEnvVar(name, k)}
-                        style={{
-                          background: "transparent",
-                          border: "none",
-                          color: "var(--text-muted)",
-                          cursor: "pointer",
-                          padding: 4,
-                          display: "flex",
-                        }}
-                      >
-                        <X size={14} />
-                      </button>
-                    </div>
-                  ))}
-                  <div
-                    style={{
-                      display: "flex",
-                      gap: "var(--sp-2)",
-                      alignItems: "center",
-                    }}
-                  >
-                    <input
-                      className="input"
-                      placeholder="KEY"
-                      value={newEnvKey}
-                      onChange={(e) => setNewEnvKey(e.target.value)}
-                      style={{
-                        width: 120,
-                        fontFamily: "var(--font-mono)",
-                        fontSize: "0.8rem",
-                      }}
-                      onKeyDown={(e) =>
-                        e.key === "Enter" && handleAddEnvVar(name)
-                      }
-                    />
-                    <span
-                      style={{ color: "var(--text-muted)", fontSize: "0.8rem" }}
-                    >
-                      =
-                    </span>
-                    <input
-                      className="input"
-                      placeholder="value"
-                      value={newEnvValue}
-                      onChange={(e) => setNewEnvValue(e.target.value)}
-                      style={{
-                        flex: 1,
-                        fontFamily: "var(--font-mono)",
-                        fontSize: "0.8rem",
-                      }}
-                      onKeyDown={(e) =>
-                        e.key === "Enter" && handleAddEnvVar(name)
-                      }
-                    />
-                    <button
-                      className="btn btn-ghost"
-                      onClick={() => handleAddEnvVar(name)}
-                      disabled={!newEnvKey.trim()}
-                      style={{ padding: "var(--sp-2)" }}
-                    >
-                      <Plus size={14} />
-                    </button>
                   </div>
                 </div>
               </div>

--- a/src/srunx/web/routers/config.py
+++ b/src/srunx/web/routers/config.py
@@ -162,7 +162,6 @@ async def update_ssh_profile(name: str, body: dict[str, Any]) -> dict[str, Any]:
         "description",
         "ssh_host",
         "proxy_jump",
-        "env_vars",
     }
     update_data = {k: v for k, v in body.items() if k in valid_fields}
     cm.update_profile(name, **update_data)

--- a/tests/integration/test_ssh_simple.py
+++ b/tests/integration/test_ssh_simple.py
@@ -51,7 +51,6 @@ class TestSimpleSSHIntegration:
                 key_filename="/home/user/.ssh/dgx_key",
                 port=22,
                 description="Test DGX server",
-                env_vars={"CUDA_VISIBLE_DEVICES": "0,1,2,3"},
             )
 
             config_manager.add_profile("dgx_test", profile)
@@ -61,7 +60,6 @@ class TestSimpleSSHIntegration:
             assert loaded_profile is not None
             assert loaded_profile.hostname == "dgx.example.com"
             assert loaded_profile.username == "researcher"
-            assert loaded_profile.env_vars["CUDA_VISIBLE_DEVICES"] == "0,1,2,3"
 
             # Test profile listing
             profiles = config_manager.list_profiles()
@@ -182,62 +180,19 @@ echo "Hello from SLURM!"
         finally:
             Path(test_path).unlink()
 
-    def test_environment_variables_handling(self):
-        """Test environment variable handling."""
-        env_vars = {
-            "CUDA_VISIBLE_DEVICES": "0,1,2,3",
-            "WANDB_API_KEY": "test_key_12345",
-            "CUSTOM_VAR": "custom_value",
-        }
+    def test_job_env_vars_handling(self):
+        """Job-level env vars are exported in the SSH submission prefix."""
+        client = SSHSlurmClient(hostname="test.example.com", username="testuser")
 
-        client = SSHSlurmClient(
-            hostname="test.example.com", username="testuser", env_vars=env_vars
+        env_setup = client.slurm._get_slurm_env_setup(
+            {
+                "CUDA_VISIBLE_DEVICES": "0,1,2,3",
+                "WANDB_API_KEY": "test_key_12345",
+                "CUSTOM_VAR": "custom_value",
+            }
         )
-
-        env_setup = client.slurm._get_slurm_env_setup()
 
         # Verify environment variables are included (with proper quoting)
         assert "export CUDA_VISIBLE_DEVICES='0,1,2,3'" in env_setup
         assert "export WANDB_API_KEY='test_key_12345'" in env_setup
         assert "export CUSTOM_VAR='custom_value'" in env_setup
-
-    def test_profile_environment_variables(self):
-        """Test profile-based environment variable management."""
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".json", delete=False
-        ) as config_file:
-            config_path = config_file.name
-
-        try:
-            config_manager = ConfigManager(config_path)
-
-            # Add profile with environment variables
-            profile = ServerProfile(
-                hostname="ml.example.com",
-                username="researcher",
-                key_filename="/keys/ml_key",
-                env_vars={
-                    "WANDB_PROJECT": "deep_learning",
-                    "CUDA_VISIBLE_DEVICES": "0,1",
-                },
-            )
-
-            config_manager.add_profile("ml_server", profile)
-
-            # Test profile retrieval and environment variables
-            loaded_profile = config_manager.get_profile("ml_server")
-            assert loaded_profile.env_vars["WANDB_PROJECT"] == "deep_learning"
-            assert loaded_profile.env_vars["CUDA_VISIBLE_DEVICES"] == "0,1"
-
-            # Test profile update (basic functionality)
-            success = config_manager.update_profile(
-                "ml_server", description="Updated ML server"
-            )
-            assert success
-
-            updated_profile = config_manager.get_profile("ml_server")
-            assert updated_profile.description == "Updated ML server"
-            assert updated_profile.env_vars["WANDB_PROJECT"] == "deep_learning"
-
-        finally:
-            Path(config_path).unlink(missing_ok=True)

--- a/tests/slurm/clients/test_ssh_remote_sbatch.py
+++ b/tests/slurm/clients/test_ssh_remote_sbatch.py
@@ -35,7 +35,6 @@ def _bare_adapter(
     adapter._key_filename = None
     adapter._port = 22
     adapter._proxy_jump = None
-    adapter._env_vars = {}
     adapter._mounts = ()
     adapter.submission_source = "cli"
 

--- a/tests/slurm/clients/test_ssh_run.py
+++ b/tests/slurm/clients/test_ssh_run.py
@@ -35,7 +35,6 @@ def _bare_adapter(callbacks: list[Callback] | None = None) -> SlurmSSHClient:
     adapter._key_filename = None
     adapter._port = 22
     adapter._proxy_jump = None
-    adapter._env_vars = {}
     adapter._mounts = ()
     # Review fix #7: submission_source is mutable per-handle state the
     # transport registry sets; tests that bypass __init__ must provide
@@ -803,7 +802,6 @@ class TestAdapterFromSpec:
             key_filename="/tmp/key",
             port=2222,
             proxy_jump=None,
-            env_vars=(("FOO", "bar"),),
             mounts=(),
         )
 
@@ -814,7 +812,6 @@ class TestAdapterFromSpec:
         assert round_trip.hostname == "clone.example.com"
         assert round_trip.username == "user"
         assert round_trip.port == 2222
-        assert round_trip.env_vars == (("FOO", "bar"),)
 
     def test_from_spec_attaches_callbacks(self) -> None:
         cb = _RecordingCallback()

--- a/tests/slurm/test_ssh_executor_pool.py
+++ b/tests/slurm/test_ssh_executor_pool.py
@@ -40,7 +40,6 @@ def _make_spec() -> SlurmSSHClientSpec:
         key_filename=None,
         port=22,
         proxy_jump=None,
-        env_vars=(),
         mounts=(),
     )
 
@@ -57,7 +56,6 @@ def _bare_adapter(*, connected: bool = True) -> SlurmSSHClient:
     adapter._key_filename = None
     adapter._port = 22
     adapter._proxy_jump = None
-    adapter._env_vars = {}
     adapter._mounts = ()
     adapter.submission_source = "web"
 

--- a/tests/ssh/cli/test_commands.py
+++ b/tests/ssh/cli/test_commands.py
@@ -42,7 +42,7 @@ class TestFlatStructure:
             assert verb in result.output
         # Sub-entity groups survive as one-level groups.
         assert "mount" in result.output
-        assert "env" in result.output
+        assert "secret" in result.output
 
     def test_profile_subcommand_is_gone(self):
         # The old `srunx ssh profile ...` nesting must no longer exist.
@@ -186,22 +186,158 @@ class TestRoundTrip:
         ok = _add("data3", str(other_dir), "/remote/sub")
         assert ok.exit_code == 0, ok.output
 
-    def test_env_set_list_via_flags(self, tmp_path: Path):
-        cfg = _cfg(tmp_path)
+
+class TestSecretCommands:
+    """``ssh secret set/list/unset`` — value never appears in output."""
+
+    def _add_profile(self, cfg: str) -> None:
+        # Direct-hostname profile so ``_build_store`` takes the direct branch
+        # (the ssh_host branch would require a real ~/.ssh/config alias).
         runner.invoke(
             ssh_app,
-            ["add", "--profile", "dgx", "--ssh-host", "dgx-host", "--config", cfg],
+            [
+                "add",
+                "--profile",
+                "dgx",
+                "--hostname",
+                "dgx.example.com",
+                "--username",
+                "researcher",
+                "--key-file",
+                "/tmp/key",
+                "--config",
+                cfg,
+            ],
         )
-        setres = runner.invoke(
+
+    def test_set_via_from_env_hides_value(self, tmp_path, monkeypatch):
+        cfg = _cfg(tmp_path)
+        self._add_profile(cfg)
+
+        secret_value = "sk-super-secret-value"
+        monkeypatch.setenv("MY_TOKEN", secret_value)
+
+        fake_store = MagicMock()
+        # Patch RemoteSecretStore + connection so no real SSH happens.
+        with (
+            patch(
+                "srunx.ssh.cli.secret_impl.RemoteSecretStore", return_value=fake_store
+            ),
+            patch("srunx.ssh.cli.secret_impl.SSHConnection"),
+            patch("srunx.ssh.cli.secret_impl.RemoteFileManager"),
+            patch("srunx.ssh.cli.secret_impl.get_ssh_config_host", return_value=None),
+        ):
+            res = runner.invoke(
+                ssh_app,
+                [
+                    "secret",
+                    "set",
+                    "--profile",
+                    "dgx",
+                    "API_KEY",
+                    "--from-env",
+                    "MY_TOKEN",
+                    "--config",
+                    cfg,
+                ],
+            )
+
+        assert res.exit_code == 0, res.output
+        # Value must never leak into stdout; only the KEY is named.
+        assert secret_value not in res.output
+        assert "API_KEY" in res.output
+        fake_store.set_secret.assert_called_once_with("API_KEY", secret_value)
+
+    def test_set_via_getpass_hides_value(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        self._add_profile(cfg)
+
+        secret_value = "hunter2-hidden"
+        fake_store = MagicMock()
+        with (
+            patch(
+                "srunx.ssh.cli.secret_impl.getpass.getpass",
+                return_value=secret_value,
+            ),
+            patch(
+                "srunx.ssh.cli.secret_impl.RemoteSecretStore", return_value=fake_store
+            ),
+            patch("srunx.ssh.cli.secret_impl.SSHConnection"),
+            patch("srunx.ssh.cli.secret_impl.RemoteFileManager"),
+            patch("srunx.ssh.cli.secret_impl.get_ssh_config_host", return_value=None),
+        ):
+            res = runner.invoke(
+                ssh_app,
+                ["secret", "set", "--profile", "dgx", "API_KEY", "--config", cfg],
+            )
+
+        assert res.exit_code == 0, res.output
+        assert secret_value not in res.output
+        fake_store.set_secret.assert_called_once_with("API_KEY", secret_value)
+
+    def test_set_rejects_reserved_prefix(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        self._add_profile(cfg)
+        res = runner.invoke(
             ssh_app,
-            ["env", "set", "--profile", "dgx", "FOO", "bar", "--config", cfg],
+            [
+                "secret",
+                "set",
+                "--profile",
+                "dgx",
+                "SLURM_FOO",
+                "--from-env",
+                "PATH",
+                "--config",
+                cfg,
+            ],
         )
-        assert setres.exit_code == 0, setres.output
-        listed = runner.invoke(
-            ssh_app, ["env", "list", "--profile", "dgx", "--config", cfg]
-        )
-        assert listed.exit_code == 0
-        assert "FOO" in listed.output
+        assert res.exit_code != 0
+        assert "reserved" in _strip_ansi(res.output).lower()
+
+    def test_list_prints_key_names_only(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        self._add_profile(cfg)
+
+        fake_store = MagicMock()
+        fake_store.list_keys.return_value = ["API_KEY", "WANDB_TOKEN"]
+        with (
+            patch(
+                "srunx.ssh.cli.secret_impl.RemoteSecretStore", return_value=fake_store
+            ),
+            patch("srunx.ssh.cli.secret_impl.SSHConnection"),
+            patch("srunx.ssh.cli.secret_impl.RemoteFileManager"),
+            patch("srunx.ssh.cli.secret_impl.get_ssh_config_host", return_value=None),
+        ):
+            res = runner.invoke(
+                ssh_app, ["secret", "list", "--profile", "dgx", "--config", cfg]
+            )
+
+        assert res.exit_code == 0, res.output
+        out = _strip_ansi(res.output)
+        assert "API_KEY" in out
+        assert "WANDB_TOKEN" in out
+
+    def test_unset_removes_key(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        self._add_profile(cfg)
+
+        fake_store = MagicMock()
+        with (
+            patch(
+                "srunx.ssh.cli.secret_impl.RemoteSecretStore", return_value=fake_store
+            ),
+            patch("srunx.ssh.cli.secret_impl.SSHConnection"),
+            patch("srunx.ssh.cli.secret_impl.RemoteFileManager"),
+            patch("srunx.ssh.cli.secret_impl.get_ssh_config_host", return_value=None),
+        ):
+            res = runner.invoke(
+                ssh_app,
+                ["secret", "unset", "--profile", "dgx", "API_KEY", "--config", cfg],
+            )
+
+        assert res.exit_code == 0, res.output
+        fake_store.unset_secret.assert_called_once_with("API_KEY")
 
 
 class TestCurrentProfileFallback:

--- a/tests/ssh/core/test_client.py
+++ b/tests/ssh/core/test_client.py
@@ -36,7 +36,6 @@ class TestInit:
             port=2222,
             proxy_jump="bastion.com",
             ssh_config_path="/custom/ssh/config",
-            env_vars={"CUDA_VISIBLE_DEVICES": "0,1"},
             verbose=True,
         )
 

--- a/tests/ssh/core/test_config.py
+++ b/tests/ssh/core/test_config.py
@@ -171,6 +171,44 @@ class TestConfigManager:
         assert result is False
 
 
+class TestLegacyEnvVarsConfig:
+    """REQ-11 / F6: a legacy config.json with a profile ``env_vars`` block must
+    still load (ServerProfile ``extra='ignore'`` drops the stray key)."""
+
+    def test_legacy_env_vars_ignored_on_load(
+        self, temp_config_file, sample_config_data
+    ):
+        # sample_config_data carries a stray ``env_vars`` block on both
+        # profiles — exactly the removed mechanism's persisted shape.
+        with open(temp_config_file, "w") as f:
+            json.dump(sample_config_data, f)
+
+        config_manager = ConfigManager(temp_config_file)
+
+        # Load must not raise, and the profile is usable.
+        profile = config_manager.get_profile("test-profile")
+        assert profile is not None
+        assert profile.hostname == "example.com"
+        # The stray key is dropped from the model (extra=ignore).
+        assert not hasattr(profile, "env_vars")
+
+        # list_profiles round-trips both legacy profiles without error.
+        profiles = config_manager.list_profiles()
+        assert set(profiles) == {"test-profile", "dgx-profile"}
+
+    def test_server_profile_extra_ignore_drops_env_vars(self):
+        profile = ServerProfile.model_validate(
+            {
+                "hostname": "h",
+                "username": "u",
+                "key_filename": "/k",
+                "env_vars": {"WANDB_PROJECT": "proj"},
+            }
+        )
+        assert profile.hostname == "h"
+        assert not hasattr(profile, "env_vars")
+
+
 class TestMountConfigExcludePatterns:
     """Tests for MountConfig.exclude_patterns field.
 

--- a/tests/ssh/core/test_secret_store.py
+++ b/tests/ssh/core/test_secret_store.py
@@ -1,0 +1,378 @@
+"""Tests for srunx.ssh.core.secret_store.RemoteSecretStore.
+
+Mocks ``SSHConnection.execute_command`` and ``RemoteFileManager`` so we can
+capture the emitted shell commands and the bytes written to the temp file
+without touching a real cluster. The security-critical invariants are:
+
+* the secret value is written only via SFTP (``write_remote_file``) and never
+  appears in a command string;
+* ``list_keys`` returns key names only;
+* KEY / value validation matches ``JobEnvironment`` parity + single-line guard;
+* writes are atomic (temp file + ``mv``), chmod 0600 file / 0700 dir;
+* a symlink target is refused.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from srunx.ssh.core.connection import SSHConnection
+from srunx.ssh.core.secret_store import RemoteSecretStore
+
+_HOME = "/home/tester"
+# Account-scoped: no ``secrets/`` subdir, no profile name in the path.
+_SECRET_PATH = f"{_HOME}/.config/srunx/secrets.env"
+_SECRET_DIR = f"{_HOME}/.config/srunx"
+
+
+class _FakeConn:
+    """Records every executed command and replays scripted responses."""
+
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+        # Response for a `cat <path>` — the current file contents.
+        self.file_contents = ""
+        # Exit code the `cat <path>` read returns (non-zero => read failure
+        # on a file that exists, e.g. chmod 000 / ACL / transient error).
+        self.cat_exit_code = 0
+        # `id -u` / owner uid used by the symlink/owner guard.
+        self.uid = "1000"
+        self.owner_result = "ABSENT"  # what the guard probe returns
+        # Non-zero exit codes to inject for a command prefix, e.g.
+        # {"chmod 700": 1} makes any `chmod 700 ...` fail.
+        self.fail_prefixes: dict[str, int] = {}
+
+    def execute_command(self, command: str) -> tuple[str, str, int]:
+        self.commands.append(command)
+        if command == 'echo "$HOME"':
+            return (_HOME + "\n", "", 0)
+        if command.startswith("cat "):
+            if self.cat_exit_code != 0:
+                return ("", "cat: Permission denied", self.cat_exit_code)
+            return (self.file_contents, "", 0)
+        if command == "id -u":
+            return (self.uid + "\n", "", 0)
+        # symlink/owner guard probe
+        if command.startswith("if [ -h "):
+            return (self.owner_result + "\n", "", 0)
+        for prefix, code in self.fail_prefixes.items():
+            if command.startswith(prefix):
+                return ("", f"{prefix} failed", code)
+        # mkdir/chmod/mv all succeed
+        return ("", "", 0)
+
+
+@pytest.fixture
+def conn() -> _FakeConn:
+    return _FakeConn()
+
+
+@pytest.fixture
+def files() -> MagicMock:
+    fm = MagicMock()
+    fm.file_exists.return_value = False
+    return fm
+
+
+@pytest.fixture
+def store(conn: _FakeConn, files: MagicMock) -> RemoteSecretStore:
+    return RemoteSecretStore(cast(SSHConnection, conn), files)
+
+
+class TestSecretPath:
+    def test_secret_path_is_deterministic_and_home_resolved(self, store, conn):
+        assert store.secret_path() == _SECRET_PATH
+        # Cached — resolved once.
+        store.secret_path()
+        assert conn.commands.count('echo "$HOME"') == 1
+
+    def test_secret_path_is_account_scoped_no_profile_name(self, store):
+        """Path is flat + account-scoped: no ``secrets/`` subdir, no profile."""
+        path = store.secret_path()
+        assert path == _SECRET_PATH
+        assert "/secrets/" not in path
+        assert "gmo" not in path
+
+    def test_exists_delegates_to_file_manager(self, store, files):
+        files.file_exists.return_value = True
+        assert store.exists() is True
+        files.file_exists.assert_called_with(_SECRET_PATH)
+
+
+class TestSetSecret:
+    def test_set_writes_export_line_via_sftp_not_command(self, store, conn, files):
+        store.set_secret("API_KEY", "sk-secret-123")
+
+        # Value written via SFTP only.
+        assert files.write_remote_file.call_count == 1
+        temp_path, content = files.write_remote_file.call_args[0]
+        assert "export API_KEY='sk-secret-123'" in content
+        # Value never appears in any executed command string.
+        for cmd in conn.commands:
+            assert "sk-secret-123" not in cmd
+
+    def test_set_chmods_dir_0700_and_file_0600(self, store, conn, files):
+        store.set_secret("API_KEY", "v")
+        temp_path, _content = files.write_remote_file.call_args[0]
+        # The 0700 parent dir is ``~/.config/srunx`` (secures the temp-file
+        # permission window), not a ``secrets/`` subdir.
+        assert any("chmod 700" in c and _SECRET_DIR in c for c in conn.commands)
+        assert any("chmod 600" in c and temp_path in c for c in conn.commands)
+
+    def test_set_is_atomic_temp_then_mv(self, store, conn, files):
+        store.set_secret("API_KEY", "v")
+        temp_path, _content = files.write_remote_file.call_args[0]
+        # temp file lives in the same (account) dir as the target and is mv'd
+        # over it — no ``secrets/`` subdir, no profile name in the temp name.
+        assert temp_path.startswith(f"{_SECRET_DIR}/.secrets.")
+        assert "gmo" not in temp_path
+        assert any(c.startswith("mv -f ") and _SECRET_PATH in c for c in conn.commands)
+
+    def test_set_upsert_replaces_existing_key(self, store, conn, files):
+        conn.file_contents = "export API_KEY='old'\nexport OTHER='keep'\n"
+        files.file_exists.return_value = True
+        store.set_secret("API_KEY", "new")
+        _temp, content = files.write_remote_file.call_args[0]
+        assert "export API_KEY='new'" in content
+        assert "export API_KEY='old'" not in content
+        # Unrelated key preserved.
+        assert "export OTHER='keep'" in content
+        assert content.count("export API_KEY=") == 1
+
+    def test_set_single_quote_escaped(self, store, files):
+        store.set_secret("MSG", "it's ok")
+        _temp, content = files.write_remote_file.call_args[0]
+        assert "export MSG='it'\\''s ok'" in content
+
+    def test_set_refuses_symlink_target(self, store, conn, files):
+        conn.owner_result = "SYMLINK"
+        with pytest.raises(RuntimeError, match="symlink"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+    def test_set_refuses_foreign_owner(self, store, conn, files):
+        conn.owner_result = "4242"  # a uid different from `id -u` (1000)
+        with pytest.raises(RuntimeError, match="another user"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+
+class TestSetExitCodeChecks:
+    """Hardening: mkdir/chmod/mv failures must abort before publishing."""
+
+    def test_mkdir_failure_aborts_before_write(self, store, conn, files):
+        conn.fail_prefixes = {"mkdir -p ": 1}
+        with pytest.raises(RuntimeError, match="create secrets directory"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+    def test_dir_chmod_failure_aborts_before_write(self, store, conn, files):
+        conn.fail_prefixes = {"chmod 700 ": 1}
+        with pytest.raises(RuntimeError, match="chmod 0700"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+    def test_temp_chmod_failure_aborts_before_mv(self, store, conn, files):
+        conn.fail_prefixes = {"chmod 600 ": 1}
+        with pytest.raises(RuntimeError, match="chmod 0600"):
+            store.set_secret("API_KEY", "v")
+        # File was written to temp, but no mv happened.
+        files.write_remote_file.assert_called_once()
+        assert not any(c.startswith("mv -f ") for c in conn.commands)
+        # Temp is cleaned up on the aborted write.
+        files.cleanup_file.assert_called_once()
+
+    def test_mv_failure_raises_and_cleans_temp(self, store, conn, files):
+        conn.fail_prefixes = {"mv -f ": 1}
+        with pytest.raises(RuntimeError, match="store secret"):
+            store.set_secret("API_KEY", "v")
+        files.cleanup_file.assert_called_once()
+
+
+class TestDirectoryGuard:
+    """Hardening: the secrets directory itself is symlink/owner-guarded."""
+
+    def test_refuses_symlink_directory(self, store, conn, files):
+        conn.owner_result = "SYMLINK"
+        with pytest.raises(RuntimeError, match="symlink"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+    def test_refuses_foreign_owned_directory(self, store, conn, files):
+        conn.owner_result = "4242"
+        with pytest.raises(RuntimeError, match="another user"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+    def test_refuses_when_owner_undeterminable(self, store, conn, files):
+        # `[ -e ]` true but no stat form yields an owner uid -> fail-closed.
+        conn.owner_result = ""  # empty, but the path exists (not ABSENT)
+        with pytest.raises(RuntimeError, match="cannot determine owner"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+    def test_refuses_when_connecting_user_undeterminable(self, store, conn, files):
+        conn.owner_result = "1000"  # a real owner uid
+        conn.uid = ""  # `id -u` returns nothing
+        with pytest.raises(RuntimeError, match="cannot determine connecting user"):
+            store.set_secret("API_KEY", "v")
+        files.write_remote_file.assert_not_called()
+
+
+class TestTamperingRejection:
+    """Hardening: sourced file is re-rendered from validated records only."""
+
+    def test_set_rejects_unrecognised_line(self, store, conn, files):
+        conn.file_contents = "export API_KEY='ok'\nrm -rf ~\n"
+        files.file_exists.return_value = True
+        with pytest.raises(RuntimeError, match="did not write"):
+            store.set_secret("NEW", "v")
+        files.write_remote_file.assert_not_called()
+
+    def test_set_rejects_comment_line(self, store, conn, files):
+        conn.file_contents = "# injected\nexport API_KEY='ok'\n"
+        files.file_exists.return_value = True
+        with pytest.raises(RuntimeError, match="did not write"):
+            store.set_secret("NEW", "v")
+
+    def test_unset_rejects_unrecognised_line(self, store, conn, files):
+        conn.file_contents = "export API_KEY='ok'\nmalicious code\n"
+        files.file_exists.return_value = True
+        with pytest.raises(RuntimeError, match="did not write"):
+            store.unset_secret("API_KEY")
+
+    def test_rerender_keeps_only_known_records(self, store, conn, files):
+        conn.file_contents = "export A='1'\nexport B='2'\n"
+        files.file_exists.return_value = True
+        store.set_secret("C", "3")
+        _temp, content = files.write_remote_file.call_args[0]
+        lines = [ln for ln in content.splitlines() if ln]
+        assert lines == ["export A='1'", "export B='2'", "export C='3'"]
+
+    def test_value_round_trips_through_rerender(self, store, conn, files):
+        # A value with an embedded single quote must survive parse -> re-render.
+        conn.file_contents = "export MSG='it'\\''s ok'\n"
+        files.file_exists.return_value = True
+        store.set_secret("OTHER", "x")
+        _temp, content = files.write_remote_file.call_args[0]
+        # Original record preserved byte-for-byte after the round-trip.
+        assert "export MSG='it'\\''s ok'" in content
+
+    def test_blank_lines_ignored_not_rejected(self, store, conn, files):
+        conn.file_contents = "export A='1'\n\n\nexport B='2'\n"
+        files.file_exists.return_value = True
+        store.set_secret("C", "3")
+        _temp, content = files.write_remote_file.call_args[0]
+        assert "export A='1'" in content
+        assert "export B='2'" in content
+        assert "export C='3'" in content
+
+
+class TestReadFailureNotAbsent:
+    """A read failure on an existing file must not be treated as "empty".
+
+    Otherwise ``set`` re-renders from an empty record set and atomically
+    overwrites the file, wiping every existing secret (data loss).
+    """
+
+    def test_read_failure_raises_not_empty_string(self, store, conn, files):
+        files.file_exists.return_value = True
+        conn.cat_exit_code = 1
+        conn.file_contents = "export API_KEY='keep-me'\n"
+        with pytest.raises(RuntimeError, match="could not be read"):
+            store._read()
+
+    def test_set_aborts_and_does_not_overwrite_on_read_failure(
+        self, store, conn, files
+    ):
+        files.file_exists.return_value = True
+        conn.cat_exit_code = 1  # existing file, but unreadable
+        conn.file_contents = "export API_KEY='keep-me'\n"
+        with pytest.raises(RuntimeError, match="could not be read"):
+            store.set_secret("NEW", "v")
+        # Existing file is never re-rendered/overwritten.
+        files.write_remote_file.assert_not_called()
+
+    def test_unset_aborts_and_does_not_overwrite_on_read_failure(
+        self, store, conn, files
+    ):
+        files.file_exists.return_value = True
+        conn.cat_exit_code = 1
+        conn.file_contents = "export API_KEY='keep-me'\n"
+        with pytest.raises(RuntimeError, match="could not be read"):
+            store.unset_secret("API_KEY")
+        files.write_remote_file.assert_not_called()
+        # The file is not deleted either — the aborted read protects it.
+        files.cleanup_file.assert_not_called()
+
+    def test_absent_file_still_treated_as_empty_new_file(self, store, conn, files):
+        """Regression guard: genuine absence still yields empty + new file."""
+        files.file_exists.return_value = False
+        # cat is never reached for an absent file.
+        store.set_secret("API_KEY", "v")
+        _temp, content = files.write_remote_file.call_args[0]
+        assert "export API_KEY='v'" in content
+
+
+class TestKeyValidation:
+    @pytest.mark.parametrize("bad_key", ["1BAD", "has space", "with-dash", ""])
+    def test_reject_invalid_identifier(self, store, bad_key):
+        with pytest.raises(ValueError, match="valid identifier"):
+            store.set_secret(bad_key, "v")
+
+    @pytest.mark.parametrize("bad_key", ["SLURM_FOO", "SBATCH_BAR"])
+    def test_reject_reserved_prefix(self, store, bad_key):
+        with pytest.raises(ValueError, match="reserved"):
+            store.set_secret(bad_key, "v")
+
+    @pytest.mark.parametrize(
+        "bad_value", ["line1\nline2", "carriage\rreturn", "a\x00b"]
+    )
+    def test_reject_multiline_or_control_value(self, store, bad_value):
+        with pytest.raises(ValueError, match="single line"):
+            store.set_secret("API_KEY", bad_value)
+
+
+class TestListKeys:
+    def test_list_returns_names_only_never_values(self, store, conn, files):
+        conn.file_contents = (
+            "export API_KEY='sk-secret'\nexport WANDB='wandb-token-xyz'\n"
+        )
+        files.file_exists.return_value = True
+        keys = store.list_keys()
+        assert keys == ["API_KEY", "WANDB"]
+        # No value leaks into the returned data.
+        assert "sk-secret" not in keys
+        assert "wandb-token-xyz" not in keys
+
+    def test_list_empty_when_no_file(self, store, files):
+        files.file_exists.return_value = False
+        assert store.list_keys() == []
+
+
+class TestUnsetSecret:
+    def test_unset_removes_line_preserving_others(self, store, conn, files):
+        conn.file_contents = "export API_KEY='x'\nexport OTHER='y'\n"
+        files.file_exists.return_value = True
+        store.unset_secret("API_KEY")
+        _temp, content = files.write_remote_file.call_args[0]
+        assert "export API_KEY=" not in content
+        assert "export OTHER='y'" in content
+        assert any(c.startswith("mv -f ") for c in conn.commands)
+
+    def test_unset_deletes_file_when_empty(self, store, conn, files):
+        conn.file_contents = "export API_KEY='x'\n"
+        files.file_exists.return_value = True
+        store.unset_secret("API_KEY")
+        # File becomes empty -> removed via cleanup_file, no temp write.
+        files.cleanup_file.assert_called_once_with(_SECRET_PATH)
+        files.write_remote_file.assert_not_called()
+
+    def test_unset_noop_when_file_absent(self, store, files):
+        files.file_exists.return_value = False
+        store.unset_secret("API_KEY")
+        files.write_remote_file.assert_not_called()
+        files.cleanup_file.assert_not_called()

--- a/tests/ssh/core/test_slurm.py
+++ b/tests/ssh/core/test_slurm.py
@@ -191,22 +191,6 @@ class TestJobEnvPropagation:
         # Single quote escaped as '\'' within the single-quoted value.
         assert "export MSG='it'\\''s working'" in captured["inner"]
 
-    def test_job_env_overrides_profile_custom_env(self, client):
-        client.connection.custom_env_vars = {"FOO": "profile"}
-        client.files.write_remote_file = Mock()
-        client.files.validate_remote_script = Mock(return_value=(True, ""))
-        captured = self._capture_remote_command(client)
-
-        client.slurm.submit_sbatch_job(
-            "#!/bin/bash\necho hi",
-            job_name="test_job",
-            job_env_vars={"FOO": "job"},
-        )
-
-        # Job key wins ({**profile, **job}); only the job value is exported.
-        assert "export FOO='job'" in captured["inner"]
-        assert "export FOO='profile'" not in captured["inner"]
-
     def test_no_job_env_omits_export_all_temp_upload(self, client):
         """No job env → no --export=ALL, so the script's export policy wins."""
         client.files.write_remote_file = Mock()
@@ -225,6 +209,104 @@ class TestJobEnvPropagation:
         client.slurm.submit_remote_sbatch_file("/remote/run.sh", job_name="test_job")
 
         assert "--export=ALL" not in captured["inner"]
+
+
+class TestSecretDelivery:
+    """REQ-8, REQ-9: profile secret file is sourced + triggers --export=ALL."""
+
+    def _bind_secret_store(self, client, *, exists: bool):
+        """Bind a profile secret store and stub its remote-facing methods."""
+        client.slurm.bind_profile_name("gmo")
+        store = client.slurm._secret_store
+        store.exists = Mock(return_value=exists)
+        # Account-scoped path: no ``secrets/`` subdir, no profile name.
+        store.secret_path = Mock(return_value="/home/tester/.config/srunx/secrets.env")
+        return store
+
+    def test_env_setup_sources_secret_file_when_present(self, client):
+        self._bind_secret_store(client, exists=True)
+        setup = client.slurm._get_slurm_env_setup()
+        # Path is shlex.quote'd; a plain path with no metacharacters is emitted
+        # verbatim (no surrounding quotes needed). Non-blocking ``if ... fi``
+        # form so an unreadable/absent file never fails the actual command.
+        assert (
+            "if [ -r /home/tester/.config/srunx/secrets.env ]; then "
+            "set -a; . /home/tester/.config/srunx/secrets.env; set +a; fi"
+        ) in setup
+
+    def test_source_prefix_is_non_blocking_not_and_guarded(self, client):
+        """The source prefix must not ``&&``-guard the real slurm command.
+
+        A ``[ -r ] && ...`` chain returns non-zero (and short-circuits the
+        joined command line) when the file is unreadable/removed between probe
+        and run — blocking squeue/scancel/sbatch. The ``if ...; then ...; fi``
+        form always exits 0, so the joined command still runs.
+        """
+        self._bind_secret_store(client, exists=True)
+        setup = client.slurm._get_slurm_env_setup()
+        # The secret source segment must be an ``if``-form (always exit 0),
+        # never a ``[ -r ... ] &&`` guard.
+        assert "if [ -r " in setup
+        assert "[ -r /home/tester/.config/srunx/secrets.env ] &&" not in setup
+
+    def test_env_setup_omits_source_when_absent(self, client):
+        self._bind_secret_store(client, exists=False)
+        setup = client.slurm._get_slurm_env_setup()
+        assert "set -a" not in setup
+
+    def test_secret_path_with_special_chars_is_shell_quoted(self, client):
+        """A resolved secret path containing a space is single-quoted."""
+        store = self._bind_secret_store(client, exists=True)
+        store.secret_path = Mock(return_value="/home/my user/.config/srunx/secrets.env")
+        setup = client.slurm._get_slurm_env_setup()
+        assert ". '/home/my user/.config/srunx/secrets.env'" in setup
+
+    def test_secret_file_probed_once_per_submit_temp_upload(self, client):
+        """The --export=ALL decision and the source prefix share one probe."""
+        store = self._bind_secret_store(client, exists=True)
+        client.files.write_remote_file = Mock()
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = TestJobEnvPropagation()._capture_remote_command(client)
+
+        client.slurm.submit_sbatch_job("#!/bin/bash\necho hi", job_name="test_job")
+
+        # Single existence probe drove both the --export=ALL flag and the
+        # sourced secret prefix — they are consistent by construction.
+        assert store.exists.call_count == 1
+        assert "--export=ALL" in captured["inner"]
+        assert "secrets.env" in captured["inner"]
+
+    def test_secret_file_probed_once_per_submit_in_place(self, client):
+        store = self._bind_secret_store(client, exists=True)
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = TestJobEnvPropagation()._capture_remote_command(client)
+
+        client.slurm.submit_remote_sbatch_file("/remote/run.sh", job_name="test_job")
+
+        assert store.exists.call_count == 1
+        assert "--export=ALL" in captured["inner"]
+        assert "secrets.env" in captured["inner"]
+
+    def test_secret_present_adds_export_all_temp_upload(self, client):
+        self._bind_secret_store(client, exists=True)
+        client.files.write_remote_file = Mock()
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = TestJobEnvPropagation()._capture_remote_command(client)
+
+        # No job env vars, but a secret file exists -> --export=ALL applies.
+        client.slurm.submit_sbatch_job("#!/bin/bash\necho hi", job_name="test_job")
+
+        assert "--export=ALL" in captured["inner"]
+        assert "secrets.env" in captured["inner"]
+
+    def test_secret_present_adds_export_all_in_place(self, client):
+        self._bind_secret_store(client, exists=True)
+        client.files.validate_remote_script = Mock(return_value=(True, ""))
+        captured = TestJobEnvPropagation()._capture_remote_command(client)
+
+        client.slurm.submit_remote_sbatch_file("/remote/run.sh", job_name="test_job")
+
+        assert "--export=ALL" in captured["inner"]
 
 
 class TestCleanupJobFiles:

--- a/tests/ssh/test_components.py
+++ b/tests/ssh/test_components.py
@@ -126,12 +126,20 @@ class TestSlurmRemoteClient:
 
     def test_get_slurm_env_setup(self):
         conn = MagicMock(spec=SSHConnection)
-        conn.custom_env_vars = {"FOO": "bar"}
         fm = MagicMock(spec=RemoteFileManager)
         slurm = SlurmRemoteClient(conn, fm)
+        # Job-level env vars are exported in the prefix; no profile-env merge.
+        setup = slurm._get_slurm_env_setup({"FOO": "bar"})
+        assert "export FOO='bar'" in setup
+
+    def test_get_slurm_env_setup_no_secret_when_profile_absent(self):
+        conn = MagicMock(spec=SSHConnection)
+        fm = MagicMock(spec=RemoteFileManager)
+        slurm = SlurmRemoteClient(conn, fm)
+        # No profile bound -> no secret store, no source-prefix line.
+        assert slurm._secret_store is None
         setup = slurm._get_slurm_env_setup()
-        assert "FOO" in setup
-        assert "bar" in setup
+        assert "set -a" not in setup
 
     def test_handle_slurm_error_logs_without_raising(self):
         conn = MagicMock(spec=SSHConnection)

--- a/tests/transport/test_review_fixes.py
+++ b/tests/transport/test_review_fixes.py
@@ -387,7 +387,6 @@ class TestStatusSnapshotDoesNotRefresh:
         adapter._key_filename = None
         adapter._port = 22
         adapter._proxy_jump = None
-        adapter._env_vars = {}
         adapter._mounts = ()
         adapter.submission_source = "cli"
 


### PR DESCRIPTION
## 背景

`srunx ssh env`（プロファイル単位の `custom_env_vars`）は、値を **config.json に平文保存**し、投入時にリモートの sbatch コマンド文字列へ載せて **`ps` で露出**していた。API キーの置き場所として不適切。

## 変更

### 追加: `srunx ssh secret set/list/unset`
- **`set KEY --profile <p>`**: 値は getpass 隠し入力（または `--from-env VAR`）。**インライン値の位置引数は受け付けない**。リモートの**アカウント単位の単一ファイル** `$HOME/.config/srunx/secrets.env`（親 dir 0700 / ファイル 0600）に SFTP で `export KEY='...'` を upsert。
  - パスは**プロファイル名でキーしない**（リモートアカウント=`$HOME` が自然なスコープ。rename 孤児化・マシン間のプロファイル名不一致を回避）。
  - KEY 検証（識別子・`SLURM_`/`SBATCH_` 拒否）+ 単行値のみ。書き込みは temp+atomic rename・chmod は exit-code チェック・symlink/所有者 fail-closed ガード・**検証済みレコードのみ再描画**（改ざん行は拒否、source しない）。
- **`list`** はキー名のみ表示、**`unset`** は行削除（空なら削除）。値は config/logs/stdout/コマンド引数/履歴に一切出ない。

### 配送
プロファイル経由の SSH 投入時、srunx が `bash -l` submit シェルで secret ファイルを source し、**存在時のみ `--export=ALL`** を付与 → 計算ノードのジョブに届く。**スクリプト無編集・`--env` 不要**。`--export=ALL` は `#SBATCH --export=NONE` を上書き（秘密を届ける意図）。**gmo 実機でエンドツーエンド検証済み**。

### 削除（後方互換なし・完全削除）
`ssh env` CLI + impl、`ServerProfile.env_vars`、`ConfigManager.set/unset_profile_env_var`、`SSHConnection.custom_env_vars` と配線一式、`SlurmSSHClientSpec.env_vars`、web の profile-update `env_vars`、**frontend の profile env 編集 UI**。`ServerProfile` は `extra="ignore"` で旧 config もロード可。

## 設計
秘密は domain（`JobEnvironment`）に混ぜず、`RemoteSecretStore` を `ssh/core` に新設。`--export=ALL` と source 前置は SSH アダプタ層に限定（DIP）。`JobOperations.submit` シグネチャ不変（ISP）。keyring/vault は不採用（remote 0600 ファイル方式のみ）。

## 失敗系ハードニング（Codex レビュー指摘）
- read 失敗を「不在」と混同せず例外化 → `set` が既存秘密を消失しない。
- source 前置を `if [ -r ]; then …; fi`（非ブロッキング）に → 壊れた secret ファイルが `squeue`/`scancel` 等をブロックしない。

## テスト / 検証
- フルスイート **2201 passed, 2 skipped**、`mypy` / `ruff check` / `ruff format --check` クリーン、frontend `npm run build` 成功
- gmo 実機で set→list→ジョブ受信→unset を確認
- レビュー: Claude(post-impl / spec-compliance / delta×3) + Codex（設計 + 全ブランチ）— すべて APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)