### PR TITLE
fix(mcp): support mcp 2.x and bound the requirement to tested majors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,12 @@ Changelog = "https://github.com/ksterx/srunx/releases"
 
 [project.optional-dependencies]
 mcp = [
-    "mcp[cli]>=1.27.0",
+    # Both majors work — ``srunx.mcp.app`` binds whichever server class the
+    # installed mcp provides. The cap is on the *next* major, because that is
+    # the failure this range exists to prevent: 2.0 renamed the class and its
+    # module with no alias, and an unbounded ``>=1.27.0`` happily resolved it,
+    # so a fresh install got an MCP server that died at import.
+    "mcp[cli]>=1.27.0,<3",
 ]
 
 [project.scripts]

--- a/src/srunx/mcp/app.py
+++ b/src/srunx/mcp/app.py
@@ -1,43 +1,100 @@
-"""FastMCP singleton for srunx tools.
+"""The MCP server singleton for srunx tools.
 
-The ``mcp`` instance lives here (not in ``server.py``) so that tool modules
+The server instance lives here (not in ``server.py``) so that tool modules
 under :mod:`srunx.mcp.tools` can register themselves with ``@mcp.tool()``
 decorators without creating a circular import against the entry-point
 module. ``server.py`` imports this module + every tool module to trigger
 decorator side-effects, then calls :meth:`mcp.run`.
+
+Both ``mcp`` majors are supported from this one place. 2.0 renamed the class
+and the module holding it — ``mcp.server.fastmcp.FastMCP`` became
+``mcp.server.mcpserver.MCPServer`` — with no compatibility alias, so an
+unbounded requirement resolved 2.x on a fresh install and the server died at
+import while reporting that ``mcp`` was not installed at all.
+
+Everything srunx uses is identical across both: the constructor's ``name`` and
+``instructions``, the ``tool()`` decorator, and ``run()`` defaulting to stdio.
+This module holds the only import of ``mcp`` in the codebase, so the entire
+difference is which name gets bound here. Verified against 2.0.0 — all fifteen
+tools register and dispatch unchanged.
 """
 
 from __future__ import annotations
 
 import sys
 
-try:
-    from mcp.server.fastmcp import FastMCP
-except ModuleNotFoundError:
-    sys.stderr.write(
-        "srunx-mcp: the 'mcp' package is not installed in this Python "
-        "environment.\n"
+
+def _installed_mcp_version() -> str | None:
+    """The installed ``mcp`` distribution's version, or None if there is none.
+
+    Tells "no mcp at all" apart from "an mcp whose API moved". Reporting the
+    second as the first sends a user to reinstall a package they already have,
+    which is what happened when 2.0 shipped: every call failed while the error
+    said the package was missing.
+    """
+    import importlib.metadata
+
+    try:
+        return importlib.metadata.version("mcp")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _unsupported_version_message(version: str) -> str:
+    return (
+        f"srunx-mcp: found 'mcp' {version}, but it provides neither\n"
+        "'mcp.server.mcpserver' (2.x) nor 'mcp.server.fastmcp' (1.x).\n"
+        "srunx supports mcp 1.x and 2.x.\n"
         "\n"
-        "Fix:\n"
-        "  1. Preferred (zero-install):\n"
-        "       uvx --from 'srunx[mcp]' srunx-mcp\n"
-        "     Register it with Claude Code as:\n"
-        "       claude mcp add --scope user srunx -- "
-        "uvx --from 'srunx[mcp]' srunx-mcp\n"
+        "Fix — reinstall within the supported range:\n"
+        "  uv tool install --force --with 'mcp[cli]>=1.27.0,<3' srunx\n"
         "\n"
-        "  2. Globally installed binary:\n"
-        "       uv tool install --force --with 'mcp[cli]' srunx\n"
-        "     then register:\n"
-        "       claude mcp add --scope user srunx -- srunx-mcp\n"
-        "\n"
-        "Note: 'uv run --extra mcp srunx-mcp' resolves extras against the\n"
-        "current working directory's pyproject.toml, so it only works when\n"
-        "launched from inside the srunx source tree.\n"
+        "or, for a zero-install run (the range comes from srunx's own\n"
+        "metadata, so no --with is needed):\n"
+        "  uvx --from 'srunx[mcp]' srunx-mcp\n"
     )
-    sys.exit(1)
 
 
-mcp = FastMCP(
+_NOT_INSTALLED_MESSAGE = (
+    "srunx-mcp: the 'mcp' package is not installed in this Python environment.\n"
+    "\n"
+    "Fix:\n"
+    "  1. Preferred (zero-install):\n"
+    "       uvx --from 'srunx[mcp]' srunx-mcp\n"
+    "     Register it with Claude Code as:\n"
+    "       claude mcp add --scope user srunx -- "
+    "uvx --from 'srunx[mcp]' srunx-mcp\n"
+    "\n"
+    "  2. Globally installed binary:\n"
+    "       uv tool install --force --with 'mcp[cli]' srunx\n"
+    "     then register:\n"
+    "       claude mcp add --scope user srunx -- srunx-mcp\n"
+    "\n"
+    "Note: 'uv run --extra mcp srunx-mcp' resolves extras against the\n"
+    "current working directory's pyproject.toml, so it only works when\n"
+    "launched from inside the srunx source tree.\n"
+)
+
+
+try:  # mcp >= 2
+    from mcp.server.mcpserver import MCPServer as _Server
+except ModuleNotFoundError:
+    try:  # mcp 1.x
+        from mcp.server.fastmcp import FastMCP as _Server
+    except ModuleNotFoundError:
+        _version = _installed_mcp_version()
+        # Installed but offering neither entry point means a major past what
+        # this knows about, or a broken install. Saying so beats the
+        # "not installed" advice, which would send the user in circles.
+        sys.stderr.write(
+            _NOT_INSTALLED_MESSAGE
+            if _version is None
+            else _unsupported_version_message(_version)
+        )
+        sys.exit(1)
+
+
+mcp = _Server(
     "srunx",
     instructions=(
         "SLURM job management tools. Use these to submit jobs, monitor status, "

--- a/tests/architecture/test_mcp_dependency_bounds.py
+++ b/tests/architecture/test_mcp_dependency_bounds.py
@@ -1,0 +1,40 @@
+"""The published metadata must not let an unsupported ``mcp`` major resolve.
+
+``srunx.mcp.app`` binds whichever server class the installed mcp provides, so
+1.x and 2.x both work. What must not happen again is an *unbounded* range: 2.0
+renamed ``mcp.server.fastmcp.FastMCP`` to ``mcp.server.mcpserver.MCPServer``
+with no alias, and ``>=1.27.0`` resolved it happily — a fresh install got an
+MCP server that died at import, reporting that mcp was not installed at all.
+The next major can rename things just as freely.
+
+Read from the installed distribution's metadata rather than by locating and
+parsing ``pyproject.toml``: that is what a user's resolver actually sees, and
+it keeps the test free of any assumption about where the file sits.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+from packaging.requirements import Requirement
+
+
+def _mcp_requirement() -> Requirement:
+    for raw in importlib.metadata.requires("srunx") or []:
+        req = Requirement(raw)
+        if req.name == "mcp":
+            return req
+    raise AssertionError("srunx no longer declares an 'mcp' dependency")
+
+
+@pytest.mark.parametrize("version", ["1.27.0", "1.29.0", "2.0.0"])
+def test_supported_majors_resolve(version: str):
+    """Both are verified to work; excluding either would be its own bug."""
+    assert _mcp_requirement().specifier.contains(version)
+
+
+def test_an_untested_major_cannot_resolve():
+    """Not a guess about 3.0 — the point is that the range stays bounded, so a
+    rename lands as a resolution result rather than a broken server."""
+    assert not _mcp_requirement().specifier.contains("3.0.0")

