### PR TITLE
fix(sync): stop mirrors deleting the owner marker; make its write actually atomic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,7 @@ src/srunx/
 │   ├── notifications/ # Notification domain (Slack + future channels)
 │   │   ├── sanitize.py, presets.py, service.py, legacy_slack.py, formatting.py
 │   │   └── adapters/  # DeliveryAdapter + SlackWebhookDeliveryAdapter + registry
-│   └── storage/       # SQLite persistence at $XDG_CONFIG_HOME/srunx/srunx.db
+│   └── storage/       # SQLite persistence at $XDG_CONFIG_HOME/srunx/srunx.observability.storage
 │       ├── connection.py, migrations.py, models.py, cli_helpers.py
 │       └── repositories/  # JobRepository, DeliveryRepository, EndpointRepository, ...
 │
@@ -610,7 +610,14 @@ at first-cell-start and at final terminal.
 
 ### Notification + State Persistence (new in 2026-Q2)
 
-srunx stores durable state in a SQLite DB at **`$XDG_CONFIG_HOME/srunx/srunx.db`** (or `~/.config/srunx/srunx.db` when the env var is unset). Schema lives in `src/srunx/db/migrations.py` (`SCHEMA_V1`).
+srunx stores durable state in a SQLite DB at
+**`$XDG_CONFIG_HOME/srunx/srunx.observability.storage`** (or
+`~/.config/srunx/srunx.observability.storage` when the env var is unset). The
+filename is that odd because it was derived from the defining module's dotted
+path; it is kept as-is because renaming it would orphan every existing local DB
+without a migration. See `get_db_path()` in
+`src/srunx/observability/storage/connection.py`. Schema lives in
+`src/srunx/observability/storage/migrations.py`.
 
 Tables (abbreviated):
 - `jobs` — every SLURM submission, annotated with `submission_source` (`cli` / `web` / `workflow`) and `workflow_run_id`.

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -52,6 +52,27 @@ class RsyncClient:
         ".tox/",
         "node_modules/",
         ".DS_Store",
