### PR TITLE
fix(sync)!: make sync additive by default, harden the MCP sync tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,17 @@ mount names via `--mount` (no `profile` / `mount` positional sub-noun).
 - `uv run srunx ssh sync` - Sync current directory's mount (auto-detect profile and mount from cwd)
 - `uv run srunx ssh sync --profile <profile> --mount <name>` - Sync a specific mount
 - `uv run srunx ssh sync --dry-run` - Preview sync without transferring
+- `uv run srunx ssh sync --delete` - Mirror: also delete destination files missing from the source
+
+##### Sync is additive by default
+`RsyncClient.push()` defaults to `delete=False`, so **no** caller inherits
+mirror semantics by accident — a sync adds and updates, and leaves
+destination-only files (checkpoints, job logs, job outputs) alone. Mirroring
+is opt-in per call site: `srunx ssh sync --delete`, the Web
+file/template/job sync routes (`delete=True` explicit), and MCP
+`sync_files(delete=True)`. This is the standing fix for the incident where
+auto-sync silently pruned remote-only outputs; see
+`src/srunx/sync/mount_helpers.py`.
 
 ##### Account secrets (`ssh secret`)
 Secrets (API keys etc.) are stored in a single **remote** `0600` file per

--- a/docs/how-to/mcp-usage.md
+++ b/docs/how-to/mcp-usage.md
@@ -84,14 +84,32 @@ Claude Code calls `sync_files` with `transport="<profile>"` plus the mount
 name, then calls `submit_job` with the same `transport="<profile>"`. The
 sync uses your configured mount points from that SSH profile.
 
-For explicit paths instead of named mounts:
+Sync targets are always named mounts — `sync_files` takes a `mount` name
+and nothing else, so an agent cannot push an arbitrary directory to an
+arbitrary remote path. Register the directory as a mount first:
 
-``` text
-> Sync ./src to ~/workspace/src on the remote cluster (dry run first)
+``` bash
+srunx ssh mount add --profile myserver --mount src \
+    --local ./src --remote /home/researcher/workspace/src
 ```
 
-Claude Code calls `sync_files` with `local_path` and `remote_path`,
-first with `dry_run=True` to preview, then again to execute.
+Give `--remote` an absolute path. An unquoted `~` is expanded by your
+*local* shell before srunx ever sees it, so on a machine whose home
+differs from the cluster's it would register something like
+`/Users/alice/workspace/src` as the remote destination.
+
+Syncing is additive: new and changed files are copied, and files that
+exist only on the cluster (checkpoints, job logs, outputs) are left
+alone. To mirror instead, ask for deletion explicitly:
+
+``` text
+> Preview a mirror of the src mount on myserver, then run it
+```
+
+Claude Code calls `sync_files` with `dry_run=True, delete=True` to show
+the deletions, then again to execute. A real mirror refuses without
+changing anything if it would delete more than `max_delete` files
+(default 100).
 
 ## Use a Remote Cluster
 

--- a/docs/how-to/sync.md
+++ b/docs/how-to/sync.md
@@ -67,13 +67,28 @@ result = rsync.pull("~/work/my_project/outputs/", "./local_outputs/")
 result = rsync.push(
     local_path="./src",
     remote_path="~/workspace/src/",
-    delete=True,        # Remove remote files not in local (default)
+    delete=False,        # Default: keep remote-only files
     dry_run=False,       # Set True to preview without transferring
 )
 ```
 
-- `delete=True` (default): Remote mirrors local exactly. Files on the
-  remote that don't exist locally are deleted.
+- `delete=False` (default): additive. New and changed files are copied;
+  files that exist only on the remote are left alone. This is the default
+  because remote-only files are typically things a job produced —
+  checkpoints, logs, outputs — which by definition do not exist locally.
+- `delete=True`: mirror. Remote-only files are deleted. Pair it with
+  `max_delete=N` to bound how much a mirror out of a wrong or
+  half-populated source directory can remove.
+- `max_delete=N` is a blast-radius cap, **not** an atomic refusal. rsync
+  deletes up to `N` entries, skips the rest, finishes transferring, and
+  only then exits 25 — so when the cap trips, the destination has
+  already changed. If you need "refuse without touching anything",
+  count the deletions in a separate `dry_run=True` call and decide
+  before you push. The MCP `sync_files` tool does this preflight for
+  you; a direct `RsyncClient.push()` does not.
+- `max_delete` must be `>= 1`. Zero is rejected: `--max-delete=0` means
+  *unlimited* on rsync 2.6.x / openrsync, so it cannot be forwarded
+  safely. To forbid deletion, leave `delete=False`.
 - Directories automatically get a trailing `/` so rsync copies contents,
   not the directory itself.
 
@@ -259,7 +274,7 @@ project roots. See [Web UI guide](../how-to/webui.md) for details.
 | Class / Method | Description |
 |----|----|
 | `RsyncClient(hostname, username, ...)` | Create an rsync wrapper with SSH connection parameters |
-| `RsyncClient.push(local, remote, ...)` | Sync local to remote (`--delete` by default) |
+| `RsyncClient.push(local, remote, ...)` | Sync local to remote (additive; no `--delete` unless `delete=True`) |
 | `RsyncClient.pull(remote, local, ...)` | Sync remote to local (no `--delete` by default) |
 | `RsyncClient.get_default_remote_path()` | Returns `~/.config/srunx/workspace/{repo_name}/` |
 | `RsyncResult.success` | `True` if rsync exited with code 0 |

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -493,25 +493,40 @@ resource and environment configuration for each job.
 
 ### sync_files
 
-Sync files between local machine and remote SLURM cluster using rsync.
-Supports two modes: mount-based (using a named mount from the SSH profile)
-or path-based (using explicit local and remote paths).
+Sync a configured mount from the local machine to a remote SLURM cluster
+using rsync. Only mounts registered on the SSH profile can be synced —
+there is no free-form path mode, so an arbitrary source cannot be pushed
+to an arbitrary destination.
 
 **Parameters:**
 
 | Name | Type | Required | Default | Description |
 |----|----|----|----|----|
 | `transport` | str | Yes |  | SSH profile name to sync through. There is no current-profile fallback — it must be explicit |
-| `mount` | str \| null | No | `null` | Mount point name from the SSH profile to sync |
-| `local_path` | str \| null | No | `null` | Local directory path (alternative to `mount`) |
-| `remote_path` | str \| null | No | `null` | Remote directory path (alternative to `mount`) |
-| `dry_run` | bool | No | `false` | Show what would be transferred without actually syncing |
+| `mount` | str | Yes |  | Mount name from that SSH profile. Call `list_ssh_profiles` to see the mounts each profile defines |
+| `dry_run` | bool | No | `false` | Preview only: report what would be transferred and deleted without touching the cluster |
+| `delete` | bool | No | `false` | Mirror — also DELETE cluster files that no longer exist locally. Destroys remote-only data (checkpoints, job logs, outputs) |
+| `max_delete` | int | No | `100` | Refuse the mirror, changing nothing, if it would delete more than this many *entries*. Must be `>= 1` |
+
+!!! note "`max_delete` counts entries, not files"
+    Entries are files **and** directories, matching rsync's own
+    `--max-delete` unit. Removing a directory that holds two files counts
+    as three entries — both files plus the directory — so set the cap
+    above the file count you have in mind.
+
+!!! warning
+    `delete=True` removes files that exist only on the cluster, which is
+    exactly what a running job produces. Preview with `dry_run=True`
+    first. A real mirror is preflighted: deletions are counted in a dry
+    run before anything is touched, so exceeding `max_delete` refuses
+    without modifying the remote.
 
 !!! note
-    You must provide either `mount` or `local_path`. When using
-    `mount`, the local and remote paths are read from the SSH profile
-    configuration. When using `local_path` without `remote_path`, a
-    default remote path is derived.
+    Deletion counts are exact. Path *strings* have one limit: rsync
+    separates its flag block from the filename with whitespace whose
+    width varies by version, so a filename that itself begins with
+    spaces loses those leading spaces in `deleted_paths`. The deletion
+    is still counted, so the cap and refusal logic are unaffected.
 
 **Return value:**
 
@@ -523,9 +538,17 @@ or path-based (using explicit local and remote paths).
   "local": "/home/user/projects/ml-project",
   "remote": "/home/researcher/projects/ml-project",
   "dry_run": false,
