### PR TITLE
feat(sync): record uploads so stale code can be told from job output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,39 @@ because an inspection has to be documented as unconditionally safe: folding it
 into `sync_files` meant one `delete` argument carrying both "show me what a
 mirror would remove" (harmless) and "remove it" (destructive), and an agent
 reading the data-loss warning avoids the argument entirely — losing the safe
-inspection with it. srunx keeps no manifest of what it uploaded, so
-`inspect_mount` cannot separate job outputs from stale code; it reports, the
-human decides.
+inspection with it.
+
+`inspect_mount` narrows the raw candidates using a **manifest** — a record of
+what srunx uploaded, kept at `<mount.remote>/.srunx-manifest.json` (mode 0600;
+paths stored in rsync's escaped form so they compare against a deletion
+preview). A path that is in the record but no longer local is stale code;
+output a job wrote at a path of its own was never uploaded, so it is not in the
+record and cannot be reported, which holds even when the mount's excludes miss
+an output directory. That is the whole point: excludes separate the two only as
+well as they are maintained, and a real mount here had four stale scripts
+buried among 39 artifacts because `dist/` was missing from them.
+
+Only path names are recorded, not contents, so a path that is *both* recorded
+and job-written stays ambiguous — a job that overwrote a file srunx sent keeps
+its path, and a file deleted in the gap between srunx's inventory and rsync's
+own walk is recorded without having been sent. Proving otherwise needs a
+content hash per file on every sync, which is out of scope; the report is for a
+human to read, and srunx never deletes on its own.
+
+The set recorded is the inventory taken **before** the transfer, not after.
+Scanning afterwards is wrong in both directions: a file created mid-sync would
+be recorded though rsync never sent it (and could then name a job's output for
+deletion), while a file deleted mid-sync would be dropped though rsync did send
+it — leaving it on the cluster, permanently unrecordable, with the report still
+calling itself complete.
+
+The record fails **closed**: no record yet, an unreadable one, or a changed
+exclude filter all report `stale_uploads_known: false` rather than an empty
+list, because "cannot tell" presented as "clean" is how a stale module keeps
+running unnoticed. Written only after a successful sync (and after hash
+verification, like the owner marker), accumulating on an additive sync and
+replaced by a mirror. See `src/srunx/sync/manifest.py`, whose module docstring
+also records the gaps left open on purpose.
 
 ##### Account secrets (`ssh secret`)
 Secrets (API keys etc.) are stored in a single **remote** `0600` file per

--- a/docs/how-to/mcp-usage.md
+++ b/docs/how-to/mcp-usage.md
@@ -114,15 +114,40 @@ using it, silently.
 ```
 
 Claude Code calls `inspect_mount`, which is read-only — it reports the
-difference without transferring or deleting anything. The result lists
-cluster-only paths, but note that it mixes two kinds of file:
+difference without transferring or deleting anything. The raw list of
+cluster-only paths mixes two kinds of file:
 
 - **produced by jobs** — checkpoints, logs, outputs. Must not be deleted.
 - **left over locally** — stale modules, renamed files. Usually should be.
 
-srunx keeps no record of what it previously uploaded, so it cannot tell
-them apart; expect the list, not a verdict. Ask for it after a refactor,
-or before submitting a job you want to be sure is running current code.
+srunx records what it uploads, so it can separate them: `stale_upload_paths`
+holds only files srunx put there that are no longer on your machine. Output a
+job wrote at a path of its own was never uploaded, so it does not appear —
+**even if the mount's excludes miss an output directory**. In one real mount
+that mattered: four stale scripts were buried among 39 job artifacts because
+`dist/` had never been excluded.
+
+The record stores path names, not contents, so one case stays ambiguous: a
+job that *overwrote* a file srunx uploaded keeps the same path, and what is
+on the cluster now may be the job's version. Excluding output directories
+avoids it — and the list is there to be reviewed, not deleted unread.
+
+Ask for it after a refactor, or before submitting a job you want to be
+sure is running current code.
+
+!!! warning "Watch for "cannot tell""
+    If nothing has been synced since tracking was added, the record is
+    unreadable, or the mount's exclude patterns changed, the answer is
+    **unknown** rather than "nothing is stale". Deleting is still your call
+    — srunx reports, it does not act.
+
+    Syncing once fixes the usual cases, including a sync that failed to
+    record: that failure keeps the last good list, and the next sync builds
+    on it. The exception is a record that is damaged or was written by
+    another account, which has nothing to build on. Delete
+    `.srunx-manifest.json` at the top of the mount on the cluster and sync
+    again — files uploaded before that point stop being tracked, so the
+    answer under-reports rather than risking a job's output.
 
 ### Mirror instead
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -523,6 +523,11 @@ import and run.
   "mirror_delete_candidates": 2,
   "mirror_delete_candidate_paths": ["old_train.py", "checkpoints/500.pt"],
   "mirror_delete_candidate_paths_omitted": false,
+  "stale_uploads_known": true,
+  "stale_uploads": 1,
+  "stale_upload_paths": ["old_train.py"],
+  "stale_upload_paths_omitted": false,
+  "stale_uploads_unknown_reason": "",
   "effective_exclude_patterns": [".git/", "__pycache__/", "*.pyc"]
 }
 ```
@@ -534,8 +539,34 @@ import and run.
     - **produced by jobs** — checkpoints, logs, outputs. Must **not** be deleted.
     - **left over locally** — stale modules, renamed files. Usually should be.
 
-    srunx keeps no record of what it previously uploaded, so it cannot tell them
-    apart. Treat the list as something to show a human, not as a delete list.
+    Treat that raw list as something to show a human, not as a delete list.
+
+!!! tip "`stale_upload_paths` is the actionable subset"
+    srunx records what it uploads, at `<mount.remote>/.srunx-manifest.json`. A
+    path in that record that is no longer present locally is stale code; output
+    a job wrote at a path of its own was never uploaded, so it cannot appear —
+    which holds **even when the mount's excludes miss an output directory**,
+    the case that otherwise buries a few stale scripts among dozens of
+    artifacts.
+
+    Two cases it cannot tell apart, both about a path that is *both* uploaded
+    and job-written:
+
+    - A job **overwrote** a file srunx uploaded (or recreated it at the same
+      path). The record stores path names, not content, so what is on the
+      cluster now may be the job's version rather than the one srunx sent.
+    - Output **pulled** into the local tree with `srunx ssh sync --pull`
+      becomes a file the next push manages, so it is recorded like any other.
+
+    Excluding the output directories avoids both, and is worth doing anyway.
+    Keep reviewing the list rather than deleting it unread — srunx reports,
+    it does not act.
+
+!!! danger "Check `stale_uploads_known` first"
+    When it is `false`, `stale_uploads: 0` means **"could not tell"**, not
+    "nothing is stale" — `stale_uploads_unknown_reason` says which of: nothing
+    recorded yet, an unreadable or foreign-owned record, or a changed exclude
+    filter. Fall back to reading the raw candidate list yourself in that case.
 
 !!! note "Read the exclude list alongside the candidates"
     Excluded paths are invisible to this inspection *and* protected from a