+        # srunx's own control file on the remote side. It has no local
+        # counterpart, so without this a mirror (``--delete``) deletes it on
+        # every sync — taking with it the ownership marker that stops one
+        # machine from syncing over another's mount. Excluding a path also
+        # protects it from deletion, which is the point here.
+        #
+        # Anchored with a leading slash so it matches only the transfer root.
+        # A bare ``.srunx-owner.json`` matches that basename at *every* depth,
+        # which would silently skip a user's own ``subdir/.srunx-owner.json``;
+        # only the file at the mount root is srunx's.
+        #
+        # Known consequence: mirror paths that don't go through
+        # ``mount_sync_session`` (``srunx ssh sync --delete``, the MCP and Web
+        # mirror callers) don't rewrite the marker, so after one workstation
+        # mirrors over a mount another one owned, the marker still names the old
+        # host and the next ordinary auto-sync is refused. That is the safe
+        # direction to fail — nothing is lost, and ``--force-sync`` (or
+        # ``[sync] owner_check = false``) clears it — but it is only truly fixed
+        # by giving every configured-mount push one shared entry point that owns
+        # the marker's lifecycle.
+        "/.srunx-owner.json",
     ]
 
     def __init__(
@@ -449,14 +470,41 @@ class RsyncClient:
         *,
         stdin: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        """Run *remote_cmd* on the configured host via ssh.
+        """Run *remote_cmd* on the configured host via ssh, under ``sh``.
 
         Reuses the same SSH options rsync uses (key, port, ProxyJump,
         ssh_config) so that anything rsync can reach, this can reach
         too. ``stdin`` is piped through to the remote process — used
-        by the owner-marker writer to send JSON via ``tee``.
+        by the owner-marker writer to send its JSON.
+
+        The command is wrapped in ``sh -c`` instead of being handed to the
+        account's login shell. OpenSSH evaluates a remote command *with that
+        login shell*, and the ``if ...; then ...; fi`` scripts here are not
+        valid csh/tcsh — still the default shell on some HPC accounts. Without
+        the wrapper those commands fail on every invocation, and because the
+        callers downgrade failures (a missing marker is a warning, an
+        unavailable hash skips verification) the breakage would be silent:
+        the cross-workstation overwrite guard and the post-sync hash check
+        would both quietly stop working.
+
+        The wrapper only holds for a single-line command. csh cannot carry a
+        newline through single quotes, so a multi-line script gets split and the
+        fragments parsed by csh itself — which not only fails but can run pieces
+        of the script as separate commands. Rather than leave that as a trap for
+        the next caller, a newline is rejected outright; join steps with ``;``.
+
+        Raises:
+            ValueError: If *remote_cmd* spans multiple lines.
         """
-        ssh_cmd = [*self._build_ssh_cmd(), self._ssh_dest(), remote_cmd]
+        if "\n" in remote_cmd:
+            raise ValueError(
+                "remote_cmd must be a single line — a csh/tcsh login shell "
+                "splits newlines out of the quoted argument and parses the "
+                "fragments itself, running part of the script as separate "
+                "commands. Join the steps with ';' instead."
+            )
+        wrapped = f"sh -c {shlex.quote(remote_cmd)}"
+        ssh_cmd = [*self._build_ssh_cmd(), self._ssh_dest(), wrapped]
         logger.debug("ssh: {}", shlex.join(ssh_cmd))
         return subprocess.run(  # noqa: S603
             ssh_cmd,
@@ -497,27 +545,241 @@ class RsyncClient:
         )
 
     def write_remote_file(self, remote_path: str, content: str) -> None:
-        """Atomically write *content* to *remote_path* via ssh + tee.
+        """Write *content* to *remote_path* atomically (temp file + rename).
 
-        ``tee`` (without ``-a``) truncates and rewrites the destination
-        in one shell op so a concurrent reader either sees the old
-        content or the new content — never a half-written file. The
-        parent directory is assumed to exist (the rsync that just ran
-        guarantees it for the owner-marker case).
+        ``mv`` within one directory is a ``rename(2)``, so a concurrent reader
+        sees either the previous file or the complete new one. Writing with
+        ``tee`` straight at the target does **not** give that: ``tee``
+        truncates first, so a reader in that window sees an empty file. This
+        function used to do exactly that while documenting the opposite.
 
-        Raises :class:`RuntimeError` if ssh / tee exits non-zero so the
-        caller can surface the failure rather than silently leaving a
-        stale marker on disk.
+        The target is rejected when it is a symlink (``tee`` / ``mv`` would act
+        on whatever it points at, letting a planted link redirect the write
+        outside the mount) or a directory (``mv`` would move the new file
+        *inside* it and exit 0, reporting success while the control file stays
+        unreadable). A probe that cannot be completed is also an error, since
+        its silence proves nothing.
+
+        Those checks are made twice — once up front and once immediately before
+        the rename — and the result is verified afterwards. GNU coreutils can
+        refuse a directory destination outright (``mv -T``) and that path is
+        taken when available; elsewhere a swap in the instant before the rename
+        is detected rather than prevented, and never reported as success.
+
+        Known limit: a peer could point our temp directory's name at a *different
+        directory we own*, which passes the ownership check. That costs nothing
+        (they cannot reach inside a directory of ours) beyond the publish
+        possibly crossing filesystems. Closing it would need fd-relative
+        operations, which a shell cannot express — it would mean driving this
+        over SFTP instead of ssh.
+
+        The parent directory is assumed to exist (for the owner-marker case
+        the rsync that just ran guarantees it).
+
+        Raises:
+            ValueError: If *remote_path* is login-relative. The write anchors
+                its working directory inside a private temp directory, which
+                would change how such a path resolves.
+            RuntimeError: If the target is a symlink or a directory, if the
+                target could not be probed, or if any write / publish step
+                exits non-zero — so the caller surfaces the failure instead of
+                silently leaving a stale file behind.
         """
-        quoted = shlex.quote(remote_path)
-        # Use ``> /dev/null`` so tee's stdout doesn't echo the JSON
-        # back through ssh (waste of bytes + stdout pollution).
-        result = self._ssh_run(f"tee -- {quoted} > /dev/null", stdin=content)
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"ssh write to {remote_path!r} failed "
-                f"(exit {result.returncode}): {result.stderr.strip()}"
+        if not remote_path.startswith(("/", "~")):
+            # The write anchors its working directory inside a private temp
+            # directory (so the directory entry cannot be swapped out from under
+            # it), which changes how a login-relative path would resolve: the
+            # rename would land inside the temp directory and the verification
+            # would look somewhere else entirely. Rejecting is better than
+            # writing the file somewhere the caller did not ask for.
+            raise ValueError(
+                f"remote_path must be absolute or ~-relative, got "
+                f"{remote_path!r} — a login-relative path cannot be resolved "
+                "safely by this writer"
             )
+
+        quoted = shlex.quote(remote_path)
+        prefix = shlex.quote(f"{PurePosixPath(remote_path).parent}/.srunx-write.")
+
+        # The whole guarded sequence runs in ONE ssh invocation. Split across
+        # several it cost that many connections — that many key exchanges, and
+        # that many hardware-key touches — on *every* synced submission, since
+        # the owner marker is rewritten each time. Sharing one shell also shrinks
+        # the window between checking the target and renaming over it to near
+        # zero, and lets the checks repeat immediately before the rename.
+        #
+        # The temp lives inside a directory we create with ``mkdir -m 700``, and
+        # that is what makes writing it safe. Two earlier attempts were not:
+        #
+        # 1. ``mktemp`` then ``chmod`` then ``cat`` — mktemp closes the file, so
+        #    the later steps reopened it **by name**. Another account with write
+        #    access to the directory could unlink it and leave a symlink in that
+        #    gap. Verified locally: the sequence truncated an unrelated file
+        #    through the planted link — arbitrary overwrite, not just a broken
+        #    marker.
+        # 2. A single ``set -C`` redirection — noclobber only refuses an existing
+        #    *regular* file (POSIX XCU 2.7.2). Verified locally: with a FIFO
+        #    planted at the predictable name, the redirection did not fail, it
+        #    **hung** in open(). An attacker could stall every sync, or read the
+        #    marker content, and then have ``mv`` publish their object.
+        #
+        # ``mkdir`` is the exclusive-create primitive that covers every kind of
+        # inode: verified to fail with "File exists" against both a planted FIFO
+        # and a planted symlink. Mode 700 means nobody else can enter the
+        # directory afterwards, so the file created inside it cannot be swapped —
+        # no name is reopened in an untrusted directory at any point.
+        #
+        # ``umask 022`` fixes the marker's mode at creation, since it must stay
+        # readable to other accounts on a shared mount: an unreadable marker
+        # reads as "no owner" and disables the guard for them.
+        #
+        # The directory sits beside the target so publishing is a rename within
+        # one filesystem — across filesystems ``mv`` becomes copy+unlink and
+        # stops being atomic.
+        #
+        # Cleanup removes the known filename and then ``rmdir``s, rather than
+        # ``rm -rf``, so an unexpected entry is never deleted recursively.
+        #
+        # Exit codes are distinct so the failure can be reported precisely
+        # rather than as one opaque "ssh failed".
+        script = (
+            f"set -u; "
+            f"if [ -h {quoted} ]; then exit 3; fi; "
+            f"if [ -d {quoted} ]; then exit 4; fi; "
+            f"d={prefix}$$; "
+            f'mkdir -m 700 -- "$d" || exit 5; '
+            # ``cd`` into the directory we just created and work in relative
+            # paths from here on. Mode 700 stops others entering it, but it does
+            # NOT protect the directory *entry*: write permission on the parent
+            # lets a watcher rename our directory away and recreate one under the
+            # same name, after which a path like "$d/file" would resolve into
+            # theirs. A shell's working directory follows the inode, not the
+            # name, so nothing below reopens a path an attacker controls.
+            f'cd -- "$d" || {{ rmdir -- "$d"; exit 5; }}; '
+            # ``mkdir`` then ``cd`` is itself a TOCTOU: write permission on the
+            # parent lets a peer rename our entry away and put their own
+            # directory (or a symlink) under the same name before we open it. We
+            # would then create, chmod and write inside *their* directory, where
+            # they can swap the file for a symlink — back to the arbitrary
+            # overwrite this whole sequence exists to prevent. So verify what we
+            # actually entered: a peer can only create directories owned by
+            # themselves, so a uid match rules that out. Compared via
+            # ``ls -ldn`` + ``id -u`` because ``test -O`` is a bash/ksh
+            # extension, absent from POSIX test and from dash — the /bin/sh on
+            # most Linux clusters. No cleanup here: if this fails we are standing
+            # in someone else's directory and must not delete anything in it.
+            f'[ "$(ls -ldn . | awk \'NR==1{{print $3}}\')" = "$(id -u)" ] '
+            f"|| exit 5; "
+            # Random basename via mktemp — safe to use here precisely because
+            # this directory is ours and unreachable by others, which was not
+            # true of the mount root. It matters because on a non-GNU ``mv``
+            # (BSD, BusyBox) a target swapped for a symlink-to-directory makes
+            # the publish land at ``<referent>/<basename>``: a predictable name
+            # like the PID could be guessed and made to collide with a file the
+            # attacker wants destroyed. ``$$`` was no good — it is already
+            # exposed in the directory name.
+            f'f=$(mktemp -- ./w.XXXXXX) || {{ cd /; rmdir -- "$d"; exit 5; }}; '
+            # mktemp creates 0600; the published marker must stay readable to
+            # other accounts on a shared mount, since an unreadable marker reads
+            # as "no owner" and disables the guard for them. Reopening by name is
+            # fine *inside* this directory — the risk it carried at the mount
+            # root does not exist where no one else can reach.
+            # No ``--`` here: BSD chmod does not accept it and treats it as a
+            # filename ("chmod: --: No such file or directory"), which failed
+            # every write on macOS-family remotes. Safe to omit because mktemp's
+            # template starts with "./", so the name can never look like a flag.
+            f'chmod 644 "$f" || {{ rm -f -- "$f"; cd /; rmdir -- "$d"; exit 9; }}; '
+            f'cat > "$f" || {{ rm -f -- "$f"; cd /; rmdir -- "$d"; exit 6; }}; '
+            # Re-check right before the rename: a target swapped in after the
+            # first check would otherwise be followed by ``mv``.
+            f"if [ -h {quoted} ] || [ -d {quoted} ]; then "
+            f'rm -f -- "$f"; cd /; rmdir -- "$d"; exit 3; fi; '
+            # GNU coreutils can refuse a directory destination outright with
+            # ``-T``, which closes the swap race instead of only detecting it.
+            # ``mv --version`` is the reliable probe: it succeeds on GNU and
+            # fails on BSD, where ``-T`` does not exist (verified — BSD reports
+            # "illegal option -- T"). Blindly retrying without ``-T`` on any
+            # error would be wrong, since "no such option" and "target is a
+            # directory" would be indistinguishable.
+            f"if mv --version >/dev/null 2>&1; then "
+            f'mv -fT -- "$f" {quoted} '
+            f'|| {{ rm -f -- "$f"; cd /; rmdir -- "$d"; exit 7; }}; '
+            f"else "
+            f'mv -f -- "$f" {quoted} '
+            f'|| {{ rm -f -- "$f"; cd /; rmdir -- "$d"; exit 7; }}; '
+            f"fi; "
+            # Leave the directory before removing it, or the rmdir can fail with
+            # the working directory still inside it.
+            f'cd /; rmdir -- "$d" 2>/dev/null; '
+            # Verify what the rename actually produced. If the target was
+            # swapped for a directory (or a symlink to one) in the instant
+            # between the recheck above and this rename, ``mv`` moved the temp
+            # *inside* it and exited 0. Preventing that portably is not
+            # possible — ``mv -T`` is a GNU extension, and its failure cannot
+            # be told apart from "target is a directory", so falling back on
+            # error would silently drop the guard on BSD. Detecting it is
+            # portable, and refusing to call that success is what matters:
+            # otherwise the caller believes the marker was updated when the
+            # content landed somewhere else entirely.
+            # Nothing is deleted on this path, on purpose. An earlier version
+            # removed ``<target>/marker`` to avoid leaving the relocated file
+            # behind, but if the target was swapped for a symlink to some other
+            # directory, that path resolves to an unrelated pre-existing file and
+            # the cleanup deletes it — under the syncing user's credentials, and
+            # possibly outside the mount. A leftover file costs disk space; a
+            # wrong ``rm`` costs data. The error tells the operator what to
+            # inspect instead.
+            f"if [ ! -f {quoted} ] || [ -h {quoted} ]; then exit 8; fi"
+        )
+        result = self._ssh_run(script, stdin=content)
+        if result.returncode == 0:
+            return
+
+        detail = result.stderr.strip()
+        reasons = {
+            3: (
+                f"refusing to write {remote_path!r}: it is a symlink or a "
+                "directory. Following a symlink could write outside the mount, "
+                "and renaming onto a directory would move the file inside it "
+                "while reporting success"
+            ),
+            4: (
+                f"refusing to write {remote_path!r}: it exists as a directory, "
+                "so publishing would move the new file inside it instead of "
+                "replacing it"
+            ),
+            5: (
+                f"could not set up the private temp directory beside "
+                f"{remote_path!r} — anything already occupying that name "
+                "(file, symlink, FIFO) lands here, since the directory is "
+                "created exclusively, and so does a directory that turned out "
+                "not to be owned by this account (which means another user "
+                "swapped it in between creating and entering it)"
+            ),
+            6: f"could not write the temp file beside {remote_path!r}",
+            9: (
+                f"could not make the replacement for {remote_path!r} readable "
+                "(chmod failed); publishing it owner-only would hide the marker "
+                "from other accounts sharing the mount, which reads as "
+                '"no owner" and disables the guard for them'
+            ),
+            7: f"could not publish {remote_path!r} (rename failed)",
+            8: (
+                f"published {remote_path!r} but it is not a regular file "
+                "afterwards — something replaced the target mid-write, so the "
+                "content may have landed elsewhere and this file was NOT "
+                "updated. Nothing was deleted in response, since the swapped-in "
+                "path could point anywhere; inspect it on the cluster and remove "
+                "any stray 'marker' file yourself before retrying"
+            ),
+        }
+        reason = reasons.get(
+            result.returncode,
+            f"ssh write to {remote_path!r} failed",
+        )
+        raise RuntimeError(
+            f"{reason} (exit {result.returncode})" + (f": {detail}" if detail else "")
+        )
 
     # Custom exit codes wired into the remote shell snippet for
     # remote_sha256. Chosen above the common shell-defined range
@@ -563,15 +825,19 @@ class RsyncClient:
         # exit codes disambiguate "file missing" and "no tool" from
         # genuine failures so the Python side doesn't have to grep
         # stderr to make that distinction.
+        # Written on ONE line. A multi-line script breaks on csh/tcsh login
+        # shells even inside ``sh -c '...'``: csh cannot carry a newline through
+        # single quotes, so it splits the text and parses the fragments itself.
+        # Verified against tcsh — the newline form produced ``Unmatched '``,
+        # ``Ambiguous output redirect`` and ``else: endif not found``, and ran
+        # part of the script as separate commands.
         script = (
-            f"test -f {quoted} || exit {self._SHA256_REMOTE_MISSING_EXIT}\n"
-            f"if command -v sha256sum >/dev/null 2>&1; then\n"
-            f"  sha256sum -- {quoted}\n"
-            f"elif command -v shasum >/dev/null 2>&1; then\n"
-            f"  shasum -a 256 -- {quoted}\n"
-            f"else\n"
-            f"  exit {self._SHA256_REMOTE_NO_TOOL_EXIT}\n"
-            f"fi"
+            f"test -f {quoted} || exit {self._SHA256_REMOTE_MISSING_EXIT}; "
+            f"if command -v sha256sum >/dev/null 2>&1; then "
+            f"sha256sum -- {quoted}; "
+            f"elif command -v shasum >/dev/null 2>&1; then "
+            f"shasum -a 256 -- {quoted}; "
+            f"else exit {self._SHA256_REMOTE_NO_TOOL_EXIT}; fi"
         )
         result = self._ssh_run(script)
         if result.returncode == 0:

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -942,3 +942,388 @@ class TestRemoteSha256:
             )
             with pytest.raises(RuntimeError, match="parse sha256"):
                 client.remote_sha256("/r/ml/train.sbatch")