-  "output": "sending incremental file list\nsrc/train.py\n..."
+  "delete": false,
+  "files_transferred": 12,
+  "entries_deleted": 0,
+  "deleted_paths": [],
+  "deleted_paths_omitted": false
 }
 ```
+
+`deleted_paths` lists every deletion. Past a very large number of
+deletions the list is omitted and `deleted_paths_omitted` is `true` —
+the count stays exact, and the list is never silently shortened.
 
 ## Configuration
 

--- a/src/srunx/mcp/tools/sync.py
+++ b/src/srunx/mcp/tools/sync.py
@@ -1,38 +1,216 @@
-"""MCP tool: rsync-based file sync between local + remote SLURM cluster."""
+"""MCP tool: rsync-based file sync between local + remote SLURM cluster.
+
+This tool is reachable by an autonomous agent, which shapes three choices
+that differ from the CLI's:
+
+* **Mount-name only.** There is no free-form ``local_path`` / ``remote_path``
+  pair. An agent that can name arbitrary source and destination paths can
+  push anything the SSH credential can reach to anywhere it can write;
+  restricting the surface to pre-registered mounts makes that structurally
+  impossible instead of relying on a path check to catch it.
+* **Additive by default.** ``delete`` is opt-in, and even when opted in it
+  is capped by ``max_delete`` so a wrong or empty source tree cannot prune
+  a whole remote directory.
+* **Nothing is truncated.** The response reports exact transfer/deletion
+  counts and enumerates every deleted path, because a caller that has to
+  decide whether a sync was safe cannot do it from a clipped preview. The
+  deletion list is bounded by ``max_delete``, which is what keeps "report
+  everything" affordable.
+"""
 
 from __future__ import annotations
 
+import io
+import re
 from typing import Any
 
 from srunx.mcp.app import mcp
 from srunx.mcp.helpers import err, ok
 
+# rsync's ``--itemize-changes`` marks a removal with the literal pseudo-flag
+# ``*deleting``; every other itemize line starts with a flag block whose first
+# char is the update type.
+#
+# The path group is optional and permitted to be empty so that a deletion is
+# still *recognised* when the filename is made purely of spaces. Requiring
+# ``\s+(.+)`` there would fail to match such a line, and a missed deletion is
+# not cosmetic: it under-counts the mirror preflight and lets a sync past the
+# cap that should have stopped it.
+_DELETING_RE = re.compile(r"^\*deleting(?:\s(.*))?$")
+
+# Update types that mean file data actually crossed the wire: ``<`` (sent)
+# and ``>`` (received). Everything else rsync can put here describes a change
+# that moved no data, and counting any of them would inflate a number we
+# promise is exact:
+#   ``c`` — a *local* creation/change (a directory, a symlink's target)
+#   ``h`` — a hard link, created rather than transferred
+#   ``.`` — attributes only; contents already matched
+# This is the same distinction rsync draws in its own "regular files
+# transferred" statistic.
+_TRANSFER_FLAGS = "<>"
+
+# Only regular files (``f``) carry transferred data. Directories (``d``),
+# symlinks (``L``), devices (``D``) and specials (``S``) are recreated on the
+# far side instead. Requiring a valid item type here also rejects English
+# chatter that happens to start with a flag letter.
+_FILE_ITEM_TYPES = "f"
+
+# Ceiling on deletions for a mirror sync, in rsync's own unit: filesystem
+# *entries*, so a removed directory costs one on top of each file inside it.
+# Bounds the damage a wrong source tree can cause on a real run.
+DEFAULT_MAX_DELETE = 100
+
+# Beyond this many deletions we report the count but omit the path list,
+# flagging the omission explicitly (``deleted_paths_omitted``) rather than
+# silently clipping it — a truncated list read as complete is worse than an
+# absent one.
+_MAX_REPORTED_DELETIONS = 1000
+
+# rsync exits 25 (RERR_DEL_LIMIT) when --max-delete is exceeded.
+_RERR_DEL_LIMIT = 25
+
+
+def _parse_itemized(
+    stdout: str, *, max_paths: int | None = None
+) -> tuple[list[str], int, int]:
+    """Parse rsync ``-i`` output into (deleted paths, deletion count, transfers).
+
+    ``max_paths`` bounds how many deletion *paths* are retained; the returned
+    count is always exact. This split matters because an uncapped preview of a
+    huge destination emits one line per deletable file, and retaining all of
+    them would allocate millions of strings for a caller that only reports a
+    number — or discards the list entirely above its reporting limit.
+    ``max_paths=0`` collects no paths at all, which is what the mirror
+    preflight wants since it only compares a count against the cap.
+
+    The flag block is located by splitting on whitespace rather than by a
+    fixed offset, because its width is version-dependent: GNU rsync 3.x emits
+    11 characters (``YXcstpoguax``) while openrsync / rsync 2.6.9 — the stock
+    binary on macOS — emit 9 (``YXcstpogz``). A fixed-offset predicate silently
+    matches nothing on the shorter form and reports zero transfers.
+
+    A line counts as a transfer only when its first token is shaped like a
+    real flag block — a transfer update type followed by a file item type.
+    Everything else is rsync chatter ("sending incremental file list", byte
+    totals, ``created directory ...``, the ``Deletions stopped ...`` warning)
+    and is ignored rather than miscounted. Directory entries are skipped for
+    the same reason: creating a directory moves no file data.
+
+    Trailing whitespace is never stripped from a line, because it can be part
+    of the filename.
+    """
+    deleted: list[str] = []
+    deleted_count = 0
+    transferred = 0
+    # Iterate the buffer instead of materialising splitlines() into a list, so
+    # a mount with very many changed files doesn't cost a second full copy of
+    # rsync's output. (The captured stdout itself still lives in memory —
+    # bounding that would mean streaming inside RsyncClient.)
+    for line in io.StringIO(stdout):
+        line = line.rstrip("\r\n")
+        if not line.strip():
+            continue
+        match = _DELETING_RE.match(line)
+        if match:
+            deleted_count += 1
+            if max_paths is not None and len(deleted) >= max_paths:
+                continue
+            raw_path = match.group(1) or ""
+            # The separator's width is version-dependent (one space on
+            # openrsync, three on GNU rsync), so drop the indent — but keep
+            # the raw value when stripping would empty it, which is how a
+            # name consisting only of spaces survives.
+            #
+            # Known limit: a filename that legitimately *starts* with spaces
+            # is indistinguishable from a wider separator in this format, so
+            # its leading spaces are lost here. Preserving them instead would
+            # prefix every GNU-rsync path with the separator's two extra
+            # spaces — wrong in the common case to be right in a rare one.
+            # The deletion is still counted either way, which is what the cap
+            # and the refusal decision depend on.
+            deleted.append(raw_path.lstrip() or raw_path)
+            continue
+        # The flag block is the first whitespace-delimited token. The filename
+        # is whatever follows and is NOT required to be present or non-blank:
+        # a name made only of spaces is legal, and demanding a non-empty
+        # remainder would drop such a transfer from the count. What qualifies
+        # the line is the flag block's shape, checked below.
+        parts = line.split(None, 1)
+        flags = parts[0] if parts else ""
+        if len(flags) < 2:
+            continue
+        if flags[0] not in _TRANSFER_FLAGS or flags[1] not in _FILE_ITEM_TYPES:
+            continue
+        transferred += 1
+    return deleted, deleted_count, transferred
+
 
 @mcp.tool()
 def sync_files(
     transport: str,
-    mount: str | None = None,
-    local_path: str | None = None,
-    remote_path: str | None = None,
+    mount: str,
     dry_run: bool = False,
+    delete: bool = False,
+    max_delete: int = DEFAULT_MAX_DELETE,
 ) -> dict[str, Any]:
-    """Sync files between local machine and a remote SLURM cluster using rsync.
+    """Sync a configured mount from this machine to a remote SLURM cluster.
 
-    Can sync using a configured mount point (transport + mount), or using
-    explicit paths (local_path + remote_path).
+    Copies new and changed files only. Files that exist on the cluster but
+    not locally are left untouched unless ``delete=True``.
 
     Args:
-        transport: SSH profile name to sync against. Required and must name an
-            SSH profile — there is no local-to-local sync, and (unlike the CLI)
-            no implicit current-profile fallback. ``"local"`` is rejected.
-        mount: Mount point name from the SSH profile to sync
-        local_path: Local directory path (alternative to mount)
-        remote_path: Remote directory path (alternative to mount)
-        dry_run: If true, show what would be transferred without actually syncing
+        transport: SSH profile name to sync against. Required and must name
+            an SSH profile — there is no local-to-local sync, and (unlike
+            the CLI) no implicit current-profile fallback. ``"local"`` is
+            rejected. Call ``list_ssh_profiles`` to see profiles and the
+            mounts each one defines.
+        mount: Mount name from that SSH profile. Only pre-registered mounts
+            can be synced; arbitrary paths are not accepted.
+        dry_run: Preview only. Reports exactly what would be transferred and
+            deleted without touching the cluster. Prefer this first whenever
+            you are unsure, and always before a ``delete=True`` run.
+        delete: Mirror the mount — also DELETE cluster files that no longer
+            exist locally. **This destroys remote-only data** such as
+            training checkpoints, job logs, and outputs written by jobs on
+            the cluster, which by definition do not exist locally. Leave it
+            off unless the user explicitly asked for a mirror, and preview
+            with ``dry_run=True`` before running it.
+        max_delete: Refuse the mirror, without changing anything, if it would
+            delete more than this many **entries**. Entries are files *and*
+            directories, matching rsync's own ``--max-delete`` unit: removing
+            a directory holding two files counts as three entries (both files
+            plus the directory), so set this above the file count you have in
+            mind. Guards against mirroring from a wrong or half-populated
+            local directory. Must be >= 1; to sync without deleting, leave
+            ``delete`` off. Only applies to a real ``delete=True`` run — a
+            ``dry_run`` preview is never capped, so it can show the whole list.
+
+    Returns:
+        On success: ``files_transferred``, ``entries_deleted``, and the
+        ``deleted_paths`` list. Past a very large number of deletions the list
+        is omitted and ``deleted_paths_omitted`` is set — the count stays
+        exact, and no list is ever silently shortened.
+
+        The two counts use different units on purpose, because that is what
+        rsync reports: ``entries_deleted`` includes removed directories, while
+        ``files_transferred`` counts only regular files whose data actually
+        crossed the wire — matching rsync's own "regular files transferred"
+        statistic. Directory creations, symlinks, devices, hard links and
+        attribute-only touch-ups move no data and are excluded, so a sync can
+        legitimately change the remote while reporting zero transfers.
+
+        Counts are reliable; path *strings* have one documented limit. rsync
+        separates its flag block from the filename with whitespace whose width
+        varies by version, so a filename that itself begins with spaces cannot
+        be told apart from that separator, and those leading spaces are lost
+        from the reported string. Such a deletion is still counted, so the
+        cap and the refusal logic are unaffected.
     """
     try:
+        from srunx.common.config import get_config
         from srunx.ssh.core.config import ConfigManager
-        from srunx.web.sync_utils import build_rsync_client
+        from srunx.sync.lock import SyncLockTimeoutError, acquire_sync_lock
+        from srunx.sync.mount_helpers import build_rsync_client
 
         pname = transport.strip() if transport else ""
         if not pname or pname == "local":
@@ -41,58 +219,153 @@ def sync_files(
                 "there is no local sync."
             )
 
+        if max_delete < 1:
+            return err(
+                f"max_delete must be >= 1, got {max_delete}. To sync without "
+                "deleting anything, leave delete=False (the default) instead "
+                "of capping deletions at zero."
+            )
+
         cm = ConfigManager()
         profile = cm.get_profile(pname)
         if not profile:
             return err(f"SSH profile '{pname}' not found")
 
-        if mount:
-            mount_cfg = next((m for m in profile.mounts if m.name == mount), None)
-            if not mount_cfg:
-                available = [m.name for m in profile.mounts]
-                return err(
-                    f"Mount '{mount}' not found in profile '{pname}'. "
-                    f"Available: {available}"
-                )
-
-            rsync = build_rsync_client(profile)
-            result = rsync.push(
-                mount_cfg.local,
-                mount_cfg.remote,
-                dry_run=dry_run,
-                exclude_patterns=mount_cfg.exclude_patterns,
-            )
-            if not result.success:
-                return err(
-                    f"rsync failed (exit {result.returncode}): "
-                    f"{result.stderr[:500] if result.stderr else 'unknown error'}"
-                )
-            return ok(
-                profile=pname,
-                mount=mount,
-                local=mount_cfg.local,
-                remote=mount_cfg.remote,
-                dry_run=dry_run,
-                output=result.stdout[:2000] if result.stdout else "",
+        mount_cfg = next((m for m in profile.mounts if m.name == mount), None)
+        if not mount_cfg:
+            available = [m.name for m in profile.mounts]
+            return err(
+                f"Mount '{mount}' not found in profile '{pname}'. "
+                f"Available: {available}"
             )
 
-        if local_path:
-            rsync = build_rsync_client(profile)
-            result = rsync.push(local_path, remote_path, dry_run=dry_run)
-            if not result.success:
-                return err(
-                    f"rsync failed (exit {result.returncode}): "
-                    f"{result.stderr[:500] if result.stderr else 'unknown error'}"
+        rsync = build_rsync_client(profile)
+        timeout = get_config().sync.lock_timeout_seconds
+
+        # Hold the per-(profile, mount) lock that every srunx writer of a mount
+        # takes — submission auto-sync, workflow runs, `srunx ssh sync`, and the
+        # Web sync route — so an agent-driven sync cannot interleave with any of
+        # them and leave a half-written tree on the cluster. The mirror preflight
+        # below runs inside the same lock as the push it guards, which is what
+        # lets the refusal claim the remote is unchanged. Note the lock is
+        # advisory and machine-local: it cannot stop a cluster-side job from
+        # writing, nor a sync launched from another workstation.
+        try:
+            with acquire_sync_lock(pname, mount_cfg.name, timeout=timeout):
+                # rsync's --max-delete is NOT an atomic precheck. It deletes up
+                # to the cap, skips the remaining deletions, finishes
+                # transferring, and only then exits 25 — verified against
+                # openrsync: a capped run left the destination modified. So the
+                # cap alone can never justify reporting "nothing changed".
+                # Counting the deletions in a dry run first is what lets a
+                # refusal actually mean the remote is untouched.
+                if delete and not dry_run:
+                    preview = rsync.push(
+                        mount_cfg.local,
+                        mount_cfg.remote,
+                        delete=True,
+                        dry_run=True,
+                        itemize=True,
+                        # The preflight carries the cap too. Without it, a
+                        # mirror against a wrong or empty source enumerates
+                        # every deletable path before we get to refuse it, so
+                        # the cap would bound the damage but not the memory —
+                        # the process could die counting deletions it was
+                        # about to reject. With it, rsync stops counting at
+                        # the cap and exits 25, which IS the refusal signal.
+                        max_delete=max_delete,
+                        exclude_patterns=mount_cfg.exclude_patterns,
+                    )
+                    if preview.returncode == _RERR_DEL_LIMIT:
+                        return err(
+                            f"Refused to mirror: it would delete more than "
+                            f"{max_delete} entries under '{mount_cfg.remote}' "
+                            f"(the max_delete cap; entries count directories "
+                            f"as well as files). Nothing was changed. Re-run "
+                            f"with dry_run=True to see the deletions, and only "
+                            f"raise max_delete if they are expected."
+                        )
+                    if not preview.success:
+                        return err(
+                            f"Mirror preflight failed (exit "
+                            f"{preview.returncode}): "
+                            f"{preview.stderr[:500] if preview.stderr else 'unknown error'}. "
+                            f"Nothing was changed. If '{mount_cfg.remote}' does "
+                            f"not exist on the cluster yet, sync once with "
+                            f"delete=False to create it — a preview cannot "
+                            f"create the destination, because a dry run is not "
+                            f"allowed to modify the remote."
+                        )
+                    # Count only: the preflight compares against the cap and
+                    # never reports paths, so retaining none keeps this bounded
+                    # regardless of how many deletions the remote holds.
+                    _, would_delete_count, _ = _parse_itemized(
+                        preview.stdout or "", max_paths=0
+                    )
+                    if would_delete_count > max_delete:
+                        return err(
+                            f"Refused to mirror: it would delete "
+                            f"{would_delete_count} entries (files and "
+                            f"directories) under '{mount_cfg.remote}', over the "
+                            f"max_delete cap of {max_delete}. Nothing was "
+                            f"changed. Re-run with dry_run=True to see the full "
+                            f"list, and only raise max_delete if those "
+                            f"deletions are expected."
+                        )
+
+                result = rsync.push(
+                    mount_cfg.local,
+                    mount_cfg.remote,
+                    delete=delete,
+                    dry_run=dry_run,
+                    # Always itemize: the per-file lines ARE the report, for a
+                    # real push as much as for a preview.
+                    itemize=True,
+                    # Kept as a backstop behind the preflight for a real
+                    # mirror. A preview passes no cap: it changes nothing, and
+                    # capping it would replace the very list the caller asked
+                    # to see with an error.
+                    max_delete=max_delete if (delete and not dry_run) else None,
+                    exclude_patterns=mount_cfg.exclude_patterns,
                 )
-            return ok(
-                profile=pname,
-                local=local_path,
-                remote=remote_path or rsync.get_default_remote_path(local_path),
-                dry_run=dry_run,
-                output=result.stdout[:2000] if result.stdout else "",
+        except SyncLockTimeoutError as exc:
+            return err(str(exc))
+
+        if not result.success:
+            if result.returncode == _RERR_DEL_LIMIT:
+                return err(
+                    f"Mirror hit the max_delete cap of {max_delete} even though "
+                    f"the preflight check passed, so the remote changed in "
+                    f"between. Files may already have been deleted or "
+                    f"transferred — re-run with dry_run=True to see the "
+                    f"current difference before retrying."
+                )
+            return err(
+                f"rsync failed (exit {result.returncode}): "
+                f"{result.stderr[:500] if result.stderr else 'unknown error'}"
             )
 
-        return err("Specify either mount or local_path for sync")
+        # Retain one path beyond the reporting limit: that is all it takes to
+        # know the limit was exceeded, without holding a list we would drop.
+        deleted_paths, deleted_count, transferred = _parse_itemized(
+            result.stdout or "", max_paths=_MAX_REPORTED_DELETIONS + 1
+        )
+        omit_paths = deleted_count > _MAX_REPORTED_DELETIONS
+        return ok(
+            profile=pname,
+            mount=mount_cfg.name,
+            local=mount_cfg.local,
+            remote=mount_cfg.remote,
+            dry_run=dry_run,
+            delete=delete,
+            files_transferred=transferred,
+            # The exact count, not len(deleted_paths) — that list is capped.
+            # Named "entries" because rsync emits (and caps) one deletion per
+            # filesystem entry, directories included.
+            entries_deleted=deleted_count,
+            deleted_paths=[] if omit_paths else deleted_paths,
+            deleted_paths_omitted=omit_paths,
+        )
 
     except Exception as e:
         return err(str(e))

--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -223,6 +223,16 @@ def sync_mount(
             help="Reverse direction: sync remote → local (default is local → remote)",
         ),
     ] = False,
+    delete: Annotated[
+        bool,
+        typer.Option(
+            "--delete",
+            help=(
+                "Mirror: also delete destination files missing from the source. "
+                "Off by default — sync only adds and updates."
+            ),
+        ),
+    ] = False,
     config: _ConfigOpt = None,
 ):
     """Sync a mount between local and remote via rsync.
@@ -230,6 +240,11 @@ def sync_mount(
     By default syncs local → remote (push). Pass ``--pull`` to reverse the
     direction and sync remote → local — useful for pulling back results or
     checkpoints a job wrote on the cluster.
+
+    Sync **adds and updates only**. Files that exist on the destination but
+    not in the source are left alone unless you pass ``--delete``, which
+    switches to mirror semantics. Combine ``--delete --dry-run`` to see
+    exactly what a mirror would remove before committing to it.
 
     With no ``--profile`` / ``--mount``, auto-detects the profile (current
     profile) and the mount (from the current working directory). Works even
@@ -240,9 +255,12 @@ def sync_mount(
       srunx ssh sync --profile pyxis --mount ml-project
       srunx ssh sync --profile pyxis --mount ml-project --dry-run
       srunx ssh sync --pull                           # pull remote → local
+      srunx ssh sync --delete --dry-run               # preview a mirror's deletions
       srunx ssh sync --profile pyxis --mount ml-project --pull --dry-run
     """
+    from srunx.common.config import get_config
     from srunx.ssh.core.config import MountConfig
+    from srunx.sync.lock import acquire_sync_lock
     from srunx.sync.rsync import RsyncClient
 
     try:
@@ -336,23 +354,37 @@ def sync_mount(
                 exclude_patterns=all_excludes or None,
             )
 
-        # itemize=dry_run so the preview lists every file rsync *would*
-        # touch; a real sync stays quiet (itemize defaults off).
-        if pull:
-            # Trailing slash on the remote source so rsync copies the
-            # mount's *contents* into the local dir (mirroring push),
-            # not the directory itself one level deeper.
-            remote_src = resolved_mount.remote.rstrip("/") + "/"
-            result = rsync.pull(
-                remote_src, resolved_mount.local, dry_run=dry_run, itemize=dry_run
-            )
-        else:
-            result = rsync.push(
-                resolved_mount.local,
-                resolved_mount.remote,
-                dry_run=dry_run,
-                itemize=dry_run,
-            )
+        # Hold the per-(profile, mount) lock for the transfer, the same one the
+        # submission and workflow sync paths take. A manual sync that skipped
+        # it could interleave with an in-flight auto-sync — or with the MCP
+        # mirror preflight, whose "nothing changed between the check and the
+        # push" guarantee only holds while every writer queues on this lock.
+        # SyncLockTimeoutError subclasses RuntimeError, so the handler below
+        # already reports contention.
+        lock_timeout = get_config().sync.lock_timeout_seconds
+        with acquire_sync_lock(profile_name, resolved_mount.name, timeout=lock_timeout):
+            # itemize=dry_run so the preview lists every file rsync *would*
+            # touch; a real sync stays quiet (itemize defaults off).
+            if pull:
+                # Trailing slash on the remote source so rsync copies the
+                # mount's *contents* into the local dir (mirroring push),
+                # not the directory itself one level deeper.
+                remote_src = resolved_mount.remote.rstrip("/") + "/"
+                result = rsync.pull(
+                    remote_src,
+                    resolved_mount.local,
+                    delete=delete,
+                    dry_run=dry_run,
+                    itemize=dry_run,
+                )
+            else:
+                result = rsync.push(
+                    resolved_mount.local,
+                    resolved_mount.remote,
+                    delete=delete,
+                    dry_run=dry_run,
+                    itemize=dry_run,
+                )
 
         if result.returncode == 0:
             if dry_run:

--- a/src/srunx/ssh/core/client.py
+++ b/src/srunx/ssh/core/client.py
@@ -189,7 +189,7 @@ class SSHSlurmClient:
         local_path: str | None = None,
         remote_path: str | None = None,
         *,
-        delete: bool = True,
+        delete: bool = False,
         dry_run: bool = False,
         exclude_patterns: list[str] | None = None,
     ) -> str:

--- a/src/srunx/ssh/core/file_manager.py
+++ b/src/srunx/ssh/core/file_manager.py
@@ -166,7 +166,7 @@ class RemoteFileManager:
         local_path: str | None = None,
         remote_path: str | None = None,
         *,
-        delete: bool = True,
+        delete: bool = False,
         dry_run: bool = False,
         exclude_patterns: list[str] | None = None,
     ) -> str:
@@ -177,7 +177,11 @@ class RemoteFileManager:
                 or cwd.
             remote_path: Remote destination. If None, uses the default
                 ``~/.config/srunx/workspace/{repo_name}/``.
-            delete: Remove remote files not present locally (default True).
+            delete: Remove remote files not present locally. **Defaults to
+                False**, matching :meth:`RsyncClient.push`: a wrapper that
+                re-introduced mirror-by-default would defeat that guarantee
+                for its own callers, which is exactly how remote-only
+                checkpoints and job logs got deleted before.
             dry_run: Preview what would be transferred without syncing.
             exclude_patterns: Additional exclude patterns for this sync.
 

--- a/src/srunx/sync/mount_helpers.py
+++ b/src/srunx/sync/mount_helpers.py
@@ -20,9 +20,11 @@ Two functions live here:
   remote-side outputs/checkpoints inside mounts).
 
 The ``delete`` default change is the user-visible behavioural fix for
-Codex's blocker #4 on PR #134. Callers that explicitly want the old
-mirror-style behaviour pass ``delete=True`` (e.g. the manual
-``srunx ssh sync`` command).
+Codex's blocker #4 on PR #134. It later became the default of
+:meth:`RsyncClient.push` itself, so *no* caller inherits mirror
+semantics by accident — the manual ``srunx ssh sync`` command opts in
+via its ``--delete`` flag, and the Web file/template/job sync routes
+pass ``delete=True`` explicitly.
 """
 
 from __future__ import annotations
@@ -69,9 +71,9 @@ def sync_mount_by_name(
     """Sync a named mount's local directory to remote via rsync.
 
     ``delete`` is **False by default** so callers that don't opt in
-    can't accidentally wipe remote-only outputs. The manual
-    ``srunx ssh sync`` command and any explicit ""mirror this exactly""
-    callers should pass ``delete=True``. Auto-sync paths (PR #134
+    can't accidentally wipe remote-only outputs. Any explicit
+    ""mirror this exactly"" caller passes ``delete=True`` (the Web
+    file/template/job sync routes do). Auto-sync paths (PR #134
     Phase 1) leave the default.
 
     ``dry_run=True`` runs rsync with ``-n -i`` (no transfer + itemize)

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -11,7 +11,7 @@ import sys
 import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import IO, ClassVar
 
 from srunx.common.logging import get_logger
@@ -115,10 +115,11 @@ class RsyncClient:
         local_path: str | Path,
         remote_path: str | None = None,
         *,
-        delete: bool = True,
+        delete: bool = False,
         dry_run: bool = False,
         itemize: bool = False,
         verbose: bool = False,
+        max_delete: int | None = None,
         exclude_patterns: Sequence[str] | None = None,
     ) -> RsyncResult:
         """Sync a local directory/file to the remote server.
@@ -127,8 +128,28 @@ class RsyncClient:
             local_path: Local file or directory to push.
             remote_path: Destination path on the remote server.
                 If None, uses ``get_default_remote_path()``.
-            delete: Remove remote files not present locally (default True).
-            dry_run: Perform a trial run with no changes made.
+            delete: Remove remote files not present locally. **Defaults to
+                False**: a push that silently prunes remote-only files
+                (training checkpoints, run logs) is a data-loss footgun, and
+                every historical incident here came from a caller inheriting
+                a mirror-by-default. Mirror semantics are opt-in — callers
+                that genuinely want them pass ``delete=True`` explicitly.
+            max_delete: Blast-radius cap for a mirror — **not** an atomic
+                refusal. rsync deletes up to this many entries, skips the
+                remaining deletions, finishes transferring, and only then exits
+                25, so on a cap hit the destination *has already changed*
+                (verified against openrsync). A caller that needs "refuse
+                without touching anything" must count deletions in a separate
+                dry run and decide before calling; the MCP
+                :func:`~srunx.mcp.tools.sync.sync_files` tool does exactly
+                that. Only meaningful with ``delete=True``. Must be >= 1 —
+                see :class:`ValueError` below.
+            dry_run: Perform a trial run that changes nothing on the remote —
+                no transfers, no deletions, and no directory creation. Note
+                that rsync without ``--mkpath`` cannot evaluate a transfer
+                against a missing destination parent, so a preview of a
+                not-yet-created destination fails rather than reporting an
+                empty diff.
             itemize: Add ``--itemize-changes`` so the result lists every
                 file rsync *would* (or did) touch, with the standard
                 ``YXcstpoguax`` flag prefix. Required for ``dry_run``
@@ -141,7 +162,27 @@ class RsyncClient:
 
         Returns:
             RsyncResult with returncode, stdout, and stderr.
+
+        Raises:
+            ValueError: If ``max_delete`` is 0 or negative. Zero cannot be
+                forwarded safely (rsync 2.6.x / openrsync read
+                ``--max-delete=0`` as *unlimited*, inverting the strictest cap
+                into no cap at all), and silently downgrading the call to
+                ``delete=False`` would be worse: the caller asked for a mirror
+                that refuses rather than one that quietly leaves extra
+                destination files behind. To forbid deletion, pass
+                ``delete=False`` explicitly.
         """
+        if max_delete is not None and max_delete < 1:
+            raise ValueError(
+                f"max_delete must be >= 1, got {max_delete}. To forbid "
+                "deletion entirely, pass delete=False — 0 cannot be forwarded "
+                "to rsync safely (2.6.x / openrsync read --max-delete=0 as "
+                "unlimited), and quietly dropping --delete instead would turn "
+                "a mirror that should refuse into one that silently leaves "
+                "extra destination files in place."
+            )
+
         if remote_path is None:
             remote_path = self.get_default_remote_path(local_path)
 
@@ -154,9 +195,25 @@ class RsyncClient:
 
         dst = self._format_remote(remote_path)
 
-        # Ensure remote directory exists when --mkpath is unavailable
+        # Ensure remote directory exists when --mkpath is unavailable.
+        #
+        # Deliberately restricted to real runs. A dry run must not touch the
+        # remote at all: otherwise "nothing was changed" stops being true, and
+        # a preview whose destination is a *file* path would create a
+        # directory exactly where that file belongs. The cost is that a first
+        # mirror against a not-yet-existing destination fails its preflight —
+        # a safe, explicit failure that ``sync_files`` explains how to work
+        # around, which is a better trade than a preview with side effects.
         if not self._supports_mkpath and not dry_run:
-            self._ensure_remote_dir(remote_path)
+            # A file destination needs its *parent* created. ``mkdir -p`` on
+            # the file path itself would put a directory where the file goes,
+            # after which rsync can never write it.
+            if local.is_dir() or remote_path.endswith("/"):
+                self._ensure_remote_dir(remote_path)
+            else:
+                parent = str(PurePosixPath(remote_path).parent)
+                if parent not in (".", "/", ""):
+                    self._ensure_remote_dir(parent)
 
         excludes = self._merge_excludes(exclude_patterns)
         cmd = self._build_rsync_cmd(
@@ -166,6 +223,7 @@ class RsyncClient:
             dry_run=dry_run,
             itemize=itemize,
             verbose=verbose,
+            max_delete=max_delete,
             excludes=excludes,
         )
         if verbose:
@@ -249,6 +307,7 @@ class RsyncClient:
         dry_run: bool,
         itemize: bool = False,
         verbose: bool = False,
+        max_delete: int | None = None,
         excludes: list[str],
     ) -> list[str]:
         """Build the full rsync command."""
@@ -262,8 +321,20 @@ class RsyncClient:
         ssh_cmd = self._build_ssh_cmd()
         cmd.extend(["-e", shlex.join(ssh_cmd)])
 
+        # A zero cap never reaches here — ``push`` rejects it outright, because
+        # ``--max-delete=0`` means *unlimited* on rsync 2.6.x / openrsync
+        # (stock on macOS) rather than "delete nothing". Verified: a
+        # ``--delete --max-delete=0`` run against openrsync deleted every
+        # destination-only file and exited 0, turning the strictest possible
+        # cap into no cap at all.
         if delete:
             cmd.append("--delete")
+            if max_delete is not None:
+                # Bounds a mirror's blast radius: rsync stops deleting and
+                # exits 25 once the cap is exceeded. Only emitted alongside
+                # --delete, since without it rsync deletes nothing and the
+                # flag would be inert noise.
+                cmd.append(f"--max-delete={max_delete}")
         if dry_run:
             cmd.append("-n")
         if itemize:

--- a/src/srunx/web/routers/files.py
+++ b/src/srunx/web/routers/files.py
@@ -315,15 +315,20 @@ async def sync_mount(body: SyncRequest) -> dict[str, str]:
     SSH connection is misconfigured, the endpoint returns an appropriate
     error rather than silently failing.
     """
-    profile = await anyio.to_thread.run_sync(_get_current_profile)
-    if profile is None:
+    from ..sync_utils import get_current_profile_with_name, locked_sync_mount
+
+    # Resolved together so the lock is taken under the same profile whose paths
+    # get synced; two separate lookups could disagree.
+    resolved = await anyio.to_thread.run_sync(get_current_profile_with_name)
+    if resolved is None:
         raise HTTPException(status_code=503, detail="No SSH profile configured")
+    profile_name, profile = resolved
 
     try:
-        from ..sync_utils import sync_mount_by_name
-
         await anyio.to_thread.run_sync(
-            lambda: sync_mount_by_name(profile, body.mount, delete=True)
+            lambda: locked_sync_mount(
+                profile, body.mount, profile_name=profile_name, delete=True
+            )
         )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/src/srunx/web/routers/jobs.py
+++ b/src/srunx/web/routers/jobs.py
@@ -406,18 +406,23 @@ def _submit_via_tmp_upload(
     ``delete=True`` on the optional mount sync) so existing clients
     that always send ``script_content`` see no contract change.
     """
-    from ..sync_utils import get_current_profile, sync_mount_by_name
+    from ..sync_utils import get_current_profile_with_name, locked_sync_mount
 
     if req.mount_name:
-        profile = get_current_profile()
-        if profile is None:
+        # Profile and name together: the lock must be keyed to the same
+        # profile whose paths are synced.
+        resolved = get_current_profile_with_name()
+        if resolved is None:
             raise HTTPException(
                 status_code=503,
                 detail="No SSH profile configured; cannot sync mount",
             )
+        profile_name, profile = resolved
         try:
             logger.info("Syncing mount '{}' before job submission", req.mount_name)
-            sync_mount_by_name(profile, req.mount_name, delete=True)
+            locked_sync_mount(
+                profile, req.mount_name, profile_name=profile_name, delete=True
+            )
         except ValueError as exc:
             raise HTTPException(
                 status_code=404,

--- a/src/srunx/web/routers/templates.py
+++ b/src/srunx/web/routers/templates.py
@@ -131,14 +131,19 @@ async def apply_template(
 
     # Sync mount before submission if requested
     if req.mount_name:
-        from ..sync_utils import get_current_profile, sync_mount_by_name
+        from ..sync_utils import get_current_profile_with_name, locked_sync_mount
 
-        profile = await anyio.to_thread.run_sync(get_current_profile)
-        if profile:
+        # Profile and name together: the lock must be keyed to the same
+        # profile whose paths are synced.
+        resolved = await anyio.to_thread.run_sync(get_current_profile_with_name)
+        if resolved:
+            profile_name, profile = resolved
             mount_name = req.mount_name
             try:
                 await anyio.to_thread.run_sync(
-                    lambda: sync_mount_by_name(profile, mount_name, delete=True)
+                    lambda: locked_sync_mount(
+                        profile, mount_name, profile_name=profile_name, delete=True
+                    )
                 )
             except ValueError as exc:
                 raise HTTPException(

--- a/src/srunx/web/sync_utils.py
+++ b/src/srunx/web/sync_utils.py
@@ -28,29 +28,107 @@ from srunx.sync.mount_helpers import (
 )
 
 
-def get_current_profile() -> ServerProfile | None:
-    """Get the current SSH profile from web config or ConfigManager.
+def get_current_profile_name() -> str | None:
+    """Resolve the active SSH profile *name*.
 
-    Checks ``SRUNX_SSH_PROFILE`` (via :func:`get_web_config`) first,
-    then falls back to :meth:`ConfigManager.get_current_profile_name`.
+    Checks ``SRUNX_SSH_PROFILE`` (via :func:`get_web_config`) first, then
+    falls back to :meth:`ConfigManager.get_current_profile_name`.
 
-    Returns ``None`` if no profile is configured.
+    Exposed separately from :func:`get_current_profile` because
+    :class:`ServerProfile` does not carry its own name, yet the name is the
+    key :func:`~srunx.sync.lock.acquire_sync_lock` serialises on — a caller
+    that needs the lock needs the name, not just the profile.
     """
     from srunx.ssh.core.config import ConfigManager
 
     from .config import get_web_config
 
-    config = get_web_config()
-    cm = ConfigManager()
+    name = get_web_config().ssh_profile
+    if not name:
+        name = ConfigManager().get_current_profile_name()
+    return name or None
 
-    profile_name = config.ssh_profile
-    if not profile_name:
-        profile_name = cm.get_current_profile_name()
 
+def get_current_profile() -> ServerProfile | None:
+    """Get the current SSH profile from web config or ConfigManager.
+
+    Returns ``None`` if no profile is configured.
+    """
+    from srunx.ssh.core.config import ConfigManager
+
+    profile_name = get_current_profile_name()
     if not profile_name:
         return None
 
-    return cm.get_profile(profile_name)
+    return ConfigManager().get_profile(profile_name)
+
+
+def get_current_profile_with_name() -> tuple[str, ServerProfile] | None:
+    """Resolve the active profile **and** its name in one shot.
+
+    A caller that needs the sync lock must not look these up separately: the
+    active profile can change between the two lookups, and syncing profile A's
+    paths while holding profile B's lock serialises against nothing at all.
+
+    Returns ``None`` when no profile is configured or the resolved name has no
+    stored profile.
+    """
+    from srunx.ssh.core.config import ConfigManager
+
+    name = get_current_profile_name()
+    if not name:
+        return None
+    profile = ConfigManager().get_profile(name)
+    if profile is None:
+        return None
+    return name, profile
+
+
+def locked_sync_mount(
+    profile: ServerProfile,
+    mount_name: str,
+    *,
+    profile_name: str,
+    delete: bool = False,
+) -> str:
+    """Sync a mount while holding its per-(profile, mount) sync lock.
+
+    Web routes that sync a mount on their own — the file browser, template
+    submission, job submission — must queue on the same lock as every other
+    srunx writer (submission auto-sync, workflow runs, ``srunx ssh sync``, the
+    MCP sync tool). Otherwise two syncs interleave and leave a mixed tree, and
+    the MCP mirror preflight's "nothing changed between the check and the push"
+    guarantee stops holding.
+
+    **Do not call this while already holding the lock.** ``flock`` is per-fd,
+    so re-acquiring inside the same process blocks until the timeout expires.
+    The workflow submission path already holds locks for every mount it
+    touches and calls :func:`sync_mount_by_name` directly for that reason.
+
+    Args:
+        profile: The profile whose mount is being synced.
+        mount_name: Mount to sync, as named on *profile*.
+        profile_name: The name *profile* was resolved under — required, and
+            passed in rather than looked up here on purpose. Re-resolving the
+            active profile inside this call could return a different one than
+            the caller fetched, which would sync one profile's paths while
+            holding another's lock. Use
+            :func:`get_current_profile_with_name` to obtain the pair
+            atomically.
+        delete: Mirror instead of syncing additively.
+
+    Raises:
+        ValueError: If *mount_name* is not defined on the profile.
+        RuntimeError: On rsync failure, or
+            :class:`~srunx.sync.lock.SyncLockTimeoutError` (a RuntimeError
+            subclass) when another sync holds the lock.
+    """
+    from srunx.common.config import get_config
+    from srunx.sync.lock import acquire_sync_lock
+
+    timeout = get_config().sync.lock_timeout_seconds
+    with acquire_sync_lock(profile_name, mount_name, timeout=timeout):
+        return sync_mount_by_name(profile, mount_name, delete=delete)
 
 
 def find_mount(profile: ServerProfile, mount_name: str):

--- a/tests/mcp/tools/test_sync.py
+++ b/tests/mcp/tools/test_sync.py
@@ -1,46 +1,281 @@
 """Tests for srunx.mcp.tools.sync.
 
-``sync_files`` now takes ``transport`` as a required first argument: it must
-name an SSH profile. There is no local-to-local sync and (unlike the CLI) no
-implicit current-profile fallback, so the former ``get_current_profile_name``
-paths are replaced by explicit ``transport`` + ``ConfigManager.get_profile``.
+``sync_files`` takes ``transport`` (an SSH profile name — there is no
+local-to-local sync and no implicit current-profile fallback) plus ``mount``,
+which is now the *only* way to name what gets synced: the former free-form
+``local_path`` / ``remote_path`` pair was removed so an agent cannot push an
+arbitrary source to an arbitrary destination.
+
+The remaining safety properties covered here: deletion is opt-in and capped,
+itemize is always requested so the response can report exactly what moved,
+and the per-mount sync lock is held across the transfer.
 """
 
+import inspect
 from unittest.mock import MagicMock, patch
 
-from srunx.mcp.tools.sync import sync_files
+from srunx.mcp.tools.sync import DEFAULT_MAX_DELETE, _parse_itemized, sync_files
 
 
-class TestSyncFiles:
-    """Test sync_files tool."""
+def _profile_with_mount(
+    name: str = "ml",
+    local: str = "/local/ml",
+    remote: str = "/remote/ml",
+    exclude_patterns: list[str] | None = None,
+) -> MagicMock:
+    """Build a profile mock exposing a single named mount."""
+    mount = MagicMock()
+    mount.name = name
+    mount.local = local
+    mount.remote = remote
+    mount.exclude_patterns = exclude_patterns if exclude_patterns is not None else []
+
+    profile = MagicMock()
+    profile.mounts = [mount]
+    return profile
+
+
+def _rsync_returning(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> MagicMock:
+    rsync = MagicMock()
+    rsync.push.return_value = MagicMock(
+        success=returncode == 0,
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    return rsync
+
+
+class TestParseItemized:
+    """rsync ``-i`` output → (deleted paths, deletion count, transfer count).
+
+    The flag block's width differs between rsync builds, so both widths are
+    covered with output captured from real binaries. The count is returned
+    separately from the path list so the list can be bounded while the count
+    stays exact.
+    """
+
+    def test_max_paths_bounds_the_list_but_not_the_count(self):
+        """An uncapped preview must not materialise every deletable path.
+
+        ``sync_files`` reports a number and, above its reporting limit, no
+        list at all — so retaining every path would allocate strings purely
+        to throw them away.
+        """
+        stdout = "".join(f"*deleting f{i}.pt\n" for i in range(500))
+        deleted, deleted_count, _ = _parse_itemized(stdout, max_paths=10)
+        assert deleted_count == 500  # exact
+        assert len(deleted) == 10  # bounded
+        assert deleted[0] == "f0.pt"
+
+    def test_max_paths_zero_collects_nothing(self):
+        """What the mirror preflight uses: a count, with no path retained."""
+        stdout = "".join(f"*deleting f{i}.pt\n" for i in range(1000))
+        deleted, deleted_count, _ = _parse_itemized(stdout, max_paths=0)
+        assert deleted_count == 1000
+        assert deleted == []
+
+    def test_removed_directory_counts_its_own_entry(self):
+        """Verbatim openrsync output for deleting a dir holding two files.
+
+        Two *files* produce four deletion lines, because each removed
+        directory gets its own. That is rsync's unit and the unit
+        ``--max-delete`` caps, which is why the response says
+        ``entries_deleted`` rather than a file count.
+        """
+        stdout = (
+            "*deleting old/sub/f2.txt\n"
+            "*deleting old/sub/\n"
+            "*deleting old/f1.txt\n"
+            "*deleting old/\n"
+        )
+        deleted, deleted_count, transferred = _parse_itemized(stdout)
+        assert deleted_count == 4
+        assert len(deleted) == 4
+        assert transferred == 0
+
+    def test_whitespace_only_transfer_name_is_counted(self):
+        """A file named only of spaces still moved data.
+
+        ``split(None, 1)`` yields just the flag token here, so requiring a
+        non-blank filename would drop the transfer from the count and break
+        the exact-count contract.
+        """
+        deleted, _, transferred = _parse_itemized(">f+++++++    \n")
+        assert deleted == []
+        assert transferred == 1
+
+    def test_gnu_rsync_11_char_flags(self):
+        """GNU rsync 3.x: ``YXcstpoguax`` — 11 characters."""
+        stdout = (
+            "sending incremental file list\n"
+            "*deleting   old/checkpoint.pt\n"
+            "*deleting   old/\n"
+            ">f+++++++++ data/new.csv\n"
+            ">f.st...... train.py\n"
+            "\n"
+        )
+        deleted, deleted_count, transferred = _parse_itemized(stdout)
+        assert deleted == ["old/checkpoint.pt", "old/"]
+        assert transferred == 2
+
+    def test_openrsync_9_char_flags(self):
+        """openrsync / rsync 2.6.9 (stock on macOS): ``YXcstpogz`` — 9 chars.
+
+        Verbatim output from ``rsync -az -n -i --delete``. A fixed 11-offset
+        parser matches none of these and reports zero transfers.
+        """
+        stdout = (
+            "*deleting gone3.txt\n"
+            "*deleting gone2.txt\n"
+            "*deleting gone1.txt\n"
+            ">f+++++++ a.txt\n"
+        )
+        deleted, deleted_count, transferred = _parse_itemized(stdout)
+        assert deleted == ["gone3.txt", "gone2.txt", "gone1.txt"]
+        assert transferred == 1
+
+    def test_directory_entries_are_not_counted_as_files(self):
+        """``cd+++++++++`` creates a directory — no file data moves."""
+        deleted, deleted_count, transferred = _parse_itemized(
+            "cd+++++++++ data/\n>f+++++++++ data/a.csv\n"
+        )
+        assert deleted == []
+        assert transferred == 1
+
+    def test_attribute_only_changes_are_not_transfers(self):
+        """``.f...p.....`` fixed up permissions; contents already matched."""
+        deleted, deleted_count, transferred = _parse_itemized(
+            ".f...p..... train.py\n.d..t...... data/\n>f+++++++++ new.csv\n"
+        )
+        assert deleted == []
+        assert transferred == 1
+
+    def test_chatter_is_ignored(self):
+        """Stats/summary lines must not be miscounted as transfers."""
+        stdout = (
+            "sending incremental file list\n"
+            "\n"
+            "sent 1,234 bytes  received 56 bytes  2,580.00 bytes/sec\n"
+            "total size is 7,890  speedup is 6.11\n"
+            "Deletions stopped due to --max-delete limit (2 skipped)\n"
+        )
+        assert _parse_itemized(stdout) == ([], 0, 0)
+
+    def test_created_directory_chatter_is_not_a_transfer(self):
+        """GNU rsync prints this when it builds the destination (--mkpath).
+
+        ``created`` starts with ``c``, a real update type, so a parser that
+        only checks the first character counts one phantom file on every
+        first sync. The item-type check is what rejects it.
+        """
+        stdout = "created directory /remote/ml\n>f+++++++++ a.txt\n"
+        deleted, deleted_count, transferred = _parse_itemized(stdout)
+        assert deleted == []
+        assert transferred == 1
+
+    def test_only_transferred_regular_files_are_counted(self):
+        """Symlinks, hard links and local creations move no file data.
+
+        rsync marks them ``cL`` / ``hf`` / ``c*`` — ``c`` being a *local*
+        creation and ``h`` a link — and omits them from its own "regular
+        files transferred" statistic. Counting them would overstate
+        ``files_transferred``: here only ``plain.txt`` was transferred.
+        """
+        stdout = (
+            "cL+++++++++ link -> target\n"
+            "hf+++++++++ hardlink\n"
+            "cD+++++++++ dev\n"
+            ">f+++++++++ plain.txt\n"
+        )
+        assert _parse_itemized(stdout) == ([], 0, 1)
+
+    def test_sent_direction_is_counted(self):
+        """``<f`` (sent) counts the same as ``>f`` (received)."""
+        assert _parse_itemized("<f+++++++++ a.txt\n>f+++++++++ b.txt\n") == ([], 0, 2)
+
+    def test_paths_with_spaces(self):
+        deleted, deleted_count, transferred = _parse_itemized(
+            ">f+++++++ my data/file one.csv\n*deleting old dir/file two.pt\n"
+        )
+        assert deleted == ["old dir/file two.pt"]
+        assert transferred == 1
+
+    def test_trailing_whitespace_in_name_is_preserved(self):
+        """Stripping the line would corrupt a name that ends in a space."""
+        deleted, deleted_count, _ = _parse_itemized("*deleting trailing space .pt \n")
+        assert deleted == ["trailing space .pt "]
+
+    def test_whitespace_only_name_is_still_counted(self):
+        """Verbatim openrsync output for a destination file named ``'   '``.
+
+        The deletion must be *counted* even if the name is only spaces: a
+        missed deletion under-counts the preflight and lets a mirror through
+        the cap that should have refused it.
+        """
+        deleted, deleted_count, _ = _parse_itemized(
+            "*deleting trailing space .pt\n*deleting    \n>f+++++++ keep.txt\n"
+        )
+        assert len(deleted) == 2
+        assert deleted[0] == "trailing space .pt"
+        assert deleted[1].strip() == ""  # name preserved as whitespace
+
+    def test_crlf_line_endings(self):
+        deleted, deleted_count, transferred = _parse_itemized(
+            "*deleting a.pt\r\n>f+++++++ b.txt\r\n"
+        )
+        assert deleted == ["a.pt"]
+        assert transferred == 1
+
+    def test_empty_output(self):
+        assert _parse_itemized("") == ([], 0, 0)
+
+
+class TestSyncFilesGuards:
+    """Argument / profile / mount validation before any rsync runs."""
 
     def test_transport_local_rejected(self):
-        """transport='local' is rejected — there is no local sync."""
         result = sync_files(transport="local", mount="ml")
         assert result["success"] is False
         assert "SSH profile" in result["error"]
 
     def test_transport_empty_rejected(self):
-        """Blank transport is rejected before any profile lookup."""
         result = sync_files(transport="   ", mount="ml")
         assert result["success"] is False
         assert "SSH profile" in result["error"]
 
-    @patch("srunx.ssh.core.config.ConfigManager")
-    def test_no_sync_target_returns_error(self, mock_cm_cls):
-        """Valid profile but neither mount_name nor local_path → error."""
-        profile = MagicMock()
-        cm = MagicMock()
-        cm.get_profile.return_value = profile
-        mock_cm_cls.return_value = cm
+    def test_only_registered_mounts_can_be_named(self):
+        """No free-form source/destination: ``mount`` is required and the
+        former ``local_path`` / ``remote_path`` pair is gone, so an agent
+        cannot push an arbitrary tree to an arbitrary remote path."""
+        params = inspect.signature(sync_files).parameters
+        assert "local_path" not in params
+        assert "remote_path" not in params
+        assert params["mount"].default is inspect.Parameter.empty
 
-        result = sync_files(transport="prod")
+    @patch("srunx.ssh.core.config.ConfigManager")
+    def test_negative_max_delete_rejected(self, mock_cm_cls):
+        mock_cm_cls.return_value = MagicMock()
+        result = sync_files(transport="prod", mount="ml", max_delete=-1)
         assert result["success"] is False
-        assert "mount or local_path" in result["error"]
+        assert "max_delete" in result["error"]
+
+    @patch("srunx.ssh.core.config.ConfigManager")
+    def test_zero_max_delete_rejected_with_guidance(self, mock_cm_cls):
+        """0 is ambiguous: rsync 2.6.x reads --max-delete=0 as *unlimited*.
+
+        Rather than guess, point the caller at ``delete=False``.
+        """
+        mock_cm_cls.return_value = MagicMock()
+        result = sync_files(transport="prod", mount="ml", max_delete=0)
+        assert result["success"] is False
+        assert "max_delete must be >= 1" in result["error"]
+        assert "delete=False" in result["error"]
 
     @patch("srunx.ssh.core.config.ConfigManager")
     def test_unknown_profile(self, mock_cm_cls):
-        """transport doesn't resolve to a profile → error."""
         cm = MagicMock()
         cm.get_profile.return_value = None
         mock_cm_cls.return_value = cm
@@ -50,137 +285,17 @@ class TestSyncFiles:
         assert "missing" in result["error"]
 
     @patch("srunx.ssh.core.config.ConfigManager")
-    def test_mount_unknown_mount_name(self, mock_cm_cls):
-        """profile resolved but mount_name not in profile → error with available list."""
-        existing = MagicMock()
-        existing.name = "data"
-        profile = MagicMock()
-        profile.mounts = [existing]
-
+    def test_unknown_mount_name_lists_available(self, mock_cm_cls):
         cm = MagicMock()
-        cm.get_profile.return_value = profile
+        cm.get_profile.return_value = _profile_with_mount(name="data")
         mock_cm_cls.return_value = cm
 
-        result = sync_files(transport="prod", mount="missing")
+        result = sync_files(transport="prod", mount="nope")
         assert result["success"] is False
-        assert "missing" in result["error"]
+        assert "nope" in result["error"]
         assert "data" in result["error"]  # available mounts surfaced
 
-    @patch("srunx.web.sync_utils.build_rsync_client")
-    @patch("srunx.ssh.core.config.ConfigManager")
-    def test_mount_success(self, mock_cm_cls, mock_build):
-        """mount_name resolves + rsync succeeds → success payload."""
-        mount = MagicMock()
-        mount.name = "ml"
-        mount.local = "/local/ml"
-        mount.remote = "/remote/ml"
-        mount.exclude_patterns = ["*.log"]
-
-        profile = MagicMock()
-        profile.mounts = [mount]
-
-        cm = MagicMock()
-        cm.get_profile.return_value = profile
-        mock_cm_cls.return_value = cm
-
-        rsync = MagicMock()
-        rsync.push.return_value = MagicMock(
-            success=True, returncode=0, stdout="sent 100 files", stderr=""
-        )
-        mock_build.return_value = rsync
-
-        result = sync_files(transport="prod", mount="ml")
-        assert result["success"] is True
-        assert result["profile"] == "prod"
-        assert result["mount"] == "ml"
-        assert result["local"] == "/local/ml"
-        assert result["remote"] == "/remote/ml"
-        assert result["dry_run"] is False
-        assert "sent 100 files" in result["output"]
-
-        # exclude_patterns + mount paths threaded through.
-        rsync.push.assert_called_once_with(
-            "/local/ml",
-            "/remote/ml",
-            dry_run=False,
-            exclude_patterns=["*.log"],
-        )
-
-    @patch("srunx.web.sync_utils.build_rsync_client")
-    @patch("srunx.ssh.core.config.ConfigManager")
-    def test_mount_rsync_failure(self, mock_cm_cls, mock_build):
-        """rsync non-zero exit → error payload with truncated stderr."""
-        mount = MagicMock()
-        mount.name = "ml"
-        mount.local = "/l"
-        mount.remote = "/r"
-        mount.exclude_patterns = []
-
-        profile = MagicMock()
-        profile.mounts = [mount]
-
-        cm = MagicMock()
-        cm.get_profile.return_value = profile
-        mock_cm_cls.return_value = cm
-
-        rsync = MagicMock()
-        rsync.push.return_value = MagicMock(
-            success=False, returncode=23, stdout="", stderr="permission denied"
-        )
-        mock_build.return_value = rsync
-
-        result = sync_files(transport="prod", mount="ml")
-        assert result["success"] is False
-        assert "exit 23" in result["error"]
-        assert "permission denied" in result["error"]
-
-    @patch("srunx.web.sync_utils.build_rsync_client")
-    @patch("srunx.ssh.core.config.ConfigManager")
-    def test_local_path_explicit_remote(self, mock_cm_cls, mock_build):
-        """local_path + remote_path override mount lookup."""
-        profile = MagicMock()
-        cm = MagicMock()
-        cm.get_profile.return_value = profile
-        mock_cm_cls.return_value = cm
-
-        rsync = MagicMock()
-        rsync.push.return_value = MagicMock(
-            success=True, returncode=0, stdout="ok", stderr=""
-        )
-        mock_build.return_value = rsync
-
-        result = sync_files(
-            transport="prod", local_path="/src", remote_path="/dst", dry_run=True
-        )
-        assert result["success"] is True
-        assert result["local"] == "/src"
-        assert result["remote"] == "/dst"
-        assert result["dry_run"] is True
-        rsync.push.assert_called_once_with("/src", "/dst", dry_run=True)
-
-    @patch("srunx.web.sync_utils.build_rsync_client")
-    @patch("srunx.ssh.core.config.ConfigManager")
-    def test_local_path_default_remote(self, mock_cm_cls, mock_build):
-        """remote_path omitted → falls back to RsyncClient.get_default_remote_path."""
-        profile = MagicMock()
-        cm = MagicMock()
-        cm.get_profile.return_value = profile
-        mock_cm_cls.return_value = cm
-
-        rsync = MagicMock()
-        rsync.push.return_value = MagicMock(
-            success=True, returncode=0, stdout="", stderr=""
-        )
-        rsync.get_default_remote_path.return_value = "/remote/auto"
-        mock_build.return_value = rsync
-
-        result = sync_files(transport="prod", local_path="/src")
-        assert result["success"] is True
-        assert result["remote"] == "/remote/auto"
-        rsync.get_default_remote_path.assert_called_once_with("/src")
-
     def test_catches_exception(self):
-        """Any unexpected exception → error payload with the message."""
         with patch(
             "srunx.ssh.core.config.ConfigManager",
             side_effect=RuntimeError("config broken"),
@@ -188,3 +303,256 @@ class TestSyncFiles:
             result = sync_files(transport="prod", mount="ml")
             assert result["success"] is False
             assert "config broken" in result["error"]
+
+
+@patch("srunx.sync.mount_helpers.build_rsync_client")
+@patch("srunx.ssh.core.config.ConfigManager")
+class TestSyncFilesTransfer:
+    """The rsync invocation and the reported result.
+
+    The per-mount lock is exercised for real (pytest's autouse XDG isolation
+    puts the lock file under a temp config dir), so these also prove the
+    lock is acquirable and released rather than mocked away.
+    """
+
+    def test_delete_is_off_by_default(self, mock_cm_cls, mock_build):
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount(exclude_patterns=["*.log"])
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning(">f+++++++++ train.py\n")
+        mock_build.return_value = rsync
+
+        result = sync_files(transport="prod", mount="ml")
+
+        assert result["success"] is True
+        assert result["delete"] is False
+        assert result["files_transferred"] == 1
+        assert result["entries_deleted"] == 0
+        assert result["deleted_paths"] == []
+
+        rsync.push.assert_called_once_with(
+            "/local/ml",
+            "/remote/ml",
+            delete=False,
+            dry_run=False,
+            itemize=True,
+            # No cap is passed when nothing can be deleted anyway.
+            max_delete=None,
+            exclude_patterns=["*.log"],
+        )
+
+    def test_delete_opt_in_preflights_then_pushes(self, mock_cm_cls, mock_build):
+        """A mirror counts deletions in a dry run before touching the remote."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning("*deleting   stale.pt\n>f+++++++++ train.py\n")
+        mock_build.return_value = rsync
+
+        result = sync_files(transport="prod", mount="ml", delete=True)
+
+        assert result["success"] is True
+        assert result["delete"] is True
+        assert result["entries_deleted"] == 1
+        assert result["deleted_paths"] == ["stale.pt"]
+        assert result["files_transferred"] == 1
+
+        assert rsync.push.call_count == 2
+        preflight = rsync.push.call_args_list[0].kwargs
+        assert preflight["delete"] is True
+        assert preflight["dry_run"] is True  # counts only, changes nothing
+        assert preflight["itemize"] is True
+        # The preflight is capped as well, so it cannot enumerate (and buffer)
+        # unbounded deletions before we get the chance to refuse them.
+        assert preflight["max_delete"] == DEFAULT_MAX_DELETE
+
+        real = rsync.push.call_args_list[1].kwargs
+        assert real["delete"] is True
+        assert real["dry_run"] is False
+        assert real["max_delete"] == DEFAULT_MAX_DELETE  # backstop behind preflight
+
+    def test_explicit_max_delete_forwarded(self, mock_cm_cls, mock_build):
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        mock_build.return_value = _rsync_returning()
+
+        sync_files(transport="prod", mount="ml", delete=True, max_delete=3)
+
+        assert mock_build.return_value.push.call_args.kwargs["max_delete"] == 3
+
+    def test_dry_run_still_itemizes_and_reports(self, mock_cm_cls, mock_build):
+        """A preview is only useful if it enumerates the deletions."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning("*deleting   a.pt\n*deleting   b.pt\n")
+        mock_build.return_value = rsync
+
+        result = sync_files(transport="prod", mount="ml", dry_run=True, delete=True)
+
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        assert result["entries_deleted"] == 2
+        assert result["deleted_paths"] == ["a.pt", "b.pt"]
+        # One pass only: a preview needs no preflight, since it is one.
+        rsync.push.assert_called_once()
+        kwargs = rsync.push.call_args.kwargs
+        assert kwargs["dry_run"] is True
+        assert kwargs["itemize"] is True
+        # Capping a preview would replace the requested list with an error.
+        assert kwargs["max_delete"] is None
+
+    def test_deleted_paths_are_not_truncated(self, mock_cm_cls, mock_build):
+        """Every deletion is reported — a clipped list can't be reviewed."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        stdout = "".join(f"*deleting   ckpt/{i:04d}.pt\n" for i in range(80))
+        mock_build.return_value = _rsync_returning(stdout)
+
+        result = sync_files(transport="prod", mount="ml", delete=True)
+
+        assert result["entries_deleted"] == 80
+        assert len(result["deleted_paths"]) == 80
+        assert result["deleted_paths"][-1] == "ckpt/0079.pt"
+
+    def test_preflight_refuses_before_touching_remote(self, mock_cm_cls, mock_build):
+        """Over the cap → refuse, and never run the destructive push.
+
+        This is why the preflight exists: rsync's own ``--max-delete`` deletes
+        up to the cap and transfers before exiting 25, so a refusal based on it
+        alone could not honestly claim the remote is untouched.
+        """
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        stdout = "".join(f"*deleting ckpt/{i}.pt\n" for i in range(9))
+        rsync = _rsync_returning(stdout)
+        mock_build.return_value = rsync
+
+        result = sync_files(transport="prod", mount="ml", delete=True, max_delete=5)
+
+        assert result["success"] is False
+        assert "9 entries" in result["error"]
+        assert "max_delete cap of 5" in result["error"]
+        assert "Nothing was changed" in result["error"]
+        assert "dry_run=True" in result["error"]
+        # Exactly one call — the preflight. The real mirror never ran.
+        rsync.push.assert_called_once()
+        assert rsync.push.call_args.kwargs["dry_run"] is True
+
+    def test_preflight_exit_25_refuses_without_enumerating(
+        self, mock_cm_cls, mock_build
+    ):
+        """rsync stops counting at the cap and exits 25 — that IS the refusal.
+
+        This is the path that keeps memory bounded: the preflight never has to
+        buffer every deletable path just to decide it is too many.
+        """
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning(returncode=25, stderr="del limit")
+        mock_build.return_value = rsync
+
+        result = sync_files(transport="prod", mount="ml", delete=True, max_delete=5)
+
+        assert result["success"] is False
+        assert "more than 5 entries" in result["error"]
+        assert "Nothing was changed" in result["error"]
+        # Only the preflight ran; the destructive push never started.
+        rsync.push.assert_called_once()
+        assert rsync.push.call_args.kwargs["dry_run"] is True
+
+    def test_preflight_failure_is_reported(self, mock_cm_cls, mock_build):
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning(returncode=23, stderr="permission denied")
+        mock_build.return_value = rsync
+
+        result = sync_files(transport="prod", mount="ml", delete=True)
+
+        assert result["success"] is False
+        assert "preflight failed" in result["error"]
+        assert "permission denied" in result["error"]
+        assert "Nothing was changed" in result["error"]
+        rsync.push.assert_called_once()
+
+    def test_cap_hit_after_preflight_does_not_claim_no_change(
+        self, mock_cm_cls, mock_build
+    ):
+        """Remote changed between preflight and push → say so honestly.
+
+        rsync exit 25 on the real push means deletions and transfers may
+        already have happened, so this must NOT report "nothing changed".
+        """
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        rsync = MagicMock()
+        rsync.push.side_effect = [
+            # Preflight: within the cap, so the mirror proceeds.
+            MagicMock(success=True, returncode=0, stdout="*deleting a.pt\n", stderr=""),
+            # Real push: the cap trips anyway.
+            MagicMock(success=False, returncode=25, stdout="", stderr="del limit"),
+        ]
+        mock_build.return_value = rsync
+
+        result = sync_files(transport="prod", mount="ml", delete=True, max_delete=5)
+
+        assert result["success"] is False
+        assert "Nothing was changed" not in result["error"]
+        assert "may already have been deleted" in result["error"]
+        assert rsync.push.call_count == 2
+
+    def test_huge_deletion_list_is_omitted_not_clipped(self, mock_cm_cls, mock_build):
+        """Past the reporting limit: exact count, explicit omission, no clip."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        stdout = "".join(f"*deleting ckpt/{i}.pt\n" for i in range(1500))
+        mock_build.return_value = _rsync_returning(stdout)
+
+        result = sync_files(transport="prod", mount="ml", dry_run=True, delete=True)
+
+        assert result["success"] is True
+        assert result["entries_deleted"] == 1500
+        assert result["deleted_paths"] == []
+        assert result["deleted_paths_omitted"] is True
+
+    def test_generic_rsync_failure_surfaces_stderr(self, mock_cm_cls, mock_build):
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        mock_build.return_value = _rsync_returning(
+            returncode=23, stderr="permission denied"
+        )
+
+        result = sync_files(transport="prod", mount="ml")
+        assert result["success"] is False
+        assert "exit 23" in result["error"]
+        assert "permission denied" in result["error"]
+
+    def test_lock_timeout_is_reported(self, mock_cm_cls, mock_build):
+        """A mount already being synced elsewhere fails cleanly, no rsync."""
+        from srunx.sync.lock import SyncLockTimeoutError
+
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning()
+        mock_build.return_value = rsync
+
+        from pathlib import Path
+
+        with patch(
+            "srunx.sync.lock.acquire_sync_lock",
+            side_effect=SyncLockTimeoutError(Path("/tmp/ml.lock"), 120.0),
+        ):
+            result = sync_files(transport="prod", mount="ml")
+
+        assert result["success"] is False
+        assert "sync lock" in result["error"]
+        rsync.push.assert_not_called()

--- a/tests/ssh/core/test_client.py
+++ b/tests/ssh/core/test_client.py
@@ -8,7 +8,7 @@ component methods live alongside their components — see
 ``test_connection.py``.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -87,3 +87,52 @@ class TestContextManager:
                 with client:
                     pass
                 mock_disconnect.assert_called_once()
+
+
+class TestSyncProjectDeleteDefault:
+    """``sync_project`` must not re-introduce mirror-by-default.
+
+    :meth:`RsyncClient.push` defaults to ``delete=False`` so that no caller
+    inherits mirror semantics by accident. A wrapper that passes
+    ``delete=True`` of its own accord defeats that for every one of its
+    callers — which is precisely how remote-only checkpoints and job logs
+    were deleted before. This pins the wrapper to the additive default.
+    """
+
+    def _client(self) -> SSHSlurmClient:
+        with (
+            patch("srunx.sync.rsync.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "srunx.sync.rsync.subprocess.run",
+                return_value=MagicMock(stdout="--protect-args --mkpath", stderr=""),
+            ),
+            patch(
+                "srunx.ssh.core.client.subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="/home/user/proj\n"),
+            ),
+        ):
+            return SSHSlurmClient(
+                hostname="server", username="user", key_filename="~/.ssh/id_rsa"
+            )
+
+    def test_additive_by_default(self):
+        client = self._client()
+
+        with patch.object(client._rsync_client, "push") as mock_push:
+            mock_push.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            # Explicit paths: project-root detection shells out to git, which
+            # the test suite's isolation fixture blocks.
+            client.sync_project(local_path="/local/proj", remote_path="~/proj/")
+
+        assert mock_push.call_args.kwargs["delete"] is False
+
+    def test_mirror_still_available_on_request(self):
+        client = self._client()
+
+        with patch.object(client._rsync_client, "push") as mock_push:
+            mock_push.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.sync_project(
+                local_path="/local/proj", remote_path="~/proj/", delete=True
+            )
+
+        assert mock_push.call_args.kwargs["delete"] is True

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -320,7 +320,10 @@ class TestPush:
         sep_idx = call_args.index("--")
         assert call_args[sep_idx + 1].endswith("/")
         assert call_args[sep_idx + 2] == "u@h:~/.config/srunx/workspace/test/"
-        assert "--delete" in call_args
+        # A plain push adds and updates only. Mirror semantics are opt-in:
+        # inheriting --delete by default is what silently ate remote-only
+        # checkpoints before, so no caller gets it without asking.
+        assert "--delete" not in call_args
 
     def test_push_file(self, tmp_path: Path):
         client = _make_rsync_client(hostname="h", username="u")
@@ -360,6 +363,58 @@ class TestPush:
             client.push(tmp_path, "~/dst/", delete=False)
 
         assert "--delete" not in mock_run.call_args[0][0]
+
+    def test_push_delete_is_opt_in(self, tmp_path: Path):
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/", delete=True)
+
+        assert "--delete" in mock_run.call_args[0][0]
+
+    def test_push_max_delete_caps_a_mirror(self, tmp_path: Path):
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/", delete=True, max_delete=5)
+
+        call_args = mock_run.call_args[0][0]
+        assert "--delete" in call_args
+        assert "--max-delete=5" in call_args
+
+    def test_push_max_delete_omitted_without_delete(self, tmp_path: Path):
+        """Without --delete, rsync deletes nothing — the cap would be noise."""
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/", delete=False, max_delete=5)
+
+        assert not any(a.startswith("--max-delete") for a in mock_run.call_args[0][0])
+
+    def test_push_rejects_zero_max_delete(self, tmp_path: Path):
+        """``max_delete=0`` is ambiguous and unsafe, so it is refused outright.
+
+        Forwarding it would invert the cap: on rsync 2.6.x / openrsync (stock
+        on macOS) 0 means *unlimited*, and a real ``--delete --max-delete=0``
+        run against openrsync deleted every destination-only file and exited 0.
+        Silently dropping ``--delete`` instead is also wrong — the caller asked
+        for a mirror that refuses, not one that quietly leaves extra files.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            with pytest.raises(ValueError, match="max_delete must be >= 1"):
+                client.push(tmp_path, "~/dst/", delete=True, max_delete=0)
+            mock_run.assert_not_called()
+
+    def test_push_rejects_negative_max_delete(self, tmp_path: Path):
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with pytest.raises(ValueError, match="max_delete must be >= 1"):
+            client.push(tmp_path, "~/dst/", delete=True, max_delete=-1)
 
     def test_push_dry_run(self, tmp_path: Path):
         client = _make_rsync_client(hostname="h", username="u")
@@ -545,6 +600,53 @@ class TestMkpath:
         assert mock_run.call_count == 2
         mkdir_cmd = mock_run.call_args_list[0][0][0]
         assert "mkdir" in " ".join(mkdir_cmd)
+
+    def _openrsync_client(self) -> RsyncClient:
+        """A client whose rsync lacks ``--mkpath`` (stock macOS/openrsync)."""
+        with (
+            patch("srunx.sync.rsync.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "srunx.sync.rsync.subprocess.run",
+                return_value=MagicMock(stdout="", stderr="openrsync"),
+            ),
+        ):
+            return RsyncClient(hostname="h", username="u")
+
+    def test_dry_run_never_creates_the_destination(self, tmp_path: Path):
+        """A preview must not modify the remote — not even an empty directory.
+
+        Creating it would make "nothing was changed" false in the mirror
+        preflight's refusal message, and for a *file* destination the mkdir
+        would land a directory exactly where the file belongs. A first mirror
+        against a missing destination therefore fails instead; that is a safe,
+        explicit failure with a documented workaround (sync once with
+        ``delete=False``).
+        """
+        client = self._openrsync_client()
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/", dry_run=True, delete=True, itemize=True)
+
+        # Exactly one call: the rsync itself, and it is a dry run.
+        mock_run.assert_called_once()
+        assert "mkdir" not in " ".join(mock_run.call_args[0][0])
+        assert "-n" in mock_run.call_args[0][0]
+
+    def test_file_destination_creates_parent_not_the_file_path(self, tmp_path: Path):
+        """``mkdir -p`` on a file path would block the file forever."""
+        client = self._openrsync_client()
+        script = tmp_path / "train.sh"
+        script.write_text("echo hi\n")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(script, "~/jobs/train.sh")
+
+        mkdir_cmd = " ".join(mock_run.call_args_list[0][0][0])
+        assert "mkdir" in mkdir_cmd
+        assert "~/jobs" in mkdir_cmd
+        assert "train.sh" not in mkdir_cmd
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Syncing could delete cluster-only files — checkpoints, job logs, job outputs — without the caller asking for it. The `delete` flag defaulted to on at the rsync layer, so a call site inherited mirror semantics just by not mentioning it. `src/srunx/sync/mount_helpers.py` still carries the note from the last time this bit: *"Phase 1 auto-sync ran with `delete=True` and silently ate remote-side outputs/checkpoints inside mounts."* That fix was applied to one caller, not to the default.

The MCP `sync_files` tool was the worst case, because an autonomous agent can call it directly:

| | before |
|---|---|
| deletion | on by default (inherited) |
| dry run | returned an empty string — nothing to review |
| paths | arbitrary local → arbitrary remote, no guard |
| sync lock | not taken |

So an agent could mirror a wrong directory over a cluster path and see no diff beforehand.

## What changed

**Deletion is opt-in everywhere.** `RsyncClient.push()` defaults to `delete=False`, so no caller inherits mirroring by accident. The `sync_project()` wrappers passed `delete=True` themselves and bypassed that default — switched too. Mirroring is now requested per call site: `srunx ssh sync --delete`, the Web sync routes, `sync_files(delete=True)`.

**`sync_files` takes a mount name only.** Free-form `local_path` / `remote_path` are gone, so pushing an arbitrary tree to an arbitrary remote path is structurally impossible rather than blocked by a check.

**A real mirror is preflighted.** Deletions are counted in a dry run, inside the same lock, before anything is touched. This is necessary because rsync's `--max-delete` deletes up to the cap, skips the rest, finishes transferring, and *then* exits 25 — verified against openrsync, which left the destination modified. A cap alone can never justify reporting "nothing changed".

**Reporting is exact.** Transfer and deletion counts plus the complete deletion list; past a very large number the list is omitted with an explicit `deleted_paths_omitted` flag rather than being silently shortened. Counts and paths are tracked separately so an uncapped preview does not materialise millions of strings.

**All sync paths serialize.** `srunx ssh sync` and the three Web sync routes now take the per-`(profile, mount)` lock that the submission and workflow paths already used. The preflight's guarantee only holds while every writer queues on it.

## Version-specific bugs found while verifying

Each of these was reproduced against a real rsync binary, not reasoned about:

- **itemize flag width** — the parser assumed 11 characters (GNU rsync 3.x); openrsync, stock on macOS, emits 9, so transfers counted **zero** on the developer's own machine.
- **`--max-delete=0` means *unlimited*** on rsync 2.6.x / openrsync — it only came to mean zero in rsync 3.0. Passing it inverted the strictest possible cap into no cap: a test run deleted every destination-only file and exited 0. Zero is now rejected outright.
- **whitespace-only filenames** — trailing-space stripping dropped the path entirely, so those deletions went undetected and under-counted the preflight.
- **transfer counts** included directory creations, attribute-only touch-ups, symlinks, hard links, and GNU rsync's `created directory` chatter line.
- **`mkdir -p` fallback** ran against a file destination's own path, creating a directory exactly where the file belongs (pre-existing bug).
- **`~` in a documented `--remote` example** was expanded by the *local* shell, registering a local home path as the remote destination.

## Testing

`2282 passed, 2 skipped`; `mypy` clean across 371 files; `ruff check` clean.

Test coverage added for both rsync flag widths (with output captured verbatim from real binaries), attribute-only and directory entries, whitespace-only names, CRLF, the preflight refusing before touching the remote, the honest report when the cap trips *after* a passing preflight, cap-0 rejection, file-destination parent creation, dry runs leaving the remote untouched, and `sync_project` staying additive.

## Breaking changes

- `RsyncClient.push()`, `SSHSlurmClient.sync_project()`, `SSHFileManager.sync_project()` no longer delete by default — pass `delete=True` for the old behaviour.
- `srunx ssh sync` needs `--delete` to mirror.
- MCP `sync_files`: no `local_path` / `remote_path` (use `mount`); `max_delete >= 1` required; `files_deleted` renamed to `entries_deleted`, since rsync counts removed directories as entries too (two files inside one removed directory is three entries).

The Web sync routes keep mirroring, as they already passed `delete=True` explicitly.

## Review

Iterated through 15 rounds of `codex exec review` until clean. 27 findings raised: 24 fixed, 1 rejected after failing to reproduce (type replacement was in fact reported and capped correctly), 2 documented as accepted limits — rsync's own output buffering, which would need the transfer layer reworked, and leading-space filenames, which rsync's output format cannot disambiguate from its separator (counts stay exact, so the cap is unaffected).

Four findings were cases where a safety mechanism added in this PR did not actually work: a refusal message claiming "nothing was changed" when files had already been deleted, the cap inverting on old rsync, the preflight able to exhaust memory before it could refuse, and the `sync_project()` wrappers bypassing the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBKedWVkVba5Zfpp8KmZMR
