### PR TITLE
fix(cli): show assigned nodes separately from queue reasons

### DIFF
--- a/src/srunx/cli/commands/jobs/squeue.py
+++ b/src/srunx/cli/commands/jobs/squeue.py
@@ -101,7 +101,7 @@ def squeue(
     Shows all users' jobs by default (matching native ``squeue``).
 
     Default columns: Job ID, User, Name, Status, CPUs, GPUs,
-    Elapsed, NodeList. Use ``--show-partition`` / ``--show-limit`` /
+    Elapsed, Assigned Node, Reason. Use ``--show-partition`` / ``--show-limit`` /
     ``--show-nodes`` (or ``-a`` / ``--all``) to surface the remaining
     SLURM fields. ``--format json`` always emits every field
     regardless of these flags — scripts can pick what they need.
@@ -235,8 +235,8 @@ def _render_squeue_table(jobs: list[Any], v: _SqueueColumnVisibility) -> Table:
     table.add_column("Elapsed", justify="right")
     if v.limit:
         table.add_column("Limit", justify="right")
-    table.add_column("NodeList / Reason", overflow="fold")
-    table.add_column("Requested NodeList", overflow="fold")
+    table.add_column("Assigned Node", overflow="fold")
+    table.add_column("Reason", overflow="fold")
 
     for job in jobs:
         status_name = job.status.name if hasattr(job, "status") else "UNKNOWN"
@@ -255,8 +255,8 @@ def _render_squeue_table(jobs: list[Any], v: _SqueueColumnVisibility) -> Table:
         row.append(getattr(job, "elapsed_time", None) or "N/A")
         if v.limit:
             row.append(getattr(job, "time_limit", None) or "N/A")
-        row.append(getattr(job, "nodelist", None) or "N/A")
-        row.append(getattr(job, "requested_nodelist", None) or "unspecified")
+        row.append(getattr(job, "nodelist", None) or "unassigned")
+        row.append(getattr(job, "reason", None) or "N/A")
         table.add_row(*row)
 
     return table
@@ -281,7 +281,7 @@ def _squeue_json(jobs: list[Any]) -> list[dict[str, Any]]:
             "cpus": getattr(job, "cpus", None),
             "gpus": getattr(job, "gpus", None),
             "nodelist": getattr(job, "nodelist", None),
-            "requested_nodelist": getattr(job, "requested_nodelist", None),
+            "reason": getattr(job, "reason", None),
             "elapsed_time": getattr(job, "elapsed_time", None),
             "time_limit": getattr(job, "time_limit", None),
         }
@@ -301,7 +301,7 @@ def _filter_squeue_jobs(
             getattr(job, "name", None),
             getattr(job, "partition", None),
             getattr(job, "nodelist", None),
-            getattr(job, "requested_nodelist", None),
+            getattr(job, "reason", None),
         )
         return any(
             pattern.search(str(value))

--- a/src/srunx/domain/jobs.py
+++ b/src/srunx/domain/jobs.py
@@ -337,9 +337,9 @@ class BaseJob(BaseModel):
         default=None,
         description="Comma-separated list of nodes (e.g., 'node[01-04]')",
     )