+
+
+# ---------------------------------------------------------------------------
+# write_remote_file (owner marker / control files)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteRemoteFile:
+    """Control-file writes must be atomic and must not follow symlinks.
+
+    The previous implementation piped ``tee`` straight at the target while
+    documenting that a reader "never sees a half-written file". ``tee`` empties
+    the destination first, so a reader in that window saw an empty file — and a
+    symlink at the target redirected the write outside the mount.
+    """
+
+    def _client_with_ssh(self, *results: MagicMock) -> tuple[RsyncClient, MagicMock]:
+        client = _make_rsync_client(hostname="h", username="u")
+        ssh = MagicMock(side_effect=list(results))
+        return client, ssh
+
+    @staticmethod
+    def _ok(stdout: str = "OK\n", returncode: int = 0) -> MagicMock:
+        return MagicMock(returncode=returncode, stdout=stdout, stderr="")
+
+    def test_runs_as_a_single_ssh_invocation(self):
+        """One connection, not several.
+
+        The marker is rewritten on *every* synced submission, so splitting this
+        into probe/create/write/publish cost that many key exchanges — and that
+        many hardware-key touches — each time. One shell also leaves almost no
+        window in which the target could be swapped between check and rename.
+        """
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/.srunx-owner.json", '{"a":1}')
+
+        ssh.assert_called_once()
+        script = ssh.call_args.args[0]
+        assert ssh.call_args.kwargs["stdin"] == '{"a":1}'
+        # Content lands in the temp, never at the target.
+        assert 'cat > "$f"' in script
+        # Published by a same-directory rename, which is atomic.
+        assert 'mv -f -- "$f" ' in script
+        assert "/remote/ml/.srunx-owner.json" in script
+
+    def test_temp_lives_in_an_exclusively_created_private_directory(self):
+        """``mkdir`` is the only exclusive-create covering every inode type.
+
+        Two earlier attempts failed, both verified against real shells:
+
+        * ``mktemp`` + ``chmod`` + ``cat`` reopened the temp *by name*, so a
+          symlink planted in that gap redirected the write and destroyed an
+          unrelated file — arbitrary overwrite, not just a broken marker.
+        * ``set -C`` alone only refuses an existing *regular* file (POSIX XCU
+          2.7.2). With a FIFO at the predictable name the redirection did not
+          fail — it **hung** in open(), stalling the sync indefinitely.
+
+        ``mkdir -m 700`` was verified to refuse a planted symlink, FIFO,
+        directory and regular file alike (exit 5, marker never written), and
+        mode 700 stops anyone swapping the file created inside it.
+        """
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/.srunx-owner.json", "x")
+
+        script = ssh.call_args.args[0]
+        # mktemp is used, but only *inside* our own directory — the earlier
+        # failure was calling it in the untrusted mount root.
+        assert 'mkdir -m 700 -- "$d"' in script
+        # Anchored by cd: mode 700 guards the contents, but write permission on
+        # the parent still lets a watcher swap the directory entry itself. A
+        # working directory follows the inode, so nothing reopens a path an
+        # attacker controls.
+        assert 'cd -- "$d"' in script
+        assert script.index('cd -- "$d"') < script.index("mktemp")
+        # Random basename from mktemp, safe here because the directory is ours.
+        assert "mktemp -- ./w.XXXXXX" in script
+        assert script.index("mktemp") < script.index('cat > "$f"')
+        # Cleanup is targeted, never recursive.
+        assert "rm -rf" not in script
+        assert 'rmdir -- "$d"' in script
+
+    def test_verifies_it_entered_its_own_directory(self):
+        """``mkdir`` then ``cd`` is a TOCTOU on the directory *entry*.
+
+        Write permission on the parent lets a peer rename our entry away and put
+        their own directory under the same name before we open it — after which
+        we would create, chmod and write inside theirs, where they can swap the
+        file for a symlink. A peer can only create directories owned by
+        themselves, so a uid match rules that out.
+        """
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/.srunx-owner.json", "x")
+
+        script = ssh.call_args.args[0]
+        assert '"$(id -u)"' in script
+        assert "ls -ldn ." in script
+        # Checked after entering and before anything is created inside.
+        assert script.index('cd -- "$d"') < script.index("ls -ldn .")
+        assert script.index("ls -ldn .") < script.index("mktemp")
+        # ``test -O`` is a bash/ksh extension, absent from dash (/bin/sh on most
+        # Linux clusters), so it must not be relied on.
+        assert "-O ." not in script
+
+    def test_relative_destination_is_rejected(self):
+        """Anchoring the working directory changes how a relative path resolves.
+
+        The rename would land the replacement inside the temp directory and the
+        verification would look elsewhere, so the call would report failure and
+        leave the requested file unwritten. Refusing up front beats writing to a
+        path the caller did not ask for.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            with pytest.raises(ValueError, match="must be absolute"):
+                client.write_remote_file("marker.json", "x")
+            mock_run.assert_not_called()
+
+    def test_tilde_destination_is_accepted(self):
+        """Mount remotes are commonly written ``~/work/...``."""
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("~/work/.srunx-owner.json", "x")
+
+        assert "~/work/.srunx-owner.json" in ssh.call_args.args[0]
+
+    def test_temp_is_created_beside_the_target(self):
+        """A temp elsewhere could be another filesystem, where mv copies."""
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/sub/marker.json", "x")
+
+        assert "/remote/ml/sub/.srunx-write." in ssh.call_args.args[0]
+
+    def test_checks_target_again_immediately_before_rename(self):
+        """Guards a target swapped in after the first check.
+
+        Without the second check, ``mv`` would follow a symlink planted in
+        between and write outside the mount while reporting success.
+        """
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/marker.json", "x")
+
+        script = ssh.call_args.args[0]
+        mv_at = script.index("mv -f --")
+        # Guarded up front...
+        assert script.index("-h ") < script.index('cat > "$f"')
+        # ...and again immediately before the rename (the last -d test).
+        assert script.index('cat > "$f"') < script.rindex("-d ") < mv_at
+        # The trailing -h test is the post-rename verification, not a guard.
+        assert script.rindex("-h ") > mv_at
+
+    def test_refuses_symlink_or_directory_target(self):
+        """Exit 3 is the remote guard refusing to follow / rename onto it."""
+        client, ssh = self._client_with_ssh(
+            MagicMock(returncode=3, stdout="", stderr="")
+        )
+        with patch.object(client, "_ssh_run", ssh):
+            with pytest.raises(RuntimeError, match="symlink or a directory"):
+                client.write_remote_file("/remote/ml/.srunx-owner.json", "x")
+
+    def test_refuses_directory_target(self):
+        """``mv temp dir`` succeeds by moving the file *inside* the directory.
+
+        Without this guard the write reports success while the control file
+        stays unreadable — and the rsync exclusion then keeps that bad
+        directory around indefinitely.
+        """
+        client, ssh = self._client_with_ssh(
+            MagicMock(returncode=4, stdout="", stderr="")
+        )
+        with patch.object(client, "_ssh_run", ssh):
+            with pytest.raises(RuntimeError, match="exists as a directory"):
+                client.write_remote_file("/remote/ml/.srunx-owner.json", "x")
+
+    def test_connection_failure_fails_closed(self):
+        """An ssh failure proves nothing about the target, so it must not pass."""
+        client, ssh = self._client_with_ssh(
+            MagicMock(returncode=255, stdout="", stderr="connection closed")
+        )
+        with patch.object(client, "_ssh_run", ssh):
+            with pytest.raises(RuntimeError, match="connection closed"):
+                client.write_remote_file("/remote/ml/marker.json", "x")
+
+    def test_occupied_temp_name_reported_distinctly(self):
+        """Exit 5 is the exclusive mkdir refusing whatever was planted there."""
+        client, ssh = self._client_with_ssh(
+            MagicMock(returncode=5, stdout="", stderr="File exists")
+        )
+        with patch.object(client, "_ssh_run", ssh):
+            with pytest.raises(RuntimeError, match="private temp directory"):
+                client.write_remote_file("/remote/ml/marker.json", "x")
+
+    def test_write_failure_reported_distinctly(self):
+        client, ssh = self._client_with_ssh(
+            MagicMock(returncode=6, stdout="", stderr="disk quota exceeded")
+        )
+        with patch.object(client, "_ssh_run", ssh):
+            with pytest.raises(RuntimeError, match="could not write the temp file"):
+                client.write_remote_file("/remote/ml/marker.json", "x")
+
+    def test_publish_failure_reported_distinctly(self):
+        client, ssh = self._client_with_ssh(
+            MagicMock(returncode=7, stdout="", stderr="permission denied")
+        )
+        with patch.object(client, "_ssh_run", ssh):
+            with pytest.raises(RuntimeError, match="could not publish"):
+                client.write_remote_file("/remote/ml/marker.json", "x")
+
+    def test_verifies_the_result_of_the_rename(self):
+        """The rename's outcome is checked, not assumed.
+
+        A target swapped for a directory between the last check and the rename
+        makes ``mv`` land the temp inside it and exit 0. That cannot be
+        prevented portably, so it is detected instead.
+        """
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/marker.json", "x")
+
+        script = ssh.call_args.args[0]
+        assert script.rindex("-f ") > script.index("mv -f --")
+        assert "exit 8" in script
+
+    def test_post_rename_verification_failure_is_not_success(self):
+        client, ssh = self._client_with_ssh(
+            MagicMock(returncode=8, stdout="", stderr="")
+        )
+        with patch.object(client, "_ssh_run", ssh):
+            with pytest.raises(RuntimeError, match="was NOT\n?\\s*updated|was NOT"):
+                client.write_remote_file("/remote/ml/marker.json", "x")
+
+    def test_replacement_is_readable_by_other_accounts(self):
+        """The mode is set at creation, not by a separate chmod.
+
+        On a mount shared between accounts an unreadable marker reads as
+        "no owner", so an owner-only marker would stop protecting the
+        multi-account case the marker exists for. Doing it with ``umask``
+        rather than a follow-up ``chmod`` also removes a step that would have
+        reopened the temp by name — the gap a symlink swap exploits.
+        """
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/.srunx-owner.json", "x")
+
+        script = ssh.call_args.args[0]
+        assert 'chmod 644 "$f"' in script
+        # No ``--``: BSD chmod rejects it, which broke every write on macOS
+        # remotes. Safe to omit since mktemp's template starts with "./".
+        assert "chmod 644 --" not in script
+        # Applied before the content, and before the rename publishes the inode.
+        assert script.index("chmod 644") < script.index('cat > "$f"')
+        # The private directory stays 700; only the published marker is 644.
+        assert "mkdir -m 700" in script
+
+    def test_detected_race_deletes_nothing(self):
+        """Cleaning up through a swapped target would delete the wrong file.
+
+        An earlier version removed ``<target>/marker`` so the relocated file
+        wouldn't linger. But if the target was swapped for a symlink to another
+        directory, that path resolves to an unrelated pre-existing file, and the
+        cleanup deletes it — under the syncing user's credentials, outside the
+        mount. A leftover costs disk space; a wrong ``rm`` costs data, so this
+        path reports and touches nothing.
+        """
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/marker.json", "x")
+
+        script = ssh.call_args.args[0]
+        # After the last rename branch, nothing is removed at all.
+        tail = script[script.rindex("exit 7") :]
+        assert "rm -f" not in tail
+        assert tail.rstrip().endswith("exit 8; fi")
+
+    def test_temp_is_cleaned_up_on_every_failure_path(self):
+        """A temp left beside the marker would accumulate on each failure."""
+        client, ssh = self._client_with_ssh(self._ok(""))
+        with patch.object(client, "_ssh_run", ssh):
+            client.write_remote_file("/remote/ml/marker.json", "x")
+
+        script = ssh.call_args.args[0]
+        # Everything inside the private directory is certainly ours, so every
+        # failure after it exists removes the file and then the directory:
+        # write failure, pre-rename recheck, failed rename.
+        # Rather than count call sites (brittle), pin the invariant: every
+        # deletion names the temp we created inside our own directory. Naming a
+        # path under the target is the bug this replaced — if the target was
+        # swapped for a symlink, deleting under it removes an unrelated file.
+        assert script.count("rm -f") == script.count('rm -f -- "$f"')
+        assert "/remote/ml/marker.json/" not in script
+        # And the directory is only ever removed by name, never recursively.
+        assert script.count("rmdir") == script.count('rmdir -- "$d"')
+        assert "rm -rf" not in script
+
+
+class TestRemoteCommandShell:
+    """Remote commands must not depend on the account's login shell.
+
+    OpenSSH evaluates ``ssh host "cmd"`` with the remote user's login shell.
+    The ``if ...; then ...; fi`` scripts used for the owner marker and the
+    post-sync hash check are not valid csh/tcsh — still the default on some
+    HPC accounts — and both callers downgrade failures, so the breakage would
+    be silent rather than loud.
+    """
+
+    def test_commands_are_wrapped_in_sh(self):
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client._ssh_run("if [ -f x ]; then echo y; fi")
+
+        assert mock_run.call_args[0][0][-1].startswith("sh -c ")
+
+    def test_hash_check_is_also_wrapped(self):
+        """``remote_sha256`` had the same latent problem before the wrapper."""
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=f"{'a' * 64}  /r/x\n", stderr=""
+            )
+            client.remote_sha256("/r/x")
+
+        remote_arg = mock_run.call_args[0][0][-1]
+        assert remote_arg.startswith("sh -c ")
+        assert "sha256sum" in remote_arg
+
+    def test_hash_check_is_single_line(self):
+        """csh cannot carry a newline through single quotes.
+
+        Verified against tcsh: the multi-line form produced ``Unmatched '``,
+        ``Ambiguous output redirect`` and ``else: endif not found`` — and ran
+        part of the script as separate commands — even inside ``sh -c '...'``.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=f"{'a' * 64}  /r/x\n", stderr=""
+            )
+            client.remote_sha256("/r/x")
+
+        assert "\n" not in mock_run.call_args[0][0][-1]
+
+    def test_multiline_command_is_rejected(self):
+        """A newline must fail loudly rather than break only on csh accounts."""
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            with pytest.raises(ValueError, match="single line"):
+                client._ssh_run("echo a\necho b")
+            mock_run.assert_not_called()
+
+    def test_marker_write_is_single_line(self):
+        client = _make_rsync_client(hostname="h", username="u")
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.write_remote_file("/remote/ml/.srunx-owner.json", "x")
+
+        assert "\n" not in mock_run.call_args[0][0][-1]
+
+
+class TestControlFileExcluded:
+    def test_owner_marker_is_excluded_by_default(self):
+        """Otherwise a mirror deletes it: there is no local counterpart.
+
+        Losing it silently disables the guard that stops one machine from
+        syncing over a mount another machine owns.
+        """
+        client = _make_rsync_client(hostname="h", username="u")
+        assert "/.srunx-owner.json" in client.exclude_patterns
+
+    def test_marker_survives_a_mirror(self, tmp_path: Path):
+        client = _make_rsync_client(hostname="h", username="u")
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push(tmp_path, "~/dst/", delete=True)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--delete" in cmd
+        # An --exclude'd path is also protected from deletion.
+        idx = cmd.index("/.srunx-owner.json")
+        assert cmd[idx - 1] == "--exclude"


