### PR TITLE
feat(cli): show CPUs in squeue by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,10 @@ srunx-specific commands that don't map to a SLURM binary:
 - `uv run srunx sbatch <script>` - Submit a sbatch script (positional, like real sbatch)
 - `uv run srunx sbatch --wrap "cmd ..."` - Wrap a command into a SLURM job (mutually exclusive with the positional script)
 - `uv run srunx sbatch --profile <name> ...` - Submit over SSH to a configured profile
-- `uv run srunx squeue` - List active jobs (all users by default — matches native `squeue`). Default columns: Job ID, User, Name, Status, GPUs, Elapsed, NodeList
+- `uv run srunx squeue` - List active jobs (all users by default — matches native `squeue`). Default columns: Job ID, User, Name, Status, CPUs, GPUs, Elapsed, NodeList
 - `uv run srunx squeue -j <job_id>` - Filter to a specific job (replaces the old `srunx status` for active jobs)
 - `uv run srunx squeue -u <user>` - Filter to a single user
-- `uv run srunx squeue --show-partition --show-cpus --show-limit --show-nodes` - Opt-in columns (each flag adds one)
+- `uv run srunx squeue --show-partition --show-limit --show-nodes` - Opt-in columns (each flag adds one)
 - `uv run srunx squeue -a` - Shortcut for all opt-in columns at once
 - `uv run srunx squeue -i <seconds>` - Live refresh: re-query and redraw in place every N seconds (like native `squeue -i`). Ctrl+C exits
 - `uv run srunx squeue --format json` - JSON always includes every field regardless of show flags

--- a/docs/how-to/user_guide.md
+++ b/docs/how-to/user_guide.md
@@ -169,10 +169,12 @@ Live in-place refresh (like native `squeue -i`; Ctrl+C to exit):
 srunx squeue -i 5
 ```
 
-Show additional columns (each `--show-*` flag adds one; `-a` enables all):
+Default columns are Job ID, User, Name, Status, CPUs, GPUs, Elapsed and
+NodeList. Show additional columns (each `--show-*` flag adds one; `-a`
+enables all):
 
 ``` bash