-    requested_nodelist: str | None = Field(
+    reason: str | None = Field(
         default=None,
-        description="Node list explicitly requested at submission, if any",
+        description="SLURM pending reason, if the job is waiting",
     )
     cpus: int | None = Field(
         default=None, ge=0, description="Total CPU count allocated to job"

--- a/src/srunx/slurm/clients/_ssh_queries.py
+++ b/src/srunx/slurm/clients/_ssh_queries.py
@@ -47,8 +47,8 @@ def list_active_jobs(
     Format fields (all surfaced by :meth:`SlurmSSHClient.queue`):
     ``%i`` job_id | ``%P`` partition | ``%j`` name | ``%u`` user |
     ``%T`` state (long) | ``%M`` elapsed | ``%l`` time_limit |
-    ``%D`` nodes | ``%C`` total CPUs | ``%R`` nodelist-or-reason |
-    ``%n`` requested nodelist and ``%b`` TRES_PER_NODE (for GPU extraction).
+    ``%D`` nodes | ``%C`` total CPUs | ``%N`` assigned nodelist |
+    ``%R`` pending reason and ``%b`` TRES_PER_NODE (for GPU extraction).
 
     Returns ``(entries, seen_ids)`` so the merging caller can
     dedup sacct rows against active IDs without re-scanning.
@@ -57,7 +57,7 @@ def list_active_jobs(
     # parens (e.g. "(Resources, Priority)"), so splitting on
     # whitespace with maxsplit is fragile. Pipe is the safe
     # separator — SLURM fields never contain it.
-    fmt = "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b"
+    fmt = "%i|%P|%j|%u|%T|%M|%l|%D|%C|%N|%R|%b"
     cmd = f'squeue --format "{fmt}" --noheader'
     if user:
         _validate_identifier(user, "user")
@@ -93,10 +93,12 @@ def list_active_jobs(
         time_limit = parts[6].strip()
         nodes_str = parts[7].strip()
         cpus_str = parts[8].strip()
-        nodelist = parts[9].strip()
-        requested_nodelist = parts[10].strip() or None
-        if requested_nodelist in {"(null)", "None assigned"}:
-            requested_nodelist = None
+        nodelist = parts[9].strip() or None
+        if nodelist in {"(null)", "None assigned"}:
+            nodelist = None
+        reason = parts[10].strip() or None
+        if state != "PENDING" or reason in {"(null)", "None assigned"}:
+            reason = None
         tres = parts[11].strip()
 
         num_nodes = int(nodes_str) if nodes_str.isdigit() else 1
@@ -129,7 +131,7 @@ def list_active_jobs(
                 "cpus": cpus_total,
                 "gpus": gpus_per_node * num_nodes,
                 "nodelist": nodelist,
-                "requested_nodelist": requested_nodelist,
+                "reason": reason,
                 "elapsed_time": elapsed,
                 "time_limit": time_limit,
             }

--- a/src/srunx/slurm/clients/local.py
+++ b/src/srunx/slurm/clients/local.py
@@ -441,15 +441,15 @@ class LocalClient:
         field set as the SSH adapter's :meth:`~srunx.slurm.clients.ssh.SlurmSSHClient.queue`
         so CLI callers see a consistent shape regardless of transport.
         """
-        # Pipe-delimited format — nodelist/reason (%R) can contain
+        # Pipe-delimited format — node lists/reasons can contain
         # whitespace + parens, so space-splitting is fragile.
-        # Fields: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b
+        # Fields: %i|%P|%j|%u|%T|%M|%l|%D|%C|%N|%R|%b
         # (job_id, partition, name, user, state, elapsed, limit, nodes,
-        # total_cpus, nodelist_or_reason, requested_nodelist, TRES_PER_NODE)
+        # total_cpus, assigned_nodelist, pending_reason, TRES_PER_NODE)
         cmd = [
             "squeue",
             "--format",
-            "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b",
+            "%i|%P|%j|%u|%T|%M|%l|%D|%C|%N|%R|%b",
             "--noheader",
         ]
         if user:
@@ -482,9 +482,11 @@ class LocalClient:
             nodes_str = parts[7].strip()
             cpus_str = parts[8].strip()
             nodelist = parts[9].strip() or None
-            requested_nodelist = parts[10].strip() or None
-            if requested_nodelist in {"(null)", "None assigned"}:
-                requested_nodelist = None
+            if nodelist in {"(null)", "None assigned"}:
+                nodelist = None
+            reason = parts[10].strip() or None
+            if status_str != "PENDING" or reason in {"(null)", "None assigned"}:
+                reason = None
             tres = parts[11].strip()
 
             try:
@@ -523,7 +525,7 @@ class LocalClient:
                 cpus=cpus,
                 gpus=gpus_per_node * nodes,
                 nodelist=nodelist,
-                requested_nodelist=requested_nodelist,
+                reason=reason,
             )
             job.status = status
             jobs.append(job)

--- a/src/srunx/slurm/clients/ssh.py
+++ b/src/srunx/slurm/clients/ssh.py
@@ -878,7 +878,7 @@ class SlurmSSHClient:
                 cpus=entry.get("cpus"),
                 gpus=entry.get("gpus"),
                 nodelist=entry.get("nodelist") or None,
-                requested_nodelist=entry.get("requested_nodelist") or None,
+                reason=entry.get("reason") or None,
                 elapsed_time=entry.get("elapsed_time"),
                 time_limit=entry.get("time_limit"),
             )

--- a/tests/cli/commands/jobs/test_squeue.py
+++ b/tests/cli/commands/jobs/test_squeue.py
@@ -1,7 +1,7 @@
 """Tests for ``srunx squeue`` (active-jobs listing).
 
 The command now mirrors native ``squeue`` semantics: all users' jobs by
-default, User/Status/CPUs/GPUs/NodeList columns, ``-u/--user`` to
+default, User/Status/CPUs/GPUs/Assigned Node/Reason columns, ``-u/--user`` to
 filter. The previous ``--show-gpus`` / ``--show-cpus`` flags are gone —
 CPUs and GPUs are always shown because the user explicitly asked for a
 combined CPU + GPU + NODELIST view.
@@ -35,6 +35,7 @@ def _make_job(
     cpus: int,
     gpus: int,
     nodelist: str,
+    reason: str | None = None,
     elapsed: str = "0:05",
     time_limit: str = "UNLIMITED",
 ) -> BaseJob:
@@ -47,6 +48,7 @@ def _make_job(
         cpus=cpus,
         gpus=gpus,
         nodelist=nodelist,
+        reason=reason,
         elapsed_time=elapsed,
         time_limit=time_limit,
     )
@@ -77,7 +79,8 @@ def mock_jobs() -> list[BaseJob]:
             nodes=1,
             cpus=4,
             gpus=0,
-            nodelist="(Priority)",
+            nodelist=None,
+            reason="Priority",
         ),
         _make_job(
             job_id=12347,
@@ -96,7 +99,7 @@ def mock_jobs() -> list[BaseJob]:
 class TestSqueueTable:
     def test_default_columns(self, runner: CliRunner, mock_jobs) -> None:
         """Default view: Job ID / User / Name / Status / CPUs / GPUs /
-        Elapsed / NodeList. Partition / Limit / Nodes are opt-in."""
+        Elapsed / Assigned Node / Reason. Partition / Limit / Nodes are opt-in."""
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
             client = MagicMock()
             client.queue.return_value = mock_jobs
@@ -115,8 +118,8 @@ class TestSqueueTable:
             "CPUs",
             "GPUs",
             "Elapsed",
-            "NodeList / Reason",
-            "Requested NodeList",
+            "Assigned Node",
+            "Reason",
         ):
             assert shown in result.stdout, f"default column missing: {shown}"
         # Opt-in columns must not appear by default.
@@ -126,7 +129,8 @@ class TestSqueueTable:
         assert "alice" in result.stdout
         assert "dgx-node[1-2]" in result.stdout
         assert "RUNNING" in result.stdout
-        assert "unspecified" in result.stdout
+        assert "unassigned" in result.stdout
+        assert "Priority" in result.stdout
 
     def test_show_all_flag_reveals_every_column(
         self, runner: CliRunner, mock_jobs
@@ -151,7 +155,8 @@ class TestSqueueTable:
             "GPUs",
             "Elapsed",
             "Limit",
-            "NodeList",
+            "Assigned Node",
+            "Reason",
         ):
             assert header in result.stdout, f"column missing under -a: {header}"
 
@@ -217,7 +222,8 @@ class TestSqueueJson:
         assert first["cpus"] == 32
         assert first["gpus"] == 8
         assert first["nodelist"] == "dgx-node[1-2]"
-        assert first["requested_nodelist"] is None
+        assert first["reason"] is None
+        assert "requested_nodelist" not in first
 
     def test_empty_queue_emits_empty_list(self, runner: CliRunner) -> None:
         """Pre-existing regression — ``--format json`` on empty queue
@@ -284,7 +290,7 @@ class TestSqueueRegexFilters:
     def test_include_and_exclude_match_all_queue_location_fields(
         self, runner: CliRunner, mock_jobs
     ) -> None:
-        mock_jobs[1].requested_nodelist = "gpu-special-01"
+        mock_jobs[1].reason = "gpu-special-01"
         with patch("srunx.slurm.local.Slurm") as mock_slurm:
             client = MagicMock()
             client.queue.return_value = mock_jobs

--- a/tests/slurm/clients/test_ssh_parsing.py
+++ b/tests/slurm/clients/test_ssh_parsing.py
@@ -108,13 +108,13 @@ class TestUnavailableStates:
 class TestListJobsParsing:
     """Test the list_jobs parsing logic by mocking _run_slurm_cmd."""
 
-    # Pipe-delimited format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b
-    # (job_id|partition|name|user|state|elapsed|time_limit|nodes|cpus|nodelist_or_reason|requested_nodelist|TRES_PER_NODE)
+    # Pipe-delimited format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%N|%R|%b
+    # (job_id|partition|name|user|state|elapsed|time_limit|nodes|cpus|assigned_nodelist|pending_reason|TRES_PER_NODE)
     SAMPLE_SQUEUE = """\
-18431|defq|qwen3-tts|ksterx|RUNNING|1-00:03:20|UNLIMITED|1|16|dgx-node1|dgx-node1|gpu:8
-18477|defq|cosy|ksterx|RUNNING|12:30:45|UNLIMITED|1|32|dgx-node2||gpu:NVIDIA-A100:8
-18490|defq|gemma3-cpt|alice|RUNNING|5:15:00|UNLIMITED|2|64|dgx-node[3-4]|dgx-node[3-4]|gpu:4
-18500|defq|pending|bob|PENDING|0:00|UNLIMITED|1|8|(Priority)||(null)
+18431|defq|qwen3-tts|ksterx|RUNNING|1-00:03:20|UNLIMITED|1|16|dgx-node1|None assigned|gpu:8
+18477|defq|cosy|ksterx|RUNNING|12:30:45|UNLIMITED|1|32|dgx-node2|None assigned|gpu:NVIDIA-A100:8
+18490|defq|gemma3-cpt|alice|RUNNING|5:15:00|UNLIMITED|2|64|dgx-node[3-4]|None assigned|gpu:4
+18500|defq|pending|bob|PENDING|0:00|UNLIMITED|1|8|None assigned|Priority|(null)
 """
 
     def test_parse_running_jobs(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -241,10 +241,10 @@ class TestListJobsParsing:
         assert jobs[0]["cpus"] == 16
         assert jobs[2]["cpus"] == 64
 
-    def test_parse_nodelist_running_vs_pending(
+    def test_parse_assigned_nodelist_and_pending_reason(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """%R is the nodelist for running jobs and the reason for pending ones."""
+        """%N is assigned nodes while %R is a reason only for pending jobs."""
         monkeypatch.setattr(
             "srunx.slurm.clients._ssh_queries._run_slurm_cmd",
             lambda _a, _c: self.SAMPLE_SQUEUE,
@@ -254,9 +254,9 @@ class TestListJobsParsing:
 
         assert jobs[0]["nodelist"] == "dgx-node1"
         assert jobs[2]["nodelist"] == "dgx-node[3-4]"
-        assert jobs[3]["nodelist"] == "(Priority)"
-        assert jobs[0]["requested_nodelist"] == "dgx-node1"
-        assert jobs[3]["requested_nodelist"] is None
+        assert jobs[3]["nodelist"] is None
+        assert jobs[0]["reason"] is None
+        assert jobs[3]["reason"] == "Priority"
 
     def test_empty_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
@@ -280,7 +280,7 @@ class TestListJobsParsing:
 
         assert adapter.queue(me=True) == []
         assert commands == [
-            'squeue --format "%i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b" --noheader --me'
+            'squeue --format "%i|%P|%j|%u|%T|%M|%l|%D|%C|%N|%R|%b" --noheader --me'
         ]
 
     def test_required_frontend_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -300,7 +300,7 @@ class TestListJobsParsing:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """SLURM lets users pick job names containing ``|`` (e.g.
-        ``#SBATCH --job-name=foo|bar``). Such a row splits into 12
+        ``#SBATCH --job-name=foo|bar``). Such a row splits into 13
         fields; a lenient ``< 11`` check would pass and then every
         column downstream of the name would silently shift. Guards
         that we drop those rows instead of rendering misaligned data.

--- a/tests/slurm/test_local.py
+++ b/tests/slurm/test_local.py
@@ -258,13 +258,13 @@ class TestSlurm:
     def test_queue_with_jobs(self, mock_run):
         """Test queue with jobs.
 
-        Format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%R|%n|%b — new pipe-delimited
+        Format: %i|%P|%j|%u|%T|%M|%l|%D|%C|%N|%R|%b — new pipe-delimited
         shape gained when squeue started surfacing user/CPUs/NodeList
         alongside the original columns.
         """
         mock_run.return_value.stdout = (
-            "12345|gpu|test_job1|user|RUNNING|5:00|1:00:00|1|8|node1|node1|gpu:4\n"
-            "12346|cpu|test_job2|user|PENDING|0:00|30:00|1|4|(Priority)||(null)\n"
+            "12345|gpu|test_job1|user|RUNNING|5:00|1:00:00|1|8|node1|None assigned|gpu:4\n"
+            "12346|cpu|test_job2|user|PENDING|0:00|30:00|1|4|None assigned|Priority|(null)\n"
         )
 
         client = Slurm()
@@ -278,12 +278,12 @@ class TestSlurm:
         assert jobs[0].cpus == 8
         assert jobs[0].gpus == 4  # gpu:4 per node * 1 node
         assert jobs[0].nodelist == "node1"
-        assert jobs[0].requested_nodelist == "node1"
+        assert jobs[0].reason is None
         assert jobs[1].job_id == 12346
         assert jobs[1].name == "test_job2"
         assert jobs[1]._status == JobStatus.PENDING
-        assert jobs[1].nodelist == "(Priority)"
-        assert jobs[1].requested_nodelist is None
+        assert jobs[1].nodelist is None
+        assert jobs[1].reason == "Priority"
 
     @patch("subprocess.run")
     def test_queue_with_user(self, mock_run):


### PR DESCRIPTION
## Summary
- replace the misleading requested-node column with actual scheduler allocation (`%N`)
- show pending jobs as `unassigned` with their queue reason in a separate column
- keep regex filtering aligned with job name, partition, assigned node, and reason

## Live verification
- Verified against the GMO profile: running jobs report `aic-*` assigned nodes; pending jobs report `unassigned` plus `Priority` / `Resources` / `Dependency`.

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -q tests/cli/commands/jobs/test_squeue.py tests/slurm/test_local.py tests/slurm/clients/test_ssh_parsing.py`