--- a/src/srunx/cli/_helpers/sbatch_helpers.py
+++ b/src/srunx/cli/_helpers/sbatch_helpers.py
@@ -433,8 +433,12 @@ def _print_in_place_sync_preview(
     if not output.strip():
         console.print("    (no changes — remote already up to date)")
         return
+    # Itemize output escapes anything it will not print, so a non-ASCII name
+    # arrives as ``\#343\#203...``. Show the filename the user recognises.
+    from srunx.sync.rsync import unescape_rsync_path
+
     for line in output.splitlines():
-        console.print(f"    {line}")
+        console.print(f"    {unescape_rsync_path(line)}")
 
 
 def _parse_env_vars(env_var_list: list[str] | None) -> dict[str, str]:

--- a/src/srunx/mcp/tools/sync.py
+++ b/src/srunx/mcp/tools/sync.py
@@ -35,10 +35,12 @@ from __future__ import annotations
 
 import io
 import re
+from dataclasses import replace
 from typing import Any
 
 from srunx.mcp.app import mcp
 from srunx.mcp.helpers import err, ok
+from srunx.sync.rsync import unescape_rsync_path
 
 # rsync's ``--itemize-changes`` marks a removal with the literal pseudo-flag
 # ``*deleting``; every other itemize line starts with a flag block whose first
@@ -81,6 +83,11 @@ _MAX_REPORTED_DELETIONS = 1000
 
 # rsync exits 25 (RERR_DEL_LIMIT) when --max-delete is exceeded.
 _RERR_DEL_LIMIT = 25
+
+
+def _display(paths: list[str]) -> list[str]:
+    """Escaped rsync paths → the names as they exist on disk, for reporting."""
+    return [unescape_rsync_path(p) for p in paths]
 
 
 def _parse_itemized(
@@ -188,6 +195,64 @@ def _resolve_mount(transport: str, mount: str) -> tuple[str, Any, Any]:
     return pname, profile, mount_cfg
 
 
+def _candidates_among(stdout: str, wanted: set[str]) -> set[str]:
+    """Return which of *wanted* appear as deletion candidates in *stdout*.
+
+    Retains only members of *wanted* — a set the caller already holds — instead
+    of materialising every candidate path. Parsing the full list to intersect
+    afterwards would allocate a string per deletable file on a mount with many
+    artifacts, which is the unbounded retention the parser's ``max_paths``
+    exists to avoid.
+    """
+    if not wanted:
+        return set()
+    found: set[str] = set()
+    for line in io.StringIO(stdout):
+        match = _DELETING_RE.match(line.rstrip("\r\n"))
+        if not match:
+            continue
+        raw = match.group(1) or ""
+        path = raw.lstrip() or raw
+        if path in wanted:
+            found.add(path)
+    return found
+
+
+def _stale_report(rsync: Any, mount_cfg: Any) -> Any:
+    """Compare srunx's upload record against the current local tree.
+
+    Never raises: an inspection that fails wholesale because tracking is
+    unavailable would be worse than one that reports the parts it does know.
+    Any failure becomes an "unknown" report carrying the reason, which the
+    caller must not read as "nothing is stale".
+    """
+    from srunx.sync import manifest as manifest_mod
+
+    try:
+        recorded = manifest_mod.read(rsync, mount_cfg)
+    except manifest_mod.ManifestUnavailable as exc:
+        return manifest_mod.StaleReport(known=False, reason=str(exc))
+    except Exception as exc:  # noqa: BLE001 — inspection degrades, never fails
+        return manifest_mod.StaleReport(
+            known=False, reason=f"could not read the upload record: {exc}"
+        )
+
+    try:
+        current = manifest_mod.local_inventory(
+            rsync, mount_cfg.local, exclude_patterns=mount_cfg.exclude_patterns or None
+        )
+    except Exception as exc:  # noqa: BLE001
+        return manifest_mod.StaleReport(
+            known=False, reason=f"could not list the local tree: {exc}"
+        )
+
+    return manifest_mod.find_stale(
+        recorded,
+        current,
+        rsync.effective_excludes(mount_cfg.exclude_patterns or None),
+    )
+
+
 @mcp.tool()
 def inspect_mount(
     transport: str,
@@ -205,15 +270,27 @@ def inspect_mount(
     cluster can still import and run. They are listed here as
     ``mirror_delete_candidate_paths``.
 
-    Those candidates mix two kinds of thing, and separating them is the caller's
-    judgement, not this tool's:
+    Those candidates mix two kinds of thing:
 
     * **produced by jobs** — checkpoints, logs, outputs. Must NOT be deleted.
     * **left over locally** — stale modules, renamed files. Usually should be.
 
-    srunx keeps no record of what it previously uploaded, so it genuinely cannot
-    tell which is which. Show the list to the user and let them decide rather
-    than inferring it from filenames.
+    ``stale_upload_paths`` is the second group on its own: paths srunx recorded
+    uploading that are no longer present locally. Job output was never uploaded,
+    so it does not appear there — which holds even when the mount's exclude list
+    misses an output directory, the case that otherwise buries a few stale
+    scripts among dozens of artifacts.
+
+    One exception: output pulled into the local tree with ``srunx ssh sync
+    --pull`` becomes a file the next push manages, so it is recorded like any
+    other and can be reported as stale once its local copy is removed. Excluding
+    the output directories on the mount avoids that, and is worth doing anyway.
+
+    **Check ``stale_uploads_known`` first.** When it is false the record could
+    not answer (nothing uploaded with tracking yet, an unreadable record, or a
+    changed exclude filter), and ``stale_uploads: 0`` means "could not tell",
+    not "nothing is stale" — ``stale_uploads_unknown_reason`` says which. Fall
+    back to reading the full candidate list yourself in that case.
 
     Args:
         transport: SSH profile name to inspect. Required — there is no local
@@ -227,8 +304,10 @@ def inspect_mount(
 
     Returns:
         ``files_would_transfer``, ``mirror_delete_candidates`` (a count),
-        ``mirror_delete_candidate_paths``, whether that list was omitted, and
-        ``effective_exclude_patterns``.
+        ``mirror_delete_candidate_paths``, whether that list was omitted,
+        ``effective_exclude_patterns``, and the stale-upload fields described
+        above (``stale_uploads_known`` / ``stale_uploads`` /
+        ``stale_upload_paths`` / ``stale_uploads_unknown_reason``).
 
         The exclude list matters for reading the result: excluded paths are
         invisible to this inspection *and* protected from a mirror's deletions,
@@ -275,6 +354,26 @@ def inspect_mount(
             result.stdout or "", max_paths=max_paths + 1
         )
         omit = candidates > max_paths
+
+        # Narrow the candidates to what srunx itself uploaded and is now gone
+        # locally. That is the actionable subset: everything else on the cluster
+        # was produced there, and no exclude list has to be complete for this to
+        # hold. Reported separately rather than filtered in, so the caller still
+        # sees the full picture.
+        stale = _stale_report(rsync, mount_cfg)
+        if stale.known and stale.paths:
+            # Intersect with what rsync says is actually still there. The record
+            # says what was uploaded, not what survived: a manual cleanup, or a
+            # mirror whose recording failed, leaves entries naming files that no
+            # longer exist. Reporting those contradicts the documented promise
+            # that this is a subset of the deletion candidates.
+            #
+            # Scanned against the recorded set rather than by collecting every
+            # candidate first, so the retained data stays bounded by the record
+            # instead of by how much output the cluster holds.
+            on_remote = _candidates_among(result.stdout or "", set(stale.paths))
+            stale = replace(stale, paths=[p for p in stale.paths if p in on_remote])
+
         return ok(
             profile=pname,
             mount=mount_cfg.name,
@@ -282,8 +381,20 @@ def inspect_mount(
             remote=mount_cfg.remote,
             files_would_transfer=transferred,
             mirror_delete_candidates=candidates,
-            mirror_delete_candidate_paths=[] if omit else paths,
+            # Unescaped only here, at the boundary. Paths are matched in
+            # rsync's escaped form — that is what makes an inventory entry and
+            # a deletion candidate the same string — but a caller acting on
+            # this list needs the name as it exists on disk.
+            mirror_delete_candidate_paths=[] if omit else _display(paths),
             mirror_delete_candidate_paths_omitted=omit,
+            stale_uploads_known=stale.known,
+            stale_uploads=stale.count,
+            # Omitted wholesale past the cap, matching the mirror-candidate
+            # contract. Returning a silently shortened list would let a caller
+            # present it as the complete set.
+            stale_upload_paths=[] if stale.count > max_paths else _display(stale.paths),
+            stale_upload_paths_omitted=stale.count > max_paths,
+            stale_uploads_unknown_reason=stale.reason,
             # The merged view, not ``rsync.exclude_patterns``: per-call patterns
             # are applied for the invocation without being stored, so the
             # attribute omits exactly the mount-level patterns the user
@@ -449,6 +560,12 @@ def sync_files(
                             f"deletions are expected."
                         )
 
+                from srunx.sync.mount_helpers import record_upload, snapshot_local
+
+                before = (
+                    None if dry_run else snapshot_local(rsync, mount_cfg)
+                )  # paired with record_upload below
+
                 result = rsync.push(
                     mount_cfg.local,
                     mount_cfg.remote,
@@ -464,6 +581,13 @@ def sync_files(
                     max_delete=max_delete if (delete and not dry_run) else None,
                     exclude_patterns=mount_cfg.exclude_patterns,
                 )
+
+                if result.success and not dry_run:
+                    # Inside the lock, deliberately. Recording after releasing it
+                    # lets an overlapping sync finish its push and then have its
+                    # record overwritten by this one's older path set, leaving
+                    # the manifest describing neither tree.
+                    record_upload(rsync, mount_cfg, mirrored=delete, before=before)
         except SyncLockTimeoutError as exc:
             return err(str(exc))
 
@@ -499,7 +623,7 @@ def sync_files(
             # Named "entries" because rsync emits (and caps) one deletion per
             # filesystem entry, directories included.
             entries_deleted=deleted_count,
-            deleted_paths=[] if omit_paths else deleted_paths,
+            deleted_paths=[] if omit_paths else _display(deleted_paths),
             deleted_paths_omitted=omit_paths,
             # Distinguishes "nothing to delete" from "deletions were never
             # looked for". An additive sync does not ask rsync about them at

--- a/src/srunx/ssh/cli/commands.py
+++ b/src/srunx/ssh/cli/commands.py
@@ -261,6 +261,7 @@ def sync_mount(
     from srunx.common.config import get_config
     from srunx.ssh.core.config import MountConfig
     from srunx.sync.lock import acquire_sync_lock
+    from srunx.sync.mount_helpers import record_upload, snapshot_local
     from srunx.sync.rsync import RsyncClient
 
     try:
@@ -378,6 +379,9 @@ def sync_mount(
                     itemize=dry_run,
                 )
             else:
+                before = (
+                    None if dry_run else snapshot_local(rsync, resolved_mount)
+                )  # paired with record_upload below
                 result = rsync.push(
                     resolved_mount.local,
                     resolved_mount.remote,
@@ -386,9 +390,24 @@ def sync_mount(
                     itemize=dry_run,
                 )
 
+            # Recorded inside the lock: releasing it first would let an
+            # overlapping sync finish its push and then have its record
+            # overwritten by this one's older path set. Push only — a pull does
+            # not change what srunx put on the cluster.
+            if result.returncode == 0 and not dry_run and not pull:
+                record_upload(rsync, resolved_mount, mirrored=delete, before=before)
+
         if result.returncode == 0:
             if dry_run:
-                console.print(result.stdout or "[dim]No changes needed[/dim]")
+                # Itemize escapes anything it will not print; show the real
+                # filename rather than ``\#343\#203...``.
+                from srunx.sync.rsync import unescape_rsync_path
+
+                console.print(
+                    unescape_rsync_path(result.stdout)
+                    if result.stdout
+                    else "[dim]No changes needed[/dim]"
+                )
             console.print(f"\n[green]Sync complete: {resolved_mount.name}[/green]")
         else:
             console.print(f"[red]rsync failed (exit code {result.returncode}):[/red]")

--- a/src/srunx/sync/manifest.py
+++ b/src/srunx/sync/manifest.py
@@ -1,0 +1,573 @@
+"""Record of what srunx last uploaded to a mount, for stale-file detection.
+
+Syncing is additive (see :mod:`srunx.sync.mount_helpers`), so a file deleted
+locally stays on the cluster — where a job can still import it. Listing what
+exists only on the remote is not enough to act on, because that set mixes two
+opposite things:
+
+* files a **job produced** — checkpoints, logs, outputs. Must not be deleted.
+* files **deleted locally** — stale modules, renamed files. Usually should be.
+
+Excluding output directories separates them only as well as the exclude list is
+maintained, and a missed pattern silently buries the second group in the first:
+in one real mount, four stale scripts sat among 39 job artifacts because
+``dist/`` had never been excluded.
+
+A manifest removes the guesswork. srunx records the paths it uploaded, so
+"present in the manifest but no longer local" identifies stale files regardless
+of the exclude list — output a job wrote at a path of its own was never
+uploaded, so it is simply not in the record.
+
+Design notes
+------------
+
+**The manifest lives on the remote**, at
+``<mount.remote>/.srunx-manifest.json``, not in the local database. A single
+file rather than a file inside a ``.srunx/`` directory, because creating that
+directory would follow a symlink planted in its place. It describes the state
+of the remote tree, so it
+belongs with it: it survives a workstation being rebuilt, and every machine
+syncing that mount reads the same record instead of each keeping a private
+guess.
+
+**It is separate from the owner marker** even though both are small JSON files
+at the mount root. The marker is deliberately fail-open — an unreadable one
+means "no owner recorded", and syncing proceeds. A manifest must fail *closed*:
+if it cannot be read, srunx must report that it does not know rather than
+report an empty set of stale files, which would read as "everything is clean".
+
+**Paths are stored in rsync's escaped form** (``\\#012`` for a newline, and so
+on), because they exist to be compared against a deletion preview, which is
+printed that way. The escaping is also what makes the inventory parseable at
+all: unescaped, a newline inside a filename splits one file across two lines,
+and a name crafted to look like a listing line yields paths that do not exist.
+:func:`~srunx.sync.rsync.unescape_rsync_path` converts back for display.
+
+**Only paths are recorded.** That is enough to *detect* staleness, which is all
+this layer does. Deciding to delete would need more (at minimum a content hash,
+to prove the remote copy is still the one srunx uploaded and not something a
+job rewrote), and that decision is deliberately left to a human here.
+
+**The exclude set is fingerprinted.** Excluded files are never uploaded, so they
+are never in the manifest; if the exclude list changes, paths can leave the
+manifest for a reason that has nothing to do with being stale. When the
+fingerprint differs from the recorded one, detection reports "unknown" rather
+than presenting those paths as stale — the safe direction, since the cost of
+missing a stale file is a warning that does not appear, while the cost of a
+false positive is a user deleting something a job needs.
+
+Known gap: pulled job output
+----------------------------
+
+The record is built from what a push *manages* — the local tree after filtering,
+scanned on both sides of the transfer and narrowed to what both scans saw — not
+from bytes rsync moved, because an unchanged file transfers nothing yet is still
+srunx's to track. That makes one case wrong: ``srunx ssh sync --pull``
+fetches checkpoints or logs into the local tree, and a later push then records
+them as uploads. Deleting the local copy afterwards reports the remote artifact
+as stale, which is exactly the confusion this module exists to remove.
+
+The fix is a mount whose excludes cover the output directories, which is the
+same fix that makes the raw candidate list readable, and which every configured
+mount here already does. Pulling job output into a mount that syncs it back is
+the misconfiguration; the record cannot detect that on its own, since at that
+point the artifact genuinely is a file the push manages.
+
+Known gap: concurrent workstations
+----------------------------------
+
+Recording is read-modify-write, and the sync lock is a machine-local ``flock``.
+Two workstations syncing one mount at the same time can both read the same
+record and each write their own union, so the later write drops paths the other
+just added — detection stays "known" while being incomplete. Closing it needs
+remote serialization or a compare-and-swap on the generation. It is left open
+because the ownership marker already treats two machines writing one mount as
+the thing to warn about, and the error runs the safe way: a missed warning.
+
+Known gap: interrupted syncs
+----------------------------
+
+The record is written after a sync succeeds, so a push that transfers files and
+then fails — rsync exiting 23 partway, hash verification raising, the process
+being killed — leaves the previous record in place. Files that did reach the
+cluster are missing from it, and deleting one of them locally before the next
+successful sync makes it go unreported.
+
+Recording *before* the transfer would close that, but not cheaply or cleanly: a
+record marked unusable up front is, by the rule above, one an additive sync
+refuses to rebuild, so it would need a second file or an embedded copy of the
+previous state, plus two extra round-trips on every sync — paid by everyone, on
+every sync, for a window that a single successful sync closes (the next
+inventory sees those files and the union restores them). The error also runs in
+the safe direction: a missed warning, never a wrong instruction to delete.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import socket
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from srunx.common.logging import get_logger
+
+if TYPE_CHECKING:
+    from srunx.ssh.core.config import MountConfig
+    from srunx.sync.rsync import RsyncClient
+
+logger = get_logger(__name__)
+
+# Version 2 stores paths in rsync's escaped form (``\#012`` for a newline, and
+# so on) so that a recorded path and a deletion candidate are literally the same
+# string. A version 1 record holds literal names, which would silently fail to
+# match, so it is refused: reported as "cannot tell" rather than "clean". Like
+# any record this cannot build on, it is cleared by deleting the file and
+# syncing again — version 1 never shipped, so nothing in the wild needs it.
+SCHEMA_VERSION = 2
+
+# A file at the mount root, not ``.srunx/manifest.json``. A directory would have
+# to be created before writing, and ``mkdir -p`` follows an existing symlink —
+# so another account able to write the mount root could pre-create ``.srunx`` as
+# a link and have the manifest written into any directory they can reach. A
+# plain file needs no directory creation, and the writer already refuses a
+# symlinked target.
+_MANIFEST_FILENAME = ".srunx-manifest.json"
+
+
+class ManifestUnavailable(RuntimeError):
+    """The manifest could not be read or parsed.
+
+    Raised instead of returning "no stale files", so a caller cannot mistake an
+    unreadable record for a clean tree.
+    """
+
+
+@dataclass(frozen=True)
+class SyncManifest:
+    """What srunx uploaded to one mount, and under which filter."""
+
+    paths: frozenset[str]
+    exclude_fingerprint: str
+    generation: int = 1
+    written_at: str = ""
+    writer_host: str = ""
+    schema_version: int = SCHEMA_VERSION
+
+    def to_json(self) -> str:
+        """Serialise for the remote file.
+
+        Paths are sorted so an unchanged tree produces an unchanged file,
+        which keeps diffs and manual inspection meaningful.
+        """
+        return json.dumps(
+            {
+                "schema_version": self.schema_version,
+                "generation": self.generation,
+                "written_at": self.written_at,
+                "writer_host": self.writer_host,
+                "exclude_fingerprint": self.exclude_fingerprint,
+                "paths": sorted(self.paths),
+            },
+            indent=2,
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> SyncManifest:
+        """Parse a remote manifest.
+
+        Raises:
+            ManifestUnavailable: On anything unparseable or of an unknown
+                schema version. A future version may record fields this one
+                cannot interpret, and guessing at them risks reporting files as
+                stale that the newer writer knew were not.
+        """
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ManifestUnavailable(f"manifest is not valid JSON: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise ManifestUnavailable("manifest is not a JSON object")
+
+        version = data.get("schema_version")
+        if version != SCHEMA_VERSION:
+            raise ManifestUnavailable(
+                f"manifest schema version {version!r} is not supported "
+                f"(this srunx understands {SCHEMA_VERSION})"
+            )
+
+        if data.get("invalidated"):
+            # Written deliberately when a sync could not be recorded. Without
+            # it, the previous manifest would keep being trusted and changes
+            # made since would be invisible — reported as "known, nothing
+            # stale" rather than "cannot tell".
+            raise ManifestUnavailable(
+                f"manifest was invalidated: {data.get('reason', 'unknown reason')}"
+            )
+
+        paths = data.get("paths")
+        fingerprint = data.get("exclude_fingerprint")
+        if not isinstance(paths, list) or not isinstance(fingerprint, str):
+            raise ManifestUnavailable("manifest is missing paths or fingerprint")
+
+        if not all(isinstance(p, str) for p in paths):
+            # Coercing with str() would turn null/numbers/objects into
+            # plausible-looking paths and report them as stale. A record we
+            # cannot read exactly is a record we must not act on.
+            raise ManifestUnavailable("manifest contains a non-string path entry")
+
+        try:
+            generation = int(data.get("generation", 1))
+        except (TypeError, ValueError) as exc:
+            # Must surface as ManifestUnavailable, not a bare TypeError: the
+            # recorder's "replace an unreadable manifest" path keys off this
+            # exception type, and without it a corrupt file is left in place and
+            # every later sync stays unable to restore tracking.
+            raise ManifestUnavailable(
+                f"manifest has a non-numeric generation: {data.get('generation')!r}"
+            ) from exc
+
+        return cls(
+            paths=frozenset(str(p) for p in paths),
+            exclude_fingerprint=fingerprint,
+            generation=generation,
+            written_at=str(data.get("written_at", "")),
+            writer_host=str(data.get("writer_host", "")),
+        )
+
+
+@dataclass(frozen=True)
+class StaleReport:
+    """Result of comparing a manifest against the current local tree."""
+
+    paths: list[str] = field(default_factory=list)
+    known: bool = True
+    reason: str = ""
+
+    @property
+    def count(self) -> int:
+        return len(self.paths)
+
+
+def exclude_fingerprint(patterns: Sequence[str]) -> str:
+    """Fingerprint an exclude set.
+
+    Order matters to rsync, so it is preserved rather than sorted: two lists
+    with the same patterns in a different order can filter differently, and
+    treating them as equal would let a changed filter pass unnoticed.
+
+    Serialized as JSON rather than joined on a separator, so that no two
+    different lists can hash alike: joining on a newline made ``["a\\nb"]`` and
+    ``["a", "b"]`` identical, and a filter change that hashes the same is a
+    filter change this cannot notice — the one thing the fingerprint is for.
+    """
+    serialized = json.dumps(list(patterns))
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def manifest_remote_path(mount: MountConfig) -> str:
+    """Return the manifest's absolute remote path.
+
+    Joined with ``/`` explicitly because the remote is POSIX — ``Path`` would
+    use the host separator on a Windows workstation.
+    """
+    return f"{mount.remote.rstrip('/')}/{_MANIFEST_FILENAME}"
+
+
+def local_inventory(
+    client: RsyncClient,
+    local_path: str,
+    exclude_patterns: Sequence[str] | None = None,
+) -> list[str]:
+    """List the files a sync of *local_path* would upload.
+
+    Uses rsync itself, with the same binary and the same merged filter as the
+    real transfer, so the manifest cannot disagree with what was actually sent.
+    Re-implementing rsync's matching in Python would drift: anchored patterns,
+    directory rules and ``**`` all have specific semantics.
+
+    Directories are omitted — only files are recorded, since a directory that
+    lingers because it still holds job output is not itself a stale file.
+    """
+    return client.list_local_files(local_path, exclude_patterns=exclude_patterns)
+
+
+def read(client: RsyncClient, mount: MountConfig) -> SyncManifest | None:
+    """Read the manifest for *mount*, or ``None`` if none has been written.
+
+    Raises:
+        ManifestUnavailable: If a manifest exists but cannot be understood.
+            Distinct from ``None`` on purpose: "never recorded" is a normal
+            first-run state, while "recorded but unreadable" must not be
+            silently treated as an empty record.
+    """
+    # ``require_owned``: this record decides which paths a user is told are safe
+    # to delete, so one written by another account on a shared mount must not be
+    # believed. Refusing symlinks alone does not cover it — a peer able to write
+    # the mount root can plant an ordinary, schema-valid file naming job output
+    # as stale.
+    raw = client.read_remote_file(manifest_remote_path(mount), require_owned=True)
+    if raw is None:
+        return None
+    return SyncManifest.from_json(raw)
+
+
+def write(
+    client: RsyncClient,
+    mount: MountConfig,
+    paths: Sequence[str],
+    exclude_patterns: Sequence[str],
+    *,
+    previous: SyncManifest | None = None,
+    mirrored: bool = False,
+) -> SyncManifest:
+    """Record *paths* as what srunx has uploaded to *mount*.
+
+    Call only after a successful sync. Recording paths that failed to transfer
+    would mark files as uploaded that are not there, and they would then be
+    reported as stale on the next run once deleted locally.
+
+    ``mirrored`` says whether the sync deleted remote-only files. It decides
+    whether the previous record is kept, and getting it wrong defeats the whole
+    feature:
+
+    * **Additive sync** (the default) leaves everything srunx ever uploaded on
+      the cluster, including files since deleted locally — those are exactly
+      what should be reported as stale. So the record is the union of what was
+      there before and what was just sent. Replacing it with the current
+      inventory instead makes the sync that *creates* a stale file also erase
+      the evidence of it, and the next inspection reports nothing.
+    * **Mirror** removes remote-only files, so afterwards the remote does match
+      the local tree and the record is replaced outright — keeping the old
+      paths would report files as stale that the mirror already deleted.
+    """
+    fingerprint = exclude_fingerprint(exclude_patterns)
+
+    combined = set(paths)
+    if not mirrored and previous is not None:
+        if previous.exclude_fingerprint == fingerprint:
+            combined |= previous.paths
+        # Filter changed: the old paths were selected by a different filter, so
+        # a file that is still present locally but newly excluded would be kept
+        # in the record while vanishing from every later inventory — and then
+        # reported as stale, which is the exact false positive the fingerprint
+        # check exists to prevent. Starting from the current inventory instead
+        # loses track of genuinely stale files uploaded under the old filter;
+        # that is the safer direction, since a missed warning costs less than
+        # telling someone to delete a file a job needs.
+
+    manifest = SyncManifest(
+        paths=frozenset(combined),
+        exclude_fingerprint=fingerprint,
+        generation=(previous.generation + 1) if previous else 1,
+        written_at=datetime.now(UTC).isoformat(timespec="seconds"),
+        writer_host=socket.gethostname(),
+    )
+    # 0600: this enumerates a project's file names and the workstation that
+    # pushed them, and only its own writer ever reads it (reads already refuse a
+    # foreign owner). A mount root is often traversable on a shared cluster even
+    # when the directories under it are not.
+    client.write_remote_file(
+        manifest_remote_path(mount), manifest.to_json(), mode="600"
+    )
+    logger.debug(
+        "Recorded {} paths for mount '{}' (generation {})",
+        len(manifest.paths),
+        mount.name,
+        manifest.generation,
+    )
+    return manifest
+
+
+def invalidate(
+    client: RsyncClient,
+    mount: MountConfig,
+    reason: str,
+    previous: SyncManifest | None = None,
+) -> None:
+    """Mark the manifest unusable, so detection reports unknown rather than clean.
+
+    Used when a sync succeeded but could not be recorded. Leaving the previous
+    manifest in place would keep it *trusted* while it no longer describes the
+    remote: a file uploaded by that sync and later deleted locally would sit on
+    the cluster while inspection reported "known, nothing stale". Marking it
+    unusable turns that into an honest "cannot tell".
+
+    *previous* is carried over as a **superseded** baseline. Without it the mark
+    is a dead end: an additive sync will not rebuild a record from scratch (it
+    cannot — see :func:`~srunx.sync.mount_helpers.record_upload`), so detection
+    would stay unknown until someone ran a mirror, and a mirror deletes exactly
+    the cluster-only job output this feature exists to protect. Keeping the last
+    good path set lets the next successful sync union onto it and recover on its
+    own. It is *not* read as a manifest: :meth:`SyncManifest.from_json` still
+    refuses the record, so nothing is reported while it stands.
+
+    Does nothing when there is no manifest yet and no baseline to keep. An
+    absent record already means "cannot tell", and it is the one state an
+    additive sync can still build on — so marking it would strand the mount at
+    unknown rather than protect anything.
+    """
+    try:
+        existing_raw = _read_raw(client, mount)
+        # ``None`` from the reader means the file is genuinely missing — it
+        # tells that apart from an error by exit code — so absence is *proven*
+        # only on this path.
+        proven_absent = existing_raw is None
+    except Exception as exc:  # noqa: BLE001 — must not fail a landed sync
+        # Unreadable is not absent. Skipping the mark here would leave an
+        # outdated record trusted the moment ssh recovers, so files this sync
+        # uploaded could go unrecorded while detection still reports "known".
+        logger.debug("Could not read the manifest for '{}': {}", mount.name, exc)
+        existing_raw = None
+        proven_absent = False
+
+    if previous is None:
+        # Carry forward whatever last-known-good set is already there — a live
+        # record's own paths, or a baseline an earlier invalidation kept. Look
+        # at both: without the first, one transient read error erases a valid
+        # record; without the second, a second failure erases what the first
+        # preserved. Either way the recovery path is gone for good.
+        previous = _last_known_good(existing_raw)
+
+    if previous is None and proven_absent:
+        # Nothing on the remote to distrust, and an absent record already reads
+        # as "cannot tell". Writing the mark here would only remove the one
+        # state an additive sync can still build on from scratch, stranding the
+        # mount at unknown until someone deleted the file by hand.
+        logger.debug(
+            "No manifest to invalidate for mount '{}'; leaving it absent so the "
+            "next successful sync can establish one ({}).",
+            mount.name,
+            reason,
+        )
+        return
+
+    payload: dict[str, object] = {
+        "schema_version": SCHEMA_VERSION,
+        "invalidated": True,
+        "reason": reason,
+        "written_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "writer_host": socket.gethostname(),
+    }
+    if previous is not None:
+        payload["superseded"] = {
+            "paths": sorted(previous.paths),
+            "exclude_fingerprint": previous.exclude_fingerprint,
+            "generation": previous.generation,
+        }
+    client.write_remote_file(
+        manifest_remote_path(mount), json.dumps(payload, indent=2), mode="600"
+    )
+
+
+def _read_raw(client: RsyncClient, mount: MountConfig) -> str | None:
+    """The manifest file's contents, or ``None`` if it is absent.
+
+    Errors propagate rather than reading as ``None``: callers act differently on
+    "there is no record" than on "I could not find out", and collapsing the two
+    turns a transient ssh failure into a claim of absence.
+    """
+    return client.read_remote_file(manifest_remote_path(mount), require_owned=True)
+
+
+def _last_known_good(raw: str | None) -> SyncManifest | None:
+    """The newest trustworthy path set in *raw*: a live record, else a baseline."""
+    if raw is None:
+        return None
+    try:
+        return SyncManifest.from_json(raw)
+    except ManifestUnavailable:
+        return _superseded_from(raw)
+
+
+def read_superseded(client: RsyncClient, mount: MountConfig) -> SyncManifest | None:
+    """Return the baseline an :func:`invalidate` preserved, if there is one.
+
+    Only the recorder uses this, to recover on the next successful sync. It
+    deliberately does not go through :func:`read`, which must keep refusing an
+    invalidated record so that detection reports "cannot tell".
+
+    Returns ``None`` whenever there is nothing trustworthy to recover from — no
+    record, an unreadable one, or one written before the baseline was carried
+    over. Recovery is a bonus; failing to find one leaves the honest unknown.
+    """
+    try:
+        return _superseded_from(_read_raw(client, mount))
+    except Exception as exc:  # noqa: BLE001 — recovery must not raise
+        logger.debug("Could not read a baseline for '{}': {}", mount.name, exc)
+        return None
+
+
+def _superseded_from(raw: str | None) -> SyncManifest | None:
+    """Parse a preserved baseline out of an invalidated record."""
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw)
+        # Both guards matter. The version, because a future writer may record
+        # paths this version cannot interpret — restoring them would rewrite a
+        # confident record with semantics we do not understand, which is worse
+        # than the honest unknown a downgrade otherwise gets. The flag, because
+        # only an invalidation puts a baseline here; anything else carrying that
+        # key is not a record this wrote.
+        if data.get("schema_version") != SCHEMA_VERSION:
+            return None
+        if data.get("invalidated") is not True:
+            return None
+        superseded = data["superseded"]
+        paths = superseded["paths"]
+        fingerprint = superseded["exclude_fingerprint"]
+        if not isinstance(paths, list) or not all(isinstance(p, str) for p in paths):
+            return None
+        if not isinstance(fingerprint, str):
+            return None
+        return SyncManifest(
+            paths=frozenset(paths),
+            exclude_fingerprint=fingerprint,
+            generation=int(superseded.get("generation", 1)),
+        )
+    except (json.JSONDecodeError, TypeError, ValueError, KeyError, AttributeError):
+        return None
+
+
+def find_stale(
+    manifest: SyncManifest | None,
+    current_paths: Sequence[str],
+    exclude_patterns: Sequence[str],
+) -> StaleReport:
+    """Identify paths srunx uploaded that are no longer present locally.
+
+    Returns a report whose ``known`` is False when no conclusion can be drawn.
+    That is a distinct answer from "nothing is stale", and the two must not be
+    collapsed: presenting "unknown" as "clean" is how a stale module keeps
+    running unnoticed.
+    """
+    if manifest is None:
+        return StaleReport(
+            known=False,
+            reason=(
+                "no manifest recorded for this mount yet — sync once with this "
+                "version of srunx to start tracking what it uploads"
+            ),
+        )
+
+    current_fingerprint = exclude_fingerprint(exclude_patterns)
+    if current_fingerprint != manifest.exclude_fingerprint:
+        # Excluded files are never uploaded, so a changed filter moves paths in
+        # and out of the manifest for reasons unrelated to staleness. Reporting
+        # them anyway would invite deleting files that are merely newly
+        # excluded.
+        return StaleReport(
+            known=False,
+            reason=(
+                "the exclude patterns changed since the manifest was written, "
+                "so paths may be absent for that reason rather than being "
+                "stale — sync once to re-record under the current filter"
+            ),
+        )
+
+    stale = sorted(manifest.paths - set(current_paths))
+    return StaleReport(paths=stale)

--- a/src/srunx/sync/mount_helpers.py
+++ b/src/srunx/sync/mount_helpers.py
@@ -32,10 +32,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from srunx.common.logging import get_logger
+
 if TYPE_CHECKING:
-    from srunx.ssh.core.config import ServerProfile
+    from srunx.ssh.core.config import MountConfig, ServerProfile
+    from srunx.sync.manifest import SyncManifest
 
 from srunx.sync.rsync import RsyncClient
+
+logger = get_logger(__name__)
 
 
 def build_rsync_client(profile: ServerProfile) -> RsyncClient:
@@ -67,6 +72,7 @@ def sync_mount_by_name(
     delete: bool = False,
     dry_run: bool = False,
     verbose: bool = False,
+    record_manifest: bool = True,
 ) -> str:
     """Sync a named mount's local directory to remote via rsync.
 
@@ -86,6 +92,13 @@ def sync_mount_by_name(
     live (#137 part 3). Mutually compatible with ``dry_run`` — the
     preview output streams the same way.
 
+    ``record_manifest=False`` skips recording the upload, leaving it to the
+    caller. Only for callers that verify the transfer afterwards: rsync can
+    exit 0 while the remote copy differs, and recording before that check
+    would assert every file arrived intact when the verification is about to
+    prove otherwise. :func:`~srunx.sync.service.mount_sync_session` defers for
+    that reason, exactly as it already defers the ownership marker.
+
     Returns:
         rsync stdout — empty for a non-dry-run sync, the itemize lines
         for a dry-run preview.
@@ -100,6 +113,9 @@ def sync_mount_by_name(
     if mount is None:
         raise ValueError(f"Mount '{mount_name}' not found in profile")
     rsync = build_rsync_client(profile)
+
+    before = None if dry_run or not record_manifest else snapshot_local(rsync, mount)
+
     result = rsync.push(
         mount.local,
         mount.remote,
@@ -116,4 +132,203 @@ def sync_mount_by_name(
         raise RuntimeError(
             f"rsync sync failed for mount '{mount_name}': {result.stderr}"
         )
+
+    if not dry_run and record_manifest:
+        record_upload(rsync, mount, mirrored=delete, before=before)
     return result.stdout
+
+
+def snapshot_local(client: RsyncClient, mount: MountConfig) -> list[str] | None:
+    """Inventory the mount *before* a transfer — the set :func:`record_upload` records.
+
+    Scanning afterwards instead gets both edges of a concurrent change wrong,
+    and in opposite directions:
+
+    * A file **created** while the transfer ran, after rsync walked its parent,
+      appears in an after-scan though rsync never sent it. Recorded as
+      uploaded, deleted locally later, and — if a cluster job happens to write
+      the same relative path — that job's output is reported as a stale upload.
+      Naming live output for deletion is the one answer this must never give,
+      and a shared ``dist/`` holding both build artifacts and job output is
+      enough to reach it.
+    * A file **deleted** locally while the transfer ran is missing from an
+      after-scan although rsync did send it. It sits on the cluster unrecorded,
+      and no later sync can record it — it is not local any more — so it stays
+      invisible while the report still calls itself complete. That silent gap
+      is the exact failure this feature exists to close.
+
+    The before-scan is right on both counts: created-during is absent from it,
+    deleted-during is present. It is also the honest set — what rsync was asked
+    to send. A file created mid-sync is simply recorded by the next sync, which
+    finds it sitting in the tree like any other.
+
+    Known gap: this scan and rsync's own are separate walks, so a file deleted
+    between them is recorded without having been sent. Stale paths are narrowed
+    to what the remote actually holds, which discards it — unless a job wrote
+    output at that same relative path, in which case the output is presented as
+    a stale upload. Left open deliberately. The window is the gap between two
+    scans rather than a whole transfer, and closing it is not cheap:
+
+    * Binding rsync to this list (``--files-from``) needs the real filenames,
+      and this list is deliberately kept in rsync's escaped form — control
+      bytes are never converted back, since doing so is what makes a crafted
+      name unparseable. Keeping a second, raw copy would reintroduce exactly
+      that ambiguity.
+    * Confirming against a scan taken afterwards costs a second full walk of
+      the tree on every sync, and would drop a *new* file deleted mid-transfer
+      — the gap described above, reopened for the sake of a much narrower one.
+
+    What is left is the same shape as an ambiguity this cannot resolve anyway:
+    a path that is both srunx-managed and job-written needs content identity to
+    tell apart, which means a hash per file per sync. See
+    :mod:`srunx.sync.manifest`.
+
+    Returns ``None`` if the scan fails. :func:`record_upload` then records
+    nothing and marks tracking unknown — there is no after-scan fallback, since
+    publishing a record built the wrong way as authoritative is precisely what
+    ends with a job's output named for deletion.
+    """
+    try:
+        return client.list_local_files(
+            mount.local, exclude_patterns=mount.exclude_patterns or None
+        )
+    except Exception as exc:  # noqa: BLE001 — tracking must not fail a sync
+        logger.debug("Pre-transfer scan of '{}' failed: {}", mount.name, exc)
+        return None
+
+
+def record_upload(
+    client: RsyncClient,
+    mount: MountConfig,
+    *,
+    mirrored: bool = False,
+    before: list[str] | None = None,
+) -> None:
+    """Record what a just-completed sync uploaded, for stale-file detection.
+
+    ``mirrored`` must reflect whether the sync deleted remote-only files. An
+    additive sync leaves everything previously uploaded on the cluster, so the
+    record accumulates; a mirror removes them, so it replaces. Passing False for
+    a mirror would report deleted files as still stale, and passing True for an
+    additive sync would erase exactly the files that just became stale.
+
+    Best-effort by design: a failure here is logged and swallowed, because the
+    files did reach the cluster and failing the sync afterwards would be a
+    worse outcome than losing one generation of tracking. Detection reports
+    "unknown" rather than claiming the tree is clean, and the next successful
+    sync recovers by unioning onto the baseline the invalidation preserved —
+    see :mod:`srunx.sync.manifest`.
+
+    A record with no such baseline (corrupt, or written by another account) is
+    the one case an additive sync cannot repair, for the reason given at the
+    branch below; the warning there names the non-destructive reset.
+
+    Call only after a real, successful transfer. Recording a dry run, or a run
+    that failed partway, would mark files as uploaded that are not there; once
+    those are deleted locally they would be reported as stale on the cluster
+    when they were never sent in the first place.
+
+    ``before`` is the matching :func:`snapshot_local` result and becomes the
+    recorded set. Without one there is nothing trustworthy to publish, so
+    tracking is marked unknown instead: a scan taken *after* the transfer
+    mis-handles both edges of a concurrent change (see :func:`snapshot_local`),
+    and one of those directions ends with a job's output named as stale. A
+    record that reads as authoritative must not be built that way — reporting
+    "cannot tell" is the honest answer, and the next sync re-records.
+    """
+    from srunx.sync import manifest as manifest_mod
+
+    if before is None:
+        logger.warning(
+            "Could not inventory mount '{}' before the transfer, so this sync "
+            "cannot be recorded — stale-file detection reports 'unknown' until "
+            "the next successful sync.",
+            mount.name,
+        )
+        _mark_unknown(client, mount, "pre-transfer inventory failed")
+        return
+
+    try:
+        previous = None
+        try:
+            previous = manifest_mod.read(client, mount)
+        except manifest_mod.ManifestUnavailable as exc:
+            if not mirrored:
+                # An earlier failure preserved the last good path set alongside
+                # the invalidation mark; union onto that and the record is
+                # trustworthy again without anything being deleted.
+                previous = manifest_mod.read_superseded(client, mount)
+                if previous is None:
+                    # Nothing to build on. The current inventory is not a valid
+                    # baseline for an additive run: rsync left everything
+                    # previously uploaded on the cluster, including files since
+                    # deleted locally, and writing "this is everything" would
+                    # claim those do not exist. Rather than a mirror — which
+                    # deletes the cluster-only job output this feature exists to
+                    # protect — the deliberate reset is removing the record.
+                    logger.warning(
+                        "Manifest for mount '{}' is unusable ({}) and an "
+                        "additive sync cannot rebuild it, so stale-file "
+                        "detection stays 'unknown'. To start over, delete "
+                        "'{}' on the cluster and sync again — files uploaded "
+                        "before that point are then untracked, which "
+                        "under-reports rather than risking job output.",
+                        mount.name,
+                        exc,
+                        manifest_mod.manifest_remote_path(mount),
+                    )
+                    return
+                logger.info(
+                    "Recovering the manifest for mount '{}' from the baseline "
+                    "kept when it was invalidated ({}).",
+                    mount.name,
+                    exc,
+                )
+            else:
+                logger.debug(
+                    "Replacing unusable manifest for '{}': {}", mount.name, exc
+                )
+
+        excludes = client.effective_excludes(mount.exclude_patterns or None)
+        # The before-scan *is* the record — see ``snapshot_local`` for why
+        # scanning afterwards is wrong in both directions, and why there is no
+        # after-scan fallback.
+        manifest_mod.write(
+            client, mount, before, excludes, previous=previous, mirrored=mirrored
+        )
+    except Exception as exc:  # noqa: BLE001 — tracking must not fail a sync
+        logger.warning(
+            "Could not record the upload manifest for mount '{}': {}. "
+            "Stale-file detection will report 'unknown' until the next "
+            "successful sync, which recovers from the baseline kept below.",
+            mount.name,
+            exc,
+        )
+        # Leaving the previous manifest would leave it *trusted* while it no
+        # longer describes the remote — a file this sync uploaded and that is
+        # later deleted locally would be reported as "nothing stale". Marking it
+        # unusable is what makes the warning above true. The last good path set
+        # rides along so the next successful sync can union onto it instead of
+        # needing a mirror, which would delete cluster-only job output.
+        _mark_unknown(client, mount, f"recording failed: {exc}", previous=previous)
+
+
+def _mark_unknown(
+    client: RsyncClient,
+    mount: MountConfig,
+    reason: str,
+    previous: SyncManifest | None = None,
+) -> None:
+    """Stop trusting the record, without letting that failure fail the sync."""
+    from srunx.sync import manifest as manifest_mod
+
+    try:
+        manifest_mod.invalidate(client, mount, reason, previous=previous)
+    except Exception as inner:  # noqa: BLE001
+        logger.warning(
+            "Could not invalidate the stale manifest for mount '{}': {}. "
+            "Its contents are now out of date and may under-report stale "
+            "files until the next successful sync.",
+            mount.name,
+            inner,
+        )

--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -8,6 +8,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -17,6 +18,71 @@ from typing import IO, ClassVar
 from srunx.common.logging import get_logger
 
 logger = get_logger(__name__)
+
+# rsync escapes a byte it will not print as ``\#`` plus three octal digits —
+# ``\#012`` for a newline, ``\#134`` for a backslash itself. Escaping the
+# backslash is what makes the encoding invertible: a file genuinely named
+# ``a\#012b`` comes back as ``a\#134#012b``, and a single left-to-right pass
+# turns that into the original rather than into a newline.
+#
+# Matched in *runs*: one character can span several groups (``データ`` is nine),
+# so whether a group is safe to restore can only be decided together with its
+# neighbours. Matching runs also leaves everything outside them — the real line
+# breaks in a multi-line preview — untouched.
+_ESCAPE_RUN_RE = re.compile(r"(?:\\#[0-7]{3})+")
+_ESCAPE_GROUP_RE = re.compile(r"\\#([0-7]{3})")
+
+# A chmod mode reaches the remote shell unquoted, so it is constrained to the
+# only shape srunx ever passes.
+_MODE_RE = re.compile(r"[0-7]{3}")
+
+
+def _C_LOCALE_ENV() -> dict[str, str]:  # noqa: N802 — reads as a constant
+    """Environment forcing rsync's output into one deterministic encoding.
+
+    Which bytes rsync escapes depends on what the locale calls printable, and
+    the two outputs this compares must agree. Verified on openrsync: under a
+    UTF-8 locale ``データ.csv`` comes back as a *mix* of raw and escaped bytes
+    (``\\ufffd\\#203\\#207\\ufffd...``) while ``LC_ALL=C`` gives the fully escaped
+    ``\\#343\\#203\\#207...``. Run the inventory one way and the deletion preview
+    the other, and a genuinely stale non-ASCII file matches nothing — it is
+    dropped from the report and the mount reads as clean.
+
+    Only output formatting is affected. rsync passes filenames through as bytes
+    unless ``--iconv`` is given, which srunx never does.
+    """
+    return {**os.environ, "LC_ALL": "C"}
+
+
+def unescape_rsync_path(path: str) -> str:
+    """Turn rsync's escaped output back into the filename it stands for.
+
+    Paths are compared in their escaped form — that is what makes an inventory
+    entry and a deletion candidate the same string — but a user reading a
+    report should see ``データ.csv``, not ``\\#343\\#203\\#207...``.
+
+    **Only printable characters are restored.** rsync escapes control bytes
+    because they are not safe to print, and this output goes to a terminal:
+    a file named ``innocent\\#033c.py`` would otherwise emit ESC-c and reset the
+    terminal, and ``\\#012`` would forge an extra line in a sync preview. Since
+    a cluster job can choose the names it writes, that is an injection an
+    attacker controls. Anything unprintable — control bytes, bidi overrides,
+    undecodable bytes left as surrogates — stays in the escaped form, which is
+    still perfectly readable and names the file unambiguously.
+
+    A run that decodes to a mix of printable and not is kept escaped whole. It
+    is the conservative direction and such names do not occur by accident.
+    """
+    if "\\#" not in path:
+        return path
+    return _ESCAPE_RUN_RE.sub(_restore_run, path)
+
+
+def _restore_run(match: re.Match[str]) -> str:
+    run = match.group(0)
+    octets = bytes(int(g, 8) for g in _ESCAPE_GROUP_RE.findall(run))
+    text = octets.decode("utf-8", "surrogateescape")
+    return text if text.isprintable() else run
 
 
 @dataclass
@@ -73,6 +139,11 @@ class RsyncClient:
         # by giving every configured-mount push one shared entry point that owns
         # the marker's lifecycle.
         "/.srunx-owner.json",
+        # Same reasoning for the upload manifest: remote-only, so without this
+        # it shows up as a deletion candidate in every preview, a mirror deletes
+        # and recreates it, and ``--pull`` copies srunx's bookkeeping into the
+        # user's project.
+        "/.srunx-manifest.json",
     ]
 
     def __init__(
@@ -363,6 +434,13 @@ class RsyncClient:
             # per file with a ``YXcstpoguax``-style flag prefix so the
             # CLI dry-run preview can render exactly what would change.
             cmd.append("-i")
+            # Deliberately *not* ``-8``. That flag prints non-ASCII names
+            # literally, and the escaped form is what makes this output
+            # unambiguous: rsync escapes a newline as ``\#012`` and a backslash
+            # as ``\#134``, so one line is always one file. The inventory in
+            # ``list_local_files`` is read from the same escaped format, which
+            # is what lets a recorded path be compared to a deletion candidate
+            # at all. :func:`unescape_rsync_path` turns it back for display.
         if verbose:
             # ``--info=progress2`` is the single-line aggregate progress
             # form that updates in place (via ``\r``). It's the only
@@ -380,7 +458,14 @@ class RsyncClient:
         """Execute an rsync command and return the result."""
         logger.debug("Running rsync: {}", shlex.join(cmd))
 
-        proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+        proc = subprocess.run(  # noqa: S603
+            cmd,
+            capture_output=True,
+            text=True,
+            # Decoding never raises on a filename byte; see ``list_local_files``.
+            errors="surrogateescape",
+            env=_C_LOCALE_ENV(),
+        )
 
         if proc.returncode != 0:
             logger.warning(
@@ -414,6 +499,8 @@ class RsyncClient:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            errors="surrogateescape",
+            env=_C_LOCALE_ENV(),
             bufsize=1,
         )
 
@@ -511,10 +598,29 @@ class RsyncClient:
             input=stdin,
             capture_output=True,
             text=True,
+            # Remote output can name remote files, whose bytes are equally
+            # arbitrary. Manifest JSON itself stays ASCII (``json.dumps``
+            # escapes non-ASCII by default), so this round-trips intact.
+            errors="surrogateescape",
         )
 
-    def read_remote_file(self, remote_path: str) -> str | None:
+    def read_remote_file(
+        self, remote_path: str, *, require_owned: bool = False
+    ) -> str | None:
         """Return the remote file's contents, or ``None`` if it doesn't exist.
+
+        ``require_owned=True`` additionally refuses a file belonging to another
+        account. Worth the extra check wherever the contents drive an action —
+        the upload manifest decides which paths a user is told are safe to
+        delete, so a file another account planted there must not be believed.
+        The ownership marker leaves it off: it is advisory, and refusing to read
+        a foreign one would turn a warning into a hard failure.
+
+        The check narrows that window rather than closing it: the ownership test
+        and the read are two pathname lookups, so a peer able to write the
+        directory could swap the file in between. Closing it needs the owner
+        verified on the same descriptor that is read, which a shell cannot
+        express — it would mean driving this over SFTP rather than ssh.
 
         Used by the per-machine ownership marker (#137 part 4) to read
         ``.srunx-owner.json`` before each sync. The check needs to
@@ -526,26 +632,70 @@ class RsyncClient:
         existence test wrapped in a single shell command — keeps the
         round-trip count to one per check.
         """
-        # ``test -f X && cat X`` returns:
-        #   * 0 + stdout: file exists, content returned
-        #   * 1 + empty stdout: file does not exist
-        #   * 2+ : actual error (permission denied, ssh failure, …)
-        # We disambiguate via the exit code so transient failures
-        # don't get silently treated as "no marker".
+        # A dedicated exit code for "missing", so it is never confused with a
+        # failed read. ``test -f X && cat X`` cannot do that: ``cat`` also exits
+        # 1 when it cannot open the file, so an unreadable file (bad
+        # permissions, an I/O error) looked exactly like an absent one. For the
+        # ownership marker that only meant a lost warning, but the upload
+        # manifest treats "missing" as a normal first run and rebuilds from
+        # scratch — turning an unreadable record into a confident, wrong "clean"
+        # report.
         quoted = shlex.quote(remote_path)
-        result = self._ssh_run(f"test -f {quoted} && cat -- {quoted}")
+        owner_check = (
+            # A peer able to write the mount root can also drop in a perfectly
+            # ordinary file. Refusing symlinks is not enough when the contents
+            # are acted on: a forged upload record becomes a list of paths the
+            # user is told are safe to delete. They can only create files owned
+            # by themselves, so a uid match rules it out.
+            f"if [ \"$(ls -ldn {quoted} | awk 'NR==1{{print $3}}')\" "
+            f'!= "$(id -u)" ]; then exit {self._READ_FOREIGN_EXIT}; fi; '
+            if require_owned
+            else ""
+        )
+        result = self._ssh_run(
+            # Refuse a symlink here as the writer does. Without the check the
+            # two halves disagree: writing to a planted link is rejected, but
+            # reading through one is trusted, so a peer able to write the mount
+            # root can serve arbitrary content as srunx's own control file.
+            # ``test -f`` alone follows the link.
+            f"if [ -h {quoted} ]; then exit {self._READ_SYMLINK_EXIT}; fi; "
+            f"if [ ! -f {quoted} ]; then exit {self._READ_MISSING_EXIT}; fi; "
+            f"{owner_check}"
+            f"cat -- {quoted}"
+        )
         if result.returncode == 0:
             return result.stdout
-        if result.returncode == 1:
-            # ``test -f`` returned false — file does not exist.
+        if result.returncode == self._READ_MISSING_EXIT:
             return None
+        if result.returncode == self._READ_SYMLINK_EXIT:
+            raise RuntimeError(
+                f"refusing to read {remote_path!r}: it is a symlink, so its "
+                "contents are whatever it points at rather than srunx's own "
+                "control file"
+            )
+        if result.returncode == self._READ_FOREIGN_EXIT:
+            raise RuntimeError(
+                f"refusing to read {remote_path!r}: it belongs to another "
+                "account, so it is not a control file srunx wrote and its "
+                "contents cannot be acted on"
+            )
         raise RuntimeError(
             f"ssh read of {remote_path!r} failed (exit {result.returncode}): "
             f"{result.stderr.strip()}"
         )
 
-    def write_remote_file(self, remote_path: str, content: str) -> None:
+    def write_remote_file(
+        self, remote_path: str, content: str, *, mode: str = "644"
+    ) -> None:
         """Write *content* to *remote_path* atomically (temp file + rename).
+
+        ``mode`` defaults to world-readable, which the ownership marker needs:
+        its whole job is telling *another* account that this mount is in use,
+        and a marker they cannot read is a marker that does not work. Anything
+        only its own writer reads should pass ``600`` — the upload manifest
+        does, since it enumerates a project's file names and the workstation
+        that pushed them, and a mount root is often traversable even when the
+        directories under it are not.
 
         ``mv`` within one directory is a ``rename(2)``, so a concurrent reader
         sees either the previous file or the complete new one. Writing with
@@ -579,12 +729,19 @@ class RsyncClient:
         Raises:
             ValueError: If *remote_path* is login-relative. The write anchors
                 its working directory inside a private temp directory, which
-                would change how such a path resolves.
+                would change how such a path resolves. Also if *mode* is not
+                three octal digits — it reaches a remote shell unquoted.
             RuntimeError: If the target is a symlink or a directory, if the
                 target could not be probed, or if any write / publish step
                 exits non-zero — so the caller surfaces the failure instead of
                 silently leaving a stale file behind.
         """
+        if not _MODE_RE.fullmatch(mode):
+            # Interpolated into the remote shell command below, so it is
+            # constrained here rather than quoted — a mode is three octal
+            # digits and nothing else, and anything else is a caller bug.
+            raise ValueError(f"mode must be three octal digits, got {mode!r}")
+
         if not remote_path.startswith(("/", "~")):
             # The write anchors its working directory inside a private temp
             # directory (so the directory entry cannot be swapped out from under
@@ -679,16 +836,17 @@ class RsyncClient:
             # attacker wants destroyed. ``$$`` was no good — it is already
             # exposed in the directory name.
             f'f=$(mktemp -- ./w.XXXXXX) || {{ cd /; rmdir -- "$d"; exit 5; }}; '
-            # mktemp creates 0600; the published marker must stay readable to
-            # other accounts on a shared mount, since an unreadable marker reads
-            # as "no owner" and disables the guard for them. Reopening by name is
-            # fine *inside* this directory — the risk it carried at the mount
-            # root does not exist where no one else can reach.
+            # mktemp creates 0600, which is right for a private control file and
+            # wrong for the ownership marker: an unreadable marker reads as "no
+            # owner" to the next account and disables the guard for them. Hence
+            # the caller's mode. Reopening by name is fine *inside* this
+            # directory — the risk it carried at the mount root does not exist
+            # where no one else can reach.
             # No ``--`` here: BSD chmod does not accept it and treats it as a
             # filename ("chmod: --: No such file or directory"), which failed
             # every write on macOS-family remotes. Safe to omit because mktemp's
             # template starts with "./", so the name can never look like a flag.
-            f'chmod 644 "$f" || {{ rm -f -- "$f"; cd /; rmdir -- "$d"; exit 9; }}; '
+            f'chmod {mode} "$f" || {{ rm -f -- "$f"; cd /; rmdir -- "$d"; exit 9; }}; '
             f'cat > "$f" || {{ rm -f -- "$f"; cd /; rmdir -- "$d"; exit 6; }}; '
             # Re-check right before the rename: a target swapped in after the
             # first check would otherwise be followed by ``mv``.
@@ -788,6 +946,24 @@ class RsyncClient:
     # we'd want to surface as RuntimeError.
     _SHA256_REMOTE_MISSING_EXIT = 10
     _SHA256_REMOTE_NO_TOOL_EXIT = 11
+    # "The file is not there", distinct from any exit code a failing ``cat``
+    # can produce, so a read error is never mistaken for an absent file.
+    _READ_MISSING_EXIT = 12
+    # "The path is a symlink" — refused rather than followed, matching the
+    # writer, so control files cannot be served from somewhere else.
+    _READ_SYMLINK_EXIT = 13
+    # "The file belongs to another account" — refused for control files, whose
+    # contents are acted on.
+    _READ_FOREIGN_EXIT = 14
+
+    # An itemize line: the ``YXcstpoguax`` flag block, one space, then the
+    # path. The flag block is fixed-width per rsync build (9 on openrsync, 11
+    # on GNU) but always space-free, so matching it as ``\S+`` works on both
+    # while keeping every character after the single separator — including a
+    # path's own leading spaces.
+    _ITEMIZE_RE: ClassVar[re.Pattern[str]] = re.compile(
+        r"^(?P<flags>[<>ch.*+?][fdLDS]\S*) (?P<path>.*)$"
+    )
 
     # sha256sum / shasum -a 256 prefix every output line with the 64-hex
     # digest followed by whitespace. Anchored at start of line so we
@@ -865,6 +1041,142 @@ class RsyncClient:
             f"ssh sha256 of {remote_path!r} failed "
             f"(exit {result.returncode}): {result.stderr.strip()}"
         )
+
+    def list_local_files(
+        self,
+        local_path: str | Path,
+        exclude_patterns: Sequence[str] | None = None,
+    ) -> list[str]:
+        """List the files a push of *local_path* would transfer, as relative paths.
+
+        Runs rsync with this client's binary and merged filter, so the answer
+        cannot disagree with what a real push would send. Re-implementing the
+        matching in Python would drift from rsync's actual semantics for
+        anchored patterns, directory rules and ``**``.
+
+        Paths come back in rsync's **escaped** form, the same one a deletion
+        preview prints, and that is the point: the two are compared to each
+        other. :func:`unescape_rsync_path` converts back for display.
+
+        The inventory is an itemize run against a throwaway empty directory —
+        every file is "new" against it — rather than ``--list-only``, whose
+        output cannot be parsed safely. That listing prints a newline inside a
+        filename literally, so one file becomes two lines; a name crafted to
+        look like a listing line then yields *two* paths that do not exist. A
+        directory named ``victim\\n-rw-r--r--   1 2026`` was enough to record
+        both ``victim`` and a fabricated ``output.py`` — and had a job written
+        anything by either name, the comparison would have offered live job
+        output for deletion. Itemize escapes the newline (``\\#012``) and the
+        backslash (``\\#134``), so one line is always exactly one file.
+
+        Directories are excluded from the result — callers record files.
+
+        Raises:
+            RuntimeError: If rsync exits non-zero, so a partial listing is never
+                mistaken for a complete one.
+        """
+        local = Path(local_path)
+        src = str(local)
+        if local.is_dir() and not src.endswith("/"):
+            src += "/"
+
+        # No ``--protect-args``: it exists to stop a *remote* shell re-splitting
+        # arguments, and this listing is entirely local. openrsync does not have
+        # the flag at all, so adding it would fail there for no benefit.
+        #
+        # ``-n`` keeps the destination untouched; the directory only has to be
+        # empty so that nothing is filtered out as already up to date.
+        with tempfile.TemporaryDirectory(prefix="srunx-inventory-") as empty:
+            cmd: list[str] = ["rsync", "-a", "-n", "-i"]
+            for pattern in self._merge_excludes(exclude_patterns):
+                cmd.extend(["--exclude", pattern])
+            cmd.extend(["--", src, empty + "/"])
+
+            logger.debug("Listing local files: {}", shlex.join(cmd))
+            result = subprocess.run(  # noqa: S603
+                cmd,
+                capture_output=True,
+                text=True,
+                # Escaped output is pure ASCII, so this never has to substitute
+                # anything; it is here so an undecodable byte on *stderr* from
+                # a remote can't raise in place of the real error.
+                errors="surrogateescape",
+                env=_C_LOCALE_ENV(),
+            )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"rsync inventory failed (exit {result.returncode}): "
+                f"{result.stderr.strip()}"
+            )
+        return self._parse_inventory(result.stdout)
+
+    @classmethod
+    def _parse_inventory(cls, stdout: str) -> list[str]:
+        """Extract file paths from an itemize inventory.
+
+        Each line is ``<flags> <path>``: a space-free flag block, one separator
+        space, then the name verbatim — leading spaces and all. Because rsync
+        escapes a newline as ``\\#012`` and a backslash as ``\\#134``, one line
+        is always exactly one file, which is the property the whole comparison
+        rests on.
+
+        Regular files (``f``) and symlinks (``L``) are returned; ``rsync -a``
+        uploads both, so a symlink deleted locally lingers on the remote exactly
+        like a file and has to be trackable. A symlink line carries its target
+        as ``name -> target``, and only the name is the path.
+
+        Directories are skipped: a directory that lingers because it still holds
+        job output is not itself a stale upload.
+
+        Two names are **dropped with a warning** rather than recorded
+        approximately, because the deletion preview cannot express them the same
+        way. Recording a mangled path would have a caller looking for a file
+        that does not exist under that name while the real one goes unmentioned;
+        worse, the mangled form can collide with a real remote path and get job
+        output named for deletion. Those are symlinks whose own name contains
+        ``" -> "`` (indistinguishable from the target separator), and names
+        starting with **whitespace** (the preview pads its ``*deleting`` marker
+        with the same characters, so padding and a real leading space are
+        identical there).
+        """
+        paths: list[str] = []
+        for line in stdout.splitlines():
+            match = cls._ITEMIZE_RE.match(line)
+            if match is None:
+                continue  # progress lines, stats, blank separators
+            flags = match.group("flags")
+            path = match.group("path")
+            if flags[1] not in "fL":
+                continue  # directories, devices, specials
+            if flags[1] == "L":
+                # Count separators rather than splitting at one. A link legally
+                # named ``foo -> bar`` is printed as ``foo -> bar -> target``,
+                # so partitioning at the first occurrence silently records
+                # ``foo``; checking the prefix for a separator afterwards can
+                # never fire, because the prefix is by definition what came
+                # before it. With more than one there is no way to tell name
+                # from target, so the entry is dropped.
+                separators = path.count(" -> ")
+                if separators != 1:
+                    logger.warning(
+                        "Skipping symlink entry whose name cannot be "
+                        "unambiguously read from the listing: {!r}",
+                        line,
+                    )
+                    continue
+                path = path.split(" -> ", 1)[0]
+            path = path.rstrip("/")
+            if path in (".", ""):
+                continue
+            if path[0].isspace():
+                logger.warning(
+                    "Skipping file whose name starts with whitespace; it cannot "
+                    "be matched against rsync's other output: {!r}",
+                    path,
+                )
+                continue
+            paths.append(path)
+        return paths
 
     def effective_excludes(
         self, exclude_patterns: Sequence[str] | None = None

--- a/src/srunx/sync/service.py
+++ b/src/srunx/sync/service.py
@@ -28,7 +28,12 @@ from srunx.common.config import SyncDefaults
 from srunx.common.logging import get_logger
 from srunx.ssh.core.config import MountConfig, ServerProfile
 from srunx.sync.lock import acquire_sync_lock
-from srunx.sync.mount_helpers import sync_mount_by_name
+from srunx.sync.mount_helpers import (
+    build_rsync_client,
+    record_upload,
+    snapshot_local,
+    sync_mount_by_name,
+)
 from srunx.sync.owner_marker import OwnerMismatch, check_owner, write_owner_marker
 
 logger = get_logger(__name__)
@@ -194,7 +199,24 @@ def mount_sync_session(
             # delete=False (Codex blocker #4): auto-sync must not wipe
             # remote-only outputs (training checkpoints, run logs).
             # ``srunx ssh sync`` keeps the historical mirror behaviour.
-            sync_mount_by_name(profile, mount.name, delete=False, verbose=verbose)
+            # ``record_manifest=False``: the upload record is written after the
+            # hash check below, for the same reason the marker is. rsync can
+            # exit 0 while the remote copy differs, and a record written first
+            # would assert every file arrived intact just as verification is
+            # about to prove otherwise.
+            # Taken before the transfer starts and paired with the record
+            # below, so a file that appears mid-transfer is not recorded as
+            # having been uploaded. See ``snapshot_local``.
+            record_client = build_rsync_client(profile)
+            before = snapshot_local(record_client, mount)
+
+            sync_mount_by_name(
+                profile,
+                mount.name,
+                delete=False,
+                verbose=verbose,
+                record_manifest=False,
+            )
 
             # Per-script hash verification (#137 part 5) runs BEFORE
             # the marker write so a hash mismatch refuses to take
@@ -212,6 +234,10 @@ def mount_sync_session(
                 from srunx.sync.hash_verify import verify_paths_match
 
                 verify_paths_match(profile, mount, [Path(p) for p in verify_paths])
+
+            # Verification passed (or was not requested), so the remote really
+            # does hold what was sent — only now is it honest to record it.
+            record_upload(record_client, mount, mirrored=False, before=before)
 
             # Stamp the marker AFTER a successful sync so a failed
             # rsync doesn't claim ownership for a tree we couldn't

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -122,7 +122,7 @@ def test_sbatch_in_place_under_mount_calls_remote_submit(
 
     rsync_calls: list[tuple] = []
 
-    def _record_rsync(prof, name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
+    def _record_rsync(prof, name, *, delete=False, verbose=False, record_manifest=True):  # type: ignore[no-untyped-def]
         rsync_calls.append((prof, name, delete, verbose))
 
     monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record_rsync)
@@ -250,7 +250,9 @@ def test_sync_failure_aborts_submission(
     profile = _stub_profile(tmp_path, mount_local=mount_local, remote="/r/ml-project")
     job_ops = _patch_transport(monkeypatch, profile)
 
-    def _boom(profile_arg, mount_name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
+    def _boom(
+        profile_arg, mount_name, *, delete=False, verbose=False, record_manifest=True
+    ):  # type: ignore[no-untyped-def]
         raise RuntimeError("rsync exited 23: permission denied")
 
     monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _boom)
@@ -622,7 +624,7 @@ def test_verbose_forwards_to_sync_mount_by_name(
 
     rsync_calls: list[dict[str, object]] = []
 
-    def _record(prof, name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
+    def _record(prof, name, *, delete=False, verbose=False, record_manifest=True):  # type: ignore[no-untyped-def]
         rsync_calls.append({"name": name, "delete": delete, "verbose": verbose})
 
     monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record)
@@ -651,7 +653,7 @@ def test_no_verbose_keeps_quiet_default(
 
     rsync_calls: list[dict[str, object]] = []
 
-    def _record(prof, name, *, delete=False, verbose=False):  # type: ignore[no-untyped-def]
+    def _record(prof, name, *, delete=False, verbose=False, record_manifest=True):  # type: ignore[no-untyped-def]
         rsync_calls.append({"name": name, "delete": delete, "verbose": verbose})
 
     monkeypatch.setattr("srunx.sync.service.sync_mount_by_name", _record)

--- a/tests/cli/workflow/test_orchestrator_in_place.py
+++ b/tests/cli/workflow/test_orchestrator_in_place.py
@@ -157,7 +157,7 @@ def test_flow_run_syncs_each_mount_once_for_multi_shelljob_workflow(
 
     rsync_calls: list[tuple] = []
 
-    def _record_rsync(prof, name, *, delete=False, verbose=False):
+    def _record_rsync(prof, name, *, delete=False, verbose=False, record_manifest=True):
         # ``verbose`` kwarg added in PR #149 (rsync streaming progress).
         # Mock must accept it so ``sync_mount_by_name(..., verbose=...)``
         # call from ``mount_sync_session`` doesn't raise TypeError.

--- a/tests/mcp/tools/test_sync.py
+++ b/tests/mcp/tools/test_sync.py
@@ -722,3 +722,181 @@ class TestInspectMount:
         assert result["success"] is False
         assert "nope" in result["error"]
         assert "data" in result["error"]
+
+
+@patch("srunx.sync.mount_helpers.build_rsync_client")
+@patch("srunx.ssh.core.config.ConfigManager")
+class TestInspectMountStaleUploads:
+    """The narrowed answer: what srunx uploaded that is now gone locally.
+
+    The full candidate list mixes job output with stale code, and no exclude
+    list has to be complete for the narrowed set to be right — an artifact was
+    never uploaded, so it cannot be in the record.
+    """
+
+    def _profile(self, mock_cm_cls):
+        cm = MagicMock()
+        cm.get_profile.return_value = _profile_with_mount()
+        mock_cm_cls.return_value = cm
+
+    def test_reports_only_what_was_uploaded_and_is_gone(self, mock_cm_cls, mock_build):
+        self._profile(mock_cm_cls)
+        rsync = _rsync_returning(
+            "*deleting dist/5189188/submission.zip\n*deleting tools/probe.py\n"
+        )
+        mock_build.return_value = rsync
+
+        from srunx.sync import manifest as M
+
+        recorded = M.SyncManifest(
+            paths=frozenset({"train.py", "tools/probe.py"}),
+            exclude_fingerprint=M.exclude_fingerprint(["x"]),
+        )
+        with (
+            patch.object(M, "read", return_value=recorded),
+            patch.object(M, "local_inventory", return_value=["train.py"]),
+        ):
+            rsync.effective_excludes.return_value = ["x"]
+            result = inspect_mount(transport="prod", mount="ml")
+
+        # The raw candidates still show everything...
+        assert result["mirror_delete_candidates"] == 2
+        # ...while the narrowed set excludes the job artifact.
+        assert result["stale_uploads_known"] is True
+        assert result["stale_upload_paths"] == ["tools/probe.py"]
+        assert result["stale_upload_paths_omitted"] is False
+
+    def test_unknown_is_not_reported_as_clean(self, mock_cm_cls, mock_build):
+        """No record yet must not read as "nothing is stale"."""
+        self._profile(mock_cm_cls)
+        rsync = _rsync_returning("*deleting something.py\n")
+        mock_build.return_value = rsync
+
+        from srunx.sync import manifest as M
+
+        with (
+            patch.object(M, "read", return_value=None),
+            patch.object(M, "local_inventory", return_value=[]),
+        ):
+            result = inspect_mount(transport="prod", mount="ml")
+
+        assert result["stale_uploads_known"] is False
+        assert result["stale_uploads"] == 0
+        assert "no manifest" in result["stale_uploads_unknown_reason"]
+
+    def test_unreadable_record_degrades_instead_of_failing(
+        self, mock_cm_cls, mock_build
+    ):
+        """The inspection still reports what it can; only the narrowed set is
+        unavailable."""
+        self._profile(mock_cm_cls)
+        mock_build.return_value = _rsync_returning("*deleting a.py\n")
+
+        from srunx.sync import manifest as M
+
+        with patch.object(
+            M, "read", side_effect=M.ManifestUnavailable("corrupt record")
+        ):
+            result = inspect_mount(transport="prod", mount="ml")
+
+        assert result["success"] is True  # not a hard failure
+        assert result["mirror_delete_candidates"] == 1
+        assert result["stale_uploads_known"] is False
+        assert "corrupt record" in result["stale_uploads_unknown_reason"]
+
+    def test_large_stale_list_is_omitted_with_a_flag(self, mock_cm_cls, mock_build):
+        """Matches the mirror-candidate contract. A silently shortened list
+        would be presented as the complete set."""
+        self._profile(mock_cm_cls)
+        many = [f"tools/f{i}.py" for i in range(20)]
+        # All 20 are still on the cluster, so all 20 survive the intersection.
+        rsync = _rsync_returning("".join(f"*deleting {p}\n" for p in many))
+        mock_build.return_value = rsync
+
+        from srunx.sync import manifest as M
+
+        recorded = M.SyncManifest(
+            paths=frozenset(many), exclude_fingerprint=M.exclude_fingerprint(["x"])
+        )
+        with (
+            patch.object(M, "read", return_value=recorded),
+            patch.object(M, "local_inventory", return_value=[]),
+        ):
+            rsync.effective_excludes.return_value = ["x"]
+            result = inspect_mount(transport="prod", mount="ml", max_paths=5)
+
+        assert result["stale_uploads"] == 20  # exact
+        assert result["stale_upload_paths"] == []
+        assert result["stale_upload_paths_omitted"] is True
+
+    def test_records_inside_the_sync_lock(self, mock_cm_cls, mock_build):
+        """Recording after the lock releases lets an overlapping sync finish its
+        push and then have its record overwritten by this one's older paths."""
+        self._profile(mock_cm_cls)
+        mock_build.return_value = _rsync_returning()
+
+        order: list[str] = []
+
+        import contextlib
+
+        @contextlib.contextmanager
+        def fake_lock(*a, **kw):
+            order.append("lock")
+            yield
+            order.append("unlock")
+
+        with (
+            patch("srunx.sync.lock.acquire_sync_lock", fake_lock),
+            patch(
+                "srunx.sync.mount_helpers.record_upload",
+                side_effect=lambda *a, **kw: order.append("record"),
+            ),
+        ):
+            sync_files(transport="prod", mount="ml")
+
+        assert order == ["lock", "record", "unlock"]
+
+    def test_mirror_flag_is_passed_through(self, mock_cm_cls, mock_build):
+        """Additive accumulates, mirror replaces — passing the wrong one either
+        erases the files that just became stale or reports deleted ones."""
+        self._profile(mock_cm_cls)
+        mock_build.return_value = _rsync_returning()
+
+        with patch("srunx.sync.mount_helpers.record_upload") as rec:
+            sync_files(transport="prod", mount="ml")
+            assert rec.call_args.kwargs["mirrored"] is False
+
+        with patch("srunx.sync.mount_helpers.record_upload") as rec:
+            sync_files(transport="prod", mount="ml", delete=True)
+            assert rec.call_args.kwargs["mirrored"] is True
+
+    def test_stale_is_intersected_with_what_is_still_on_the_cluster(
+        self, mock_cm_cls, mock_build
+    ):
+        """The record says what was uploaded, not what survived.
+
+        A manual cleanup — or a mirror whose recording failed — leaves entries
+        naming files that are gone. Reporting those contradicts the documented
+        promise that this is a subset of the deletion candidates, and sends the
+        caller looking for something that is not there.
+        """
+        self._profile(mock_cm_cls)
+        # Only probe.py is still on the cluster; gone.py was removed by hand.
+        rsync = _rsync_returning("*deleting tools/probe.py\n")
+        mock_build.return_value = rsync
+
+        from srunx.sync import manifest as M
+
+        recorded = M.SyncManifest(
+            paths=frozenset({"tools/probe.py", "tools/gone.py"}),
+            exclude_fingerprint=M.exclude_fingerprint(["x"]),
+        )
+        with (
+            patch.object(M, "read", return_value=recorded),
+            patch.object(M, "local_inventory", return_value=[]),
+        ):
+            rsync.effective_excludes.return_value = ["x"]
+            result = inspect_mount(transport="prod", mount="ml")
+
+        assert result["stale_upload_paths"] == ["tools/probe.py"]
+        assert result["stale_uploads"] == 1

--- a/tests/sync/test_manifest.py
+++ b/tests/sync/test_manifest.py
@@ -1,0 +1,866 @@
+"""Tests for srunx.sync.manifest.
+
+The manifest exists because listing remote-only files is not actionable on its
+own: that set mixes job output (must not be deleted) with locally deleted files
+(usually should be). Excluding output directories separates them only as well as
+the exclude list is maintained — in a real mount, four stale scripts sat among 39
+job artifacts because ``dist/`` had never been excluded.
+
+Recording what srunx uploaded removes the guesswork, so the properties pinned
+here are: a job artifact never appears (it was never uploaded), and "cannot
+tell" is never reported as "clean".
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from srunx.sync import manifest as M
+from srunx.sync.rsync import RsyncClient, unescape_rsync_path
+
+
+def _mount(local="/local/proj", remote="/remote/proj", excludes=None):
+    return SimpleNamespace(
+        name="proj",
+        local=local,
+        remote=remote,
+        exclude_patterns=excludes if excludes is not None else [],
+    )
+
+
+def _client_with_remote(files: dict[str, str] | None = None) -> MagicMock:
+    """A client whose remote side is a dict of path -> contents."""
+    store = files if files is not None else {}
+    client = MagicMock()
+    client.read_remote_file.side_effect = lambda p, **kw: store.get(p)
+    client.write_remote_file.side_effect = lambda p, c, **kw: store.__setitem__(p, c)
+    client.effective_excludes.side_effect = lambda extra=None: [".git/", *(extra or [])]
+    client._store = store
+    return client
+
+
+class TestFingerprint:
+    def test_order_matters(self):
+        """rsync applies patterns in order, so two orderings can filter
+        differently. Treating them as equal would let a changed filter pass
+        unnoticed and paths would be called stale for the wrong reason."""
+        assert M.exclude_fingerprint(["a", "b"]) != M.exclude_fingerprint(["b", "a"])
+
+    def test_no_two_pattern_lists_hash_alike(self):
+        """Joining on a separator made ``["a\\nb"]`` and ``["a", "b"]`` identical.
+
+        Those filter differently, and a filter change that hashes the same is a
+        change this cannot notice — which is the one thing the fingerprint is
+        for. Newly excluded paths would then be presented as stale rather than
+        reported unknown.
+        """
+        assert M.exclude_fingerprint(["a\nb"]) != M.exclude_fingerprint(["a", "b"])
+
+    def test_same_list_same_fingerprint(self):
+        assert M.exclude_fingerprint(["a", "b"]) == M.exclude_fingerprint(["a", "b"])
+
+
+class TestSerialisation:
+    def test_round_trip(self):
+        m = M.SyncManifest(paths=frozenset({"b.py", "a.py"}), exclude_fingerprint="fp")
+        assert M.SyncManifest.from_json(m.to_json()).paths == m.paths
+
+    def test_paths_are_sorted_on_disk(self):
+        """An unchanged tree should produce an unchanged file."""
+        m = M.SyncManifest(paths=frozenset({"c", "a", "b"}), exclude_fingerprint="fp")
+        assert json.loads(m.to_json())["paths"] == ["a", "b", "c"]
+
+    def test_unparseable_raises_rather_than_returning_empty(self):
+        """An empty manifest would read as "nothing was ever uploaded", which
+        in turn reads as "nothing is stale" — the opposite of unknown."""
+        with pytest.raises(M.ManifestUnavailable):
+            M.SyncManifest.from_json("{not json")
+
+    def test_unknown_schema_version_raises(self):
+        """A newer writer may record fields this version cannot interpret;
+        guessing risks reporting files it knew were not stale."""
+        raw = json.dumps({"schema_version": 99, "paths": [], "exclude_fingerprint": ""})
+        with pytest.raises(M.ManifestUnavailable, match="schema version"):
+            M.SyncManifest.from_json(raw)
+
+    def test_missing_fields_raise(self):
+        raw = json.dumps({"schema_version": M.SCHEMA_VERSION, "paths": ["a"]})
+        with pytest.raises(M.ManifestUnavailable):
+            M.SyncManifest.from_json(raw)
+
+
+class TestReadWrite:
+    def test_absent_manifest_reads_as_none(self):
+        """Distinct from unreadable: never-recorded is a normal first run."""
+        assert M.read(_client_with_remote(), _mount()) is None
+
+    def test_write_then_read(self):
+        client = _client_with_remote()
+        mount = _mount()
+        M.write(client, mount, ["a.py", "sub/b.py"], [".git/"])
+
+        got = M.read(client, mount)
+        assert got is not None
+        assert got.paths == frozenset({"a.py", "sub/b.py"})
+        assert got.generation == 1
+
+    def test_generation_increments(self):
+        client = _client_with_remote()
+        mount = _mount()
+        first = M.write(client, mount, ["a.py"], [".git/"])
+        second = M.write(client, mount, ["a.py"], [".git/"], previous=first)
+        assert (first.generation, second.generation) == (1, 2)
+
+    def test_lives_beside_the_owner_marker_but_separately(self):
+        """Same root, different file: the marker is fail-open by design and the
+        manifest must fail closed, so their lifecycles must not be shared."""
+        assert M.manifest_remote_path(_mount()) == "/remote/proj/.srunx-manifest.json"
+
+    def test_is_a_root_file_not_a_directory(self):
+        """A directory would need creating first, and ``mkdir -p`` follows an
+        existing symlink — so a peer able to write the mount root could redirect
+        the manifest write into any directory they can reach."""
+        path = M.manifest_remote_path(_mount())
+        assert path.count("/") == "/remote/proj/x".count("/")
+
+    def test_write_needs_no_directory_creation(self):
+        client = _client_with_remote()
+        M.write(client, _mount(), ["a.py"], [".git/"])
+        client.ensure_remote_dir.assert_not_called()
+
+
+class TestAdditiveRetention:
+    """An additive sync must not forget what it previously uploaded.
+
+    Rsync leaves a locally deleted file on the cluster, so that file is exactly
+    what should be reported. Replacing the record with the current inventory
+    makes the sync that *creates* a stale file also erase the evidence of it,
+    and the next inspection reports nothing — the feature silently does nothing.
+    """
+
+    def test_additive_sync_keeps_previously_uploaded_paths(self):
+        client = _client_with_remote()
+        mount = _mount()
+        first = M.write(client, mount, ["train.py", "tools/probe.py"], [".git/"])
+
+        # probe.py deleted locally; an ordinary sync follows.
+        second = M.write(
+            client, mount, ["train.py"], [".git/"], previous=first, mirrored=False
+        )
+
+        assert second.paths == frozenset({"train.py", "tools/probe.py"})
+
+    def test_mirror_replaces_the_record(self):
+        """A mirror removed the remote-only files, so keeping them would report
+        as stale exactly what was just deleted."""
+        client = _client_with_remote()
+        mount = _mount()
+        first = M.write(client, mount, ["train.py", "tools/probe.py"], [".git/"])
+
+        second = M.write(
+            client, mount, ["train.py"], [".git/"], previous=first, mirrored=True
+        )
+
+        assert second.paths == frozenset({"train.py"})
+
+    def test_detection_survives_a_resync(self):
+        """End to end: delete locally, sync again, still detected."""
+        client = _client_with_remote()
+        mount = _mount()
+        first = M.write(client, mount, ["train.py", "tools/probe.py"], [".git/"])
+        M.write(client, mount, ["train.py"], [".git/"], previous=first)
+
+        report = M.find_stale(M.read(client, mount), ["train.py"], [".git/"])
+        assert report.paths == ["tools/probe.py"]
+
+
+class TestFindStale:
+    def test_identifies_uploaded_then_locally_deleted(self):
+        recorded = M.SyncManifest(
+            paths=frozenset({"train.py", "tools/probe.py"}),
+            exclude_fingerprint=M.exclude_fingerprint([".git/"]),
+        )
+        report = M.find_stale(recorded, ["train.py"], [".git/"])
+
+        assert report.known is True
+        assert report.paths == ["tools/probe.py"]
+
+    def test_job_output_never_appears(self):
+        """The whole point: artifacts were never uploaded, so they cannot be in
+        the record — and this holds with no exclude pattern for them at all."""
+        recorded = M.SyncManifest(
+            paths=frozenset({"train.py"}),
+            exclude_fingerprint=M.exclude_fingerprint([]),
+        )
+        report = M.find_stale(recorded, ["train.py"], [])
+
+        assert report.known is True
+        assert report.paths == []
+
+    def test_no_manifest_is_unknown_not_clean(self):
+        report = M.find_stale(None, ["a.py"], [])
+        assert report.known is False
+        assert report.count == 0
+        assert "no manifest" in report.reason
+
+    def test_changed_excludes_make_it_unknown(self):
+        """Excluded files are never uploaded, so a changed filter moves paths
+        out of the manifest for reasons unrelated to staleness. Reporting them
+        would invite deleting files that are merely newly excluded."""
+        recorded = M.SyncManifest(
+            paths=frozenset({"data/big.bin", "train.py"}),
+            exclude_fingerprint=M.exclude_fingerprint([".git/"]),
+        )
+        report = M.find_stale(recorded, ["train.py"], [".git/", "data/"])
+
+        assert report.known is False
+        assert "exclude patterns changed" in report.reason
+        assert report.paths == []  # not presented as stale
+
+    def test_result_is_sorted(self):
+        recorded = M.SyncManifest(
+            paths=frozenset({"c.py", "a.py", "b.py"}),
+            exclude_fingerprint=M.exclude_fingerprint([]),
+        )
+        assert M.find_stale(recorded, [], []).paths == ["a.py", "b.py", "c.py"]
+
+
+class TestListLocalFiles:
+    """Inventory parsing, against real itemize output.
+
+    The inventory is an itemize run against a throwaway empty directory, not
+    ``--list-only``: that listing prints a newline inside a filename literally,
+    so a crafted name yields paths that do not exist. Itemize escapes it.
+    """
+
+    def _client(self) -> RsyncClient:
+        with (
+            patch("srunx.sync.rsync.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "srunx.sync.rsync.subprocess.run",
+                return_value=MagicMock(stdout="", stderr="openrsync"),
+            ),
+        ):
+            return RsyncClient(hostname="h", username="u")
+
+    def test_parses_real_output(self):
+        """Verbatim ``rsync -a -n -i`` output against an empty destination."""
+        stdout = "cd+++++++ ./\n>f+++++++ a.py\ncd+++++++ sub/\n>f+++++++ sub/b.py\n"
+        assert self._client()._parse_inventory(stdout) == ["a.py", "sub/b.py"]
+
+    def test_keeps_zero_byte_files(self):
+        """No size column to mis-parse: ``__init__.py`` is an ordinary entry.
+
+        It is present in essentially every Python package, and the previous
+        listing format dropped it — so it could never be reported as stale.
+        """
+        stdout = ">f+++++++ pkg/__init__.py\n>f+++++++ pkg/mod.py\n"
+        assert self._client()._parse_inventory(stdout) == [
+            "pkg/__init__.py",
+            "pkg/mod.py",
+        ]
+
+    def test_parses_gnu_style_flag_width(self):
+        """GNU rsync uses an 11-char flag block, openrsync 9. Matching the
+        block as a space-free run handles both."""
+        stdout = ">f+++++++++ with space/a b.py\n"
+        assert self._client()._parse_inventory(stdout) == ["with space/a b.py"]
+
+    def test_keeps_paths_containing_spaces(self):
+        stdout = ">f....... with space/c.py\n"
+        assert self._client()._parse_inventory(stdout) == ["with space/c.py"]
+
+    def test_skips_directories(self):
+        """A directory lingering because it holds job output is not itself a
+        stale upload."""
+        stdout = "cd+++++++ sub/\n>f+++++++ a.py\n"
+        assert self._client()._parse_inventory(stdout) == ["a.py"]
+
+    def test_tracks_symlinks_by_name(self):
+        """``rsync -a`` uploads links too, so one deleted locally lingers on the
+        cluster exactly like a file and has to be trackable. Only the name is
+        the path — the ``-> target`` half is not."""
+        stdout = "cL+++++++ latest.py -> train.py\n>f+++++++ train.py\n"
+        assert self._client()._parse_inventory(stdout) == ["latest.py", "train.py"]
+
+    def test_failure_raises_rather_than_returning_partial(self):
+        """A partial listing recorded as complete would mark the missing files
+        as never-uploaded, and they would never be reported as stale."""
+        client = self._client()
+        with patch("srunx.sync.rsync.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=23, stdout="", stderr="denied")
+            with pytest.raises(RuntimeError, match="inventory failed"):
+                client.list_local_files("/local/proj")
+
+    def test_does_not_pass_protect_args(self):
+        """It guards a *remote* shell re-splitting arguments; this listing is
+        local, and openrsync does not have the flag at all."""
+        client = self._client()
+        with patch("srunx.sync.rsync.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.list_local_files("/local/proj")
+
+        assert "--protect-args" not in run.call_args[0][0]
+
+    def test_inventory_destination_is_a_throwaway_empty_directory(self):
+        """Against a non-empty destination rsync omits files already up to
+        date, which would silently under-record. It must also be a dry run."""
+        client = self._client()
+        with patch("srunx.sync.rsync.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.list_local_files("/local/proj")
+
+        cmd = run.call_args[0][0]
+        assert "-n" in cmd and "-i" in cmd
+        dest = cmd[-1]
+        assert "srunx-inventory-" in dest
+        # Removed once the scan is done, so nothing accumulates.
+        assert not pathlib.Path(dest).exists()
+
+
+class TestFailClosedLifecycle:
+    """Every path that cannot produce a trustworthy record must end in unknown.
+
+    Reporting "known, nothing stale" when tracking is broken is the failure mode
+    that matters: it looks identical to a clean tree, so nobody investigates.
+    """
+
+    def test_corrupt_manifest_is_not_rebuilt_by_an_additive_sync(self):
+        """The current inventory is not a valid baseline for an additive run.
+
+        Rsync left everything previously uploaded on the cluster, including
+        files since deleted locally; writing "this is everything" would claim
+        those do not exist. Only a mirror actually makes the remote match.
+        """
+        from srunx.sync.mount_helpers import record_upload
+
+        client = _client_with_remote({"/remote/proj/.srunx-manifest.json": "{bad"})
+        record_upload(client, _mount(), mirrored=False, before=["train.py"])
+
+        # Nothing written: the corrupt file is left, so reads keep failing and
+        # detection keeps reporting unknown.
+        assert client._store["/remote/proj/.srunx-manifest.json"] == "{bad"
+
+    def test_an_additive_sync_recovers_from_the_preserved_baseline(self):
+        """Invalidation is otherwise a dead end.
+
+        An additive sync will not rebuild from scratch, so without a preserved
+        baseline detection stays unknown until someone runs a mirror — and a
+        mirror deletes exactly the cluster-only job output this protects.
+        """
+        client = _client_with_remote()
+        mount = _mount()
+        good = M.write(client, mount, ["train.py", "tools/probe.py"], [".git/"])
+        M.invalidate(client, mount, "recording failed: disk full", previous=good)
+
+        # While invalidated, detection must still report "cannot tell".
+        with pytest.raises(M.ManifestUnavailable):
+            M.read(client, mount)
+
+        from srunx.sync.mount_helpers import record_upload
+
+        record_upload(client, mount, mirrored=False, before=["train.py"])
+
+        recovered = M.read(client, mount)
+        assert recovered is not None
+        # probe.py was deleted locally after the failure; it is still stale.
+        assert recovered.paths == frozenset({"train.py", "tools/probe.py"})
+
+    def test_a_second_failure_does_not_erase_the_preserved_baseline(self):
+        """Otherwise one more hiccup destroys the only recovery path."""
+        client = _client_with_remote()
+        mount = _mount()
+        good = M.write(client, mount, ["train.py"], [".git/"])
+        M.invalidate(client, mount, "first failure", previous=good)
+        M.invalidate(client, mount, "second failure")
+
+        assert M.read_superseded(client, mount).paths == frozenset({"train.py"})
+
+    def test_no_baseline_means_no_rebuild(self):
+        """A corrupt record has nothing to union onto, and inventing one would
+        claim files uploaded earlier were never sent."""
+        client = _client_with_remote({"/remote/proj/.srunx-manifest.json": "{bad"})
+        assert M.read_superseded(client, _mount()) is None
+
+    def test_manifest_is_written_privately(self):
+        """It enumerates a project's file names and the pushing workstation,
+        and only its own writer reads it — a mount root is often traversable
+        on a shared cluster even when the directories under it are not."""
+        client = _client_with_remote()
+        M.write(client, _mount(), ["train.py"], [".git/"])
+        assert client.write_remote_file.call_args.kwargs["mode"] == "600"
+
+        M.invalidate(client, _mount(), "boom")
+        assert client.write_remote_file.call_args.kwargs["mode"] == "600"
+
+    def test_mirror_may_rebuild_a_corrupt_manifest(self):
+        """A mirror does make the remote match local, so it can re-baseline."""
+        from srunx.sync.mount_helpers import record_upload
+
+        client = _client_with_remote({"/remote/proj/.srunx-manifest.json": "{bad"})
+        record_upload(client, _mount(), mirrored=True, before=["train.py"])
+
+        assert M.read(client, _mount()).paths == frozenset({"train.py"})
+
+    def test_files_appearing_mid_transfer_are_not_recorded(self):
+        """The post-transfer scan can see a file rsync never sent.
+
+        A concurrent build writing into the tree after rsync walked its parent
+        would otherwise be recorded as uploaded. Delete it locally later and,
+        if a job wrote the same relative path on the cluster, that job's output
+        gets named as a stale upload.
+        """
+        from srunx.sync.mount_helpers import record_upload
+
+        client = _client_with_remote()
+        client.list_local_files.return_value = ["train.py", "dist/out.bin"]
+
+        record_upload(client, _mount(), mirrored=False, before=["train.py"])
+
+        assert M.read(client, _mount()).paths == frozenset({"train.py"})
+
+    def test_files_deleted_mid_transfer_are_still_recorded(self):
+        """rsync sent them, so they are on the cluster and genuinely stale.
+
+        Dropping them leaves a file no later sync can ever record — it is not
+        local any more — while the report still calls itself complete. That
+        silent gap is the exact failure this feature exists to close.
+        """
+        from srunx.sync.mount_helpers import record_upload
+
+        client = _client_with_remote()
+        # Present before the transfer, gone by the time it finished.
+        client.list_local_files.return_value = ["train.py"]
+
+        record_upload(
+            client, _mount(), mirrored=False, before=["train.py", "tools/probe.py"]
+        )
+
+        assert M.read(client, _mount()).paths == frozenset(
+            {"train.py", "tools/probe.py"}
+        )
+
+    def test_a_failed_pre_scan_publishes_nothing(self):
+        """There is no after-scan fallback, and that is deliberate.
+
+        A scan taken after the transfer records files rsync never sent, and if
+        a job already holds one of those paths the report ends up naming live
+        output for deletion. A record that reads as authoritative must not be
+        built that way — an existing one stops being trusted instead.
+        """
+        from srunx.sync.mount_helpers import record_upload, snapshot_local
+
+        client = _client_with_remote()
+        client.list_local_files.side_effect = RuntimeError("scan blew up")
+        assert snapshot_local(client, _mount()) is None
+
+        mount = _mount()
+        M.write(client, mount, ["train.py"], [".git/"])
+        client.list_local_files.side_effect = None
+        client.list_local_files.return_value = ["train.py", "dist/out.bin"]
+
+        record_upload(client, mount, mirrored=False, before=None)
+
+        with pytest.raises(M.ManifestUnavailable):
+            M.read(client, mount)
+        # The scan it refused to trust is nowhere in the record.
+        assert "dist/out.bin" not in client._store[M.manifest_remote_path(mount)]
+
+    def test_a_first_sync_failure_leaves_the_manifest_absent(self):
+        """Marking it would strand the mount at unknown.
+
+        Absent already reads as "cannot tell", and it is the one state an
+        additive sync can still build on — so writing the mark here removes the
+        only recovery path without protecting anything.
+        """
+        from srunx.sync.mount_helpers import record_upload
+
+        client = _client_with_remote()
+
+        record_upload(client, _mount(), mirrored=False, before=None)
+
+        assert client._store == {}
+        assert M.read(client, _mount()) is None
+
+        # And the next successful sync establishes one.
+        record_upload(client, _mount(), mirrored=False, before=["train.py"])
+        assert M.read(client, _mount()).paths == frozenset({"train.py"})
+
+    def test_a_valid_record_survives_a_transient_read_failure(self):
+        """Invalidating must carry the live record's own paths forward, not
+        only a previously preserved baseline — otherwise one hiccup erases it."""
+        client = _client_with_remote()
+        mount = _mount()
+        M.write(client, mount, ["train.py"], [".git/"])
+
+        M.invalidate(client, mount, "transient ssh error")
+
+        assert M.read_superseded(client, mount).paths == frozenset({"train.py"})
+
+    def test_an_unreadable_manifest_is_not_treated_as_absent(self):
+        """Skipping the mark on a read error leaves an outdated record trusted
+        the moment ssh recovers, so files this sync uploaded go unrecorded
+        while detection still answers "known"."""
+        client = _client_with_remote()
+        mount = _mount()
+        M.write(client, mount, ["train.py"], [".git/"])
+
+        store = client._store
+        client.read_remote_file.side_effect = RuntimeError("ssh went away")
+        M.invalidate(client, mount, "recording failed")
+
+        # Written despite the read failing — absence was never proven.
+        client.read_remote_file.side_effect = lambda p, **kw: store.get(p)
+        with pytest.raises(M.ManifestUnavailable, match="recording failed"):
+            M.read(client, mount)
+
+    def test_a_future_schema_baseline_is_not_restored(self):
+        """Its path semantics are exactly what this version cannot interpret;
+        rewriting a confident record from it is worse than staying unknown."""
+        client = _client_with_remote(
+            {
+                "/remote/proj/.srunx-manifest.json": json.dumps(
+                    {
+                        "schema_version": M.SCHEMA_VERSION + 1,
+                        "invalidated": True,
+                        "superseded": {
+                            "paths": ["train.py"],
+                            "exclude_fingerprint": "fp",
+                        },
+                    }
+                )
+            }
+        )
+        assert M.read_superseded(client, _mount()) is None
+
+    def test_a_baseline_outside_an_invalidation_is_not_restored(self):
+        """Only an invalidation puts one there; anything else carrying the key
+        is not a record this wrote."""
+        client = _client_with_remote(
+            {
+                "/remote/proj/.srunx-manifest.json": json.dumps(
+                    {
+                        "schema_version": M.SCHEMA_VERSION,
+                        "paths": [],
+                        "exclude_fingerprint": "fp",
+                        "superseded": {
+                            "paths": ["planted.py"],
+                            "exclude_fingerprint": "fp",
+                        },
+                    }
+                )
+            }
+        )
+        assert M.read_superseded(client, _mount()) is None
+
+    def test_failed_recording_invalidates_the_previous_manifest(self):
+        """Leaving it in place leaves it *trusted* while it no longer describes
+        the remote — a file this sync uploaded and later deleted locally would
+        be reported as "nothing stale"."""
+        from srunx.sync.mount_helpers import record_upload
+
+        client = _client_with_remote()
+        mount = _mount()
+        M.write(client, mount, ["train.py"], [".git/"])
+        client.effective_excludes.side_effect = RuntimeError("filter blew up")
+
+        record_upload(client, mount, mirrored=False, before=["train.py"])
+
+        with pytest.raises(M.ManifestUnavailable, match="invalidated"):
+            M.read(client, mount)
+
+    def test_invalidated_manifest_reports_unknown(self):
+        """A record that exists must stop being trusted the moment a sync it
+        does not describe has landed."""
+        client = _client_with_remote()
+        mount = _mount()
+        M.write(client, mount, ["train.py"], [".git/"])
+
+        M.invalidate(client, mount, "recording failed: disk full")
+
+        with pytest.raises(M.ManifestUnavailable, match="disk full"):
+            M.read(client, mount)
+
+
+class TestExcludeChangeDoesNotCreateFalsePositives:
+    def test_changed_filter_replaces_rather_than_merges(self):
+        """A file that is still present locally but newly excluded would be kept
+        in the record while vanishing from every later inventory — and then
+        reported as stale, the exact false positive the fingerprint guards."""
+        client = _client_with_remote()
+        mount = _mount()
+        first = M.write(client, mount, ["train.py", "data/big.bin"], [".git/"])
+
+        # ``data/`` added to the excludes; big.bin is still on disk locally.
+        second = M.write(
+            client, mount, ["train.py"], [".git/", "data/"], previous=first
+        )
+
+        assert second.paths == frozenset({"train.py"})
+        report = M.find_stale(second, ["train.py"], [".git/", "data/"])
+        assert report.paths == []  # not reported as stale
+
+
+class TestPathValidation:
+    def test_non_string_paths_are_rejected(self):
+        """Coercing null/numbers into strings would report them as stale."""
+        raw = json.dumps(
+            {
+                "schema_version": M.SCHEMA_VERSION,
+                "paths": ["ok.py", None],
+                "exclude_fingerprint": "fp",
+            }
+        )
+        with pytest.raises(M.ManifestUnavailable, match="non-string"):
+            M.SyncManifest.from_json(raw)
+
+    def test_non_numeric_generation_is_a_manifest_error(self):
+        """It must surface as ManifestUnavailable so the recorder's
+        replace-corrupt path can key off it; a bare TypeError escapes and the
+        corrupt file is left in place forever."""
+        raw = json.dumps(
+            {
+                "schema_version": M.SCHEMA_VERSION,
+                "paths": [],
+                "exclude_fingerprint": "fp",
+                "generation": None,
+            }
+        )
+        with pytest.raises(M.ManifestUnavailable, match="generation"):
+            M.SyncManifest.from_json(raw)
+
+
+class TestVerificationOrdering:
+    """Recording must not outrun the check that the transfer was intact.
+
+    rsync can exit 0 while the remote copy differs — the silent failure the
+    hash check exists to catch. A record written first asserts every file
+    arrived just as verification is about to prove otherwise. The ownership
+    marker already defers for this reason; the record follows it.
+    """
+
+    def test_session_defers_recording_until_after_verification(self):
+        from srunx.sync import service
+
+        assert "record_manifest=False" in service.__doc__ or True  # doc-free check
+        src = __import__("inspect").getsource(service.mount_sync_session)
+        # The sync is told not to record...
+        assert "record_manifest=False" in src
+        # ...and the record is written after the verification call.
+        assert src.index("verify_paths_match(") < src.index("record_upload(")
+
+
+class TestEscapedPathAgreement:
+    """Both rsync outputs must name a file the same way.
+
+    Verified against openrsync: ``--list-only`` prints ``データ.csv`` literally
+    while the deletion preview escapes it as ``\\#343\\#203...``. The two never
+    compare equal, so a genuine stale upload drops out of the intersection and
+    the report says "known, nothing stale". Both sides therefore read the
+    *escaped* form, which is also the only one that survives a newline.
+    """
+
+    def _client(self) -> RsyncClient:
+        with (
+            patch("srunx.sync.rsync.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "srunx.sync.rsync.subprocess.run",
+                return_value=MagicMock(stdout="", stderr="openrsync"),
+            ),
+        ):
+            return RsyncClient(hostname="h", username="u")
+
+    def test_inventory_keeps_escaping(self):
+        client = self._client()
+        with patch("srunx.sync.rsync.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.list_local_files("/local/proj")
+
+        assert "-8" not in run.call_args[0][0]
+
+    def test_itemize_keeps_escaping(self):
+        """The other half of the pair — they only agree if both do it."""
+        client = self._client()
+        cmd = client._build_rsync_cmd(
+            "s/", "u@h:d/", delete=True, dry_run=True, itemize=True, excludes=[]
+        )
+        assert "-8" not in cmd
+
+    def test_every_parsed_run_is_locale_normalized(self):
+        """Which bytes rsync escapes depends on the locale.
+
+        Verified on openrsync: under a UTF-8 locale ``データ.csv`` comes back as
+        a *mix* of raw and escaped bytes while ``LC_ALL=C`` escapes all of them.
+        Normalize only the inventory and a genuinely stale non-ASCII file
+        matches no deletion candidate — it drops out of the report and the
+        mount reads as clean.
+        """
+        client = self._client()
+        with patch("srunx.sync.rsync.subprocess.run") as run:
+            run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            client.list_local_files("/local/proj")
+            assert run.call_args.kwargs["env"]["LC_ALL"] == "C"
+
+            client.push("/local/proj", "/remote/proj", dry_run=True, itemize=True)
+            assert run.call_args.kwargs["env"]["LC_ALL"] == "C"
+
+    def test_unescape_restores_non_ascii_for_display(self):
+        assert (
+            unescape_rsync_path(r"\#343\#203\#207\#343\#203\#274\#343\#202\#277.csv")
+            == "データ.csv"
+        )
+
+    def test_unescape_is_invertible_because_backslash_is_escaped(self):
+        """A file genuinely named ``a\\#012b.py`` is emitted as ``a\\#134#012b.py``.
+
+        Without the backslash itself being escaped, unescaping would turn that
+        name into one containing a newline — a different file.
+        """
+        assert unescape_rsync_path(r"a\#134#012b.py") == r"a\#012b.py"
+
+    def test_control_bytes_stay_escaped(self):
+        """rsync escapes them because they are unsafe to print, and this goes
+        to a terminal. ``innocent\\#033c.py`` would emit ESC-c and reset it;
+        ``\\#012`` would forge an extra line in a sync preview. A cluster job
+        chooses the names it writes, so the input is attacker-controlled."""
+        for hostile in (r"innocent\#033c.py", r"victim\#012>f+++++++ fake.py"):
+            assert unescape_rsync_path(hostile) == hostile
+
+    def test_bidi_overrides_stay_escaped(self):
+        """U+202E reverses the rendering of what follows, which is how
+        ``txt.exe`` is made to read as ``exe.txt``."""
+        assert unescape_rsync_path(r"a\#342\#200\#256b") == r"a\#342\#200\#256b"
+
+    def test_real_line_breaks_are_left_alone(self):
+        """The CLI passes a whole multi-line preview through this."""
+        blob = ">f+++++++ \\#343\\#203\\#207.csv\n>f+++++++ b.py\n"
+        assert unescape_rsync_path(blob).count("\n") == 2
+
+    def test_unescape_leaves_plain_paths_alone(self):
+        assert unescape_rsync_path("sub/train.py") == "sub/train.py"
+
+
+class TestControlFileReadIsGuarded:
+    """The reader must refuse what the writer refuses.
+
+    Writing to a planted symlink is rejected; reading through one was not, so a
+    peer able to write the mount root could serve arbitrary content as srunx's
+    control file. A forged upload record becomes paths presented to the user as
+    safe to delete.
+    """
+
+    def _client(self) -> RsyncClient:
+        with (
+            patch("srunx.sync.rsync.shutil.which", return_value="/usr/bin/rsync"),
+            patch(
+                "srunx.sync.rsync.subprocess.run",
+                return_value=MagicMock(stdout="", stderr="openrsync"),
+            ),
+        ):
+            return RsyncClient(hostname="h", username="u")
+
+    def test_symlinked_control_file_is_refused(self):
+        client = self._client()
+        with patch.object(client, "_ssh_run") as ssh:
+            ssh.return_value = MagicMock(
+                returncode=client._READ_SYMLINK_EXIT, stdout="", stderr=""
+            )
+            with pytest.raises(RuntimeError, match="symlink"):
+                client.read_remote_file("/remote/proj/.srunx-manifest.json")
+
+    def test_missing_stays_distinct_from_unreadable(self):
+        """Conflating them lets an unreadable record look like a first run,
+        which an additive sync then rebuilds into a confident wrong answer."""
+        client = self._client()
+        with patch.object(client, "_ssh_run") as ssh:
+            ssh.return_value = MagicMock(
+                returncode=client._READ_MISSING_EXIT, stdout="", stderr=""
+            )
+            assert client.read_remote_file("/remote/proj/x.json") is None
+
+        with patch.object(client, "_ssh_run") as ssh:
+            ssh.return_value = MagicMock(returncode=1, stdout="", stderr="denied")
+            with pytest.raises(RuntimeError):
+                client.read_remote_file("/remote/proj/x.json")
+
+    def test_read_checks_symlink_before_existence(self):
+        client = self._client()
+        with patch.object(client, "_ssh_run") as ssh:
+            ssh.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+            client.read_remote_file("/remote/proj/x.json")
+
+        script = ssh.call_args.args[0]
+        assert script.index("-h ") < script.index("! -f ")
+
+    def test_foreign_owned_manifest_is_refused(self):
+        """Refusing symlinks is not enough on a shared mount.
+
+        A peer able to write the mount root can plant an ordinary, schema-valid
+        file naming job output as stale — and the user is told those paths are
+        safe to delete. They can only create files owned by themselves.
+        """
+        client = self._client()
+        with patch.object(client, "_ssh_run") as ssh:
+            ssh.return_value = MagicMock(
+                returncode=client._READ_FOREIGN_EXIT, stdout="", stderr=""
+            )
+            with pytest.raises(RuntimeError, match="another account"):
+                client.read_remote_file("/r/x.json", require_owned=True)
+
+    def test_ownership_check_is_opt_in(self):
+        """The advisory marker leaves it off: refusing to read a foreign one
+        would turn a warning into a hard failure."""
+        client = self._client()
+        with patch.object(client, "_ssh_run") as ssh:
+            ssh.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+            client.read_remote_file("/r/x.json")
+            assert "id -u" not in ssh.call_args.args[0]
+
+            client.read_remote_file("/r/x.json", require_owned=True)
+            assert "id -u" in ssh.call_args.args[0]
+
+    def test_a_newline_in_a_name_cannot_forge_an_entry(self):
+        """Verbatim itemize output for a directory crafted to look like a line.
+
+        With ``--list-only`` this exact tree recorded ``victim`` *and* a
+        fabricated ``output.py``, neither of which exists. Had a job written
+        anything by either name, the comparison would have offered live job
+        output for deletion. Escaping makes one line exactly one file.
+        """
+        stdout = (
+            ">f+++++++ plain.py\n"
+            "cd+++++++ victim\\#012-rw-r--r--            1 2026/\n"
+            ">f+++++++ victim\\#012-rw-r--r--            1 2026/out.py\n"
+        )
+        assert self._client()._parse_inventory(stdout) == [
+            "plain.py",
+            "victim\\#012-rw-r--r--            1 2026/out.py",
+        ]
+
+    def test_drops_names_starting_with_whitespace(self):
+        """Trailing whitespace is fine; leading is not.
+
+        The inventory keeps a leading space, but the deletion preview pads its
+        ``*deleting`` marker with the same characters, so the two sides can
+        never be matched. Recording it would make a stale `` foo.py`` look
+        like the plain ``foo.py`` a job may have written.
+        """
+        stdout = ">f+++++++  leading.py\n>f+++++++ trailing.py \n"
+        assert self._client()._parse_inventory(stdout) == ["trailing.py "]
+
+    def test_undecodable_filename_bytes_survive_a_json_round_trip(self):
+        """A Linux filename can be any bytes at all.
+
+        Escaped output is ASCII, so this cannot arise from the inventory — but
+        stderr and other rsync output are decoded with surrogate escapes rather
+        than raising, and anything that reaches the record has to survive it.
+        """
+        undecodable = "bad\udcffname.py"
+        payload = json.dumps({"paths": [undecodable]})
+        assert payload.isascii()
+        assert json.loads(payload)["paths"] == [undecodable]

--- a/tests/sync/test_service.py
+++ b/tests/sync/test_service.py
@@ -72,7 +72,9 @@ class TestEnsureMountSynced:
         # mount-resident outputs/checkpoints must survive a sync.
         # ``verbose=False`` is the default surfaced by the CLI when the
         # user did not pass ``--verbose`` (#137 part 3).
-        fake_rsync.assert_called_once_with(profile, "ml", delete=False, verbose=False)
+        fake_rsync.assert_called_once_with(
+            profile, "ml", delete=False, verbose=False, record_manifest=False
+        )
         assert outcome.performed is True
         assert outcome.warnings == ()
 
@@ -159,6 +161,7 @@ class TestEnsureMountSynced:
             *,
             delete: bool = False,
             verbose: bool = False,
+            record_manifest: bool = True,
         ) -> str:
             raise RuntimeError("rsync exited 23: permission denied")
 


### PR DESCRIPTION
## The problem

Syncing is additive (since #228's fix), so a file you delete locally **stays on the cluster — and a job can still import it**. That's the failure worth catching: a refactor leaves `old_train.py` behind and a run keeps using it, silently.

`inspect_mount` already reported cluster-only paths, but that raw list is not actionable, because it mixes two opposite things:

- **produced by jobs** — checkpoints, logs, outputs. Must not be deleted.
- **left over locally** — stale modules, renamed files. Usually should be.

Excluding output directories separates them only as well as the exclude list is maintained. On a real mount here, **four stale scripts sat among 39 job artifacts** because `dist/` had never been excluded — which is what prompted this.

## What this does

srunx records the paths it uploads, in `<mount.remote>/.srunx-manifest.json` (mode 0600). `inspect_mount` then reports `stale_upload_paths`: recorded, but no longer on your machine. Output a job wrote at a path of its own was never uploaded, so it cannot appear — **regardless of the exclude list**.

It **fails closed**. No record yet, an unreadable one, or a changed exclude filter all report `stale_uploads_known: false` rather than an empty list, because "cannot tell" presented as "clean" is exactly how a stale module keeps running unnoticed.

A recording failure keeps the last good path set alongside the mark, so the next successful sync recovers on its own. Without that, recovery would have required a mirror — which deletes the cluster-only job output this feature exists to protect.

Nothing is ever deleted on the strength of this. srunx reports; the decision stays with a human.

## Notes for review

Several parts are less obvious than they look. Each was reproduced against real rsync before being fixed:

- **The inventory is an itemize run against a throwaway empty directory, not `--list-only`.** That listing prints a newline inside a filename literally, so one file becomes two lines. A directory crafted to look like a listing line produced *two paths that do not exist* — and either could have named live job output for deletion. Itemize escapes the newline (`\#012`) and the backslash (`\#134`), so one line is always exactly one file.
- **Every parsed rsync run is pinned to `LC_ALL=C`.** Which bytes rsync escapes depends on the locale: under UTF-8, openrsync returns a *mix* of raw and escaped bytes. Normalise the inventory but not the deletion preview and a stale non-ASCII file matches nothing — it drops out of the report and the mount reads as clean.
- **Paths are stored escaped and unescaped only for display — printable characters only.** Restoring control bytes would let a job-chosen filename emit `ESC c` and reset the terminal, or forge a line in a sync preview. Verified that Rich passes the ESC byte through.
- **The recorded set is the inventory taken *before* the transfer.** An after-scan is wrong in both directions: a file created mid-sync would be recorded though rsync never sent it (and could then name a job's output for deletion), while a file deleted mid-sync would be dropped though rsync *did* send it — leaving it on the cluster, permanently unrecordable, with the report still calling itself complete.

## Limits, on purpose

Only path names are recorded, not contents. So a path that is **both** recorded and job-written stays ambiguous — a job that overwrote a file srunx sent keeps its path, and a file deleted in the gap between srunx's inventory and rsync's own walk is recorded without having been sent. Resolving either needs a content hash per file on every sync. Both are documented in `srunx.sync.manifest` and `snapshot_local` rather than papered over.

## Verification

- **2397 passed, 2 skipped**; `mypy` clean (373 files); `ruff` clean.
- ~40 new tests in `tests/sync/test_manifest.py`, plus MCP coverage.
- Fifteen adversarial review rounds; the last returned no actionable defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBKedWVkVba5Zfpp8KmZMR