-srunx squeue --show-partition --show-cpus --show-limit --show-nodes
+srunx squeue --show-partition --show-limit --show-nodes
 srunx squeue -a
 ```
 

--- a/src/srunx/cli/commands/jobs/squeue.py
+++ b/src/srunx/cli/commands/jobs/squeue.py
@@ -55,10 +55,6 @@ def squeue(
         bool,
         typer.Option("--show-partition", help="Add the Partition column."),
     ] = False,
-    show_cpus: Annotated[
-        bool,
-        typer.Option("--show-cpus", help="Add the CPUs column."),
-    ] = False,
     show_limit: Annotated[
         bool,
         typer.Option("--show-limit", help="Add the time-limit column."),
@@ -72,7 +68,7 @@ def squeue(
         typer.Option(
             "--all",
             "-a",
-            help="Shortcut for --show-partition --show-cpus --show-limit --show-nodes.",
+            help="Shortcut for --show-partition --show-limit --show-nodes.",
         ),
     ] = False,
     format: Annotated[
@@ -87,12 +83,11 @@ def squeue(
 
     Shows all users' jobs by default (matching native ``squeue``).
 
-    Default columns: Job ID, User, Name, Status, GPUs, Elapsed,
-    NodeList. Use ``--show-partition`` / ``--show-cpus`` /
-    ``--show-limit`` / ``--show-nodes`` (or ``-a`` / ``--all``) to
-    surface the remaining SLURM fields. ``--format json`` always
-    emits every field regardless of these flags — scripts can pick
-    what they need.
+    Default columns: Job ID, User, Name, Status, CPUs, GPUs,
+    Elapsed, NodeList. Use ``--show-partition`` / ``--show-limit`` /
+    ``--show-nodes`` (or ``-a`` / ``--all``) to surface the remaining
+    SLURM fields. ``--format json`` always emits every field
+    regardless of these flags — scripts can pick what they need.
 
     ``-i N`` / ``--iterate N`` re-queries the queue every ``N``
     seconds and redraws the table in place (like native
@@ -128,12 +123,11 @@ def squeue(
             )
             raise typer.Exit(code=2)
 
-    # Column-visibility flags — the four SLURM fields flagged as
+    # Column-visibility flags — the three SLURM fields flagged as
     # "useful but not always needed" are hidden by default; ``--show-X``
     # (or ``-a``) surfaces them.
     visibility = _SqueueColumnVisibility(
         partition=show_partition or show_all,
-        cpus=show_cpus or show_all,
         limit=show_limit or show_all,
         nodes=show_nodes or show_all,
     )
@@ -185,7 +179,6 @@ class _SqueueColumnVisibility:
     """Which opt-in columns the squeue table should render."""
 
     partition: bool
-    cpus: bool
     limit: bool
     nodes: bool
 
@@ -206,8 +199,7 @@ def _render_squeue_table(jobs: list[Any], v: _SqueueColumnVisibility) -> Table:
     table.add_column("Status")
     if v.nodes:
         table.add_column("Nodes", justify="right")
-    if v.cpus:
-        table.add_column("CPUs", justify="right")
+    table.add_column("CPUs", justify="right", style="green")
     table.add_column("GPUs", justify="right", style="yellow")
     table.add_column("Elapsed", justify="right")
     if v.limit:
@@ -226,8 +218,7 @@ def _render_squeue_table(jobs: list[Any], v: _SqueueColumnVisibility) -> Table:
         row.append(colorize_state(status_name))
         if v.nodes:
             row.append(str(getattr(job, "nodes", None) or "N/A"))
-        if v.cpus:
-            row.append(str(getattr(job, "cpus", None) or 0))
+        row.append(str(getattr(job, "cpus", None) or 0))
         row.append(str(getattr(job, "gpus", None) or 0))
         row.append(getattr(job, "elapsed_time", None) or "N/A")
         if v.limit:

--- a/tests/cli/commands/jobs/test_squeue.py
+++ b/tests/cli/commands/jobs/test_squeue.py
@@ -1,10 +1,10 @@
 """Tests for ``srunx squeue`` (active-jobs listing).
 
 The command now mirrors native ``squeue`` semantics: all users' jobs by
-default, User/Partition/CPUs/GPUs/NodeList columns, ``-u/--user`` to
-filter. The previous ``--show-gpus`` flag is gone — GPUs are always
-shown because the user explicitly asked for a combined CPU + GPU +
-NODELIST view.
+default, User/Status/CPUs/GPUs/NodeList columns, ``-u/--user`` to
+filter. The previous ``--show-gpus`` / ``--show-cpus`` flags are gone —
+CPUs and GPUs are always shown because the user explicitly asked for a
+combined CPU + GPU + NODELIST view.
 """
 
 from __future__ import annotations
@@ -95,8 +95,8 @@ def mock_jobs() -> list[BaseJob]:
 
 class TestSqueueTable:
     def test_default_columns(self, runner: CliRunner, mock_jobs) -> None:
-        """Default view: Job ID / User / Name / Status / GPUs / Elapsed /
-        NodeList. Partition / CPUs / Limit / Nodes are opt-in."""
+        """Default view: Job ID / User / Name / Status / CPUs / GPUs /
+        Elapsed / NodeList. Partition / Limit / Nodes are opt-in."""
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
             client = MagicMock()
             client.queue.return_value = mock_jobs
@@ -112,13 +112,14 @@ class TestSqueueTable:
             "User",
             "Name",
             "Status",
+            "CPUs",
             "GPUs",
             "Elapsed",
             "NodeList",
         ):
             assert shown in result.stdout, f"default column missing: {shown}"
         # Opt-in columns must not appear by default.
-        for hidden in ("Partition", "CPUs", "Limit", "Nodes"):
+        for hidden in ("Partition", "Limit", "Nodes"):
             assert hidden not in result.stdout, f"opt-in column leaked: {hidden}"
         # Default-set values still surface.
         assert "alice" in result.stdout
@@ -160,16 +161,15 @@ class TestSqueueTable:
             mock_slurm.return_value = client
             result = runner.invoke(
                 app,
-                ["squeue", "--local", "--show-partition", "--show-cpus"],
+                ["squeue", "--local", "--show-partition", "--show-nodes"],
                 env={"COLUMNS": "200"},
             )
 
         assert result.exit_code == 0
         assert "Partition" in result.stdout
-        assert "CPUs" in result.stdout
-        # The two NOT requested remain hidden.
+        assert "Nodes" in result.stdout
+        # The one NOT requested remains hidden.
         assert "Limit" not in result.stdout
-        assert "Nodes" not in result.stdout
 
     def test_empty_queue(self, runner: CliRunner) -> None:
         with patch("srunx.slurm.local.Slurm") as mock_slurm:


### PR DESCRIPTION
## What

`srunx squeue` now renders the **CPUs** column unconditionally, right next to GPUs.

```
┏━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ Job ID ┃ User  ┃ Name  ┃ Status  ┃ CPUs ┃ GPUs ┃ Elapsed ┃ NodeList      ┃
┡━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ 101    │ alice │ train │ RUNNING │   32 │    8 │ 1:02:03 │ dgx-node[1-2] │
│ 102    │ bob   │ prep  │ PENDING │    4 │    0 │    0:00 │ N/A           │
└────────┴───────┴───────┴─────────┴──────┴──────┴─────────┴───────────────┘
```

## Why

The table was already meant to be a combined CPU + GPU + NodeList view — that's why `--show-gpus` was dropped earlier and GPUs made unconditional. CPUs was the half of that pair still sitting behind `--show-cpus`, so the most common question ("how much of the node is this job holding?") cost a flag.

## Notes

- One-shot and `-i` live-refresh share the same render function, so the two layouts can't drift.
- `--format json` is unchanged — it has always emitted every field regardless of the `--show-*` flags.
- Data source is the existing `cpus` field, populated identically on the local-SLURM and SSH paths.

## Breaking

`--show-cpus` is **removed** rather than kept as a no-op: a flag that adds an already-present column is misleading in `--help`. `-a` / `--all` no longer lists it. Scripts passing `--show-cpus` will fail with "No such option" — drop the flag.

## Verification

- `uv run pytest tests/` → 2401 passed, 2 skipped
- `uv run mypy .` → clean (374 files)
- `uv run ruff check .` / `ruff format --check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oZcwdfu1ZnrbE1Hk1MYt9