### PR TITLE
fix(ssh): respect script's #SBATCH --job-name when -J unspecified

### DIFF
--- a/src/srunx/cli/_helpers/sbatch_helpers.py
+++ b/src/srunx/cli/_helpers/sbatch_helpers.py
@@ -5,6 +5,7 @@ These were siblings of ``sbatch`` in the old monolithic ``main.py``; they live
 here so ``commands/jobs.py`` only holds Typer command functions.
 """
 
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -32,6 +33,7 @@ def _submit_via_transport(
     config: Any,
     extra_sbatch_args: list[str] | None = None,
     force_sync: bool = False,
+    inject_job_name: bool = True,
 ) -> Any:
     """Dispatch a submit to the right adapter method + optional mount sync.
 
@@ -62,6 +64,15 @@ def _submit_via_transport(
     overrides of the script's ``#SBATCH`` directives, matching real
     sbatch's precedence. Closes Codex blocker #1: previously these
     flags silently no-op'd in ShellJob (positional-script) mode.
+
+    ``inject_job_name`` controls whether ``--job-name`` reaches the
+    remote sbatch command line. It is ``False`` when the user did not
+    type ``-J`` on a positional script, so the script's own ``#SBATCH
+    --job-name`` (or SLURM's default) wins instead of being clobbered
+    by srunx's logical name. ``job.name`` still carries the resolved
+    logical name for display / history regardless — the two concerns
+    are deliberately separate. Non-CLI callers keep the default
+    ``True`` so workflow / Web / MCP submissions still name their jobs.
     """
     from srunx.common.exceptions import TransportError
     from srunx.domain import ShellJob as _ShellJob
@@ -96,7 +107,9 @@ def _submit_via_transport(
         logger.warning(w)
 
     if plan.mode == SubmissionMode.TEMP_UPLOAD:
-        return rt.job_ops.submit(job, submission_context=sub_ctx)
+        return rt.job_ops.submit(
+            job, submission_context=sub_ctx, inject_job_name=inject_job_name
+        )
 
     # IN_PLACE branch: hold the per-(profile,mount) lock across the
     # entire sync + sbatch handoff so a concurrent invocation can't
@@ -145,7 +158,7 @@ def _submit_via_transport(
             submitted = rt.job_ops.submit_remote_sbatch(
                 plan.remote_script_path,
                 submit_cwd=plan.submit_cwd,
-                job_name=job.name,
+                job_name=job.name if inject_job_name else None,
                 extra_sbatch_args=extra_sbatch_args or None,
                 callbacks_job=job,
             )
@@ -229,6 +242,100 @@ def _build_extra_sbatch_args(
         args.append(f"--error={log_dir_user}/%x_%j.log")
 
     return args
+
+
+def _job_name_from_tokens(tokens: list[str]) -> str | None:
+    """Extract ``--job-name`` / ``-J`` from one ``#SBATCH`` line's tokens.
+
+    Handles the four sbatch spellings — ``--job-name=X`` / ``--job-name X``
+    / ``-J X`` / ``-JX`` — and returns the LAST one on the line (matching
+    SLURM's last-wins semantics within a directive line). ``None`` when the
+    line carries no job-name option.
+    """
+    result: str | None = None
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.startswith("--job-name="):
+            result = tok.split("=", 1)[1]
+        elif tok in ("--job-name", "-J") and i + 1 < len(tokens):
+            result = tokens[i + 1]
+            i += 1
+        elif tok.startswith("-J") and len(tok) > 2:
+            result = tok[2:]
+        i += 1
+    return result or None
+
+
+def _script_job_name(script_path: Path | str) -> str | None:
+    """Return the job name declared by a script's ``#SBATCH`` directives.
+
+    Mirrors ``sbatch``'s own directive scan: read ``#SBATCH`` lines from the
+    top of the file, stop at the first non-blank, non-comment line (the first
+    executable command), and honour the LAST ``--job-name`` / ``-J`` seen.
+    Returns ``None`` when no such directive exists or the file can't be read
+    — callers fall back to SLURM's default naming.
+
+    Only the job-name option is parsed (not a general ``#SBATCH`` grammar);
+    a ``%x`` / env-expansion inside a name is returned verbatim (best-effort
+    — the value is used only for srunx's own display, never re-injected).
+    """
+    try:
+        # ``errors="replace"`` so a non-UTF-8 byte anywhere in the script
+        # (e.g. a locale-encoded comment) never raises — such scripts are
+        # valid shell and previously submitted fine (rsync is byte-exact,
+        # the remote sbatch reads the bytes); this display-only scan must
+        # not become a new failure point. ``UnicodeDecodeError`` subclasses
+        # ``ValueError``, NOT ``OSError``, so it would otherwise escape.
+        text = Path(script_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    found: str | None = None
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#SBATCH"):
+            try:
+                tokens = shlex.split(stripped[len("#SBATCH") :])
+            except ValueError:
+                continue
+            name = _job_name_from_tokens(tokens)
+            if name is not None:
+                found = name  # last directive wins, matching SLURM
+            continue
+        if stripped.startswith("#"):
+            continue  # shebang / comment line — keep scanning
+        break  # first executable line ends #SBATCH processing
+    return found
+
+
+def _resolve_job_name(
+    script: Path | str, cli_name: str, *, cli_name_explicit: bool
+) -> tuple[str, bool]:
+    """Resolve ``(logical job name, inject-as---job-name?)`` for a positional script.
+
+    Name precedence mirrors ``sbatch``: an explicit CLI ``-J`` wins, else
+    the script's own ``#SBATCH --job-name`` / ``-J`` directive, else the
+    script's file name (sbatch(1): "The default job name is the name of the
+    batch script"). Resolved offline so srunx's CLI display / history match
+    the scheduler without a post-submit ``squeue`` / ``sacct`` query.
+
+    The second element says whether to place ``--job-name`` on the sbatch
+    command line. Injection is suppressed **only** when the script declares
+    its own directive and the user didn't type ``-J`` — then the directive
+    must win. With no directive we inject the resolved name so SLURM agrees
+    with srunx; this is essential on the temp-upload path, where the script
+    is uploaded to a random ``job_<uuid>.sh`` and SLURM's *default* name
+    would be that opaque temp filename rather than the source basename.
+    """
+    if cli_name_explicit:
+        return cli_name, True
+    directive = _script_job_name(script)
+    if directive is not None:
+        return directive, False
+    return Path(script).name, True
 
 
 def _parse_gres_gpu(gres: str | None) -> int | None:

--- a/src/srunx/cli/commands/jobs/sbatch.py
+++ b/src/srunx/cli/commands/jobs/sbatch.py
@@ -15,6 +15,7 @@ from srunx.cli._helpers.sbatch_helpers import (
     _parse_env_vars,
     _parse_gres_gpu,
     _print_in_place_sync_preview,
+    _resolve_job_name,
     _submit_via_transport,
 )
 from srunx.cli._helpers.transport import resolve_transport
@@ -307,6 +308,23 @@ def sbatch(
 
     environment = JobEnvironment.model_validate(env_config)
 
+    # Did the user actually type ``-J`` / ``--name``? The option defaults
+    # to "job"; only an explicit value may override a script's own
+    # ``#SBATCH --job-name``. Same ParameterSource pattern as the resource
+    # flags below.
+    from click.core import ParameterSource
+
+    name_explicit = ctx.get_parameter_source("name") == ParameterSource.COMMANDLINE
+
+    # ``inject_job_name`` = should ``--job-name`` go on the sbatch command
+    # line? Default True; only a positional script that declares its own
+    # ``#SBATCH --job-name`` (and no explicit ``-J``) suppresses it, so the
+    # script's directive wins. ``--wrap`` always injects — it has no
+    # user-authored directive to protect, and suppressing would let a stray
+    # ``SBATCH_JOB_NAME`` in the environment rename the job out from under
+    # the name srunx records.
+    inject_job_name = True
+
     job: Job | ShellJob
     if script is not None:
         # ShellJob's schema is intentionally thin: it records the script
@@ -318,8 +336,16 @@ def sbatch(
         # --export=ALL locally / remote export prefix + --export=ALL over
         # SSH), so --env is effective for positional scripts identically to
         # --wrap.
+        #
+        # ``name`` is resolved the way SLURM will name the job (explicit
+        # -J > script's #SBATCH --job-name > script basename) so srunx's
+        # display / history match the scheduler without a post-submit
+        # query; ``inject_job_name`` rides along from the same resolution.
+        effective_name, inject_job_name = _resolve_job_name(
+            script, name, cli_name_explicit=name_explicit
+        )
         shell_data: dict[str, Any] = {
-            "name": name,
+            "name": effective_name,
             "script_path": str(script),
             "environment": environment,
         }
@@ -417,8 +443,6 @@ def sbatch(
     # ParameterSource); never forward defaults nor config-injected
     # values, so the on-disk ``#SBATCH`` directives stay authoritative
     # for anything the user did not explicitly override.
-    from click.core import ParameterSource
-
     log_dir_user = (
         log_dir
         if ctx.get_parameter_source("log_dir") == ParameterSource.COMMANDLINE
@@ -474,6 +498,7 @@ def sbatch(
             config=config,
             extra_sbatch_args=extra_sbatch_args,
             force_sync=force_sync,
+            inject_job_name=inject_job_name,
         )
         client = (
             _slurm_local.Slurm(callbacks=callbacks)

--- a/src/srunx/slurm/clients/local.py
+++ b/src/srunx/slurm/clients/local.py
@@ -96,6 +96,7 @@ class LocalClient:
         workflow_run_id: int | None = None,
         *,
         submission_context: SubmissionRenderContext | None = None,
+        inject_job_name: bool = True,
     ) -> RunnableJobType:
         """Submit a job to SLURM.
 
@@ -119,6 +120,11 @@ class LocalClient:
                 :class:`~srunx.slurm.protocols.JobOperations`
                 conformance and ignored — local submission performs no
                 mount translation.
+            inject_job_name: Accepted for
+                :class:`~srunx.slurm.protocols.JobOperations`
+                conformance and ignored — the local path never injects a
+                ``--job-name`` flag (a ShellJob's own ``#SBATCH`` directives
+                always win), so there is nothing to suppress.
 
         Returns:
             Job instance with updated job_id and status.
@@ -127,6 +133,7 @@ class LocalClient:
             subprocess.CalledProcessError: If job submission fails.
         """
         del submission_context  # unused on the local path (see docstring)
+        del inject_job_name  # unused on the local path (see docstring)
         result = None
 
         if isinstance(job, Job):

--- a/src/srunx/slurm/clients/ssh.py
+++ b/src/srunx/slurm/clients/ssh.py
@@ -637,6 +637,7 @@ class SlurmSSHClient:
         job: RunnableJobType,
         *,
         submission_context: SubmissionRenderContext | None = None,
+        inject_job_name: bool = True,
     ) -> RunnableJobType:
         """Submit *job* over SSH and return it with ``job_id`` populated.
 
@@ -710,9 +711,16 @@ class SlurmSSHClient:
                 # Job-level env rides on ``job.environment`` (ISP — no env
                 # params on the JobOperations.submit protocol); the SSH adapter
                 # realizes it as the remote export prefix + ``--export=ALL``.
+                #
+                # ``inject_job_name=False`` (CLI positional script with no
+                # explicit ``-J``) suppresses the ``--job-name`` command-line
+                # flag so the script's own ``#SBATCH --job-name`` — already
+                # present in ``script_content`` — is not overridden. The
+                # resolved logical name still travels on ``job.name`` for the
+                # DB record + callbacks fired below.
                 result = self._client.slurm.submit_sbatch_job(
                     script_content,
-                    job_name=job.name,
+                    job_name=job.name if inject_job_name else None,
                     job_env_vars=job.environment.env_vars,
                 )
         except paramiko.AuthenticationException as exc:

--- a/src/srunx/slurm/protocols.py
+++ b/src/srunx/slurm/protocols.py
@@ -60,6 +60,7 @@ class JobOperations(Protocol):
         job: RunnableJobType,
         *,
         submission_context: SubmissionRenderContext | None = None,
+        inject_job_name: bool = True,
     ) -> RunnableJobType:
         """Submit *job* to SLURM and return the populated job object.
 
@@ -74,6 +75,15 @@ class JobOperations(Protocol):
         / ``log_dir`` paths get rewritten to the remote-mount equivalents.
         Local implementations accept the kwarg for Protocol conformance
         but ignore it (local submission never performs mount translation).
+
+        ``inject_job_name`` controls whether the job's name is placed on
+        the ``sbatch`` command line as ``--job-name`` (which would override
+        a script's own ``#SBATCH --job-name``). The CLI passes ``False``
+        when the user did not explicitly type ``-J`` on a positional
+        script, so the script's directive wins. Defaults to ``True`` so
+        workflow / Web / MCP callers keep naming their jobs. Local
+        implementations accept it for conformance and ignore it (the local
+        path never injects ``--job-name``).
         """
         ...
 

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -146,6 +146,9 @@ def test_sbatch_in_place_under_mount_calls_remote_submit(
     call_kwargs = job_ops.submit_remote_sbatch.call_args
     assert call_kwargs.args[0] == "/cluster/share/ml-project/train.sbatch"
     assert call_kwargs.kwargs["submit_cwd"].startswith("/cluster/share/ml-project")
+    # No ``-J`` was typed, so srunx must NOT inject ``--job-name`` — the
+    # script's own ``#SBATCH --job-name=train`` directive has to win.
+    assert call_kwargs.kwargs["job_name"] is None
 
     # The legacy temp-upload path must NOT have fired.
     job_ops.submit.assert_not_called()

--- a/tests/cli/test_sbatch_job_name.py
+++ b/tests/cli/test_sbatch_job_name.py
@@ -1,0 +1,318 @@
+"""Tests for job-name handling in ``srunx sbatch``.
+
+Covers two coupled behaviours introduced to fix the SSH job-name bug:
+
+* **Injection suppression** — when the user does NOT type ``-J`` on a
+  positional script, srunx must not inject ``--job-name`` on the sbatch
+  command line (which would override the script's own ``#SBATCH
+  --job-name``). This applies to both SSH submission paths: TEMP_UPLOAD
+  (``submit``) and IN_PLACE (``submit_remote_sbatch``).
+* **Offline name resolution (系統2)** — srunx's logical ``job.name``
+  (shown in CLI output / recorded in history) is resolved before submit
+  the way SLURM itself would: explicit ``-J`` wins, else the script's
+  own ``#SBATCH --job-name`` / ``-J`` directive, else the script's
+  basename. No post-submit ``squeue``/``sacct`` query.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from srunx.cli._helpers.sbatch_helpers import (
+    _resolve_job_name,
+    _script_job_name,
+)
+from srunx.cli.main import app
+from srunx.ssh.core.config import MountConfig, ServerProfile
+
+# ── Unit: offline #SBATCH job-name parser ─────────────────────────────
+
+
+def _write(tmp_path: Path, body: str, name: str = "job.sbatch") -> Path:
+    p = tmp_path / name
+    p.write_text(body)
+    return p
+
+
+def test_script_job_name_equals_form(tmp_path: Path) -> None:
+    script = _write(tmp_path, "#!/bin/bash\n#SBATCH --job-name=g4_26b\necho hi\n")
+    assert _script_job_name(script) == "g4_26b"
+
+
+def test_script_job_name_space_form(tmp_path: Path) -> None:
+    script = _write(tmp_path, "#!/bin/bash\n#SBATCH --job-name my_job\necho hi\n")
+    assert _script_job_name(script) == "my_job"
+
+
+def test_script_job_name_short_flag_forms(tmp_path: Path) -> None:
+    assert _script_job_name(_write(tmp_path, "#SBATCH -J short1\n")) == "short1"
+    assert _script_job_name(_write(tmp_path, "#SBATCH -Jshort2\n")) == "short2"
+
+
+def test_script_job_name_last_directive_wins(tmp_path: Path) -> None:
+    script = _write(
+        tmp_path,
+        "#!/bin/bash\n#SBATCH --job-name=first\n#SBATCH --job-name=second\necho hi\n",
+    )
+    assert _script_job_name(script) == "second"
+
+
+def test_script_job_name_stops_at_first_command(tmp_path: Path) -> None:
+    # A ``--job-name`` appearing AFTER the first executable line is not a
+    # directive SLURM would honour, so we must not pick it up.
+    script = _write(
+        tmp_path,
+        "#!/bin/bash\necho start\n#SBATCH --job-name=too_late\n",
+    )
+    assert _script_job_name(script) is None
+
+
+def test_script_job_name_none_when_absent(tmp_path: Path) -> None:
+    script = _write(tmp_path, "#!/bin/bash\n#SBATCH --nodes=2\necho hi\n")
+    assert _script_job_name(script) is None
+
+
+def test_script_job_name_unreadable_returns_none(tmp_path: Path) -> None:
+    assert _script_job_name(tmp_path / "does-not-exist.sbatch") is None
+
+
+# ── Unit: name resolution + injection decision ────────────────────────
+
+
+def test_resolve_explicit_wins_and_injects(tmp_path: Path) -> None:
+    # Explicit -J overrides even a script directive, and is injected.
+    script = _write(tmp_path, "#SBATCH --job-name=from_script\n")
+    assert _resolve_job_name(script, "cli_name", cli_name_explicit=True) == (
+        "cli_name",
+        True,
+    )
+
+
+def test_resolve_from_directive_suppresses_injection(tmp_path: Path) -> None:
+    # Script declares its own name and no -J → use it AND don't inject
+    # (let the directive win on the scheduler).
+    script = _write(tmp_path, "#!/bin/bash\n#SBATCH --job-name=from_script\necho hi\n")
+    assert _resolve_job_name(script, "job", cli_name_explicit=False) == (
+        "from_script",
+        False,
+    )
+
+
+def test_resolve_basename_fallback_injects(tmp_path: Path) -> None:
+    # No directive, no -J → basename, and DO inject it so the scheduler
+    # agrees with srunx (the temp-upload path would otherwise name the job
+    # after a random job_<uuid>.sh).
+    script = _write(tmp_path, "#!/bin/bash\necho hi\n", name="train.sbatch")
+    assert _resolve_job_name(script, "job", cli_name_explicit=False) == (
+        "train.sbatch",
+        True,
+    )
+
+
+# ── Integration harness (SSH transport with mocked job_ops) ───────────
+
+
+def _stub_profile(tmp_path: Path, mount_local: Path, remote: str) -> ServerProfile:
+    key = tmp_path / "id_rsa"
+    key.write_text("dummy")
+    return ServerProfile(
+        hostname="h",
+        username="u",
+        key_filename=str(key),
+        mounts=(MountConfig(name="ml", local=str(mount_local), remote=remote),),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.delenv("SRUNX_SSH_PROFILE", raising=False)
+    monkeypatch.setenv("SRUNX_SYNC_OWNER_CHECK", "0")
+
+
+def _patch_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    profile: ServerProfile,
+    profile_name: str = "ml-cluster",
+) -> MagicMock:
+    from srunx.domain import JobStatus
+    from srunx.runtime.rendering import SubmissionRenderContext
+    from srunx.transport.registry import TransportHandle
+
+    job_ops = MagicMock(name="JobOperations")
+    # ``submit`` (TEMP_UPLOAD) returns a copy of the job with a job_id so
+    # the CLI's post-submit display reads the resolved ``job.name``.
+    job_ops.submit.side_effect = lambda j, **_: type(j)(
+        **{**j.model_dump(), "job_id": 99}
+    )
+
+    def _fake_remote_submit(remote_path, *, callbacks_job, **_kwargs):
+        callbacks_job.job_id = 42
+        callbacks_job.status = JobStatus.PENDING
+        if hasattr(callbacks_job, "script_path"):
+            callbacks_job.script_path = remote_path
+        return callbacks_job
+
+    job_ops.submit_remote_sbatch.side_effect = _fake_remote_submit
+
+    handle = TransportHandle(
+        scheduler_key=f"ssh:{profile_name}",
+        profile_name=profile_name,
+        transport_type="ssh",
+        job_ops=job_ops,
+        queue_client=job_ops,
+        executor_factory=None,
+        submission_context=SubmissionRenderContext(
+            mount_name=None,
+            mounts=tuple(profile.mounts),
+            default_work_dir=None,
+        ),
+    )
+
+    def _fake_build(
+        profile_name_arg,
+        *,
+        callbacks=None,
+        submission_source="web",
+        mount_name=None,
+        pool_size=2,
+    ):
+        return handle, MagicMock(name="pool")
+
+    monkeypatch.setattr("srunx.transport.registry._build_ssh_handle", _fake_build)
+    monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", lambda *a, **k: None)
+
+    from srunx.ssh.core.config import ConfigManager
+
+    monkeypatch.setattr(ConfigManager, "get_profile", lambda self, name: profile)
+    return job_ops
+
+
+# ── IN_PLACE path (script under a mount) ──────────────────────────────
+
+
+def test_in_place_no_explicit_j_suppresses_job_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\n#SBATCH --job-name=g4_26b\necho hi\n")
+    profile = _stub_profile(tmp_path, mount_local, "/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    result = CliRunner().invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    # No -J → don't inject --job-name; let the script's directive win.
+    assert job_ops.submit_remote_sbatch.call_args.kwargs["job_name"] is None
+    # 系統2: srunx's displayed name mirrors the script's directive.
+    assert "Job name: g4_26b" in result.stdout
+
+
+def test_in_place_explicit_j_injects_job_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "train.sbatch"
+    script.write_text("#!/bin/bash\n#SBATCH --job-name=g4_26b\necho hi\n")
+    profile = _stub_profile(tmp_path, mount_local, "/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    result = CliRunner().invoke(
+        app, ["sbatch", str(script), "--profile", "ml-cluster", "-J", "explicit"]
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert job_ops.submit_remote_sbatch.call_args.kwargs["job_name"] == "explicit"
+    assert "Job name: explicit" in result.stdout
+
+
+def test_in_place_no_directive_injects_basename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No #SBATCH --job-name and no -J: nothing to protect, so inject the
+    # resolved basename (matches SLURM's own default for an in-place run).
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    script = mount_local / "plain.sbatch"
+    script.write_text("#!/bin/bash\necho hi\n")
+    profile = _stub_profile(tmp_path, mount_local, "/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    result = CliRunner().invoke(app, ["sbatch", str(script), "--profile", "ml-cluster"])
+    assert result.exit_code == 0, result.stdout + result.stderr
+    assert job_ops.submit_remote_sbatch.call_args.kwargs["job_name"] == "plain.sbatch"
+    assert "Job name: plain.sbatch" in result.stdout
+
+
+# ── TEMP_UPLOAD path (script outside every mount) ─────────────────────
+
+
+def test_temp_upload_no_explicit_j_suppresses_job_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    outside = tmp_path / "scratch" / "run.sbatch"
+    outside.parent.mkdir()
+    outside.write_text("#!/bin/bash\n#SBATCH --job-name=g4_26b\necho hi\n")
+    profile = _stub_profile(tmp_path, mount_local, "/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    result = CliRunner().invoke(
+        app, ["sbatch", str(outside), "--profile", "ml-cluster"]
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+
+    job_ops.submit.assert_called_once()
+    assert job_ops.submit.call_args.kwargs["inject_job_name"] is False
+    assert "Job name: g4_26b" in result.stdout
+
+
+def test_temp_upload_explicit_j_injects_job_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    outside = tmp_path / "scratch" / "run.sbatch"
+    outside.parent.mkdir()
+    outside.write_text("#!/bin/bash\n#SBATCH --job-name=g4_26b\necho hi\n")
+    profile = _stub_profile(tmp_path, mount_local, "/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    result = CliRunner().invoke(
+        app, ["sbatch", str(outside), "--profile", "ml-cluster", "-J", "explicit"]
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    job_ops.submit.assert_called_once()
+    assert job_ops.submit.call_args.kwargs["inject_job_name"] is True
+    assert "Job name: explicit" in result.stdout
+
+
+def test_temp_upload_no_directive_injects_basename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Outside every mount (TEMP_UPLOAD), no directive, no -J: the script is
+    # uploaded to a random job_<uuid>.sh, so SLURM's default name would be
+    # that opaque temp name. Inject the resolved basename so the scheduler
+    # matches what srunx records.
+    mount_local = tmp_path / "ml-project"
+    mount_local.mkdir()
+    outside = tmp_path / "scratch" / "run.sbatch"
+    outside.parent.mkdir()
+    outside.write_text("#!/bin/bash\necho hi\n")
+    profile = _stub_profile(tmp_path, mount_local, "/r/ml-project")
+    job_ops = _patch_transport(monkeypatch, profile)
+
+    result = CliRunner().invoke(
+        app, ["sbatch", str(outside), "--profile", "ml-cluster"]
+    )
+    assert result.exit_code == 0, result.stdout + result.stderr
+    job_ops.submit.assert_called_once()
+    assert job_ops.submit.call_args.kwargs["inject_job_name"] is True
+    assert "Job name: run.sbatch" in result.stdout


### PR DESCRIPTION
## 背景

`srunx sbatch <script> --profile <name>` を `-J` 未指定で叩くと、スクリプト自身の `#SBATCH --job-name=g4_26b` が SLURM 上で既定名 `job` に潰されていた。SSH 経由では CLI 既定名 `"job"` を無条件に `--job-name=job` としてコマンド行へ注入しており、SLURM ではコマンド行が `#SBATCH` ディレクティブを上書きするため。ローカル投入では注入しないので、SSH とローカルで挙動が非対称だった。

（Claude + Codex 双方で機序を検証済み。）

## 修正

2つの関心を分離した：

- **注入するか** — ユーザーが `-J` を明示入力したかで判定。抑止するのは「positional スクリプトが自前の `#SBATCH --job-name` を持ち、かつ `-J` 未指定」のときだけ。それ以外は解決名を注入する。`--wrap` は常に注入（保護すべきディレクティブが無く、環境変数 `SBATCH_JOB_NAME` による横取りも防ぐ）。ワークフロー / Web / MCP は既定 `True` で従来どおり。
- **表示・履歴に出す名前** — 投入前にオフラインで SLURM と同じ規則で解決（明示 `-J` > スクリプトの `#SBATCH --job-name`/`-J` > スクリプトの basename）。投入後の `squeue`/`sacct` 照会に依存しないため、ロックダウンされたクラスタでも機能する。

### 最終ルール

| ケース | SLURM 上の名前 | `--job-name` 注入 |
|---|---|---|
| `-J foo` 明示 | `foo` | する |
| スクリプトに `#SBATCH --job-name=X`・`-J` 無し | `X`（スクリプト尊重） | **しない** |
| ディレクティブ無し・`-J` 無し | basename | する（tmp アップロード名 `job_<uuid>.sh` 化を防ぐ） |
| `--wrap` | 従来どおり | 常にする |

## テスト / 品質

- `tests/cli/test_sbatch_job_name.py`（新規）+ 既存 in-place テストに `--job-name` 引数のアサーション追加
- 全 2246 passed / 2 skipped、`mypy .`（371 ファイル問題なし）、`ruff check .` 全通過

## レビュー

- Claude（独立サブエージェント）+ Codex の 2 系統でレビュー。指摘 3 点（非 UTF-8 スクリプトでの例外、tmp アップロード時の名前食い違い、`--wrap` の抑止回帰）をすべて修正し、再レビューで APPROVED。

## 既知の残課題（対象外・非ブロッキング）

- スペース等を含むファイル名は SLURM 側でサニタイズされ、srunx 表示（生の basename）と僅かに異なり得る（病的入力の cosmetic）。
- `--local` 経路は本修正の対象外（元々このバグは無い）。ローカルの ShellJob は `{stem}.slurm` にレンダリングして投入するため、ディレクティブ無しのとき SLURM 実名と表示が食い違い得る（本修正以前からの性質）。名前一致の保証は SSH 経路のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)