--- a/uv.lock
+++ b/uv.lock
@@ -2529,7 +2529,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.136.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.27.0" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.27.0,<3" },
     { name = "paramiko", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.13.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },


### PR DESCRIPTION
## The breakage

`mcp` 2.0.0 shipped on 2026-07-28 and renamed the server class **and** the module holding it:

| | mcp 1.x | mcp 2.0 |
|---|---|---|
| module | `mcp.server.fastmcp` | `mcp.server.mcpserver` |
| class | `FastMCP` | `MCPServer` |

No compatibility alias. The `mcp` extra was `mcp[cli]>=1.27.0` with **no upper bound**, so any fresh install resolves 2.x and `srunx-mcp` dies at import. Every MCP call returns a bare `-32000`.

**srunx 4.1.0 on PyPI is broken this way right now** — `uv tool install srunx` + the `mcp` extra reproduces it.

Worse, the diagnostic was actively misleading: it caught `ModuleNotFoundError` and printed *"the 'mcp' package is not installed"*. The package was installed. That sent whoever hit it off reinstalling something they already had.

## The fix

`srunx.mcp.app` now binds whichever server class is present, preferring 2.x:

```python
try:  # mcp >= 2
    from mcp.server.mcpserver import MCPServer as _Server
except ModuleNotFoundError:  # mcp 1.x
    from mcp.server.fastmcp import FastMCP as _Server
```

**Nothing else changed.** That module holds the only import of `mcp` in the codebase, and everything srunx uses is identical across both majors — the constructor's `name`/`instructions`, the `tool()` decorator, and `run()` defaulting to stdio.

Verified against both, not assumed:

| mcp | tools registered | tool call | stdio `initialize` |
|---|---|---|---|
| 2.0.0 | 15 / 15 | ✅ `get_config` returns JSON | ✅ `tools` capability |
| 1.29.0 | 15 / 15 | ✅ | ✅ |
| 1.27.0 (repo env) | 15 / 15 | ✅ | ✅ |

## Why the requirement is `<3` and not unbounded again

Removing the bound would repeat the mistake. 2.0 was free to rename what it liked and the next major will be too — a bound turns that into a **resolution result** instead of a server that dies at import. It moves forward when a port has actually been verified, which is what happened here.

A regression test asserts the published metadata admits 1.27.0 / 1.29.0 / 2.0.0 and rejects 3.0.0. It reads `importlib.metadata.requires("srunx")` — what a user's resolver actually sees — rather than locating and parsing `pyproject.toml`.

## Diagnostic

Now distinguishes the two cases and names the version it found:

```
srunx-mcp: found 'mcp' 3.0.0, but it provides neither
'mcp.server.mcpserver' (2.x) nor 'mcp.server.fastmcp' (1.x).
```

## Verification

- **2401 passed, 2 skipped**; `mypy` clean (374 files); `ruff` clean.
- Both error branches exercised in throwaway environments (mcp 2.0.0 installed; no mcp at all).

Suggest releasing as **v4.1.1** — the published 4.1.0 is broken for new installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBKedWVkVba5Zfpp8KmZMR