### PR DESCRIPTION
Follow-up to #231. Two long-standing defects around srunx's remote control file, `.srunx-owner.json` — the marker that records which workstation owns a mount so a second one cannot sync over it.

## The marker was deleted by every mirror

It lives at the mount root and has no local counterpart, so a `--delete` sync pruned it. Because the next sync writes it again, the loss was invisible — leaving windows where the guard against cross-workstation overwrites silently did nothing.

It is now excluded from transfers, which also protects it from deletion. The pattern is anchored (`/.srunx-owner.json`): a bare name matches that basename at **every** depth and would silently skip a user's own `subdir/.srunx-owner.json`.

## The write claimed to be atomic and was not

The old implementation piped `tee` straight at the target. That empties the file first, so a concurrent reader saw an **empty marker** — precisely what the docstring promised could not happen. It also followed a symlink at the target, letting a planted link redirect the write outside the mount.

The replacement writes into a private directory created with `mkdir -m 700`, publishes by rename, and runs as one ssh invocation.

## How it got there

Every intermediate attempt was rejected for a concrete reason, and each was verified against real shells and binaries rather than reasoned about. Recording them because the failure modes are not obvious:

| Attempt | Why it was wrong |
|---|---|
| `mktemp` + `chmod` + `cat` | mktemp closes the file, so the later steps reopen it **by name**. A symlink planted in that gap redirected the write and destroyed an unrelated file — **arbitrary overwrite**, not just a broken marker. |
| single `set -C` redirect | noclobber only refuses an existing *regular* file (POSIX XCU 2.7.2). With a FIFO at the predictable name the redirect did not fail — it **hung in open()**, a trivial way to stall every sync. |
| `mkdir -m 700` | Correct: verified to refuse a planted symlink, FIFO, directory and regular file alike. But mode 700 guards the *contents*, not the directory **entry**. |
| `cd` into it | Needed — a working directory follows the inode, not the name. The entry can still be swapped between `mkdir` and `cd`, so the entered directory's ownership is verified. |

