### PR TITLE
fix(transport): pick the mount from cwd instead of warning about it

### DIFF
--- a/src/srunx/cli/_helpers/transport.py
+++ b/src/srunx/cli/_helpers/transport.py
@@ -60,14 +60,21 @@ def resolve_transport(
     callbacks: Sequence[Callback] | None = None,
     submission_source: str = "cli",
     mount_name: str | None = None,
+    allow_cwd_mount: bool = True,
     pool_size: int = 2,
     policy: TransportPolicy = DEFAULT_POLICY,
 ) -> Iterator[ResolvedTransport]:
     """:func:`srunx.transport.registry.resolve_transport` for CLI callers.
 
-    Identical behaviour, except a :class:`TransportSelectionError` raised
-    while resolving the transport is re-raised as ``typer.BadParameter`` so
-    Typer renders it as a normal flag error instead of a traceback.
+    Two differences from the registry function:
+
+    * A :class:`TransportSelectionError` raised while resolving the
+      transport is re-raised as ``typer.BadParameter`` so Typer renders
+      it as a normal flag error instead of a traceback.
+    * ``allow_cwd_mount`` defaults to ``True``. The CLI has no
+      ``--mount`` flag, and a one-shot CLI process's cwd is a direct
+      expression of user intent — unlike a long-lived Web / MCP server,
+      whose cwd is an accident of how it was launched.
     """
     try:
         with registry.resolve_transport(
@@ -78,6 +85,7 @@ def resolve_transport(
             callbacks=callbacks,
             submission_source=submission_source,
             mount_name=mount_name,
+            allow_cwd_mount=allow_cwd_mount,
             pool_size=pool_size,
             policy=policy,
         ) as resolved:

--- a/src/srunx/runtime/submission_plan.py
+++ b/src/srunx/runtime/submission_plan.py
@@ -23,6 +23,7 @@ test.
 from __future__ import annotations
 
 import enum
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -80,20 +81,32 @@ class SubmissionPlan:
 
 
 def resolve_mount_for_path(path: Path, profile: ServerProfile) -> MountConfig | None:
-    """Return the profile mount whose ``local`` root contains *path*.
+    """Return the profile mount whose ``local`` root contains *path*."""
+    return resolve_mount_among(path, profile.mounts)
+
+
+def resolve_mount_among(
+    path: Path, mounts: Sequence[MountConfig]
+) -> MountConfig | None:
+    """Return the mount in *mounts* whose ``local`` root contains *path*.
 
     Uses longest-prefix match so nested mounts (unusual but legal)
     resolve to the deepest one. Resolves symlinks on *path* first to
     avoid leaking outside the mount via symlink traversal — the same
     convention the web router's shell-script guard uses.
+
+    Takes a bare mount sequence rather than a ``ServerProfile`` so
+    callers that only hold the mounts (the transport registry's cwd
+    auto-selection) share this matching policy instead of reimplementing
+    it.
     """
-    if not profile.mounts:
+    if not mounts:
         return None
 
     resolved = path.resolve()
     best: MountConfig | None = None
     best_len = -1
-    for mount in profile.mounts:
+    for mount in mounts:
         mount_root = Path(mount.local).expanduser().resolve()
         try:
             resolved.relative_to(mount_root)

--- a/src/srunx/transport/registry.py
+++ b/src/srunx/transport/registry.py
@@ -42,6 +42,7 @@ import threading
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from rich.console import Console
@@ -454,11 +455,27 @@ def _build_local_handle(slurm: Slurm | None = None) -> TransportHandle:
     )
 
 
+def _select_mount_for_cwd(mounts: Sequence[Any]) -> Any | None:
+    """Return the mount owning the current working directory, if any.
+
+    Returns ``None`` when the cwd sits outside every mount, or when the
+    cwd cannot be read at all (it was deleted underneath the process).
+    """
+    from srunx.runtime.submission_plan import resolve_mount_among
+
+    try:
+        cwd = Path.cwd()
+    except OSError:
+        return None
+    return resolve_mount_among(cwd, mounts)
+
+
 def _resolve_submission_context(
     *,
     profile_name: str,
     profile_mounts: Sequence[Any] | None,
     mount_name: str | None,
+    allow_cwd_mount: bool = False,
 ) -> SubmissionRenderContext | None:
     """Decide the ``SubmissionRenderContext`` for an SSH profile.
 
@@ -468,9 +485,22 @@ def _resolve_submission_context(
     Returns ``None`` when the profile has no mounts at all (no
     translation possible). Otherwise returns a context with
     ``mount_name`` set to either the caller's explicit choice, the
-    single mount's name (auto-selection), or ``None`` when the profile
-    declares multiple mounts and the caller did not pick one (logs a
-    warning so the silent no-translation fallback is visible).
+    single mount's name, the mount that owns the current working
+    directory (only when *allow_cwd_mount*), or ``None`` when none of
+    those apply.
+
+    The cwd fallback exists because the CLI has no ``--mount`` flag —
+    ``mount_name`` is only ever passed by the Web and MCP surfaces, so
+    without it a multi-mount profile could never get path translation
+    from the CLI at all. Mount ``local`` roots are unique per profile
+    (enforced in ``ConfigManager.add_profile_mount``) and matching is
+    longest-prefix, so the cwd picks out at most one mount.
+
+    It is opt-in because cwd only carries user intent for a one-shot
+    CLI process. For a long-lived server (Web app, MCP) the cwd is
+    wherever the process happened to be launched, so honouring it there
+    would make identical requests render different remote paths on two
+    machines.
     """
     from srunx.runtime.rendering import SubmissionRenderContext
 
@@ -483,13 +513,22 @@ def _resolve_submission_context(
         if len(mounts) == 1:
             resolved_mount_name = mounts[0].name
         else:
-            logger.warning(
-                "SSH profile {!r} declares {} mounts; no mount selected "
-                "so path translation is disabled. Pass mount_name "
-                "explicitly to enable translation.",
-                profile_name,
-                len(mounts),
-            )
+            cwd_mount = _select_mount_for_cwd(mounts) if allow_cwd_mount else None
+            if cwd_mount is not None:
+                resolved_mount_name = cwd_mount.name
+            else:
+                # Not a warning: read-only commands (squeue / sinfo /
+                # tail) build a handle too and never translate a path,
+                # so this is only interesting when debugging a
+                # submission that skipped translation.
+                logger.debug(
+                    "SSH profile {!r} declares {} mounts and none was "
+                    "selected (cwd fallback {}); path translation is "
+                    "disabled.",
+                    profile_name,
+                    len(mounts),
+                    "missed" if allow_cwd_mount else "off",
+                )
     return SubmissionRenderContext(
         mount_name=resolved_mount_name,
         mounts=mounts,
@@ -503,6 +542,7 @@ def _build_ssh_handle(
     submission_source: str,
     callbacks: Sequence[Callback] | None = None,
     mount_name: str | None = None,
+    allow_cwd_mount: bool = False,
     pool_size: int = 2,
 ) -> tuple[TransportHandle, Any]:
     """Build an SSH :class:`TransportHandle` and its backing executor pool.
@@ -525,9 +565,11 @@ def _build_ssh_handle(
         mount_name: Explicit mount selection for path translation. When
             ``None`` and the profile declares exactly one mount we
             auto-select it so ``flow run --profile`` gets mount
-            translation out of the box. Multi-mount profiles with no
-            explicit ``mount_name`` fall back to "no translation" and
-            emit a warning.
+            translation out of the box. Multi-mount profiles fall back
+            to ``allow_cwd_mount``, then to "no translation".
+        allow_cwd_mount: Let a multi-mount profile fall back to the
+            mount owning the current working directory. CLI-only —
+            see :func:`_resolve_submission_context`.
         pool_size: Number of pooled SSH adapters. Default ``2`` for
             single-shot CLI / MCP. Long-lived callers (Web app lifespan)
             should pass a higher value (e.g. 8) to handle concurrent
@@ -586,6 +628,7 @@ def _build_ssh_handle(
             profile_name=profile_name,
             profile_mounts=profile.mounts,
             mount_name=mount_name,
+            allow_cwd_mount=allow_cwd_mount,
         )
 
         handle = TransportHandle(
@@ -658,6 +701,7 @@ def resolve_transport(
     callbacks: Sequence[Callback] | None = None,
     submission_source: str = "cli",
     mount_name: str | None = None,
+    allow_cwd_mount: bool = False,
     pool_size: int = 2,
     policy: TransportPolicy = DEFAULT_POLICY,
 ) -> Iterator[ResolvedTransport]:
@@ -692,6 +736,10 @@ def resolve_transport(
         mount_name: Explicit mount selection forwarded to the SSH
             handle builder for path translation. ``None`` triggers
             single-mount auto-selection.
+        allow_cwd_mount: Forwarded to the SSH handle builder. Defaults
+            to ``False`` so long-lived callers (Web app, MCP server)
+            stay deterministic; the CLI wrapper in
+            ``srunx.cli._helpers.transport`` turns it on.
         pool_size: Pool size forwarded to the SSH executor pool. Default
             ``2`` matches single-shot CLI usage; long-lived callers pass
             a larger value.
@@ -725,6 +773,7 @@ def resolve_transport(
             callbacks=callbacks,
             submission_source=submission_source,
             mount_name=mount_name,
+            allow_cwd_mount=allow_cwd_mount,
             pool_size=pool_size,
         )
     else:

--- a/tests/cli/test_sbatch_in_place.py
+++ b/tests/cli/test_sbatch_in_place.py
@@ -93,6 +93,7 @@ def _patch_transport(
         callbacks=None,
         submission_source="web",
         mount_name=None,
+        allow_cwd_mount=False,
         pool_size=2,
     ):
         return handle, MagicMock(name="pool")

--- a/tests/cli/test_sbatch_job_name.py
+++ b/tests/cli/test_sbatch_job_name.py
@@ -179,6 +179,7 @@ def _patch_transport(
         callbacks=None,
         submission_source="web",
         mount_name=None,
+        allow_cwd_mount=False,
         pool_size=2,
     ):
         return handle, MagicMock(name="pool")

--- a/tests/cli/workflow/test_orchestrator_in_place.py
+++ b/tests/cli/workflow/test_orchestrator_in_place.py
@@ -109,6 +109,7 @@ def _patch_workflow_transport(
         callbacks=None,
         submission_source="web",
         mount_name=None,
+        allow_cwd_mount=False,
         pool_size=2,
     ):
         return handle, MagicMock(name="pool")

--- a/tests/cli/workflow/test_orchestrator_sweep_in_place.py
+++ b/tests/cli/workflow/test_orchestrator_sweep_in_place.py
@@ -277,6 +277,7 @@ def _patch_sweep_transport(
         callbacks=None,
         submission_source="web",
         mount_name=None,
+        allow_cwd_mount=False,
         pool_size=2,
     ):
         return handle, MagicMock(name="pool")

--- a/tests/transport/test_registry.py
+++ b/tests/transport/test_registry.py
@@ -451,3 +451,108 @@ class TestSSHBannerBody:
             source_display="via --profile",
         )
         assert "SSH profile: ghost" in body
+
+
+class TestSubmissionContextMountSelection:
+    """Mount auto-selection for :func:`_resolve_submission_context`."""
+
+    class _FakeMount:
+        def __init__(self, name: str, local: str) -> None:
+            self.name = name
+            self.local = local
+            self.remote = f"/remote/{name}"
+
+    def _resolve(self, mounts, mount_name=None, allow_cwd_mount=True):
+        return _registry._resolve_submission_context(
+            profile_name="gmo",
+            profile_mounts=mounts,
+            mount_name=mount_name,
+            allow_cwd_mount=allow_cwd_mount,
+        )
+
+    def test_no_mounts_returns_none(self):
+        assert self._resolve([]) is None
+
+    def test_single_mount_auto_selected_regardless_of_cwd(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        monkeypatch.chdir(outside)
+        mount = self._FakeMount("only", str(tmp_path / "proj"))
+        ctx = self._resolve([mount])
+        assert ctx is not None
+        assert ctx.mount_name == "only"
+
+    def test_explicit_mount_name_wins_over_cwd(self, tmp_path, monkeypatch):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        monkeypatch.chdir(a)
+        ctx = self._resolve(
+            [self._FakeMount("a", str(a)), self._FakeMount("b", str(b))],
+            mount_name="b",
+        )
+        assert ctx is not None
+        assert ctx.mount_name == "b"
+
+    def test_cwd_selects_the_owning_mount(self, tmp_path, monkeypatch):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        (a / "sub" / "deeper").mkdir(parents=True)
+        b.mkdir()
+        monkeypatch.chdir(a / "sub" / "deeper")
+        ctx = self._resolve(
+            [self._FakeMount("a", str(a)), self._FakeMount("b", str(b))]
+        )
+        assert ctx is not None
+        assert ctx.mount_name == "a"
+
+    def test_nested_mounts_resolve_to_the_deepest(self, tmp_path, monkeypatch):
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        inner.mkdir(parents=True)
+        monkeypatch.chdir(inner)
+        ctx = self._resolve(
+            [self._FakeMount("outer", str(outer)), self._FakeMount("inner", str(inner))]
+        )
+        assert ctx is not None
+        assert ctx.mount_name == "inner"
+
+    def test_cwd_outside_every_mount_disables_translation_quietly(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        outside = tmp_path / "outside"
+        for d in (a, b, outside):
+            d.mkdir()
+        monkeypatch.chdir(outside)
+        with caplog.at_level("WARNING"):
+            ctx = self._resolve(
+                [self._FakeMount("a", str(a)), self._FakeMount("b", str(b))]
+            )
+        assert ctx is not None
+        assert ctx.mount_name is None
+        # Read-only commands (squeue / sinfo / tail) build a handle too;
+        # the no-translation fallback must not shout at them.
+        assert "path translation" not in caplog.text
+
+    def test_cwd_fallback_is_off_by_default(self, tmp_path, monkeypatch):
+        """Long-lived callers (Web app, MCP) must not inherit the cwd.
+
+        Their working directory is an accident of how the process was
+        launched, so honouring it would make identical requests resolve
+        to different remote paths on two machines.
+        """
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        monkeypatch.chdir(a)
+        ctx = _registry._resolve_submission_context(
+            profile_name="gmo",
+            profile_mounts=[self._FakeMount("a", str(a)), self._FakeMount("b", str(b))],
+            mount_name=None,
+        )
+        assert ctx is not None
+        assert ctx.mount_name is None


### PR DESCRIPTION
## The problem

Running any command against a multi-mount SSH profile printed this:

```
WARNING | SSH profile 'gmo' declares 6 mounts; no mount selected so path
translation is disabled. Pass mount_name explicitly to enable translation.
```

Two things were wrong with it.

**The advice is not actionable from the CLI.** `mount_name` is only ever passed by the Web (`?mount=`) and MCP (`mount=`) surfaces — there is no `--mount` flag. So every CLI invocation against a multi-mount profile fell into the "no mount selected" branch, and there was no way for the user to get out of it. In practice a multi-mount profile could never get path translation from the CLI at all.

**It fired on commands that never translate a path.** `squeue`, `sinfo`, `gpus` and `tail` build an SSH handle like everything else, so `srunx squeue --profile gmo` opened with a warning about a submission feature it does not use.

## The fix

**Fall back to the mount owning the current working directory.** Mount `local` roots are unique per profile (`ConfigManager.add_profile_mount` enforces exactly this, citing cwd auto-detection as the reason) and matching is longest-prefix, so the cwd resolves to at most one mount. This is the same policy `resolve_mount_for_path` already applies to a positional script path; its body is extracted as `resolve_mount_among` so both callers share one matcher instead of growing a second copy.

**Drop the residual message to DEBUG.** It is only interesting when debugging a submission that skipped translation, and is silent for the read-only commands passing through the same code.

## Opt-in, not ambient

The cwd fallback is gated behind `allow_cwd_mount`, enabled by the CLI wrapper in `srunx.cli._helpers.transport` and off everywhere else.

A one-shot CLI process's cwd expresses user intent. A Web app's or MCP server's cwd is an accident of how the process was launched — honouring it there would let identical requests render different remote `work_dir` / `log_dir` paths depending on the launch directory. Codex caught this in review; the first draft had the fallback in the shared resolver.

Verified from inside a mount:

```
CLI  (allow_cwd_mount=True) : TILIP
MCP/Web (default)           : None
```

`TransportRegistry.get()` (Web app, background pollers) and `srunx.mcp.transport` both reach `_build_ssh_handle` without the flag, so they keep explicit, deterministic mount selection.

## Not changed

The `mount_name is None` → no translation invariant in `_translate_abs_path` is untouched (`tests/runtime/test_rendering.py` asserts it deliberately). This PR only reduces how often `mount_name` ends up `None`.

## Side effect worth noting

`sbatch --profile <multi-mount>` run from inside a mount now gets `work_dir` / `log_dir` translated to their remote equivalents, where before it silently did not. That is the behaviour the mount config always implied.

## Testing

- 2408 passed, 2 skipped; `mypy .` and `ruff check .` clean.
- New `TestSubmissionContextMountSelection` covers: no mounts, single-mount auto-select, explicit name winning over cwd, cwd selecting its owner, nested mounts resolving to the deepest, cwd outside every mount staying quiet, and the fallback being off by default.
- Four existing test doubles that mirror `_build_ssh_handle`'s signature were updated for the new keyword argument.
- Manually confirmed `srunx squeue -u <user>` against the real cluster no longer prints the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SskDKRgQfB3ga4dvHxfCij