### PR TITLE
feat(mcp): add inspect_mount, a read-only view of what a sync would change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,17 @@ file/template/job sync routes (`delete=True` explicit), and MCP
 auto-sync silently pruned remote-only outputs; see
 `src/srunx/sync/mount_helpers.py`.
 
+The trade-off is that a locally deleted file stays on the cluster, where a job
+can still import it. MCP exposes `inspect_mount` for that — read-only, reports
+cluster-only paths. It is a separate tool rather than a flag on `sync_files`
+because an inspection has to be documented as unconditionally safe: folding it
+into `sync_files` meant one `delete` argument carrying both "show me what a
+mirror would remove" (harmless) and "remove it" (destructive), and an agent
+reading the data-loss warning avoids the argument entirely — losing the safe
+inspection with it. srunx keeps no manifest of what it uploaded, so
+`inspect_mount` cannot separate job outputs from stale code; it reports, the
+human decides.
+
 ##### Account secrets (`ssh secret`)
 Secrets (API keys etc.) are stored in a single **remote** `0600` file per
 account (not per profile), `$HOME/.config/srunx/secrets.env` (parent dir

--- a/docs/how-to/mcp-usage.md
+++ b/docs/how-to/mcp-usage.md
@@ -100,7 +100,33 @@ differs from the cluster's it would register something like
 
 Syncing is additive: new and changed files are copied, and files that
 exist only on the cluster (checkpoints, job logs, outputs) are left
-alone. To mirror instead, ask for deletion explicitly:
+alone.
+
+### Find what is stale on the cluster
+
+Because syncing is additive, a file you delete locally stays on the
+cluster — and a job can still import it. That is the failure worth
+knowing about: a refactor leaves `old_train.py` behind and a run keeps
+using it, silently.
+
+``` text
+> What's on the ml-project mount that isn't here locally any more?
+```
+
+Claude Code calls `inspect_mount`, which is read-only — it reports the
+difference without transferring or deleting anything. The result lists
+cluster-only paths, but note that it mixes two kinds of file:
+
+- **produced by jobs** — checkpoints, logs, outputs. Must not be deleted.
+- **left over locally** — stale modules, renamed files. Usually should be.
+
+srunx keeps no record of what it previously uploaded, so it cannot tell
+them apart; expect the list, not a verdict. Ask for it after a refactor,
+or before submitting a job you want to be sure is running current code.
+
+### Mirror instead
+
+To make the cluster match your machine exactly, ask for deletion:
 
 ``` text
 > Preview a mirror of the src mount on myserver, then run it
@@ -108,7 +134,7 @@ alone. To mirror instead, ask for deletion explicitly:
 
 Claude Code calls `sync_files` with `dry_run=True, delete=True` to show
 the deletions, then again to execute. A real mirror refuses without
-changing anything if it would delete more than `max_delete` files
+changing anything if it would delete more than `max_delete` entries
 (default 100).
 
 ## Use a Remote Cluster

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -1,10 +1,10 @@
 ---
-description: Complete reference for the 14 tools exposed by the srunx MCP server — submit_job, run_workflow, get_job_status, sync_files, and more.
+description: Complete reference for the 15 tools exposed by the srunx MCP server — submit_job, run_workflow, get_job_status, inspect_mount, sync_files, and more.
 ---
 
 # MCP Tool Reference
 
-Complete reference for all 14 tools exposed by the srunx MCP server.
+Complete reference for all 15 tools exposed by the srunx MCP server.
 
 The server is started with `uvx --from 'srunx[mcp]' srunx-mcp` (or the
 plain `srunx-mcp` binary after `uv tool install --with 'mcp[cli]' srunx`)
@@ -491,6 +491,60 @@ resource and environment configuration for each job.
 
 ## File Sync
 
+### inspect_mount
+
+Report what syncing a mount would change — **without changing anything**.
+
+Read-only: it never transfers, deletes, or creates anything on the cluster.
+
+Its purpose is answering a question `sync_files` cannot: **what is on the
+cluster that no longer exists locally?** Syncing is additive, so those files
+stay — including code deleted in a local refactor, which a job can still
+import and run.
+
+**Parameters:**
+
+| Name | Type | Required | Default | Description |
+|----|----|----|----|----|
+| `transport` | str | Yes |  | SSH profile name to inspect. No current-profile fallback — it must be explicit |
+| `mount` | str | Yes |  | Mount name from that SSH profile |
+| `max_paths` | int | No | `1000` | Cap on how many paths to list. Counts stay exact; past the cap the list is omitted, never shortened |
+
+**Return value:**
+
+``` json
+{
+  "success": true,
+  "profile": "myserver",
+  "mount": "ml-project",
+  "local": "/home/user/projects/ml-project",
+  "remote": "/home/researcher/projects/ml-project",
+  "files_would_transfer": 3,
+  "mirror_delete_candidates": 2,
+  "mirror_delete_candidate_paths": ["old_train.py", "checkpoints/500.pt"],
+  "mirror_delete_candidate_paths_omitted": false,
+  "effective_exclude_patterns": [".git/", "__pycache__/", "*.pyc"]
+}
+```
+
+!!! warning "The candidates mix two very different things"
+    `mirror_delete_candidate_paths` lists everything a mirror *would* remove,
+    and that set contains both:
+
+    - **produced by jobs** — checkpoints, logs, outputs. Must **not** be deleted.
+    - **left over locally** — stale modules, renamed files. Usually should be.
+
+    srunx keeps no record of what it previously uploaded, so it cannot tell them
+    apart. Treat the list as something to show a human, not as a delete list.
+
+!!! note "Read the exclude list alongside the candidates"
+    Excluded paths are invisible to this inspection *and* protected from a
+    mirror's deletions, so a path absent from the candidates may simply be
+    excluded rather than in sync.
+
+The inspection takes no sync lock: it only reads, so it does not queue behind a
+running sync. The trade is that its snapshot can be a moment stale.
+
 ### sync_files
 
 Sync a configured mount from the local machine to a remote SLURM cluster
@@ -542,9 +596,15 @@ to an arbitrary destination.
   "files_transferred": 12,
   "entries_deleted": 0,
   "deleted_paths": [],
-  "deleted_paths_omitted": false
+  "deleted_paths_omitted": false,
+  "mirror_candidates_inspected": false
 }
 ```
+
+`mirror_candidates_inspected` separates "nothing to delete" from "deletions were
+never looked for". An additive sync does not ask rsync about them at all, so
+`entries_deleted: 0` must **not** be read as "nothing is stale on the cluster" —
+that is what `inspect_mount` answers.
 
 `deleted_paths` lists every deletion. Past a very large number of
 deletions the list is omitted and `deleted_paths_omitted` is `true` —

--- a/src/srunx/mcp/tools/sync.py
+++ b/src/srunx/mcp/tools/sync.py
@@ -1,6 +1,19 @@
-"""MCP tool: rsync-based file sync between local + remote SLURM cluster.
+"""MCP tools: rsync-based file sync between local + remote SLURM cluster.
 
-This tool is reachable by an autonomous agent, which shapes three choices
+Two tools live here, split on purpose:
+
+* :func:`inspect_mount` — read-only. Reports what a sync *would* change,
+  including what exists only on the cluster.
+* :func:`sync_files` — performs the sync.
+
+They are separate rather than one tool with a flag because the inspection has
+to be described as unconditionally safe to be usable. Folding it into
+``sync_files`` meant one ``delete`` argument carrying both "show me what a
+mirror would remove" (harmless) and "remove it" (destructive), so the argument's
+documentation had to warn about data loss — and an agent reading that warning
+avoids the argument altogether, losing the safe inspection with it.
+
+The sync tool is reachable by an autonomous agent, which shapes three choices
 that differ from the CLI's:
 
 * **Mount-name only.** There is no free-form ``local_path`` / ``remote_path``
@@ -145,6 +158,144 @@ def _parse_itemized(
     return deleted, deleted_count, transferred
 
 
+def _resolve_mount(transport: str, mount: str) -> tuple[str, Any, Any]:
+    """Resolve ``(profile_name, profile, mount_config)`` for a tool call.
+
+    Raises :class:`ValueError` with a caller-facing message, which the tools
+    turn into their error payload — shared so that both the read-only inspect
+    tool and the sync tool reject the same inputs with the same wording.
+    """
+    from srunx.ssh.core.config import ConfigManager
+
+    pname = transport.strip() if transport else ""
+    if not pname or pname == "local":
+        raise ValueError(
+            "an SSH profile name is required (transport='<profile>'); "
+            "there is no local sync"
+        )
+
+    cm = ConfigManager()
+    profile = cm.get_profile(pname)
+    if not profile:
+        raise ValueError(f"SSH profile '{pname}' not found")
+
+    mount_cfg = next((m for m in profile.mounts if m.name == mount), None)
+    if not mount_cfg:
+        available = [m.name for m in profile.mounts]
+        raise ValueError(
+            f"Mount '{mount}' not found in profile '{pname}'. Available: {available}"
+        )
+    return pname, profile, mount_cfg
+
+
+@mcp.tool()
+def inspect_mount(
+    transport: str,
+    mount: str,
+    max_paths: int = _MAX_REPORTED_DELETIONS,
+) -> dict[str, Any]:
+    """Report what syncing a mount would change, without changing anything.
+
+    Read-only: this never transfers, deletes, or creates anything on the
+    cluster. Call it freely, including before a sync you are unsure about.
+
+    Its main job is answering a question ``sync_files`` cannot: **what is on the
+    cluster that no longer exists locally?** A sync is additive, so those files
+    stay — including code deleted in a local refactor, which a job on the
+    cluster can still import and run. They are listed here as
+    ``mirror_delete_candidate_paths``.
+
+    Those candidates mix two kinds of thing, and separating them is the caller's
+    judgement, not this tool's:
+
+    * **produced by jobs** — checkpoints, logs, outputs. Must NOT be deleted.
+    * **left over locally** — stale modules, renamed files. Usually should be.
+
+    srunx keeps no record of what it previously uploaded, so it genuinely cannot
+    tell which is which. Show the list to the user and let them decide rather
+    than inferring it from filenames.
+
+    Args:
+        transport: SSH profile name to inspect. Required — there is no local
+            inspection, and (unlike the CLI) no implicit current-profile
+            fallback. Call ``list_ssh_profiles`` for the available profiles and
+            the mounts each defines.
+        mount: Mount name from that SSH profile.
+        max_paths: Cap on how many paths to list. Counts stay exact regardless;
+            past the cap the list is omitted rather than shortened, and
+            ``mirror_delete_candidate_paths_omitted`` says so.
+
+    Returns:
+        ``files_would_transfer``, ``mirror_delete_candidates`` (a count),
+        ``mirror_delete_candidate_paths``, whether that list was omitted, and
+        ``effective_exclude_patterns``.
+
+        The exclude list matters for reading the result: excluded paths are
+        invisible to this inspection *and* protected from a mirror's deletions,
+        so something absent from the candidates may simply be excluded rather
+        than in sync.
+    """
+    try:
+        from srunx.sync.mount_helpers import build_rsync_client
+
+        if max_paths < 0:
+            raise ValueError(f"max_paths must be >= 0, got {max_paths}")
+
+        pname, profile, mount_cfg = _resolve_mount(transport, mount)
+        rsync = build_rsync_client(profile)
+
+        # One pass with --delete --dry-run reports both halves at once: what
+        # would transfer, and what a mirror would delete. A dry run changes
+        # nothing on the remote — not even a directory — so asking about
+        # deletions here carries no risk of performing any.
+        #
+        # No cap is passed: a cap exists to bound a real mirror's damage, and
+        # capping an inspection would replace the very list it was asked for
+        # with an error. No lock is taken either — this only reads, and making
+        # callers queue behind a running sync (or time out) to look at a
+        # snapshot is a worse trade than a snapshot that is a moment stale.
+        result = rsync.push(
+            mount_cfg.local,
+            mount_cfg.remote,
+            delete=True,
+            dry_run=True,
+            itemize=True,
+            exclude_patterns=mount_cfg.exclude_patterns,
+        )
+        if not result.success:
+            return err(
+                f"Inspection failed (exit {result.returncode}): "
+                f"{result.stderr[:500] if result.stderr else 'unknown error'}. "
+                f"If '{mount_cfg.remote}' does not exist on the cluster yet, "
+                f"there is nothing to inspect — sync once with "
+                f"sync_files(delete=False) to create it."
+            )
+
+        paths, candidates, transferred = _parse_itemized(
+            result.stdout or "", max_paths=max_paths + 1
+        )
+        omit = candidates > max_paths
+        return ok(
+            profile=pname,
+            mount=mount_cfg.name,
+            local=mount_cfg.local,
+            remote=mount_cfg.remote,
+            files_would_transfer=transferred,
+            mirror_delete_candidates=candidates,
+            mirror_delete_candidate_paths=[] if omit else paths,
+            mirror_delete_candidate_paths_omitted=omit,
+            # The merged view, not ``rsync.exclude_patterns``: per-call patterns
+            # are applied for the invocation without being stored, so the
+            # attribute omits exactly the mount-level patterns the user
+            # configured — the ones most likely to explain a missing candidate.
+            effective_exclude_patterns=rsync.effective_excludes(
+                mount_cfg.exclude_patterns
+            ),
+        )
+    except Exception as e:
+        return err(str(e))
+
+
 @mcp.tool()
 def sync_files(
     transport: str,
@@ -155,8 +306,13 @@ def sync_files(
 ) -> dict[str, Any]:
     """Sync a configured mount from this machine to a remote SLURM cluster.
 
-    Copies new and changed files only. Files that exist on the cluster but
-    not locally are left untouched unless ``delete=True``.
+    Copies new and changed files only. Files that exist on the cluster but not
+    locally are left untouched unless ``delete=True``.
+
+    That means a file deleted locally stays on the cluster, where a job can
+    still pick it up. This tool does not report those — call ``inspect_mount``
+    to see them. It is read-only, so it is safe to call before or after a sync;
+    reach for it rather than setting ``delete=True`` to find out what is stale.
 
     Args:
         transport: SSH profile name to sync against. Required and must name
@@ -208,16 +364,8 @@ def sync_files(
     """
     try:
         from srunx.common.config import get_config
-        from srunx.ssh.core.config import ConfigManager
         from srunx.sync.lock import SyncLockTimeoutError, acquire_sync_lock
         from srunx.sync.mount_helpers import build_rsync_client
-
-        pname = transport.strip() if transport else ""
-        if not pname or pname == "local":
-            return err(
-                "sync_files requires an SSH profile name (transport='<profile>'); "
-                "there is no local sync."
-            )
 
         if max_delete < 1:
             return err(
@@ -226,19 +374,7 @@ def sync_files(
                 "of capping deletions at zero."
             )
 
-        cm = ConfigManager()
-        profile = cm.get_profile(pname)
-        if not profile:
-            return err(f"SSH profile '{pname}' not found")
-
-        mount_cfg = next((m for m in profile.mounts if m.name == mount), None)
-        if not mount_cfg:
-            available = [m.name for m in profile.mounts]
-            return err(
-                f"Mount '{mount}' not found in profile '{pname}'. "
-                f"Available: {available}"
-            )
-
+        pname, profile, mount_cfg = _resolve_mount(transport, mount)
         rsync = build_rsync_client(profile)
         timeout = get_config().sync.lock_timeout_seconds
 
@@ -365,6 +501,11 @@ def sync_files(
             entries_deleted=deleted_count,
             deleted_paths=[] if omit_paths else deleted_paths,
             deleted_paths_omitted=omit_paths,
+            # Distinguishes "nothing to delete" from "deletions were never
+            # looked for". An additive sync does not ask rsync about them at
+            # all, so entries_deleted=0 must not be read as "nothing is stale
+            # on the cluster" — that question is what inspect_mount answers.
+            mirror_candidates_inspected=delete,
         )
 
     except Exception as e:

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -866,6 +866,24 @@ class RsyncClient:
             f"(exit {result.returncode}): {result.stderr.strip()}"
         )
 
+    def effective_excludes(
+        self, exclude_patterns: Sequence[str] | None = None
+    ) -> list[str]:
+        """Return the patterns a call passing *exclude_patterns* would filter on.
+
+        ``push`` / ``pull`` merge per-call patterns on top of the instance's for
+        that invocation only, without storing them, so
+        :attr:`exclude_patterns` alone under-reports what a given call actually
+        filtered on — it omits exactly the mount-level patterns a user
+        configured.
+
+        That matters wherever the filter is reported back to a user: an excluded
+        path is invisible to an inspection *and* protected from a mirror's
+        deletions, so a missing pattern makes the report read as "in sync" when
+        it really means "never looked at".
+        """
+        return list(self._merge_excludes(exclude_patterns))
+
     def _merge_excludes(self, extra: Sequence[str] | None) -> list[str]:
         """Merge per-call exclude patterns with instance patterns."""
         if not extra:

--- a/tests/mcp/tools/test_sync.py
+++ b/tests/mcp/tools/test_sync.py
@@ -1,20 +1,26 @@
 """Tests for srunx.mcp.tools.sync.
 
-``sync_files`` takes ``transport`` (an SSH profile name — there is no
-local-to-local sync and no implicit current-profile fallback) plus ``mount``,
-which is now the *only* way to name what gets synced: the former free-form
-``local_path`` / ``remote_path`` pair was removed so an agent cannot push an
-arbitrary source to an arbitrary destination.
+Both tools take ``transport`` (an SSH profile name — there is no local-to-local
+sync and no implicit current-profile fallback) plus ``mount``, which is the
+*only* way to name what is synced: the former free-form ``local_path`` /
+``remote_path`` pair was removed so an agent cannot push an arbitrary source to
+an arbitrary destination.
 
-The remaining safety properties covered here: deletion is opt-in and capped,
-itemize is always requested so the response can report exactly what moved,
-and the per-mount sync lock is held across the transfer.
+Properties covered: deletion is opt-in and capped, itemize is always requested
+so the response can report exactly what moved, the per-mount sync lock is held
+across a transfer — and ``inspect_mount`` reports cluster-only files while
+holding no lock and changing nothing.
 """
 
 import inspect
 from unittest.mock import MagicMock, patch
 
-from srunx.mcp.tools.sync import DEFAULT_MAX_DELETE, _parse_itemized, sync_files
+from srunx.mcp.tools.sync import (
+    DEFAULT_MAX_DELETE,
+    _parse_itemized,
+    inspect_mount,
+    sync_files,
+)
 
 
 def _profile_with_mount(
@@ -36,7 +42,10 @@ def _profile_with_mount(
 
 
 def _rsync_returning(
-    stdout: str = "", returncode: int = 0, stderr: str = ""
+    stdout: str = "",
+    returncode: int = 0,
+    stderr: str = "",
+    exclude_patterns: list[str] | None = None,
 ) -> MagicMock:
     rsync = MagicMock()
     rsync.push.return_value = MagicMock(
@@ -44,6 +53,9 @@ def _rsync_returning(
         returncode=returncode,
         stdout=stdout,
         stderr=stderr,
+    )
+    rsync.exclude_patterns = (
+        exclude_patterns if exclude_patterns is not None else [".git/"]
     )
     return rsync
 
@@ -556,3 +568,157 @@ class TestSyncFilesTransfer:
         assert result["success"] is False
         assert "sync lock" in result["error"]
         rsync.push.assert_not_called()
+
+
+@patch("srunx.sync.mount_helpers.build_rsync_client")
+@patch("srunx.ssh.core.config.ConfigManager")
+class TestInspectMount:
+    """The read-only counterpart to ``sync_files``.
+
+    It exists because an additive sync leaves cluster-only files in place, and
+    ``sync_files`` cannot report them: with ``delete=False`` rsync is never asked
+    about deletions, so its result says nothing about what is stale. Asking via
+    ``delete=True`` is a preview and harmless, but the ``delete`` argument has to
+    be documented as destructive — so an agent reading that avoids it, and the
+    safe inspection with it. Hence a separate tool.
+    """
+
+    def test_is_read_only(self, mock_cm_cls, mock_build):
+        """A dry run with --delete: reports deletions, performs none."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount(exclude_patterns=["*.log"])
+        mock_cm_cls.return_value = cm
+        mock_build.return_value = _rsync_returning("*deleting stale.py\n")
+
+        result = inspect_mount(transport="prod", mount="ml")
+
+        assert result["success"] is True
+        kwargs = mock_build.return_value.push.call_args.kwargs
+        assert kwargs["dry_run"] is True
+        assert kwargs["delete"] is True  # asks about deletions...
+        assert kwargs["itemize"] is True
+        # ...and passes no cap: a cap bounds a real mirror's damage, and capping
+        # an inspection would replace the requested list with an error.
+        assert "max_delete" not in kwargs or kwargs["max_delete"] is None
+        assert kwargs["exclude_patterns"] == ["*.log"]
+
+    def test_reports_cluster_only_paths(self, mock_cm_cls, mock_build):
+        """The answer to "what did I delete locally that is still up there?"."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        mock_build.return_value = _rsync_returning(
+            "*deleting old_train.py\n*deleting ckpt/500.pt\n>f+++++++ train.py\n"
+        )
+
+        result = inspect_mount(transport="prod", mount="ml")
+
+        assert result["mirror_delete_candidates"] == 2
+        assert result["mirror_delete_candidate_paths"] == [
+            "old_train.py",
+            "ckpt/500.pt",
+        ]
+        assert result["mirror_delete_candidate_paths_omitted"] is False
+        assert result["files_would_transfer"] == 1
+
+    def test_reports_effective_excludes(self, mock_cm_cls, mock_build):
+        """Excluded paths are invisible here *and* safe from a mirror.
+
+        Without the list, an absent candidate is ambiguous: in sync, or merely
+        excluded?
+        """
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning()
+        rsync.effective_excludes.return_value = [".git/", "*.pyc", "data/"]
+        mock_build.return_value = rsync
+
+        result = inspect_mount(transport="prod", mount="ml")
+        assert result["effective_exclude_patterns"] == [".git/", "*.pyc", "data/"]
+
+    def test_effective_excludes_include_the_mount_patterns(
+        self, mock_cm_cls, mock_build
+    ):
+        """The merged view, not the client attribute.
+
+        Per-call patterns are applied for the invocation without being stored,
+        so ``rsync.exclude_patterns`` omits exactly the mount-level patterns the
+        user configured — the ones most likely to explain a missing candidate.
+        Reporting those would make an excluded path read as "in sync".
+        """
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount(
+            exclude_patterns=["data/raw/", "*.h5"]
+        )
+        mock_cm_cls.return_value = cm
+        rsync = _rsync_returning()
+        mock_build.return_value = rsync
+
+        inspect_mount(transport="prod", mount="ml")
+
+        rsync.effective_excludes.assert_called_once_with(["data/raw/", "*.h5"])
+
+    def test_takes_no_lock(self, mock_cm_cls, mock_build):
+        """Reading should not queue behind a running sync, or time out on one."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        mock_build.return_value = _rsync_returning()
+
+        with patch("srunx.sync.lock.acquire_sync_lock") as mock_lock:
+            result = inspect_mount(transport="prod", mount="ml")
+
+        assert result["success"] is True
+        mock_lock.assert_not_called()
+
+    def test_large_candidate_list_is_omitted_not_shortened(
+        self, mock_cm_cls, mock_build
+    ):
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        stdout = "".join(f"*deleting f{i}.pt\n" for i in range(50))
+        mock_build.return_value = _rsync_returning(stdout)
+
+        result = inspect_mount(transport="prod", mount="ml", max_paths=10)
+
+        assert result["mirror_delete_candidates"] == 50  # exact
+        assert result["mirror_delete_candidate_paths"] == []
+        assert result["mirror_delete_candidate_paths_omitted"] is True
+
+    def test_negative_max_paths_rejected(self, mock_cm_cls, mock_build):
+        mock_cm_cls.return_value = MagicMock()
+        result = inspect_mount(transport="prod", mount="ml", max_paths=-1)
+        assert result["success"] is False
+        assert "max_paths" in result["error"]
+
+    def test_missing_destination_explains_itself(self, mock_cm_cls, mock_build):
+        """rsync cannot diff against a destination that does not exist yet."""
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+        mock_build.return_value = _rsync_returning(
+            returncode=23, stderr="No such file or directory"
+        )
+
+        result = inspect_mount(transport="prod", mount="ml")
+
+        assert result["success"] is False
+        assert "nothing to inspect" in result["error"]
+        assert "delete=False" in result["error"]
+
+    def test_rejects_local_transport(self, mock_cm_cls, mock_build):
+        result = inspect_mount(transport="local", mount="ml")
+        assert result["success"] is False
+        assert "SSH profile" in result["error"]
+
+    def test_unknown_mount_lists_available(self, mock_cm_cls, mock_build):
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount(name="data")
+        mock_cm_cls.return_value = cm
+
+        result = inspect_mount(transport="prod", mount="nope")
+        assert result["success"] is False
+        assert "nope" in result["error"]
+        assert "data" in result["error"]

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -1327,3 +1327,55 @@ class TestControlFileExcluded:
         # An --exclude'd path is also protected from deletion.
         idx = cmd.index("/.srunx-owner.json")
         assert cmd[idx - 1] == "--exclude"
+
+
+class TestEffectiveExcludes:
+    """The merged view of what a call would actually filter on.
+
+    ``push``/``pull`` apply per-call patterns for the invocation without
+    storing them, so the instance attribute alone omits exactly the mount-level
+    patterns a user configured. Anything reporting the filter back to a user
+    needs the merge, since an excluded path is invisible to an inspection *and*
+    protected from a mirror's deletions.
+    """
+
+    def test_merges_per_call_patterns(self):
+        client = _make_rsync_client(hostname="h", username="u")
+        merged = client.effective_excludes(["data/raw/", "*.h5"])
+
+        assert "data/raw/" in merged
+        assert "*.h5" in merged
+        # Defaults are still there.
+        assert ".git/" in merged
+        # And the instance attribute is left alone.
+        assert "data/raw/" not in client.exclude_patterns
+
+    def test_no_extra_returns_the_instance_patterns(self):
+        client = _make_rsync_client(hostname="h", username="u")
+        assert client.effective_excludes() == client.exclude_patterns
+        assert client.effective_excludes(None) == client.exclude_patterns
+
+    def test_does_not_duplicate(self):
+        client = _make_rsync_client(hostname="h", username="u")
+        merged = client.effective_excludes([".git/", "data/"])
+        assert merged.count(".git/") == 1
+
+    def test_returns_a_copy(self):
+        """Mutating the result must not corrupt the client's own list."""
+        client = _make_rsync_client(hostname="h", username="u")
+        merged = client.effective_excludes()
+        merged.append("injected/")
+        assert "injected/" not in client.exclude_patterns
+
+    def test_matches_what_push_actually_passes(self):
+        """The reported merge must equal the flags rsync receives."""
+        client = _make_rsync_client(hostname="h", username="u")
+        extra = ["data/raw/", "*.h5"]
+
+        with patch("srunx.sync.rsync.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.push("/tmp", "~/d/", exclude_patterns=extra)
+
+        cmd = mock_run.call_args[0][0]
+        passed = [cmd[i + 1] for i, a in enumerate(cmd) if a == "--exclude"]
+        assert passed == client.effective_excludes(extra)


### PR DESCRIPTION
Closes the gap #231 opened. Making syncing additive stopped it silently deleting cluster-only files — and created the opposite problem.

## The problem

A file deleted locally now **stays on the cluster**, where a job can still import it. Delete `old_train.py` in a refactor and a run may keep using it, with nothing to suggest anything is wrong.

Nothing surfaced that. `sync_files` with `delete=False` never asks rsync about deletions, so its result says nothing about what is stale. Asking via `delete=True` is a harmless preview, but that argument has to be documented as destructive — so an agent reading the data-loss warning avoids it, **and the safe inspection with it**.

## `inspect_mount`

Read-only. One `--delete --dry-run --itemize` pass reports both what would transfer and what a mirror would remove; a dry run changes nothing on the remote, so asking about deletions carries no risk of performing any.

```json
{
  "files_would_transfer": 3,
  "mirror_delete_candidates": 2,
  "mirror_delete_candidate_paths": ["old_train.py", "checkpoints/500.pt"],
  "mirror_delete_candidate_paths_omitted": false,
  "effective_exclude_patterns": [".git/", "__pycache__/", "*.pyc"]
}
```

### Why a separate tool, not a flag

An inspection has to be documented as **unconditionally safe** to be usable by an agent. Folded into `sync_files`, one `delete` argument would carry both "show me what a mirror would remove" (harmless) and "remove it" (destructive), so its documentation must warn about data loss — and that warning is exactly what makes an agent avoid the argument. Separating them is what lets the docstring say "read-only" without qualification.

### It reports; it does not decide

The candidates mix two kinds of thing:

- **produced by jobs** — checkpoints, logs, outputs. Must **not** be deleted.
- **left over locally** — stale modules, renamed files. Usually should be.

srunx keeps no record of what it previously uploaded, so it genuinely cannot tell them apart. Verified against real rsync — one stale module and three job artifacts land in the same list:

```
mirror_delete_candidates = 4
  - ckpt/500.pt      ← job output
  - ckpt/            ← job output
  - run.log          ← job output
  - old_train.py     ← stale code
```

Both the docstring and the docs say so, rather than inviting a guess from filenames.

## Also

- **`sync_files` returns `mirror_candidates_inspected`**, separating "nothing to delete" from "deletions were never looked for". An additive sync does not ask rsync about them at all, so `entries_deleted: 0` must not read as "nothing is stale on the cluster".
- **`RsyncClient.effective_excludes()`** returns the merged per-call exclude view. `push`/`pull` apply per-call patterns for the invocation *without storing them*, so `exclude_patterns` alone omits exactly the mount-level patterns a user configured — the ones most likely to explain a missing candidate. Reporting those would make an excluded path read as "in sync" when it means "never looked at". A test pins the reported merge to the flags rsync actually receives.
- **No sync lock is taken.** The inspection only reads, and making callers queue behind a running sync — or time out on one — to look at a snapshot is a worse trade than a snapshot that is a moment stale.

Why the exclude list is in the response at all: excluded paths are invisible to the inspection **and** protected from a mirror's deletions, so a path absent from the candidates may simply be excluded rather than in sync. Without the list that ambiguity is unresolvable.

## Testing

`2322 passed, 2 skipped`; mypy clean across 371 files; ruff clean.

The MCP server was loaded to confirm it registers 15 tools including the new one. Beyond unit tests, the core behaviour was exercised against real rsync with a mount holding both stale code and job artifacts — confirming both that the candidates are found and that the remote is unchanged afterwards.

## Not addressed

Telling job output apart from stale code needs a manifest of what srunx previously uploaded: "I sent this, and it is no longer here locally" is the only signal that separates the two. That is a substantially larger change, and it wants the configured-mount push paths unified first, so it is left for a follow-up. Until then this tool reports and the user decides.

## Review

`codex exec review` — one finding, accepted: the reported exclude list omitted mount-level patterns, which is what `effective_excludes()` above fixes. Clean on re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBKedWVkVba5Zfpp8KmZMR