Details worth knowing:

- **Ownership check** uses `ls -ldn` + `id -u`, not `test -O`, which is absent from POSIX test and from dash — the `/bin/sh` on most Linux clusters.
- **Publish basename** comes from `mktemp` inside the private directory. A predictable one (the PID, already exposed in the directory name) can be made to collide: `mv` into a symlinked directory lands the source under its own basename, so a fixed name overwrites an existing file wherever the attacker points.
- **`mv -T`** refuses a directory destination outright and is used when available, detected with `mv --version`. Retrying without `-T` on error would be wrong — "no such option" and "target is a directory" are indistinguishable. Elsewhere the swap is detected afterwards and never reported as success.
- **Mode 644, not mktemp's 600.** On a mount shared between accounts an unreadable marker reads as "no owner" and disables the guard for them.
- **The detected-race path deletes nothing.** Removing `<target>/…` would resolve through the swapped-in symlink and delete an unrelated file. A leftover costs disk space; a wrong `rm` costs data.

## Remote commands run under `sh`, single-line

OpenSSH evaluates a remote command with the account's **login** shell, where `if …; then …; fi` is invalid csh/tcsh — still the default on some HPC accounts. Worse, a newline inside the quoted argument is split out and its fragments parsed by csh itself, running part of the script as separate commands (verified against tcsh: `Unmatched '`, `Ambiguous output redirect`, `else: endif not found`).

This also fixes `remote_sha256`, which had the same latent problem: on those accounts post-sync hash verification failed every time and its caller silently skipped it. A newline in a remote command is now rejected outright so the next caller cannot reintroduce a csh-only breakage.

## Also

The DB filename is documented correctly: `srunx.observability.storage`, derived from the defining module's dotted path, not the `srunx.db` the docs claimed — plus why renaming it would orphan existing local databases.

## Known limits, stated in the code

- A peer could point the temp directory's name at a *different directory we own*, which passes the ownership check. They cannot reach inside it, so nothing is overwritten; the publish may cross filesystems. Closing this needs fd-relative operations, which a shell cannot express — it would mean driving this over SFTP.
- Mirror paths that bypass `mount_sync_session` don't rewrite the marker, so after one workstation mirrors over a mount another owned, the marker still names the old host and the next ordinary auto-sync is refused. That is the safe direction to fail, and `--force-sync` clears it, but it is only truly fixed by giving every configured-mount push one shared entry point that owns the marker's lifecycle.

## Testing

`2307 passed, 2 skipped`; mypy clean across 371 files; ruff clean.

`RsyncClient.write_remote_file` gains 22 tests — it had **none** before. Coverage includes both rsync flag widths, single-invocation behaviour, the ownership check, refusal of symlink/directory/FIFO/occupied names, per-stage failure reporting, post-rename verification, and that cleanup only ever names paths inside our own directory.

Beyond the unit tests, the generated scripts were executed against real `sh` and `tcsh`, and the attacks were reproduced: a planted symlink, FIFO, directory and regular file are each refused (exit 5) with the victim file untouched and no marker written. The pre-fix sequence was confirmed to destroy the victim, so the tests pin a difference that was demonstrated rather than assumed.

## Breaking changes

- `RsyncClient.write_remote_file` rejects a login-relative `remote_path`; the write anchors its working directory, so such a path would resolve somewhere unintended. Absolute and `~`-relative paths — what every caller passes — are unaffected.
- `RsyncClient._ssh_run` rejects multi-line commands.

## Review

Iterated through 14 rounds of `codex exec review` until clean. 17 findings, all accepted; three were P1 (arbitrary overwrite via reopen-by-name, the FIFO hang, the mkdir-to-cd swap). One earlier fix was **withdrawn** on review — a cleanup step added in an early round turned out to be able to delete the wrong file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBKedWVkVba5Zfpp8KmZMR
