### PR TITLE
feat(cli): extend squeue filters and node requests

### DIFF
--- a/src/srunx/cli/commands/jobs/squeue.py
+++ b/src/srunx/cli/commands/jobs/squeue.py
@@ -1,5 +1,6 @@
 """``srunx squeue`` — list active jobs on the cluster."""
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -39,6 +40,18 @@ def squeue(
                 "Default is all users."
             ),
         ),
+    ] = None,
+    me: Annotated[
+        bool,
+        typer.Option("--me", help="Show only your jobs (native squeue --me)."),
+    ] = False,
+    include: Annotated[
+        list[str] | None,
+        typer.Option("-I", "--include", help="Keep jobs matching this regex (repeatable)."),
+    ] = None,
+    exclude: Annotated[
+        list[str] | None,
+        typer.Option("-x", "--exclude", help="Hide jobs matching this regex (repeatable)."),
     ] = None,
     iterate: Annotated[
         float | None,
@@ -107,6 +120,17 @@ def squeue(
     """
     import json
 
+    if me and user:
+        typer.secho("--me cannot be used with --user.", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=2)
+
+    try:
+        include_patterns = [re.compile(pattern) for pattern in include or []]
+        exclude_patterns = [re.compile(pattern) for pattern in exclude or []]
+    except re.error as exc:
+        typer.secho(f"Invalid regular expression: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=2) from None
+
     if iterate is not None:
         if iterate <= 0:
             typer.secho(
@@ -138,12 +162,13 @@ def squeue(
             def fetch() -> list[Any]:
                 if rt.transport_type == "local":
                     client = _slurm_local.Slurm()
-                    jobs = client.queue(user=user)
+                    jobs = client.queue(me=True) if me else client.queue(user=user)
                 else:
-                    jobs = rt.job_ops.queue(user=user)
+                    jobs = rt.job_ops.queue(me=True) if me else rt.job_ops.queue(user=user)
                 if job_filter:
                     wanted = {int(j) for j in job_filter}
                     jobs = [j for j in jobs if j.job_id in wanted]
+                jobs = _filter_squeue_jobs(jobs, include_patterns, exclude_patterns)
                 return jobs
 
             if iterate is not None:
@@ -204,7 +229,8 @@ def _render_squeue_table(jobs: list[Any], v: _SqueueColumnVisibility) -> Table:
     table.add_column("Elapsed", justify="right")
     if v.limit:
         table.add_column("Limit", justify="right")
-    table.add_column("NodeList", overflow="fold")
+    table.add_column("NodeList / Reason", overflow="fold")
+    table.add_column("Requested NodeList", overflow="fold")
 
     for job in jobs:
         status_name = job.status.name if hasattr(job, "status") else "UNKNOWN"
@@ -224,6 +250,7 @@ def _render_squeue_table(jobs: list[Any], v: _SqueueColumnVisibility) -> Table:
         if v.limit:
             row.append(getattr(job, "time_limit", None) or "N/A")
         row.append(getattr(job, "nodelist", None) or "N/A")
+        row.append(getattr(job, "requested_nodelist", None) or "unspecified")
         table.add_row(*row)
 
     return table
@@ -248,10 +275,32 @@ def _squeue_json(jobs: list[Any]) -> list[dict[str, Any]]:
             "cpus": getattr(job, "cpus", None),
             "gpus": getattr(job, "gpus", None),
             "nodelist": getattr(job, "nodelist", None),
+            "requested_nodelist": getattr(job, "requested_nodelist", None),
             "elapsed_time": getattr(job, "elapsed_time", None),
             "time_limit": getattr(job, "time_limit", None),
         }
         for job in jobs
+    ]
+
+
+def _filter_squeue_jobs(
+    jobs: list[Any], include_patterns: list[re.Pattern[str]], exclude_patterns: list[re.Pattern[str]]
+) -> list[Any]:
+    """Apply repeatable regex filters across the queue's useful location fields."""
+    def matches(job: Any, patterns: list[re.Pattern[str]]) -> bool:
+        values = (
+            getattr(job, "name", None),
+            getattr(job, "partition", None),
+            getattr(job, "nodelist", None),
+            getattr(job, "requested_nodelist", None),
+        )
+        return any(pattern.search(str(value)) for pattern in patterns for value in values if value)
+
+    return [
+        job
+        for job in jobs
+        if (not include_patterns or matches(job, include_patterns))
+        and not matches(job, exclude_patterns)
     ]
 
 

--- a/src/srunx/cli/commands/jobs/squeue.py
+++ b/src/srunx/cli/commands/jobs/squeue.py
@@ -47,11 +47,15 @@ def squeue(
     ] = False,
     include: Annotated[
         list[str] | None,
-        typer.Option("-I", "--include", help="Keep jobs matching this regex (repeatable)."),
+        typer.Option(
+            "-I", "--include", help="Keep jobs matching this regex (repeatable)."
+        ),
     ] = None,
     exclude: Annotated[
         list[str] | None,
-        typer.Option("-x", "--exclude", help="Hide jobs matching this regex (repeatable)."),
+        typer.Option(
+            "-x", "--exclude", help="Hide jobs matching this regex (repeatable)."
+        ),
     ] = None,
     iterate: Annotated[
         float | None,
@@ -164,7 +168,9 @@ def squeue(
                     client = _slurm_local.Slurm()
                     jobs = client.queue(me=True) if me else client.queue(user=user)
                 else:
-                    jobs = rt.job_ops.queue(me=True) if me else rt.job_ops.queue(user=user)
+                    jobs = (
+                        rt.job_ops.queue(me=True) if me else rt.job_ops.queue(user=user)
+                    )
                 if job_filter:
                     wanted = {int(j) for j in job_filter}
                     jobs = [j for j in jobs if j.job_id in wanted]
@@ -284,9 +290,12 @@ def _squeue_json(jobs: list[Any]) -> list[dict[str, Any]]:
 
 
 def _filter_squeue_jobs(
-    jobs: list[Any], include_patterns: list[re.Pattern[str]], exclude_patterns: list[re.Pattern[str]]
+    jobs: list[Any],
+    include_patterns: list[re.Pattern[str]],
+    exclude_patterns: list[re.Pattern[str]],
 ) -> list[Any]:
     """Apply repeatable regex filters across the queue's useful location fields."""
+
     def matches(job: Any, patterns: list[re.Pattern[str]]) -> bool:
         values = (
             getattr(job, "name", None),
@@ -294,7 +303,12 @@ def _filter_squeue_jobs(
             getattr(job, "nodelist", None),
             getattr(job, "requested_nodelist", None),
         )
-        return any(pattern.search(str(value)) for pattern in patterns for value in values if value)
+        return any(
+            pattern.search(str(value))
+            for pattern in patterns
+            for value in values
+            if value
+        )
 
     return [
         job

--- a/src/srunx/domain/jobs.py
+++ b/src/srunx/domain/jobs.py
@@ -337,6 +337,10 @@ class BaseJob(BaseModel):
         default=None,
         description="Comma-separated list of nodes (e.g., 'node[01-04]')",
     )
+    requested_nodelist: str | None = Field(
+        default=None,
+        description="Node list explicitly requested at submission, if any",
+    )
     cpus: int | None = Field(
         default=None, ge=0, description="Total CPU count allocated to job"
     )

--- a/src/srunx/slurm/clients/_ssh_queries.py
+++ b/src/srunx/slurm/clients/_ssh_queries.py
@@ -29,7 +29,7 @@ logger = get_logger(__name__)
 
 
 def list_active_jobs(
-    client: SlurmSSHClient, user: str | None = None
+    client: SlurmSSHClient, user: str | None = None, me: bool = False
 ) -> tuple[list[dict[str, Any]], set[int]]:
     """Return active (PENDING / RUNNING / ...) jobs from ``squeue`` only.
 
@@ -48,7 +48,7 @@ def list_active_jobs(
     ``%i`` job_id | ``%P`` partition | ``%j`` name | ``%u`` user |
     ``%T`` state (long) | ``%M`` elapsed | ``%l`` time_limit |
     ``%D`` nodes | ``%C`` total CPUs | ``%R`` nodelist-or-reason |
-    ``%b`` TRES_PER_NODE (for GPU extraction).
+    ``%n`` requested nodelist and ``%b`` TRES_PER_NODE (for GPU extraction).
 
     Returns ``(entries, seen_ids)`` so the merging caller can
     dedup sacct rows against active IDs without re-scanning.
@@ -57,11 +57,13 @@ def list_active_jobs(
     # parens (e.g. "(Resources, Priority)"), so splitting on
     # whitespace with maxsplit is fragile. Pipe is the safe
     # separator — SLURM fields never contain it.
-    fmt = "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b"
+    fmt = "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b"
     cmd = f'squeue --format "{fmt}" --noheader'
     if user:
         _validate_identifier(user, "user")
         cmd += f" --user {user}"
+    elif me:
+        cmd += " --me"
 
     output = _run_slurm_cmd(client, cmd)
     jobs: list[dict[str, Any]] = []
@@ -75,7 +77,7 @@ def list_active_jobs(
         # subsequent indexing would silently misalign every column
         # downstream of the embedded pipe. Better to drop the row
         # than render corrupted data in an admin's queue listing.
-        if len(parts) != 11:
+        if len(parts) != 12:
             continue
 
         try:
@@ -92,7 +94,10 @@ def list_active_jobs(
         nodes_str = parts[7].strip()
         cpus_str = parts[8].strip()
         nodelist = parts[9].strip()
-        tres = parts[10].strip()
+        requested_nodelist = parts[10].strip() or None
+        if requested_nodelist in {"(null)", "None assigned"}:
+            requested_nodelist = None
+        tres = parts[11].strip()
 
         num_nodes = int(nodes_str) if nodes_str.isdigit() else 1
         try:
@@ -124,6 +129,7 @@ def list_active_jobs(
                 "cpus": cpus_total,
                 "gpus": gpus_per_node * num_nodes,
                 "nodelist": nodelist,
+                "requested_nodelist": requested_nodelist,
                 "elapsed_time": elapsed,
                 "time_limit": time_limit,
             }

--- a/src/srunx/slurm/clients/local.py
+++ b/src/srunx/slurm/clients/local.py
@@ -431,11 +431,11 @@ class LocalClient:
             logger.error(f"Failed to cancel job {job_id}: {e}")
             raise
 
-    def queue(self, user: str | None = None) -> list[BaseJob]:
+    def queue(self, user: str | None = None, me: bool = False) -> list[BaseJob]:
         """List active jobs.
 
         ``user=None`` shows all users' jobs (matches native ``squeue``).
-        Pass a username to filter.
+        Pass a username to filter, or ``me=True`` for native ``squeue --me``.
 
         Returns: list of :class:`BaseJob` populated with the same
         field set as the SSH adapter's :meth:`~srunx.slurm.clients.ssh.SlurmSSHClient.queue`
@@ -443,17 +443,19 @@ class LocalClient:
         """
         # Pipe-delimited format — nodelist/reason (%R) can contain
         # whitespace + parens, so space-splitting is fragile.
-        # Fields: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b
+        # Fields: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b
         # (job_id, partition, name, user, state, elapsed, limit, nodes,
-        # total_cpus, nodelist_or_reason, TRES_PER_NODE)
+        # total_cpus, nodelist_or_reason, requested_nodelist, TRES_PER_NODE)
         cmd = [
             "squeue",
             "--format",
-            "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b",
+            "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b",
             "--noheader",
         ]
         if user:
             cmd.extend(["--user", user])
+        elif me:
+            cmd.append("--me")
 
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
 
@@ -463,7 +465,7 @@ class LocalClient:
                 continue
 
             parts = line.split("|")
-            if len(parts) < 11:
+            if len(parts) < 12:
                 continue
 
             try:
@@ -480,7 +482,10 @@ class LocalClient:
             nodes_str = parts[7].strip()
             cpus_str = parts[8].strip()
             nodelist = parts[9].strip() or None
-            tres = parts[10].strip()
+            requested_nodelist = parts[10].strip() or None
+            if requested_nodelist in {"(null)", "None assigned"}:
+                requested_nodelist = None
+            tres = parts[11].strip()
 
             try:
                 status = JobStatus(status_str)
@@ -518,6 +523,7 @@ class LocalClient:
                 cpus=cpus,
                 gpus=gpus_per_node * nodes,
                 nodelist=nodelist,
+                requested_nodelist=requested_nodelist,
             )
             job.status = status
             jobs.append(job)

--- a/src/srunx/slurm/clients/ssh.py
+++ b/src/srunx/slurm/clients/ssh.py
@@ -839,7 +839,7 @@ class SlurmSSHClient:
         job._last_refresh = _time.time() + 10**9
         return job
 
-    def queue(self, user: str | None = None) -> list[BaseJob]:
+    def queue(self, user: str | None = None, me: bool = False) -> list[BaseJob]:
         """List *active* jobs (all users by default).
 
         Adapts :func:`srunx.slurm.clients._ssh_queries.list_active_jobs`
@@ -853,11 +853,11 @@ class SlurmSSHClient:
         ``user=None`` shows **all users' jobs**, matching native
         ``squeue`` and the local :meth:`~srunx.slurm.local.Slurm.queue`.
         Pass a username explicitly (e.g. from ``-u`` / ``--user``) to
-        filter to that user.
+        filter to that user. Pass ``me=True`` for native ``squeue --me``.
         """
         from srunx.domain import BaseJob, JobStatus
 
-        raw_entries, _ = _list_active_jobs_impl(self, user=user)
+        raw_entries, _ = _list_active_jobs_impl(self, user=user, me=me)
         out: list[BaseJob] = []
         for entry in raw_entries:
             status_str = str(entry.get("status", "UNKNOWN"))
@@ -878,6 +878,7 @@ class SlurmSSHClient:
                 cpus=entry.get("cpus"),
                 gpus=entry.get("gpus"),
                 nodelist=entry.get("nodelist") or None,
+                requested_nodelist=entry.get("requested_nodelist") or None,
                 elapsed_time=entry.get("elapsed_time"),
                 time_limit=entry.get("time_limit"),
             )

--- a/src/srunx/slurm/protocols.py
+++ b/src/srunx/slurm/protocols.py
@@ -138,11 +138,12 @@ class JobOperations(Protocol):
         """
         ...
 
-    def queue(self, user: str | None = None) -> list[BaseJob]:
+    def queue(self, user: str | None = None, me: bool = False) -> list[BaseJob]:
         """List active jobs.
 
         ``user=None`` means "all users", matching native SLURM
-        ``squeue`` semantics. Pass a username to filter. Empty list
+        ``squeue`` semantics. Pass a username to filter, or ``me=True`` to
+        use native scheduler-side current-user filtering. Empty list
         if there are no active jobs; never raises.
         """
         ...

--- a/tests/cli/commands/jobs/test_squeue.py
+++ b/tests/cli/commands/jobs/test_squeue.py
@@ -115,7 +115,8 @@ class TestSqueueTable:
             "CPUs",
             "GPUs",
             "Elapsed",
-            "NodeList",
+            "NodeList / Reason",
+            "Requested NodeList",
         ):
             assert shown in result.stdout, f"default column missing: {shown}"
         # Opt-in columns must not appear by default.
@@ -125,6 +126,7 @@ class TestSqueueTable:
         assert "alice" in result.stdout
         assert "dgx-node[1-2]" in result.stdout
         assert "RUNNING" in result.stdout
+        assert "unspecified" in result.stdout
 
     def test_show_all_flag_reveals_every_column(
         self, runner: CliRunner, mock_jobs
@@ -215,6 +217,7 @@ class TestSqueueJson:
         assert first["cpus"] == 32
         assert first["gpus"] == 8
         assert first["nodelist"] == "dgx-node[1-2]"
+        assert first["requested_nodelist"] is None
 
     def test_empty_queue_emits_empty_list(self, runner: CliRunner) -> None:
         """Pre-existing regression — ``--format json`` on empty queue
@@ -255,6 +258,48 @@ class TestSqueueUserFilter:
 
         assert result.exit_code == 0
         client.queue.assert_called_once_with(user=None)
+
+    def test_me_flag_uses_native_scheduler_filter(
+        self, runner: CliRunner, mock_jobs
+    ) -> None:
+        with patch("srunx.slurm.local.Slurm") as mock_slurm:
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(app, ["squeue", "--local", "--me", "--format", "json"])
+
+        assert result.exit_code == 0
+        client.queue.assert_called_once_with(me=True)
+
+    def test_me_and_user_are_incompatible(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["squeue", "--local", "--me", "--user", "alice"])
+
+        assert result.exit_code == 2
+        assert "cannot be used" in result.output
+
+
+class TestSqueueRegexFilters:
+    def test_include_and_exclude_match_all_queue_location_fields(
+        self, runner: CliRunner, mock_jobs
+    ) -> None:
+        mock_jobs[1].requested_nodelist = "gpu-special-01"
+        with patch("srunx.slurm.local.Slurm") as mock_slurm:
+            client = MagicMock()
+            client.queue.return_value = mock_jobs
+            mock_slurm.return_value = client
+            result = runner.invoke(
+                app,
+                ["squeue", "--local", "--format", "json", "-I", "gpu", "-x", "multi_gpu"],
+            )
+
+        assert result.exit_code == 0
+        assert [job["job_id"] for job in json.loads(result.stdout)] == [12345, 12346]
+
+    def test_invalid_regex_has_usage_exit_code(self, runner: CliRunner) -> None:
+        result = runner.invoke(app, ["squeue", "--local", "--include", "["])
+
+        assert result.exit_code == 2
+        assert "invalid regular expression" in result.output.lower()
 
 
 class TestSqueueJobIdFilter:

--- a/tests/cli/commands/jobs/test_squeue.py
+++ b/tests/cli/commands/jobs/test_squeue.py
@@ -266,7 +266,9 @@ class TestSqueueUserFilter:
             client = MagicMock()
             client.queue.return_value = mock_jobs
             mock_slurm.return_value = client
-            result = runner.invoke(app, ["squeue", "--local", "--me", "--format", "json"])
+            result = runner.invoke(
+                app, ["squeue", "--local", "--me", "--format", "json"]
+            )
 
         assert result.exit_code == 0
         client.queue.assert_called_once_with(me=True)
@@ -289,7 +291,16 @@ class TestSqueueRegexFilters:
             mock_slurm.return_value = client
             result = runner.invoke(
                 app,
-                ["squeue", "--local", "--format", "json", "-I", "gpu", "-x", "multi_gpu"],
+                [
+                    "squeue",
+                    "--local",
+                    "--format",
+                    "json",
+                    "-I",
+                    "gpu",
+                    "-x",
+                    "multi_gpu",
+                ],
             )
 
         assert result.exit_code == 0

--- a/tests/slurm/clients/test_ssh_parsing.py
+++ b/tests/slurm/clients/test_ssh_parsing.py
@@ -108,13 +108,13 @@ class TestUnavailableStates:
 class TestListJobsParsing:
     """Test the list_jobs parsing logic by mocking _run_slurm_cmd."""
 
-    # Pipe-delimited format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b
-    # (job_id|partition|name|user|state|elapsed|time_limit|nodes|cpus|nodelist_or_reason|TRES_PER_NODE)
+    # Pipe-delimited format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b
+    # (job_id|partition|name|user|state|elapsed|time_limit|nodes|cpus|nodelist_or_reason|requested_nodelist|TRES_PER_NODE)
     SAMPLE_SQUEUE = """\
-18431|defq|qwen3-tts|ksterx|RUNNING|1-00:03:20|UNLIMITED|1|16|dgx-node1|gpu:8
-18477|defq|cosy|ksterx|RUNNING|12:30:45|UNLIMITED|1|32|dgx-node2|gpu:NVIDIA-A100:8
-18490|defq|gemma3-cpt|alice|RUNNING|5:15:00|UNLIMITED|2|64|dgx-node[3-4]|gpu:4
-18500|defq|pending|bob|PENDING|0:00|UNLIMITED|1|8|(Priority)|(null)
+18431|defq|qwen3-tts|ksterx|RUNNING|1-00:03:20|UNLIMITED|1|16|dgx-node1|dgx-node1|gpu:8
+18477|defq|cosy|ksterx|RUNNING|12:30:45|UNLIMITED|1|32|dgx-node2||gpu:NVIDIA-A100:8
+18490|defq|gemma3-cpt|alice|RUNNING|5:15:00|UNLIMITED|2|64|dgx-node[3-4]|dgx-node[3-4]|gpu:4
+18500|defq|pending|bob|PENDING|0:00|UNLIMITED|1|8|(Priority)||(null)
 """
 
     def test_parse_running_jobs(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -255,6 +255,8 @@ class TestListJobsParsing:
         assert jobs[0]["nodelist"] == "dgx-node1"
         assert jobs[2]["nodelist"] == "dgx-node[3-4]"
         assert jobs[3]["nodelist"] == "(Priority)"
+        assert jobs[0]["requested_nodelist"] == "dgx-node1"
+        assert jobs[3]["requested_nodelist"] is None
 
     def test_empty_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
@@ -263,6 +265,23 @@ class TestListJobsParsing:
         )
         adapter = object.__new__(SlurmSSHClient)
         assert adapter.list_jobs() == []
+
+    def test_queue_with_me_uses_native_scheduler_filter(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        commands: list[str] = []
+
+        def run(_adapter, command: str) -> str:
+            commands.append(command)
+            return ""
+
+        monkeypatch.setattr("srunx.slurm.clients._ssh_queries._run_slurm_cmd", run)
+        adapter = object.__new__(SlurmSSHClient)
+
+        assert adapter.queue(me=True) == []
+        assert commands == [
+            'squeue --format "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b" --noheader --me'
+        ]
 
     def test_required_frontend_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Every job dict must have command and resources for frontend type."""
@@ -288,9 +307,9 @@ class TestListJobsParsing:
         """
         bogus = (
             "18431|defq|qwen3-tts|ksterx|RUNNING|1-00:03:20|"
-            "UNLIMITED|1|8|dgx-node1|gpu:8\n"
+            "UNLIMITED|1|8|dgx-node1||gpu:8\n"
             "18432|defq|mal|icious|name|alice|RUNNING|"
-            "0:05|1:00:00|1|8|dgx-node2|gpu:8\n"  # 13 fields (bad)
+            "0:05|1:00:00|1|8|dgx-node2||gpu:8\n"  # 14 fields (bad)
         )
         monkeypatch.setattr(
             "srunx.slurm.clients._ssh_queries._run_slurm_cmd",

--- a/tests/slurm/test_local.py
+++ b/tests/slurm/test_local.py
@@ -258,13 +258,13 @@ class TestSlurm:
     def test_queue_with_jobs(self, mock_run):
         """Test queue with jobs.
 
-        Format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%b — new pipe-delimited
+        Format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b — new pipe-delimited
         shape gained when squeue started surfacing user/CPUs/NodeList
         alongside the original columns.
         """
         mock_run.return_value.stdout = (
-            "12345|gpu|test_job1|user|RUNNING|5:00|1:00:00|1|8|node1|gpu:4\n"
-            "12346|cpu|test_job2|user|PENDING|0:00|30:00|1|4|(Priority)|(null)\n"
+            "12345|gpu|test_job1|user|RUNNING|5:00|1:00:00|1|8|node1|node1|gpu:4\n"
+            "12346|cpu|test_job2|user|PENDING|0:00|30:00|1|4|(Priority)||(null)\n"
         )
 
         client = Slurm()
@@ -278,10 +278,12 @@ class TestSlurm:
         assert jobs[0].cpus == 8
         assert jobs[0].gpus == 4  # gpu:4 per node * 1 node
         assert jobs[0].nodelist == "node1"
+        assert jobs[0].requested_nodelist == "node1"
         assert jobs[1].job_id == 12346
         assert jobs[1].name == "test_job2"
         assert jobs[1]._status == JobStatus.PENDING
         assert jobs[1].nodelist == "(Priority)"
+        assert jobs[1].requested_nodelist is None
 
     @patch("subprocess.run")
     def test_queue_with_user(self, mock_run):
@@ -294,6 +296,14 @@ class TestSlurm:
         args, kwargs = mock_run.call_args
         assert "--user" in args[0]
         assert "testuser" in args[0]
+
+    @patch("subprocess.run")
+    def test_queue_with_me_uses_native_scheduler_filter(self, mock_run):
+        mock_run.return_value.stdout = ""
+
+        Slurm().queue(me=True)
+
+        assert "--me" in mock_run.call_args.args[0]
 
     @patch("srunx.slurm.local.Slurm.retrieve")
     @patch("time.sleep")


### PR DESCRIPTION
## Summary
- show Slurm requested node lists separately from NodeList / pending reason
- add native scheduler-side `srunx squeue --me` filtering
- add repeatable regex include (`-I`) and exclude (`-x`) filters across job name, partition, current node/reason, and requested nodes

## Validation
- `.venv/bin/ruff check` (changed files)
- `.venv/bin/pytest -q tests/cli/commands/jobs/test_squeue.py tests/slurm/test_local.py tests/slurm/clients/test_ssh_parsing.py`
- `.venv/bin/mypy` (changed source files)