### PR TITLE
fix(sync): exclude .git as a file, not just a directory

### DIFF
--- a/src/srunx/sync/rsync.py
+++ b/src/srunx/sync/rsync.py
@@ -107,7 +107,11 @@ class RsyncClient:
     """
 
     DEFAULT_EXCLUDES: ClassVar[list[str]] = [
-        ".git/",
+        # No trailing slash: a trailing slash matches only directories, so a
+        # worktree's or submodule's `.git` (a *file* containing a local
+        # absolute `gitdir:` path) would sync anyway and break git on the
+        # remote with a confusing "fatal: not a git repository: <local path>".
+        ".git",
         "__pycache__/",
         ".venv/",
         "*.pyc",

--- a/tests/sync/test_rsync.py
+++ b/tests/sync/test_rsync.py
@@ -75,17 +75,17 @@ class TestRsyncClientInit:
 
     def test_default_excludes(self):
         client = _make_rsync_client(hostname="h", username="u")
-        assert ".git/" in client.exclude_patterns
+        assert ".git" in client.exclude_patterns
         assert "__pycache__/" in client.exclude_patterns
         assert ".venv/" in client.exclude_patterns
 
     def test_custom_excludes_merged(self):
         client = _make_rsync_client(
-            hostname="h", username="u", exclude_patterns=["data/", ".git/"]
+            hostname="h", username="u", exclude_patterns=["data/", ".git"]
         )
         assert "data/" in client.exclude_patterns
-        # .git/ should not be duplicated
-        assert client.exclude_patterns.count(".git/") == 1
+        # .git should not be duplicated
+        assert client.exclude_patterns.count(".git") == 1
 
     def test_detects_gnu_rsync_capabilities(self):
         client = _make_rsync_client(hostname="h", username="u")
@@ -517,7 +517,7 @@ class TestPushWithExcludePatterns:
         ]
         assert "data/" in exclude_values
         assert "*.log" in exclude_values
-        assert ".git/" in exclude_values
+        assert ".git" in exclude_values
 
     def test_pull_per_call_excludes(self, tmp_path: Path):
         client = _make_rsync_client(hostname="h", username="u")
@@ -531,7 +531,7 @@ class TestPushWithExcludePatterns:
             call_args[i + 1] for i, v in enumerate(call_args) if v == "--exclude"
         ]
         assert "artifacts/" in exclude_values
-        assert ".git/" in exclude_values
+        assert ".git" in exclude_values
 
     def test_constructor_excludes_merged_with_defaults(self):
         """Exclude patterns passed at construction are merged with DEFAULT_EXCLUDES."""
@@ -541,15 +541,15 @@ class TestPushWithExcludePatterns:
         assert "data/" in client.exclude_patterns
         assert "*.bin" in client.exclude_patterns
         # Defaults still present
-        assert ".git/" in client.exclude_patterns
+        assert ".git" in client.exclude_patterns
         assert "__pycache__/" in client.exclude_patterns
 
     def test_constructor_excludes_no_duplicates(self):
         """Passing a pattern already in DEFAULT_EXCLUDES doesn't create duplicates."""
         client = _make_rsync_client(
-            hostname="h", username="u", exclude_patterns=[".git/", "data/"]
+            hostname="h", username="u", exclude_patterns=[".git", "data/"]
         )
-        assert client.exclude_patterns.count(".git/") == 1
+        assert client.exclude_patterns.count(".git") == 1
         assert "data/" in client.exclude_patterns
 
     def test_constructor_and_per_call_excludes_combined(self, tmp_path: Path):
@@ -568,7 +568,7 @@ class TestPushWithExcludePatterns:
         ]
         assert "weights/" in exclude_values  # from constructor
         assert "logs/" in exclude_values  # from per-call
-        assert ".git/" in exclude_values  # from defaults
+        assert ".git" in exclude_values  # from defaults
 
 
 class TestMkpath:
@@ -1346,7 +1346,7 @@ class TestEffectiveExcludes:
         assert "data/raw/" in merged
         assert "*.h5" in merged
         # Defaults are still there.
-        assert ".git/" in merged
+        assert ".git" in merged
         # And the instance attribute is left alone.
         assert "data/raw/" not in client.exclude_patterns
 
@@ -1357,8 +1357,8 @@ class TestEffectiveExcludes:
 
     def test_does_not_duplicate(self):
         client = _make_rsync_client(hostname="h", username="u")
-        merged = client.effective_excludes([".git/", "data/"])
-        assert merged.count(".git/") == 1
+        merged = client.effective_excludes([".git", "data/"])
+        assert merged.count(".git") == 1
 
     def test_returns_a_copy(self):
         """Mutating the result must not corrupt the client's own list."""


### PR DESCRIPTION
## 概要
`DEFAULT_EXCLUDES` の `.git/` は末尾スラッシュにより**ディレクトリのみ**に一致し、git worktree / submodule の `.git`（**ファイル**、中身はローカル絶対パスの `gitdir:` 参照）が除外に一致せず同期されてしまう問題を修正。

同期先で git を使うとローカルマシンの絶対パスを含む分かりにくいエラー（`fatal: not a git repository: /Users/.../.git/worktrees/repo4`）で落ちていた。

## 変更内容
- `DEFAULT_EXCLUDES` の `".git/"` → `".git"`（末尾スラッシュを除去）
- 既存テスト（`tests/sync/test_rsync.py`）のうちデフォルト値に依存する箇所を新しい表記に更新

## 確認事項
- 既にリモートに同期済みの `.git` ファイル残骸のクリーンアップは本PRの対象外（放置する方針で合意済み）

Closes #238

## テスト
- `uv run pytest tests/sync/test_rsync.py tests/sync/test_manifest.py` — 167 passed
- `uv run ruff check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)