### PR TITLE
fix(logging): convert %-style loguru calls to brace style; soften exec-bit warning

### DIFF
--- a/src/srunx/callbacks.py
+++ b/src/srunx/callbacks.py
@@ -148,7 +148,7 @@ class NotificationWatchCallback(Callback):
             )
         except Exception as exc:
             _logger.warning(
-                "NotificationWatchCallback: failed to attach watch for job %s: %s",
+                "NotificationWatchCallback: failed to attach watch for job {}: {}",
                 job.job_id,
                 exc,
             )

--- a/src/srunx/cli/_helpers/notification_setup.py
+++ b/src/srunx/cli/_helpers/notification_setup.py
@@ -77,7 +77,7 @@ def attach_notification_watch(
             endpoint = endpoint_repo.get_by_name(endpoint_kind, endpoint_name)
             if endpoint is None:
                 logger.warning(
-                    "Endpoint %s:%s not found; skipping watch creation. "
+                    "Endpoint {}:{} not found; skipping watch creation. "
                     "Create one via `Settings → Notifications` in the Web UI "
                     "or the /api/endpoints API.",
                     endpoint_kind,
@@ -105,7 +105,7 @@ def attach_notification_watch(
             except AttachWatchError as exc:
                 conn.rollback()
                 logger.warning(
-                    "Skipping watch creation for job %s on %s:%s (preset=%s): %s",
+                    "Skipping watch creation for job {} on {}:{} (preset={}): {}",
                     job_id,
                     endpoint_kind,
                     endpoint_name,
@@ -121,8 +121,8 @@ def attach_notification_watch(
 
             if not result.created:
                 logger.debug(
-                    "Existing watch+subscription for job %s on %s:%s "
-                    "(preset=%s); reusing.",
+                    "Existing watch+subscription for job {} on {}:{} "
+                    "(preset={}); reusing.",
                     job_id,
                     endpoint_kind,
                     endpoint_name,
@@ -133,7 +133,7 @@ def attach_notification_watch(
             conn.close()
     except Exception as exc:
         logger.warning(
-            "Failed to attach notification watch for job %s: %s",
+            "Failed to attach notification watch for job {}: {}",
             job_id,
             exc,
         )

--- a/src/srunx/cli/workflow/guards.py
+++ b/src/srunx/cli/workflow/guards.py
@@ -61,7 +61,7 @@ def _warn_missing_mounts(rt: ResolvedTransport) -> None:
     ctx = rt.submission_context
     if ctx is None or not ctx.mounts:
         logger.warning(
-            "Profile '%s' has no mounts configured; workflow paths "
+            "Profile '{}' has no mounts configured; workflow paths "
             "(work_dir / log_dir / script_path) will be rendered as-is "
             "on the remote cluster.",
             rt.profile_name,

--- a/src/srunx/mcp/transport.py
+++ b/src/srunx/mcp/transport.py
@@ -103,5 +103,5 @@ def mcp_transport(
                         disconnect()
                     except Exception as exc:  # noqa: BLE001 — best-effort cleanup
                         logger.debug(
-                            "MCP SSH adapter disconnect failed (non-fatal): %s", exc
+                            "MCP SSH adapter disconnect failed (non-fatal): {}", exc
                         )

--- a/src/srunx/observability/monitoring/pollers/active_watch_poller.py
+++ b/src/srunx/observability/monitoring/pollers/active_watch_poller.py
@@ -182,7 +182,7 @@ def _parse_target_ref(
     if len(parts) < 3:
         # Legacy 2-segment — after V5 migration these should not exist.
         logger.debug(
-            "Skipping 2-segment target_ref %r (post-V5 should not occur)",
+            "Skipping 2-segment target_ref {!r} (post-V5 should not occur)",
             target_ref,
         )
         return None
@@ -388,7 +388,7 @@ class ActiveWatchPoller:
                 queue_client = self._resolve_queue_client(scheduler_key)
                 if queue_client is None:
                     logger.warning(
-                        "Unknown scheduler_key %r in %d watch(es); skipping "
+                        "Unknown scheduler_key {!r} in {} watch(es); skipping "
                         "this cycle (profile may have been removed). "
                         "Watches will be retried next cycle.",
                         scheduler_key,
@@ -405,7 +405,7 @@ class ActiveWatchPoller:
                     )
                 except Exception as exc:  # noqa: BLE001 — transport failure
                     logger.warning(
-                        "queue_by_ids failed for scheduler_key %r: %s; "
+                        "queue_by_ids failed for scheduler_key {!r}: {}; "
                         "skipping this group for this cycle.",
                         scheduler_key,
                         exc,

--- a/src/srunx/observability/storage/connection.py
+++ b/src/srunx/observability/storage/connection.py
@@ -110,7 +110,7 @@ def open_connection(db_path: Path | None = None) -> sqlite3.Connection:
         try:
             path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600
         except OSError:
-            logger.warning("Could not set 0600 perms on %s", path)
+            logger.warning("Could not set 0600 perms on {}", path)
     return conn
 
 
@@ -147,15 +147,15 @@ def _delete_legacy_history_db() -> None:
         return
     try:
         LEGACY_HISTORY_DB_PATH.unlink()
-        logger.info("Removed legacy history DB at %s", LEGACY_HISTORY_DB_PATH)
+        logger.info("Removed legacy history DB at {}", LEGACY_HISTORY_DB_PATH)
     except OSError:
         broken = LEGACY_HISTORY_DB_PATH.with_suffix(".db.broken")
         try:
             LEGACY_HISTORY_DB_PATH.rename(broken)
-            logger.warning("Could not remove legacy history DB; renamed to %s", broken)
+            logger.warning("Could not remove legacy history DB; renamed to {}", broken)
         except OSError as exc:
             logger.warning(
-                "Could not remove or rename legacy history DB %s: %s",
+                "Could not remove or rename legacy history DB {}: {}",
                 LEGACY_HISTORY_DB_PATH,
                 exc,
             )

--- a/src/srunx/observability/storage/migrations.py
+++ b/src/srunx/observability/storage/migrations.py
@@ -692,7 +692,7 @@ def apply_migrations(conn: sqlite3.Connection) -> list[str]:
     for mig in MIGRATIONS:
         if mig.name in _applied_names(conn):
             continue
-        logger.info("Applying migration %s (v%d)", mig.name, mig.version)
+        logger.info("Applying migration {} (v{})", mig.name, mig.version)
         if mig.requires_fk_off:
             applied = _apply_fk_off_migration(conn, mig)
         else:
@@ -740,7 +740,7 @@ def _apply_tx_migration(conn: sqlite3.Connection, mig: Migration) -> bool:
         return True
     except Exception:
         conn.rollback()
-        logger.error("Migration %s failed; rolled back", mig.name)
+        logger.error("Migration {} failed; rolled back", mig.name)
         raise
 
 
@@ -844,14 +844,14 @@ def _apply_fk_off_migration(conn: sqlite3.Connection, mig: Migration) -> bool:
         # record this migration, skip silently.
         if mig.name in _applied_names(conn):
             logger.info(
-                "Migration %s already applied by concurrent caller; skipping",
+                "Migration {} already applied by concurrent caller; skipping",
                 mig.name,
             )
             return False
-        logger.error("Migration %s failed", mig.name)
+        logger.error("Migration {} failed", mig.name)
         raise
     except Exception:
-        logger.error("Migration %s failed", mig.name)
+        logger.error("Migration {} failed", mig.name)
         raise
 
 

--- a/src/srunx/slurm/clients/_ssh_resources.py
+++ b/src/srunx/slurm/clients/_ssh_resources.py
@@ -54,7 +54,7 @@ def list_partition_resources(
         try:
             results.append(partition_resources(client, p))
         except Exception as e:  # noqa: BLE001 — diagnostic
-            logger.warning("Failed to get resources for partition %s: %s", p, e)
+            logger.warning("Failed to get resources for partition {}: {}", p, e)
             continue
     return results
 

--- a/src/srunx/ssh/core/file_manager.py
+++ b/src/srunx/ssh/core/file_manager.py
@@ -121,8 +121,12 @@ class RemoteFileManager:
             f"test -x {quoted_path} && echo 'executable' || echo 'not_executable'"
         )
         if stdout.strip() != "executable":
-            self.logger.warning(
-                f"Remote script file is not executable: {remote_path}. SLURM may fail to run it."
+            # Not a problem for sbatch: SLURM reads the script and runs it
+            # via its interpreter, so the execute bit is never required.
+            # Kept as a debug breadcrumb only (was a misleading WARNING).
+            self.logger.debug(
+                f"Remote script file lacks the execute bit: {remote_path}. "
+                "Harmless for sbatch (SLURM runs the script via its interpreter)."
             )
 
         stdout, stderr, exit_code = self._conn.execute_command(

--- a/src/srunx/sync/owner_marker.py
+++ b/src/srunx/sync/owner_marker.py
@@ -165,7 +165,7 @@ def read_owner_marker(profile: ServerProfile, mount: MountConfig) -> OwnerMarker
         # Malformed marker — log so it's visible in --verbose, but
         # don't raise. The next successful sync overwrites it.
         logger.debug(
-            "Owner marker at %s is malformed; ignoring",
+            "Owner marker at {} is malformed; ignoring",
             _marker_remote_path(mount),
         )
     return marker
@@ -216,7 +216,7 @@ def check_owner(
         # already in trouble and silently aborting would just hide it.
         # The rsync that follows will surface the same connection
         # problem with its own error.
-        logger.debug("Owner marker read failed (treating as absent): %s", exc)
+        logger.debug("Owner marker read failed (treating as absent): {}", exc)
         return
     if marker is None:
         return

--- a/src/srunx/sync/service.py
+++ b/src/srunx/sync/service.py
@@ -190,7 +190,7 @@ def mount_sync_session(
                 # message.
                 raise SyncAbortedError(str(exc)) from exc
 
-            logger.info("Syncing mount '%s' before submission", mount.name)
+            logger.info("Syncing mount '{}' before submission", mount.name)
             # delete=False (Codex blocker #4): auto-sync must not wipe
             # remote-only outputs (training checkpoints, run logs).
             # ``srunx ssh sync`` keeps the historical mirror behaviour.

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -276,7 +276,7 @@ def _format_ssh_banner_body(*, profile_name: str, source_display: str) -> str:
             resolved = get_ssh_config_host(profile.ssh_host)
         except Exception as exc:  # noqa: BLE001 — banner must never raise
             logger.debug(
-                "ssh_config lookup for alias %r failed: %s", profile.ssh_host, exc
+                "ssh_config lookup for alias {!r} failed: {}", profile.ssh_host, exc
             )
             resolved = None
         if resolved is not None:
@@ -324,7 +324,7 @@ def _lookup_profile_silently(name: str) -> ServerProfile | None:
     try:
         return ConfigManager().get_profile(name)
     except Exception as exc:  # noqa: BLE001 — defensive
-        logger.debug("Could not load SSH profile %r for banner: %s", name, exc)
+        logger.debug("Could not load SSH profile {!r} for banner: {}", name, exc)
         return None
 
 
@@ -350,7 +350,7 @@ def _current_profile_name() -> str | None:
             return None
         name = ConfigManager().get_current_profile_name()
     except Exception as exc:  # noqa: BLE001 — defensive
-        logger.debug("Could not read current SSH profile: %s", exc)
+        logger.debug("Could not read current SSH profile: {}", exc)
         return None
     if not name:
         return None
@@ -484,7 +484,7 @@ def _resolve_submission_context(
             resolved_mount_name = mounts[0].name
         else:
             logger.warning(
-                "SSH profile %r declares %d mounts; no mount selected "
+                "SSH profile {!r} declares {} mounts; no mount selected "
                 "so path translation is disabled. Pass mount_name "
                 "explicitly to enable translation.",
                 profile_name,
@@ -606,7 +606,7 @@ def _build_ssh_handle(
             pool.close()
         except Exception as close_exc:  # noqa: BLE001 — best-effort cleanup
             logger.debug(
-                "Pool close during orphan cleanup failed (non-fatal): %s",
+                "Pool close during orphan cleanup failed (non-fatal): {}",
                 close_exc,
             )
         raise
@@ -746,7 +746,7 @@ def resolve_transport(
             try:
                 pool.close()
             except Exception as exc:  # noqa: BLE001 — best-effort cleanup
-                logger.debug("Pool close failed (non-fatal): %s", exc)
+                logger.debug("Pool close failed (non-fatal): {}", exc)
 
 
 class TransportRegistry:
@@ -805,7 +805,7 @@ class TransportRegistry:
         try:
             disconnect()
         except Exception as exc:  # noqa: BLE001 — best-effort cleanup
-            logger.debug("Adapter disconnect failed (non-fatal): %s", exc)
+            logger.debug("Adapter disconnect failed (non-fatal): {}", exc)
 
     def resolve(self, scheduler_key: str) -> TransportHandle | None:
         """Resolve ``scheduler_key`` to a :class:`TransportHandle`.
@@ -855,7 +855,7 @@ class TransportRegistry:
                 )
             except TransportError as exc:
                 logger.warning(
-                    "Failed to build SSH transport %r: %s", scheduler_key, exc
+                    "Failed to build SSH transport {!r}: {}", scheduler_key, exc
                 )
                 return None
         else:
@@ -883,7 +883,7 @@ class TransportRegistry:
                 discard_pool.close()
             except Exception as exc:  # noqa: BLE001
                 logger.debug(
-                    "Pool close during concurrent-resolve cleanup failed: %s", exc
+                    "Pool close during concurrent-resolve cleanup failed: {}", exc
                 )
         if discard_handle is not None:
             self._disconnect_handle_quietly(discard_handle)
@@ -935,4 +935,4 @@ class TransportRegistry:
             try:
                 pool.close()
             except Exception as exc:  # noqa: BLE001 — best-effort cleanup
-                logger.debug("Pool close failed (non-fatal): %s", exc)
+                logger.debug("Pool close failed (non-fatal): {}", exc)

--- a/src/srunx/web/app.py
+++ b/src/srunx/web/app.py
@@ -442,7 +442,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
             if skip_reason is not None:
                 logger.info(
-                    "Skipping ResourceSnapshotter: %s. Set "
+                    "Skipping ResourceSnapshotter: {}. Set "
                     "SRUNX_DISABLE_RESOURCE_SNAPSHOTTER=1 to silence this.",
                     skip_reason,
                 )
@@ -468,7 +468,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
         if pollers:
             supervisor = PollerSupervisor(pollers)
-            logger.info("Starting %d background poller(s)", len(pollers))
+            logger.info("Starting {} background poller(s)", len(pollers))
     else:
         logger.info(
             "Background pollers disabled (reload mode or SRUNX_DISABLE_POLLER=1)"

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -416,7 +416,7 @@ def _submit_via_tmp_upload(
                 detail="No SSH profile configured; cannot sync mount",
             )
         try:
-            logger.info("Syncing mount '%s' before job submission", req.mount_name)
+            logger.info("Syncing mount '{}' before job submission", req.mount_name)
             sync_mount_by_name(profile, req.mount_name, delete=True)
         except ValueError as exc:
             raise HTTPException(
@@ -495,7 +495,7 @@ async def submit_job(
             raise
         except Exception:
             logger.warning(
-                "Failed to record submission / create watch for job %s",
+                "Failed to record submission / create watch for job {}",
                 job_id,
                 exc_info=True,
             )

--- a/src/srunx/web/routers/sweep_runs.py
+++ b/src/srunx/web/routers/sweep_runs.py
@@ -185,7 +185,7 @@ async def cancel_sweep_run(
             await anyio.to_thread.run_sync(orch.request_cancel)
         except Exception:  # noqa: BLE001
             logger.warning(
-                "Sweep %s: request_cancel raised in active orchestrator",
+                "Sweep {}: request_cancel raised in active orchestrator",
                 sweep_run_id,
                 exc_info=True,
             )
@@ -196,7 +196,7 @@ async def cancel_sweep_run(
             )
         except Exception:  # noqa: BLE001
             logger.warning(
-                "Sweep %s: drain_sweep_pending_cells raised",
+                "Sweep {}: drain_sweep_pending_cells raised",
                 sweep_run_id,
                 exc_info=True,
             )

--- a/src/srunx/web/services/_submission_common.py
+++ b/src/srunx/web/services/_submission_common.py
@@ -307,7 +307,7 @@ async def hold_workflow_mounts_web(
                     )
                 )
                 if outcome.performed:
-                    logger.info("Synced mount '%s'", mount.name)
+                    logger.info("Synced mount '{}'", mount.name)
         except BaseException:
             stack.close()
             raise

--- a/src/srunx/web/services/sweep_submission.py
+++ b/src/srunx/web/services/sweep_submission.py
@@ -57,7 +57,7 @@ async def run_sweep_background(
         await orchestrator.arun_from_materialized(sweep_run_id)
     except Exception:  # noqa: BLE001
         logger.warning(
-            "Background sweep task for sweep_run_id=%s raised",
+            "Background sweep task for sweep_run_id={} raised",
             sweep_run_id,
             exc_info=True,
         )
@@ -67,7 +67,7 @@ async def run_sweep_background(
                 await anyio.to_thread.run_sync(pool.close)
             except Exception:  # noqa: BLE001 — pool cleanup is best-effort
                 logger.warning(
-                    "Failed to close SSH executor pool for sweep_run_id=%s",
+                    "Failed to close SSH executor pool for sweep_run_id={}",
                     sweep_run_id,
                     exc_info=True,
                 )

--- a/src/srunx/web/services/workflow_submission.py
+++ b/src/srunx/web/services/workflow_submission.py
@@ -671,7 +671,7 @@ class WorkflowSubmissionService:
                             )
                         except Exception:
                             logger.warning(
-                                "Failed to cancel orphan SLURM job %s during "
+                                "Failed to cancel orphan SLURM job {} during "
                                 "workflow-run rollback",
                                 jid,
                                 exc_info=True,
@@ -708,7 +708,7 @@ class WorkflowSubmissionService:
                     # open, the user just won't get external
                     # notifications.
                     logger.warning(
-                        "workflow_run %s: requested endpoint_id=%s not usable "
+                        "workflow_run {}: requested endpoint_id={} not usable "
                         "(missing or disabled); skipping subscription",
                         run_id,
                         run_opts.endpoint_id,


### PR DESCRIPTION
## What

Two logging fixes surfaced while triaging warnings from `srunx sbatch --profile`.

### 1. `%`-style loguru calls silently drop their args (44 sites, 17 files)
srunx loggers are **loguru**, which formats with `str.format` (`{}`). But 44
call sites passed `%s` / `%d` / `%r` placeholders with positional args. loguru
never substitutes `%`-style, so these printed the **literal placeholder** and
**silently dropped the args**:

- The reported case: `SSH profile %r declares %d mounts; no mount selected …`
  (`transport/registry.py`) printed the raw `%r`/`%d`.
- Worse, many are `except` handlers like `logger.warning("… failed: %s", exc)` —
  the exception detail vanished from the logs entirely.

Fix: converted every site to `{}` / `{!r}`. Message string spans were rewritten
byte-surgically, so **args, multi-line layout, and comments are untouched**.
Detection + verification via an AST scan (`%s`/`%d`/`%r` in a loguru call with
extra args); re-scan reports **0 remaining**. Only `%s`(53) / `%r`(7) / `%d`(4)
appeared and no messages contained literal braces, so no escaping was needed.

Note: f-string logging (`f"…{x}"`) is fine and was left as-is — Python evaluates
it before loguru sees it.

### 2. Misleading "not executable" warning → DEBUG
`ssh/core/file_manager.py` warned *"Remote script file is not executable … SLURM
may fail to run it."* on submit. This is a **false alarm**: `sbatch script.sh`
does not require the execute bit — SLURM reads the script and runs it via its
interpreter. Downgraded to `DEBUG` with corrected wording.

## Not changed (investigated, not bugs)
- **`tail --follow`**: the SSH follow path already loops correctly; a bare
  `srunx tail` is one-shot by design (native `tail` parity).
- **`.srunx-owner.json`**: auto-sync uses `delete=False` and the marker is
  re-stamped after `ssh sync`; the dry-run "deleting" line is just rsync preview.

## Verification
- AST re-scan for `%`-style loguru calls: **0 remaining**
- `uv run pytest` → **2246 passed, 2 skipped**
- `uv run mypy .` → clean
- `uv run ruff check` + `ruff format --check` → clean

No behavior change beyond log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRNLXn7ebxaYqNgisk19zT
